### PR TITLE
Add mainnet chains and token config unit-tests

### DIFF
--- a/node/pkg/governor/mainnet_chains_test.go
+++ b/node/pkg/governor/mainnet_chains_test.go
@@ -24,6 +24,9 @@ func TestChainDailyLimitRange(t *testing.T) {
 	   basically mean no value moment is allowed for that chain*/
 	min_daily_limit := uint64(0)
 
+	// Do not remove this assertion
+	assert.Greater(t, min_daily_limit, uint64(0))
+
 	/* These IS NOT a hard limit, we can adjust them as we see fit,
 	   but setting something sane such that if we accidentially go
 	   too high or too low that the unit tests will make sure it's

--- a/node/pkg/governor/mainnet_chains_test.go
+++ b/node/pkg/governor/mainnet_chains_test.go
@@ -1,0 +1,50 @@
+package governor
+
+import (
+	"github.com/certusone/wormhole/node/pkg/vaa"
+	"github.com/stretchr/testify/assert"
+
+	"testing"
+)
+
+func TestChainListSize(t *testing.T) {
+	chainConfigEntries := chainList()
+
+	/* Assuming that governed chains will not go down over time,
+	   lets set a floor of expected chains to guard against parsing
+	   or loading regressions */
+	assert.Greater(t, len(chainConfigEntries), 14)
+}
+
+func TestChainDailyLimitRange(t *testing.T) {
+	chainConfigEntries := chainList()
+
+	/* Assuming that a governed chains should always be more than zero and less than 50,000,001 */
+	for _, chainConfigEntry := range chainConfigEntries {
+		t.Run(chainConfigEntry.emitterChainID.String(), func(t *testing.T) {
+			assert.Greater(t, chainConfigEntry.dailyLimit, uint64(0))
+			assert.Less(t, chainConfigEntry.dailyLimit, uint64(50000001))
+		})
+	}
+}
+
+func TestChainListChainPresent(t *testing.T) {
+	chainConfigEntries := chainList()
+
+	chains := []uint16{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 18}
+
+	/* Assume that all chains will have governed tokens */
+	for _, chain := range chains {
+		t.Run(vaa.ChainID(chain).String(), func(t *testing.T) {
+			found := false
+			for _, chainConfigEntry := range chainConfigEntries {
+				if chainConfigEntry.emitterChainID == vaa.ChainID(chain) {
+					found = true
+					break
+				}
+			}
+
+			assert.Equal(t, found, true)
+		})
+	}
+}

--- a/node/pkg/governor/mainnet_chains_test.go
+++ b/node/pkg/governor/mainnet_chains_test.go
@@ -20,11 +20,14 @@ func TestChainListSize(t *testing.T) {
 func TestChainDailyLimitRange(t *testing.T) {
 	chainConfigEntries := chainList()
 
-	/* These are not hard limits, we can adjust them as we see fit,
+	/* These IS a hard limit, if daily limit is set to zero it would
+	   basically mean no value moment is allowed for that chain*/
+	min_daily_limit := uint64(0)
+
+	/* These IS NOT a hard limit, we can adjust them as we see fit,
 	   but setting something sane such that if we accidentially go
 	   too high or too low that the unit tests will make sure it's
 	   intentional */
-	min_daily_limit := uint64(0)
 	max_daily_limit := uint64(50000001)
 
 	/* Assuming that a governed chains should always be more than zero and less than 50,000,001 */

--- a/node/pkg/governor/mainnet_chains_test.go
+++ b/node/pkg/governor/mainnet_chains_test.go
@@ -20,18 +20,18 @@ func TestChainListSize(t *testing.T) {
 func TestChainDailyLimitRange(t *testing.T) {
 	chainConfigEntries := chainList()
 
-	/* These IS a hard limit, if daily limit is set to zero it would
-	   basically mean no value moment is allowed for that chain*/
+	/* This IS a hard limit, if daily limit is set to zero it would
+	   basically mean no value movement is allowed for that chain*/
 	min_daily_limit := uint64(0)
 
-	// Do not remove this assertion
-	assert.Greater(t, min_daily_limit, uint64(0))
-
-	/* These IS NOT a hard limit, we can adjust them as we see fit,
+	/* This IS NOT a hard limit, we can adjust it up as we see fit,
 	   but setting something sane such that if we accidentially go
-	   too high or too low that the unit tests will make sure it's
+	   too high that the unit tests will make sure it's
 	   intentional */
 	max_daily_limit := uint64(50000001)
+
+	// Do not remove this assertion
+	assert.NotEqual(t, max_daily_limit, uint64(0))
 
 	/* Assuming that a governed chains should always be more than zero and less than 50,000,001 */
 	for _, chainConfigEntry := range chainConfigEntries {

--- a/node/pkg/governor/mainnet_tokens_test.go
+++ b/node/pkg/governor/mainnet_tokens_test.go
@@ -1,0 +1,108 @@
+package governor
+
+import (
+	"github.com/certusone/wormhole/node/pkg/vaa"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestTokenListSize(t *testing.T) {
+	tokenConfigEntries := tokenList()
+
+	/* Assuming that governed tokens will not go down over time,
+	   lets set a floor to avoid parsing or loading regressions */
+	assert.Greater(t, len(tokenConfigEntries), 122)
+}
+
+func TestTokenListFloor(t *testing.T) {
+	tokenConfigEntries := tokenList()
+
+	/* Assume that we will never have a floor price of zero,
+	   otherwise this would disable the value of the notional
+	   value limit for the token */
+	for _, tokenConfigEntry := range tokenConfigEntries {
+		testLabel := vaa.ChainID(tokenConfigEntry.chain).String() + ":" + tokenConfigEntry.symbol
+		t.Run(testLabel, func(t *testing.T) {
+			assert.Greater(t, tokenConfigEntry.price, float64(0))
+		})
+	}
+
+}
+
+func TestTokenListAddressSize(t *testing.T) {
+	tokenConfigEntries := tokenList()
+
+	/* Assume that token addresses must always be 32 bytes (64 chars) */
+	for _, tokenConfigEntry := range tokenConfigEntries {
+		testLabel := vaa.ChainID(tokenConfigEntry.chain).String() + ":" + tokenConfigEntry.symbol
+		t.Run(testLabel, func(t *testing.T) {
+			assert.Equal(t, len(tokenConfigEntry.addr), 64)
+		})
+	}
+}
+
+func TestTokenListChainTokensPresent(t *testing.T) {
+	tokenConfigEntries := tokenList()
+
+	chains := []uint16{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 18}
+
+	/* Assume that all chains will have governed tokens */
+	for _, chain := range chains {
+		t.Run(vaa.ChainID(chain).String(), func(t *testing.T) {
+			found := false
+			for _, tokenConfigEntry := range tokenConfigEntries {
+				if tokenConfigEntry.chain == chain {
+					found = true
+					break
+				}
+			}
+
+			assert.Equal(t, found, true)
+		})
+	}
+}
+
+func TestTokenListTokenAddressDuplicates(t *testing.T) {
+	tokenConfigEntries := tokenList()
+
+	/* Assume that all governed token entry addresses won't include duplicates */
+	for x, tokenConfigEntry1 := range tokenConfigEntries {
+		for y, tokenConfigEntry2 := range tokenConfigEntries {
+			if x == y {
+				// don't flag duplicates at the same index
+				continue
+			}
+
+			assert.NotEqual(t, tokenConfigEntry1.addr, tokenConfigEntry2.addr)
+		}
+	}
+}
+
+func TestTokenListDecimalRange(t *testing.T) {
+	tokenConfigEntries := tokenList()
+
+	/* Assume that all governed token entries will have decimals of 6 or 8 */
+	for _, tokenConfigEntry := range tokenConfigEntries {
+		assert.Less(t, tokenConfigEntry.decimals, int64(9))
+		assert.NotEqual(t, tokenConfigEntry.decimals, int64(7))
+		assert.Greater(t, tokenConfigEntry.decimals, int64(5))
+	}
+}
+
+func TestTokenListEmptySymbols(t *testing.T) {
+	tokenConfigEntries := tokenList()
+
+	/* Assume that all governed token entry strings will be greater than zero */
+	for _, tokenConfigEntry := range tokenConfigEntries {
+		assert.Greater(t, len(tokenConfigEntry.symbol), 0)
+	}
+}
+
+func TestTokenListEmptyCoinGeckoId(t *testing.T) {
+	tokenConfigEntries := tokenList()
+
+	/* Assume that all governed token entry strings will be greater than zero */
+	for _, tokenConfigEntry := range tokenConfigEntries {
+		assert.Greater(t, len(tokenConfigEntry.coinGeckoId), 0)
+	}
+}

--- a/node/pkg/governor/mainnet_tokens_test.go
+++ b/node/pkg/governor/mainnet_tokens_test.go
@@ -1,9 +1,10 @@
 package governor
 
 import (
+	"testing"
+
 	"github.com/certusone/wormhole/node/pkg/vaa"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestTokenListSize(t *testing.T) {

--- a/node/pkg/governor/mainnet_tokens_test.go
+++ b/node/pkg/governor/mainnet_tokens_test.go
@@ -48,11 +48,11 @@ func TestTokenListChainTokensPresent(t *testing.T) {
 	tokenConfigEntries := tokenList()
 
 	/* Assume that all chains within a token bridge will have governed tokens */
-	for chain, _ := range common.KnownTokenbridgeEmitters {
-		t.Run(vaa.ChainID(chain).String(), func(t *testing.T) {
+	for e := range common.KnownTokenbridgeEmitters {
+		t.Run(vaa.ChainID(e).String(), func(t *testing.T) {
 			found := false
 			for _, tokenConfigEntry := range tokenConfigEntries {
-				if tokenConfigEntry.chain == uint16(chain) {
+				if tokenConfigEntry.chain == uint16(e) {
 					found = true
 					break
 				}

--- a/node/pkg/governor/mainnet_tokens_test.go
+++ b/node/pkg/governor/mainnet_tokens_test.go
@@ -1,8 +1,9 @@
 package governor
 
 import (
-	"github.com/certusone/wormhole/node/pkg/common"
 	"testing"
+
+	"github.com/certusone/wormhole/node/pkg/common"
 
 	"github.com/certusone/wormhole/node/pkg/vaa"
 	"github.com/stretchr/testify/assert"

--- a/node/pkg/governor/mainnet_tokens_test.go
+++ b/node/pkg/governor/mainnet_tokens_test.go
@@ -12,9 +12,9 @@ import (
 func TestTokenListSize(t *testing.T) {
 	tokenConfigEntries := tokenList()
 
-	/* Assuming that governed tokens will not go down over time,
-	   lets set a floor to avoid parsing or loading regressions */
-	assert.Greater(t, len(tokenConfigEntries), 122)
+	/* Assuming that governed tokens will need to be updated every time
+	   we regenerate it */
+	assert.Equal(t, len(tokenConfigEntries), 123)
 }
 
 func TestTokenListFloor(t *testing.T) {
@@ -47,7 +47,7 @@ func TestTokenListAddressSize(t *testing.T) {
 func TestTokenListChainTokensPresent(t *testing.T) {
 	tokenConfigEntries := tokenList()
 
-	/* Assume that all chains will have governed tokens */
+	/* Assume that all chains within a token bridge will have governed tokens */
 	for chain, _ := range common.KnownTokenbridgeEmitters {
 		t.Run(vaa.ChainID(chain).String(), func(t *testing.T) {
 			found := false
@@ -87,7 +87,7 @@ func TestTokenListDecimalRange(t *testing.T) {
 func TestTokenListEmptySymbols(t *testing.T) {
 	tokenConfigEntries := tokenList()
 
-	/* Assume that all governed token entry strings will be greater than zero */
+	/* Assume that all governed token entry symbol strings will be greater than zero */
 	for _, tokenConfigEntry := range tokenConfigEntries {
 		assert.Greater(t, len(tokenConfigEntry.symbol), 0)
 	}
@@ -96,7 +96,7 @@ func TestTokenListEmptySymbols(t *testing.T) {
 func TestTokenListEmptyCoinGeckoId(t *testing.T) {
 	tokenConfigEntries := tokenList()
 
-	/* Assume that all governed token entry strings will be greater than zero */
+	/* Assume that all governed token entry coingecko id strings will be greater than zero */
 	for _, tokenConfigEntry := range tokenConfigEntries {
 		assert.Greater(t, len(tokenConfigEntry.coinGeckoId), 0)
 	}


### PR DESCRIPTION
These unit-tests are mainly just to ensure a mainnet config update doesn't result in a regression of config expectations.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/wormhole-foundation/wormhole/1461)
<!-- Reviewable:end -->
