### PR TITLE
proto - BatchVAA gossip and publicrpc

### DIFF
--- a/node/pkg/publicrpc/publicrpcserver.go
+++ b/node/pkg/publicrpc/publicrpcserver.go
@@ -98,6 +98,11 @@ func (s *PublicrpcServer) GetSignedVAA(ctx context.Context, req *publicrpcv1.Get
 	}, nil
 }
 
+func (s *PublicrpcServer) GetSignedBatchVAA(ctx context.Context, req *publicrpcv1.GetSignedBatchVAARequest) (*publicrpcv1.GetSignedBatchVAAResponse, error) {
+	// TEMP - noop implementaion to satisfy inclusion requirement
+	return nil, status.Error(codes.Unimplemented, "not yet implemented")
+}
+
 func (s *PublicrpcServer) GetCurrentGuardianSet(ctx context.Context, req *publicrpcv1.GetCurrentGuardianSetRequest) (*publicrpcv1.GetCurrentGuardianSetResponse, error) {
 	gs := s.gst.Get()
 	if gs == nil {

--- a/proto/gossip/v1/gossip.proto
+++ b/proto/gossip/v1/gossip.proto
@@ -10,6 +10,8 @@ message GossipMessage {
     SignedHeartbeat signed_heartbeat = 3;
     SignedVAAWithQuorum signed_vaa_with_quorum = 4;
     SignedObservationRequest signed_observation_request = 5;
+    SignedBatchObservation signed_batch_observation = 6;
+    SignedBatchVAAWithQuorum signed_batch_vaa_with_quorum = 7;
   }
 }
 
@@ -113,4 +115,33 @@ message SignedObservationRequest {
 message ObservationRequest {
   uint32 chain_id = 1;
   bytes tx_hash = 2;
+}
+
+// A SignedBatchObservation is a signed statement by a given guardian node
+// that they observed a series of messages originating from a transaction.
+//
+// BatcheObervations are emitted when all the Observations from a tx reach quorum.
+//
+// The event is uniquely identified by its hash (made from hashing all the
+// individual Observation hashes).
+//
+// Messages without valid signature are dropped unceremoniously.
+message SignedBatchObservation {
+  // Guardian pubkey as truncated eth address.
+  bytes addr = 1;
+  // The observation batch's deterministic, unique hash.
+  bytes hash = 2;
+  // ECSDA signature of the hash using the node's guardian key.
+  bytes signature = 3;
+  // Transaction hash this observation was made from.
+  bytes tx_hash = 4;
+  // Chain ID for this observation.
+  uint32 chain_id = 5;
+  // Batch ID - emitterChain/transactionID
+  string batch_id = 6;
+}
+
+
+message SignedBatchVAAWithQuorum {
+  bytes batch_vaa = 1;
 }

--- a/proto/publicrpc/v1/publicrpc.proto
+++ b/proto/publicrpc/v1/publicrpc.proto
@@ -50,6 +50,13 @@ message MessageID {
   uint64 sequence = 3;
 }
 
+message BatchID {
+  // Emitter chain ID.
+  ChainID emitter_chain = 1;
+  // Hex-encoded (without leading 0x) transaction identifier.
+  string tx_id = 2;
+}
+
 // PublicRPCService service exposes endpoints to be consumed externally; GUIs, historical record keeping, etc.
 service PublicRPCService {
   // GetLastHeartbeats returns the last heartbeat received for each guardian node in the
@@ -64,6 +71,12 @@ service PublicRPCService {
   rpc GetSignedVAA (GetSignedVAARequest) returns (GetSignedVAAResponse) {
     option (google.api.http) = {
       get: "/v1/signed_vaa/{message_id.emitter_chain}/{message_id.emitter_address}/{message_id.sequence}"
+    };
+  }
+
+  rpc GetSignedBatchVAA (GetSignedBatchVAARequest) returns (GetSignedBatchVAAResponse) {
+    option (google.api.http) = {
+      get: "/v1/signed_batch_vaa/{batch_id.emitter_chain}/{batch_id.tx_id}"
     };
   }
 
@@ -95,7 +108,7 @@ service PublicRPCService {
     option (google.api.http) = {
       get: "/v1/governor/token_list"
     };
-  }  
+  }
 
 }
 
@@ -105,6 +118,14 @@ message GetSignedVAARequest {
 
 message GetSignedVAAResponse {
   bytes vaa_bytes = 1;
+}
+
+message GetSignedBatchVAARequest {
+  BatchID batch_id = 1;
+}
+
+message GetSignedBatchVAAResponse {
+  bytes batch_vaa_bytes = 1;
 }
 
 message GetLastHeartbeatsRequest {


### PR DESCRIPTION
Added a gossip message for broadcasting signed BatchVAAs, and a publicrpc endpoint for getting signed BatchVAAs.

The gossip messages follow the same paradigms as the messages for original VAAs. The new gossip messages are:
- `SignedBatchObservation`, broadcast when a guardian sees and signs a BatchVAA. This is how individual guardian signatures are shared among the guardianset to build quorum. Same paradigm as broadcasting a signed VAA with the `SignedObservation` GossipMessage. This is basically a guardian broadcasting "i saw a thing on chain, signed it".
- `SignedBatchVAAWithQuorum`, broadcast when a guardian achieves quorum on a BatchVAA (after collecting individual signatures via the `SignedBatchObservation` message). Same paradigm as broadcasting a VAA that has reached quorum with the `SignedVAAWithQuorum` GossipMessage.

The new `publicrpc` endpoint is a strongly typed spec for an endpoint that returns a signed BatchVAA, given a `chain_id` and `transaction_id`. This endpoint will be implemented by the guardian, and called from the javascript SDK. The protobuf definition is used to generate client and server code (via `buf` build) for the SDK and the guardian.

Once the definition of this new `publicrpc` endpoint is merged we can build new versions of `sdk/js-proto-*`, and they will include the new method, and have proper typescript types for the inputs and return values. The guardian will also have the new method added to its generated RPC server code, which is why this PR includes a new noop function `GetSignedBatchVAA` - the guardian must implement all the endpoints in the protobuf spec. 