### PR TITLE
EVM: replace `transfer()` with `call{value:}("")`

### DIFF
--- a/ethereum/contracts/bridge/Bridge.sol
+++ b/ethereum/contracts/bridge/Bridge.sol
@@ -86,7 +86,8 @@ contract Bridge is BridgeGovernance, ReentrancyGuard {
         // refund dust
         uint dust = amount - deNormalizeAmount(normalizedAmount, 18);
         if (dust > 0) {
-            payable(msg.sender).transfer(dust);
+            (bool dustSuccess, ) = payable(msg.sender).call{value:dust}("");
+            require(dustSuccess, "Transfer dust failed.");
         }
 
         // deposit into WETH
@@ -363,7 +364,8 @@ contract Bridge is BridgeGovernance, ReentrancyGuard {
             if (unwrapWETH) {
                 WETH().withdraw(nativeFee);
 
-                payable(feeRecipient).transfer(nativeFee);
+                (bool feeSuccess, ) = payable(feeRecipient).call{value:nativeFee}("");
+                require(feeSuccess, "Transfer fee failed.");
             } else {
                 if (transfer.tokenChain != chainId()) {
                     // mint wrapped asset
@@ -383,7 +385,8 @@ contract Bridge is BridgeGovernance, ReentrancyGuard {
         if (unwrapWETH) {
             WETH().withdraw(transferAmount);
 
-            payable(transferRecipient).transfer(transferAmount);
+            (bool success, ) = payable(transferRecipient).call{value:transferAmount}("");
+            require(success, "Transfer failed.");
         } else {
             if (transfer.tokenChain != chainId()) {
                 // mint wrapped asset


### PR DESCRIPTION
Following [this recommendation](https://ethereum.stackexchange.com/a/19343), replacing `transfer()` with `call()` should slightly reduce the cost of the tx.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/1170)
<!-- Reviewable:end -->
