### PR TITLE
aptos: token bridge VAA utils

### DIFF
--- a/aptos/Dockerfile
+++ b/aptos/Dockerfile
@@ -4,7 +4,7 @@ FROM ghcr.io/wormhole-foundation/aptos:0.3.3n@sha256:d321c61d6da379357e3e1e0765c
 COPY cert.pem* /certs/
 RUN if [ -e /certs/cert.pem ]; then cp /certs/cert.pem /etc/ssl/certs/ca-certificates.crt; fi
 
-FROM aptos as tests
+FROM aptos AS tests
 
 WORKDIR /tmp
 

--- a/aptos/token_bridge/sources/bridge_state.move
+++ b/aptos/token_bridge/sources/bridge_state.move
@@ -11,7 +11,6 @@ module token_bridge::bridge_state {
     use wormhole::emitter::{EmitterCapability};
     use wormhole::state::{get_chain_id, get_governance_contract};
     use wormhole::wormhole;
-    use wormhole::vaa::{Self, VAA};
     use wormhole::set::{Self, Set};
 
     friend token_bridge::token_bridge;

--- a/aptos/token_bridge/sources/vaa.move
+++ b/aptos/token_bridge/sources/vaa.move
@@ -1,0 +1,40 @@
+/// Token Bridge VAA utilities
+module token_bridge::vaa {
+    use wormhole::vaa::{Self, VAA};
+    use token_bridge::bridge_state::{set_vaa_consumed, bridge_contracts};
+
+    friend token_bridge::bridge_implementation;
+
+    const E_UNKNOWN_EMITTER: u64 = 0;
+
+    /// Aborts if the VAA has already been consumed. Marks the VAA as consumed
+    /// the first time around.
+    public(friend) fun replay_protect(vaa: &VAA) {
+        // this calls set::add which aborts if the element already exists
+        set_vaa_consumed(vaa::get_hash(vaa));
+    }
+
+    /// Asserts that the VAA is from a known token bridge.
+    public fun assert_known_emitter(vm: &VAA) {
+        assert!(
+            bridge_contracts(vaa::get_emitter_chain(vm)) == vaa::get_emitter_address(vm),
+            E_UNKNOWN_EMITTER
+        );
+    }
+
+    /// Parses, verifies, and replay protects a token bridge VAA.
+    /// Aborts if the VAA is not from a known token bridge emitter.
+    ///
+    /// Has a 'friend' visibility so that it's only callable by the token bridge
+    /// (otherwise the replay protection could be abused to DoS the bridge)
+    public(friend) fun parse_verify_and_replay_protect(vaa: vector<u8>): VAA {
+        let vaa = vaa::parse_and_verify(vaa);
+        assert_known_emitter(&vaa);
+        replay_protect(&vaa);
+        vaa
+    }
+}
+
+module token_bridge::vaa_test {
+
+}

--- a/aptos/wormhole/sources/set.move
+++ b/aptos/wormhole/sources/set.move
@@ -1,0 +1,32 @@
+/// A set data structure.
+module wormhole::set {
+    use aptos_std::table::{Self, Table};
+
+    /// Empty struct. Used as the value type in mappings to encode a set
+    struct Unit has store, copy, drop {}
+
+    /// A set containing elements of type `A` with support for membership
+    /// checking.
+    struct Set<phantom A: copy + drop> has store {
+        elems: Table<A, Unit>
+    }
+
+    /// Create a new Set.
+    public fun new<A: copy + drop>(): Set<A> {
+        Set {
+            elems: table::new()
+        }
+    }
+
+    /// Add a new element to the set.
+    /// Aborts if the element already exists
+    public fun add<A: copy + drop>(set: &mut Set<A>, key: A) {
+        table::add(&mut set.elems, key, Unit {})
+    }
+
+    /// Returns true iff `set` contains an entry for `key`.
+    public fun contains<A: copy + drop>(set: &Set<A>, key: A): bool {
+        table::contains(&set.elems, key)
+    }
+
+}

--- a/aptos/wormhole/sources/state.move
+++ b/aptos/wormhole/sources/state.move
@@ -7,6 +7,7 @@ module wormhole::state {
     use wormhole::u16::{U16};
     use wormhole::u32::{Self, U32};
     use wormhole::emitter;
+    use wormhole::set::{Self, Set};
 
     friend wormhole::guardian_set_upgrade;
     friend wormhole::contract_upgrade;
@@ -55,7 +56,7 @@ module wormhole::state {
         guardian_set_expiry: U32,
 
         /// Consumed governance actions
-        consumed_governance_actions: Table<vector<u8>, bool>,
+        consumed_governance_actions: Set<vector<u8>>,
 
         message_fee: u64,
 
@@ -83,7 +84,7 @@ module wormhole::state {
             guardian_sets: table::new<u64, GuardianSet>(),
             guardian_set_index: u32::from_u64(0),
             guardian_set_expiry,
-            consumed_governance_actions: table::new<vector<u8>, bool>(),
+            consumed_governance_actions: set::new<vector<u8>>(),
             message_fee,
             signer_cap,
             emitter_registry: emitter::init_emitter_registry(),
@@ -165,7 +166,7 @@ module wormhole::state {
 
     public(friend) fun set_governance_action_consumed(hash: vector<u8>) acquires WormholeState {
         let state = borrow_global_mut<WormholeState>(@wormhole);
-        table::add(&mut state.consumed_governance_actions, hash, true);
+        set::add(&mut state.consumed_governance_actions, hash);
     }
 
     public(friend) fun set_chain_id(chain_id: U16) acquires WormholeState {

--- a/scripts/check-docker-pin.sh
+++ b/scripts/check-docker-pin.sh
@@ -11,7 +11,7 @@
 #   - We ignore scratch because it's literally the docker base image
 #   - We ignore solana AS (builder|ci_tests) because it's a relative reference to another FROM call
 #
-git ls-files | grep "Dockerfile*" | xargs grep -s "FROM" | egrep -v 'sha256|scratch|solana AS (builder|ci_tests)'
+git ls-files | grep "Dockerfile*" | xargs grep -s "FROM" | egrep -v 'sha256|scratch|solana|aptos AS (builder|ci_tests|tests)'
 if [ $? -eq 0 ]; then
    echo "[!] Unpinned docker files" >&2
    exit 1


### PR DESCRIPTION
Added a slightly cleaner way to do replay protection by replacing the `Table<vector<u8>, bool>` with a custom `Set` type, which should just make the code a little easier to reason about (in particular now there's no such thing as a key being present but the value being false).

Also added a `token_bridge::vaa` module with some common utilities. In particular, `parse_verify_and_replay_protect` should be called by all token bridge functions that take VAA bytes, because it does the parsing, the verification, emitter checking, and replay protection all in one go. These checks need to be done by all token bridge functions so might as well share this bit out.