### PR TITLE
More repair_eth hijinks for making it happier wrt polygon

### DIFF
--- a/node/hack/repair_eth/repair_eth.go
+++ b/node/hack/repair_eth/repair_eth.go
@@ -248,7 +248,6 @@ func main() {
 	if !ok {
 		panic("no core contract")
 	}
-
 	ctx := context.Background()
 
 	jar, err := cookiejar.New(nil)
@@ -271,6 +270,14 @@ func main() {
 	defer conn.Close()
 	if err != nil {
 		log.Fatalf("failed to get admin client: %v", err)
+	}
+
+	// A polygon VAA that was not reobserved before the blocks aged out of guardian rpc nodes
+	ignoreAddress, _ := vaa.StringToAddress("0000000000000000000000005a58505a96d1dbf8df91cb21b54419fc36e93fde")
+	polygonIgnoredVaa := db.VAAID{
+		Sequence:       6840,
+		EmitterChain:   vaa.ChainIDPolygon,
+		EmitterAddress: ignoreAddress,
 	}
 
 	for _, emitter := range common.KnownEmitters {
@@ -299,6 +306,11 @@ func main() {
 			vId, err := db.VaaIDFromString(id)
 			if err != nil {
 				log.Fatalf("failed to parse VAAID: %v", err)
+			}
+			if *vId == polygonIgnoredVaa {
+				log.Printf("Ignored message: %+v", &polygonIgnoredVaa)
+				msgs = append(msgs[:i], msgs[i+1:]...)
+				continue
 			}
 			msgs[i] = vId
 		}


### PR DESCRIPTION
* Add a `User-Agent` header or cloudflare blocks the client on polygonscan
* Skip a known missing message on polygon so the script doesn't run forever
* Add `-sleepTime` flag to sleep between `getLogs()` loops as  polygonscan seems to block clients making > 1 request per second

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/1124)
<!-- Reviewable:end -->
