### PR TITLE
Fix CI race conditions

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -522,11 +522,13 @@ if ci_tests:
         "sdk-ci-tests",
         labels = ["ci"],
         trigger_mode = trigger_mode,
+        resource_deps = ["guardian"],
     )
     k8s_resource(
         "spydk-ci-tests",
         labels = ["ci"],
         trigger_mode = trigger_mode,
+        resource_deps = ["guardian"],
     )
 
 # e2e
@@ -664,7 +666,7 @@ if terra2:
 
 if algorand:
     k8s_yaml_with_ns("devnet/algorand-devnet.yaml")
-  
+
     docker_build(
         ref = "algorand-algod",
         context = "algorand/sandbox-algorand",
@@ -695,7 +697,7 @@ if algorand:
         labels = ["algorand"],
         trigger_mode = trigger_mode,
     )
-    
+
 
 if near:
     k8s_yaml_with_ns("devnet/near-devnet.yaml")

--- a/Tiltfile
+++ b/Tiltfile
@@ -251,6 +251,8 @@ if terra_classic:
     guardian_resource_deps = guardian_resource_deps + ["terra-terrad"]
 if terra2:
     guardian_resource_deps = guardian_resource_deps + ["terra2-terrad"]
+if algorand:
+    guardian_resource_deps = guardian_resource_deps + ["algorand"]
 
 k8s_resource(
     "guardian",


### PR DESCRIPTION
I noticed intermittent failures of `sdk-ci-tests` in CI, found that the tests were sometimes running before Algorand was ready, and that the guardian was not waiting for Algorand to come up.

This change fixes the race condition by:
- making `algorand` a `resource_dep` of the guardian
- making `guardian` a `resource_dep` of `sdk-ci-tests` & `spydk-ci-tests`