### PR TITLE
Patched Prototype Pollution in minimist

### DIFF
--- a/clients/js/package-lock.json
+++ b/clients/js/package-lock.json
@@ -5181,7 +5181,7 @@
       "dev": true,
       "peer": true,
       "dependencies": {
-        "minimist": "^1.2.5"
+        "minimist": "^1.2.6"
       },
       "bin": {
         "json5": "lib/cli.js"


### PR DESCRIPTION
Patched Update [clients/js/package-lock.json](https://github.com/certusone/wormhole/blob/-/clients/js/package-lock.json)
Upgrade minimist to version 1.2.6

```json
"dependencies": {
  "minimist": ">=1.2.5"
}
```
```json
"devDependencies": {
  "minimist": ">=1.2.6"
}
```

## Description of the bugs:
Minimist <=1.2.5 is vulnerable to Prototype Pollution via file index.js, function setKey() (lines 69-95).

**CVE-2021-44906**
`CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/certusone/wormhole/1449)
<!-- Reviewable:end -->
