### PR TITLE
cosmwasm/contracts: Adding shutdown contracts

### DIFF
--- a/cosmwasm/Cargo.lock
+++ b/cosmwasm/Cargo.lock
@@ -1509,6 +1509,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "shutdown-token-bridge-terra-2"
+version = "0.1.0"
+dependencies = [
+ "bigint",
+ "cosmwasm-std",
+ "cosmwasm-storage",
+ "cw20",
+ "cw20-base",
+ "cw20-wrapped-2",
+ "generic-array",
+ "hex",
+ "k256 0.9.6",
+ "lazy_static",
+ "schemars",
+ "serde",
+ "serde_json",
+ "sha3",
+ "shutdown-wormhole-bridge-terra-2",
+ "terraswap",
+ "thiserror",
+]
+
+[[package]]
+name = "shutdown-wormhole-bridge-terra-2"
+version = "0.1.0"
+dependencies = [
+ "cosmwasm-std",
+ "cosmwasm-storage",
+ "cw20",
+ "cw20-base",
+ "cw20-wrapped-2",
+ "generic-array",
+ "getrandom 0.2.3",
+ "hex",
+ "k256 0.9.6",
+ "lazy_static",
+ "schemars",
+ "serde",
+ "serde_json",
+ "sha3",
+ "thiserror",
+]
+
+[[package]]
 name = "signature"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/cosmwasm/Cargo.toml
+++ b/cosmwasm/Cargo.toml
@@ -4,6 +4,8 @@ members = [
     "contracts/wormhole",
     "contracts/token-bridge",
     "contracts/mock-bridge-integration",
+    "contracts/shutdown-token-bridge",
+    "contracts/shutdown-wormhole",
 ]
 
 [profile.release]

--- a/cosmwasm/contracts/shutdown-token-bridge/.cargo/config
+++ b/cosmwasm/contracts/shutdown-token-bridge/.cargo/config
@@ -1,0 +1,5 @@
+[alias]
+wasm = "build --release --target wasm32-unknown-unknown"
+wasm-debug = "build --target wasm32-unknown-unknown"
+unit-test = "test --lib --features backtraces"
+integration-test = "test --test integration"

--- a/cosmwasm/contracts/shutdown-token-bridge/Cargo.toml
+++ b/cosmwasm/contracts/shutdown-token-bridge/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "shutdown-token-bridge-terra-2"
+version = "0.1.0"
+authors = ["Yuriy Savchenko <yuriy.savchenko@gmail.com>"]
+edition = "2018"
+description = "Shutdown Wormhole token bridge"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+backtraces = ["cosmwasm-std/backtraces"]
+# use library feature to disable all init/handle/query exports
+library = []
+
+[dependencies]
+cosmwasm-std = { version = "1.0.0" }
+cosmwasm-storage = { version = "1.0.0" }
+schemars = "0.8.8"
+serde = { version = "1.0.137", default-features = false, features = ["derive"] }
+cw20 = "0.13.2"
+cw20-base = { version = "0.13.2", features = ["library"] }
+cw20-wrapped-2 = { path = "../cw20-wrapped", features = ["library"] }
+terraswap = "2.6.1"
+shutdown-wormhole-bridge-terra-2 = { path = "../shutdown-wormhole", features = ["library"] }
+thiserror = { version = "1.0.31" }
+k256 = { version = "0.9.4", default-features = false, features = ["ecdsa"] }
+sha3 = { version = "0.9.1", default-features = false }
+generic-array = { version = "0.14.4" }
+hex = "0.4.2"
+lazy_static = "1.4.0"
+bigint = "4"
+
+[dev-dependencies]
+serde_json = "1.0"

--- a/cosmwasm/contracts/shutdown-token-bridge/_tests/integration.rs
+++ b/cosmwasm/contracts/shutdown-token-bridge/_tests/integration.rs
@@ -1,0 +1,117 @@
+static WASM: &[u8] = include_bytes!("../../../target/wasm32-unknown-unknown/release/wormhole.wasm");
+
+use cosmwasm_std::{
+    from_slice,
+    Coin,
+    Env,
+    HumanAddr,
+    InitResponse,
+};
+use cosmwasm_storage::to_length_prefixed;
+use cosmwasm_vm::{
+    testing::{
+        init,
+        mock_env,
+        mock_instance,
+        MockApi,
+        MockQuerier,
+        MockStorage,
+    },
+    Api,
+    Instance,
+    Storage,
+};
+
+use wormhole::{
+    msg::InitMsg,
+    state::{
+        ConfigInfo,
+        GuardianAddress,
+        GuardianSetInfo,
+        CONFIG_KEY,
+    },
+};
+
+use hex;
+
+enum TestAddress {
+    INITIALIZER,
+}
+
+impl TestAddress {
+    fn value(&self) -> HumanAddr {
+        match self {
+            TestAddress::INITIALIZER => HumanAddr::from("initializer"),
+        }
+    }
+}
+
+fn mock_env_height(signer: &HumanAddr, height: u64, time: u64) -> Env {
+    let mut env = mock_env(signer, &[]);
+    env.block.height = height;
+    env.block.time = time;
+    env
+}
+
+fn get_config_info<S: Storage>(storage: &S) -> ConfigInfo {
+    let key = to_length_prefixed(CONFIG_KEY);
+    let data = storage
+        .get(&key)
+        .0
+        .expect("error getting data")
+        .expect("data should exist");
+    from_slice(&data).expect("invalid data")
+}
+
+fn do_init(
+    height: u64,
+    guardians: &Vec<GuardianAddress>,
+) -> Instance<MockStorage, MockApi, MockQuerier> {
+    let mut deps = mock_instance(WASM, &[]);
+    let init_msg = InitMsg {
+        initial_guardian_set: GuardianSetInfo {
+            addresses: guardians.clone(),
+            expiration_time: 100,
+        },
+        guardian_set_expirity: 50,
+        wrapped_asset_code_id: 999,
+        chain_id: 18,
+        fee_denom: "uluna".to_string(),
+    };
+    let env = mock_env_height(&TestAddress::INITIALIZER.value(), height, 0);
+    let owner = deps
+        .api
+        .canonical_address(&TestAddress::INITIALIZER.value())
+        .0
+        .unwrap();
+    let res: InitResponse = init(&mut deps, env, init_msg).unwrap();
+    assert_eq!(0, res.messages.len());
+
+    // query the store directly
+    deps.with_storage(|storage| {
+        assert_eq!(
+            get_config_info(storage),
+            ConfigInfo {
+                guardian_set_index: 0,
+                guardian_set_expirity: 50,
+                wrapped_asset_code_id: 999,
+                owner,
+                fee: Coin::new(10000, "uluna"),
+                chain_id: 18,
+            }
+        );
+        Ok(())
+    })
+    .unwrap();
+    deps
+}
+
+#[test]
+fn init_works() {
+    let guardians = vec![GuardianAddress::from(GuardianAddress {
+        bytes: hex::decode("beFA429d57cD18b7F8A4d91A2da9AB4AF05d0FBe")
+            .expect("Decoding failed")
+            .into(),
+    })];
+    let _deps = do_init(111, &guardians);
+}

--- a/cosmwasm/contracts/shutdown-token-bridge/src/contract.rs
+++ b/cosmwasm/contracts/shutdown-token-bridge/src/contract.rs
@@ -1,0 +1,191 @@
+
+use shutdown_wormhole::{
+    byte_utils::{
+        get_string_from_32,
+    },
+    error::ContractError,
+    msg::{
+        QueryMsg as WormholeQueryMsg,
+    },
+    state::{
+        vaa_archive_add,
+        vaa_archive_check,
+        GovernancePacket,
+        ParsedVAA,
+    },
+};
+
+#[allow(unused_imports)]
+use cosmwasm_std::entry_point;
+
+use cosmwasm_std::{
+    to_binary,
+    Binary,
+    CosmosMsg,
+    Deps,
+    DepsMut,
+    Env,
+    MessageInfo,
+    QueryRequest,
+    Reply,
+    Response,
+    StdError,
+    StdResult,
+    WasmMsg,
+    WasmQuery,
+};
+
+use crate::{
+    msg::{
+        ExecuteMsg,
+        InstantiateMsg,
+        MigrateMsg,
+    },
+    state::{
+        config,
+        config_read,
+        ConfigInfo,
+        UpgradeContract,
+    },
+};
+
+pub enum TransferType<A> {
+    WithoutPayload,
+    WithPayload { payload: A },
+}
+
+/// Migration code that runs the next time the contract is upgraded.
+/// This function will contain ephemeral code that we want to run once, and thus
+/// can (and should be) safely deleted after the upgrade happened successfully.
+///
+/// Most upgrades won't require any special migration logic. In those cases,
+/// this function can safely be implemented as:
+/// ```ignore
+/// Ok(Response::default())
+/// ```
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn migrate(_deps: DepsMut, _env: Env, _msg: MigrateMsg) -> StdResult<Response> {
+    Ok(Response::default())
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn instantiate(
+    deps: DepsMut,
+    _env: Env,
+    _info: MessageInfo,
+    msg: InstantiateMsg,
+) -> StdResult<Response> {
+    // Save general wormhole info
+    let state = ConfigInfo {
+        gov_chain: msg.gov_chain,
+        gov_address: msg.gov_address.into(),
+        wormhole_contract: msg.wormhole_contract,
+        wrapped_asset_code_id: msg.wrapped_asset_code_id,
+        chain_id: msg.chain_id,
+    };
+    config(deps.storage).save(&state)?;
+
+    Ok(Response::default())
+}
+
+// When CW20 transfers complete, we need to verify the actual amount that is being transferred out
+// of the bridge. This is to handle fee tokens where the amount expected to be transferred may be
+// less due to burns, fees, etc.
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn reply(_deps: DepsMut, _env: Env, _msg: Reply) -> StdResult<Response> {
+    Ok(Response::default())
+}
+
+fn parse_vaa(deps: Deps, block_time: u64, data: &Binary) -> StdResult<ParsedVAA> {
+    let cfg = config_read(deps.storage).load()?;
+    let vaa: ParsedVAA = deps.querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
+        contract_addr: cfg.wormhole_contract,
+        msg: to_binary(&WormholeQueryMsg::VerifyVAA {
+            vaa: data.clone(),
+            block_time,
+        })?,
+    }))?;
+    Ok(vaa)
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> StdResult<Response> {
+    match msg {
+        ExecuteMsg::SubmitVaa { data } => submit_vaa(deps, env, info, &data),
+    }
+}
+
+
+fn parse_and_archive_vaa(
+    deps: DepsMut,
+    env: Env,
+    data: &Binary,
+) -> StdResult<(ParsedVAA, GovernancePacket)> {
+    let state = config_read(deps.storage).load()?;
+
+    let vaa = parse_vaa(deps.as_ref(), env.block.time.seconds(), data)?;
+
+    if vaa_archive_check(deps.storage, vaa.hash.as_slice()) {
+        return ContractError::VaaAlreadyExecuted.std_err();
+    }
+    vaa_archive_add(deps.storage, vaa.hash.as_slice())?;
+
+    // check if vaa is from governance
+    if is_governance_emitter(&state, vaa.emitter_chain, &vaa.emitter_address) {
+        let gov_packet = GovernancePacket::deserialize(&vaa.payload)?;
+        return Ok((vaa, gov_packet));
+    }
+
+    return Err(StdError::generic_err("Unsupported VAA"));
+}
+
+fn submit_vaa(
+    mut deps: DepsMut,
+    env: Env,
+    _info: MessageInfo,
+    data: &Binary,
+) -> StdResult<Response> {
+    let (_vaa, payload) = parse_and_archive_vaa(deps.branch(), env.clone(), data)?;
+    handle_governance_payload(deps, env, &payload)
+}
+
+fn handle_governance_payload(
+    deps: DepsMut,
+    env: Env,
+    gov_packet: &GovernancePacket,
+) -> StdResult<Response> {
+    let cfg = config_read(deps.storage).load()?;
+    let module = get_string_from_32(&gov_packet.module);
+
+    if module != "TokenBridge" {
+        return Err(StdError::generic_err("this is not a valid module"));
+    }
+
+    if gov_packet.chain != 0 && gov_packet.chain != cfg.chain_id {
+        return Err(StdError::generic_err(
+            "the governance VAA is for another chain",
+        ));
+    }
+
+    match gov_packet.action {
+        2u8 => handle_upgrade_contract(deps, env, &gov_packet.payload),
+        _ => ContractError::InvalidVAAAction.std_err(),
+    }
+}
+
+fn handle_upgrade_contract(_deps: DepsMut, env: Env, data: &Vec<u8>) -> StdResult<Response> {
+    let UpgradeContract { new_contract } = UpgradeContract::deserialize(data)?;
+
+    Ok(Response::new()
+        .add_message(CosmosMsg::Wasm(WasmMsg::Migrate {
+            contract_addr: env.contract.address.to_string(),
+            new_code_id: new_contract,
+            msg: to_binary(&MigrateMsg {})?,
+        }))
+        .add_attribute("action", "contract_upgrade"))
+}
+
+
+fn is_governance_emitter(cfg: &ConfigInfo, emitter_chain: u16, emitter_address: &[u8]) -> bool {
+    cfg.gov_chain == emitter_chain && cfg.gov_address == emitter_address
+}

--- a/cosmwasm/contracts/shutdown-token-bridge/src/lib.rs
+++ b/cosmwasm/contracts/shutdown-token-bridge/src/lib.rs
@@ -1,0 +1,10 @@
+#[cfg(test)]
+extern crate lazy_static;
+
+pub mod contract;
+pub mod msg;
+pub mod state;
+pub mod token_address;
+
+#[cfg(test)]
+mod testing;

--- a/cosmwasm/contracts/shutdown-token-bridge/src/msg.rs
+++ b/cosmwasm/contracts/shutdown-token-bridge/src/msg.rs
@@ -1,0 +1,121 @@
+use cosmwasm_std::{
+    Binary,
+    Uint128,
+};
+use schemars::JsonSchema;
+use serde::{
+    Deserialize,
+    Serialize,
+};
+// use terraswap::asset::{
+//     Asset,
+//     AssetInfo,
+// };
+
+use crate::token_address::{
+    // ExternalTokenId,
+    TokenId,
+};
+
+type HumanAddr = String;
+
+/// The instantiation parameters of the token bridge contract. See
+/// [`crate::state::ConfigInfo`] for more details on what these fields mean.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct InstantiateMsg {
+    pub gov_chain: u16,
+    pub gov_address: Binary,
+
+    pub wormhole_contract: HumanAddr,
+    pub wrapped_asset_code_id: u64,
+
+    pub chain_id: u16,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecuteMsg {
+    // RegisterAssetHook {
+    //     chain: u16,
+    //     token_address: ExternalTokenId,
+    // },
+
+    // DepositTokens {},
+    // WithdrawTokens {
+    //     asset: AssetInfo,
+    // },
+
+    // InitiateTransfer {
+    //     asset: Asset,
+    //     recipient_chain: u16,
+    //     recipient: Binary,
+    //     fee: Uint128,
+    //     nonce: u32,
+    // },
+
+    // InitiateTransferWithPayload {
+    //     asset: Asset,
+    //     recipient_chain: u16,
+    //     recipient: Binary,
+    //     fee: Uint128,
+    //     payload: Binary,
+    //     nonce: u32,
+    // },
+
+    SubmitVaa {
+        data: Binary,
+    },
+
+    // CreateAssetMeta {
+    //     asset_info: AssetInfo,
+    //     nonce: u32,
+    // },
+
+    // CompleteTransferWithPayload {
+    //     data: Binary,
+    //     relayer: HumanAddr,
+    // },
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct MigrateMsg {}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum QueryMsg {
+    WrappedRegistry { chain: u16, address: Binary },
+    TransferInfo { vaa: Binary },
+    ExternalId { external_id: Binary },
+    IsVaaRedeemed { vaa: Binary },
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct WrappedRegistryResponse {
+    pub address: HumanAddr,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct TransferInfoResponse {
+    pub amount: Uint128,
+    pub token_address: [u8; 32],
+    pub token_chain: u16,
+    pub recipient: [u8; 32],
+    pub recipient_chain: u16,
+    pub fee: Uint128,
+    pub payload: Vec<u8>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct ExternalIdResponse {
+    pub token_id: TokenId,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct IsVaaRedeemedResponse {
+    pub is_redeemed: bool,
+}

--- a/cosmwasm/contracts/shutdown-token-bridge/src/msg.rs
+++ b/cosmwasm/contracts/shutdown-token-bridge/src/msg.rs
@@ -7,13 +7,8 @@ use serde::{
     Deserialize,
     Serialize,
 };
-// use terraswap::asset::{
-//     Asset,
-//     AssetInfo,
-// };
 
 use crate::token_address::{
-    // ExternalTokenId,
     TokenId,
 };
 
@@ -35,46 +30,9 @@ pub struct InstantiateMsg {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ExecuteMsg {
-    // RegisterAssetHook {
-    //     chain: u16,
-    //     token_address: ExternalTokenId,
-    // },
-
-    // DepositTokens {},
-    // WithdrawTokens {
-    //     asset: AssetInfo,
-    // },
-
-    // InitiateTransfer {
-    //     asset: Asset,
-    //     recipient_chain: u16,
-    //     recipient: Binary,
-    //     fee: Uint128,
-    //     nonce: u32,
-    // },
-
-    // InitiateTransferWithPayload {
-    //     asset: Asset,
-    //     recipient_chain: u16,
-    //     recipient: Binary,
-    //     fee: Uint128,
-    //     payload: Binary,
-    //     nonce: u32,
-    // },
-
     SubmitVaa {
         data: Binary,
     },
-
-    // CreateAssetMeta {
-    //     asset_info: AssetInfo,
-    //     nonce: u32,
-    // },
-
-    // CompleteTransferWithPayload {
-    //     data: Binary,
-    //     relayer: HumanAddr,
-    // },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/cosmwasm/contracts/shutdown-token-bridge/src/state.rs
+++ b/cosmwasm/contracts/shutdown-token-bridge/src/state.rs
@@ -1,0 +1,429 @@
+use schemars::JsonSchema;
+use serde::{
+    Deserialize,
+    Serialize,
+};
+
+use cosmwasm_std::{
+    Addr,
+    StdError,
+    StdResult,
+    Storage,
+    Uint128,
+};
+use cosmwasm_storage::{
+    bucket,
+    bucket_read,
+    singleton,
+    singleton_read,
+    Bucket,
+    ReadonlyBucket,
+    ReadonlySingleton,
+    Singleton,
+};
+
+use shutdown_wormhole::byte_utils::ByteUtils;
+
+use crate::token_address::{ExternalTokenId, WrappedCW20};
+
+type HumanAddr = String;
+
+static CONFIG_KEY: &[u8] = b"config";
+static TRANSFER_TMP_KEY: &[u8] = b"transfer_tmp";
+static WRAPPED_ASSET_KEY: &[u8] = b"wrapped_asset";
+static WRAPPED_ASSET_SEQ_KEY: &[u8] = b"wrapped_seq_asset";
+static WRAPPED_ASSET_ADDRESS_KEY: &[u8] = b"wrapped_asset_address";
+static BRIDGE_CONTRACTS: &[u8] = b"bridge_contracts";
+static BRIDGE_DEPOSITS: &[u8] = b"bridge_deposits";
+static NATIVE_COUNTER: &[u8] = b"native_counter";
+static BANK_TOKEN_HASHES_KEY: &[u8] = b"bank_token_hashes";
+static NATIVE_CW20_HASHES_KEY: &[u8] = b"native_cw20_hashes";
+
+/// Legacy version of [`ConfigInfo`]. Required for the migration.  In
+/// particular, the last field of [`ConfigInfo`] has been added after the
+/// Terra2 contract's deployment, which means that Terra2 needs to be migrated.
+/// See [`crate::contract::migrate`] for details on why this is necessary.
+/// Once the migration has been executed, this struct (and the corresponding
+/// migration logic) can be deleted.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct ConfigInfoLegacy {
+    /// Governance chain (typically Solana, i.e. chain id 1)
+    pub gov_chain: u16,
+
+    /// Address of governance contract (typically 0x0000000000000000000000000000000000000000000000000000000000000004)
+    pub gov_address: Vec<u8>,
+
+    /// Address of the core bridge contract
+    pub wormhole_contract: HumanAddr,
+
+    /// Code id of the wrapped token contract. When a new token is attested, the
+    /// token bridge instantiates a new contract from this code id.
+    pub wrapped_asset_code_id: u64,
+}
+
+/// Information about this contract's general parameters.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct ConfigInfo {
+    /// Governance chain (typically Solana, i.e. chain id 1)
+    pub gov_chain: u16,
+
+    /// Address of governance contract (typically 0x0000000000000000000000000000000000000000000000000000000000000004)
+    pub gov_address: Vec<u8>,
+
+    /// Address of the core bridge contract
+    pub wormhole_contract: HumanAddr,
+
+    /// Code id of the wrapped token contract. When a new token is attested, the
+    /// token bridge instantiates a new contract from this code id.
+    pub wrapped_asset_code_id: u64,
+
+    /// The wormhole id of the current chain.
+    pub chain_id: u16,
+}
+
+pub fn config(storage: &mut dyn Storage) -> Singleton<ConfigInfo> {
+    singleton(storage, CONFIG_KEY)
+}
+
+pub fn config_read(storage: &dyn Storage) -> ReadonlySingleton<ConfigInfo> {
+    singleton_read(storage, CONFIG_KEY)
+}
+
+pub fn config_read_legacy(storage: &dyn Storage) -> ReadonlySingleton<ConfigInfoLegacy> {
+    singleton_read(storage, CONFIG_KEY)
+}
+
+pub fn bridge_deposit(storage: &mut dyn Storage) -> Bucket<Uint128> {
+    bucket(storage, BRIDGE_DEPOSITS)
+}
+
+pub fn bridge_deposit_read(storage: &dyn Storage) -> ReadonlyBucket<Uint128> {
+    bucket_read(storage, BRIDGE_DEPOSITS)
+}
+
+pub fn bridge_contracts(storage: &mut dyn Storage) -> Bucket<Vec<u8>> {
+    bucket(storage, BRIDGE_CONTRACTS)
+}
+
+pub fn bridge_contracts_read(storage: &dyn Storage) -> ReadonlyBucket<Vec<u8>> {
+    bucket_read(storage, BRIDGE_CONTRACTS)
+}
+
+pub fn wrapped_asset(storage: &mut dyn Storage, chain: u16) -> Bucket<WrappedCW20> {
+    Bucket::multilevel(storage, &[WRAPPED_ASSET_KEY, &chain.to_be_bytes()])
+}
+
+pub fn wrapped_asset_read(storage: &dyn Storage, chain: u16) -> ReadonlyBucket<WrappedCW20> {
+    ReadonlyBucket::multilevel(storage, &[WRAPPED_ASSET_KEY, &chain.to_be_bytes()])
+}
+
+pub fn wrapped_asset_seq(storage: &mut dyn Storage, chain: u16) -> Bucket<u64> {
+    Bucket::multilevel(storage, &[WRAPPED_ASSET_SEQ_KEY, &chain.to_be_bytes()])
+}
+
+pub fn wrapped_asset_seq_read(storage: &mut dyn Storage, chain: u16) -> ReadonlyBucket<u64> {
+    ReadonlyBucket::multilevel(storage, &[WRAPPED_ASSET_SEQ_KEY, &chain.to_be_bytes()])
+}
+
+pub fn is_wrapped_asset(storage: &mut dyn Storage) -> Bucket<()> {
+    bucket(storage, WRAPPED_ASSET_ADDRESS_KEY)
+}
+
+pub fn is_wrapped_asset_read(storage: &dyn Storage) -> ReadonlyBucket<()> {
+    bucket_read(storage, WRAPPED_ASSET_ADDRESS_KEY)
+}
+
+pub fn bank_token_hashes(storage: &mut dyn Storage) -> Bucket<String> {
+    bucket(storage, BANK_TOKEN_HASHES_KEY)
+}
+
+pub fn bank_token_hashes_read(storage: &dyn Storage) -> ReadonlyBucket<String> {
+    bucket_read(storage, BANK_TOKEN_HASHES_KEY)
+}
+
+pub fn native_c20_hashes(storage: &mut dyn Storage) -> Bucket<Addr> {
+    bucket(storage, NATIVE_CW20_HASHES_KEY)
+}
+
+pub fn native_c20_hashes_read(storage: &dyn Storage) -> ReadonlyBucket<Addr> {
+    bucket_read(storage, NATIVE_CW20_HASHES_KEY)
+}
+
+type Serialized128 = String;
+
+/// Structure to keep track of an active CW20 transfer, required to pass state through to the reply
+/// handler for submessages during a transfer.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct TransferState {
+    pub account: String,
+    pub message: Vec<u8>,
+    pub multiplier: Serialized128,
+    pub nonce: u32,
+    pub previous_balance: Serialized128,
+    pub token_address: Addr,
+}
+
+pub fn wrapped_transfer_tmp(storage: &mut dyn Storage) -> Singleton<TransferState> {
+    singleton(storage, TRANSFER_TMP_KEY)
+}
+
+pub fn send_native(
+    storage: &mut dyn Storage,
+    asset_address: &ExternalTokenId,
+    amount: Uint128,
+) -> StdResult<()> {
+    let mut counter_bucket = bucket(storage, NATIVE_COUNTER);
+    let new_total = amount
+        + counter_bucket
+            .load(asset_address.serialize().as_slice())
+            .unwrap_or(Uint128::zero());
+    if new_total > Uint128::new(u64::MAX as u128) {
+        return Err(StdError::generic_err(
+            "transfer exceeds max outstanding bridged token amount",
+        ));
+    }
+    counter_bucket.save(asset_address.serialize().as_slice(), &new_total)
+}
+
+pub fn receive_native(
+    storage: &mut dyn Storage,
+    asset_address: &ExternalTokenId,
+    amount: Uint128,
+) -> StdResult<()> {
+    let mut counter_bucket = bucket(storage, NATIVE_COUNTER);
+    let total: Uint128 = counter_bucket.load(asset_address.serialize().as_slice())?;
+    let result = total.checked_sub(amount)?;
+    counter_bucket.save(asset_address.serialize().as_slice(), &result)
+}
+
+pub struct Action;
+
+impl Action {
+    pub const TRANSFER: u8 = 1;
+    pub const ATTEST_META: u8 = 2;
+    pub const TRANSFER_WITH_PAYLOAD: u8 = 3;
+}
+
+// 0 u8 action
+// 1 [u8] payload
+
+pub struct TokenBridgeMessage {
+    pub action: u8,
+    pub payload: Vec<u8>,
+}
+
+impl TokenBridgeMessage {
+    pub fn deserialize(data: &Vec<u8>) -> StdResult<Self> {
+        let data = data.as_slice();
+        let action = data.get_u8(0);
+        let payload = &data[1..];
+
+        Ok(TokenBridgeMessage {
+            action,
+            payload: payload.to_vec(),
+        })
+    }
+
+    pub fn serialize(&self) -> Vec<u8> {
+        [self.action.to_be_bytes().to_vec(), self.payload.clone()].concat()
+    }
+}
+
+//     0   u256     amount
+//     32  [u8; 32] token_address
+//     64  u16      token_chain
+//     66  [u8; 32] recipient
+//     98  u16      recipient_chain
+//     100 u256     fee
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct TransferInfo {
+    pub amount: (u128, u128),
+    pub token_address: ExternalTokenId,
+    pub token_chain: u16,
+    pub recipient: [u8; 32],
+    pub recipient_chain: u16,
+    pub fee: (u128, u128),
+}
+
+impl TransferInfo {
+    pub fn deserialize(data: &Vec<u8>) -> StdResult<Self> {
+        let data = data.as_slice();
+        let amount = data.get_u256(0);
+        let token_address = ExternalTokenId::deserialize(data.get_const_bytes::<32>(32));
+        let token_chain = data.get_u16(64);
+        let recipient = data.get_const_bytes::<32>(66);
+        let recipient_chain = data.get_u16(98);
+        let fee = data.get_u256(100);
+
+        Ok(TransferInfo {
+            amount,
+            token_address,
+            token_chain,
+            recipient,
+            recipient_chain,
+            fee,
+        })
+    }
+    pub fn serialize(&self) -> Vec<u8> {
+        [
+            self.amount.0.to_be_bytes().to_vec(),
+            self.amount.1.to_be_bytes().to_vec(),
+            self.token_address.serialize().to_vec(),
+            self.token_chain.to_be_bytes().to_vec(),
+            self.recipient.to_vec(),
+            self.recipient_chain.to_be_bytes().to_vec(),
+            self.fee.0.to_be_bytes().to_vec(),
+            self.fee.1.to_be_bytes().to_vec(),
+        ]
+        .concat()
+    }
+}
+
+//     0   u256     amount
+//     32  [u8; 32] token_address
+//     64  u16      token_chain
+//     66  [u8; 32] recipient
+//     98  u16      recipient_chain
+//     100 [u8; 32] sender_address
+//     132 [u8]     payload
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct TransferWithPayloadInfo {
+    pub amount: (u128, u128),
+    pub token_address: ExternalTokenId,
+    pub token_chain: u16,
+    pub recipient: [u8; 32],
+    pub recipient_chain: u16,
+    pub sender_address: [u8; 32],
+    pub payload: Vec<u8>,
+}
+
+impl TransferWithPayloadInfo {
+    pub fn deserialize(data: &Vec<u8>) -> StdResult<Self> {
+        let data = data.as_slice();
+        let amount = data.get_u256(0);
+        let token_address = ExternalTokenId::deserialize(data.get_const_bytes::<32>(32));
+        let token_chain = data.get_u16(64);
+        let recipient = data.get_const_bytes::<32>(66);
+        let recipient_chain = data.get_u16(98);
+        let sender_address = data.get_const_bytes::<32>(100);
+        let payload = TransferWithPayloadInfo::get_payload(data);
+
+        Ok(TransferWithPayloadInfo {
+            amount,
+            token_address,
+            token_chain,
+            recipient,
+            recipient_chain,
+            sender_address,
+            payload,
+        })
+
+    }
+
+    pub fn serialize(&self) -> Vec<u8> {
+        [
+            self.amount.0.to_be_bytes().to_vec(),
+            self.amount.1.to_be_bytes().to_vec(),
+            self.token_address.serialize().to_vec(),
+            self.token_chain.to_be_bytes().to_vec(),
+            self.recipient.to_vec(),
+            self.recipient_chain.to_be_bytes().to_vec(),
+            self.sender_address.to_vec(),
+            self.payload.clone(),
+        ]
+        .concat()
+    }
+
+    pub fn get_payload(data: &[u8]) -> Vec<u8> {
+        data[132..].to_vec()
+    }
+
+    /// Convert [`TransferWithPayloadInfo`] into [`TransferInfo`] for the
+    /// purpose of handling them uniformly. Transfers with payload have 0 fees.
+    pub fn as_transfer_info(&self) -> TransferInfo {
+        TransferInfo {
+            amount: self.amount,
+            token_address: self.token_address.clone(),
+            token_chain: self.token_chain,
+            recipient: self.recipient,
+            recipient_chain: self.recipient_chain,
+            fee: (0, 0),
+        }
+    }
+}
+
+// 0  [32]uint8  TokenAddress
+// 32 uint16     TokenChain
+// 34 uint8      Decimals
+// 35 [32]uint8  Symbol
+// 67 [32]uint8  Name
+
+pub struct AssetMeta {
+    pub token_address: ExternalTokenId,
+    pub token_chain: u16,
+    pub decimals: u8,
+    pub symbol: Vec<u8>,
+    pub name: Vec<u8>,
+}
+
+impl AssetMeta {
+    pub fn deserialize(data: &Vec<u8>) -> StdResult<Self> {
+        let data = data.as_slice();
+        let token_address = ExternalTokenId::deserialize(data.get_const_bytes::<32>(0));
+        let token_chain = data.get_u16(32);
+        let decimals = data.get_u8(34);
+        let symbol = data.get_bytes32(35).to_vec();
+        let name = data.get_bytes32(67).to_vec();
+
+        Ok(AssetMeta {
+            token_chain,
+            token_address,
+            decimals,
+            symbol,
+            name,
+        })
+    }
+
+    pub fn serialize(&self) -> Vec<u8> {
+        [
+            self.token_address.serialize().to_vec(),
+            self.token_chain.to_be_bytes().to_vec(),
+            self.decimals.to_be_bytes().to_vec(),
+            self.symbol.clone(),
+            self.name.clone(),
+        ]
+        .concat()
+    }
+}
+
+pub struct UpgradeContract {
+    pub new_contract: u64,
+}
+
+pub struct RegisterChain {
+    pub chain_id: u16,
+    pub chain_address: Vec<u8>,
+}
+
+impl UpgradeContract {
+    pub fn deserialize(data: &Vec<u8>) -> StdResult<Self> {
+        let data = data.as_slice();
+        let new_contract = data.get_u64(24);
+        Ok(UpgradeContract { new_contract })
+    }
+}
+
+impl RegisterChain {
+    pub fn deserialize(data: &Vec<u8>) -> StdResult<Self> {
+        let data = data.as_slice();
+        let chain_id = data.get_u16(0);
+        let chain_address = data[2..].to_vec();
+
+        Ok(RegisterChain {
+            chain_id,
+            chain_address,
+        })
+    }
+}

--- a/cosmwasm/contracts/shutdown-token-bridge/src/testing/mod.rs
+++ b/cosmwasm/contracts/shutdown-token-bridge/src/testing/mod.rs
@@ -1,0 +1,1 @@
+mod tests;

--- a/cosmwasm/contracts/shutdown-token-bridge/src/testing/tests.rs
+++ b/cosmwasm/contracts/shutdown-token-bridge/src/testing/tests.rs
@@ -1,0 +1,236 @@
+use std::convert::TryInto;
+
+use cosmwasm_std::{
+    Binary,
+    StdResult,
+};
+
+use wormhole::state::ParsedVAA;
+
+use crate::{
+    state::{
+        Action,
+        TokenBridgeMessage,
+        TransferInfo,
+        TransferWithPayloadInfo,
+    },
+    token_address::ExternalTokenId,
+};
+
+#[test]
+fn binary_check() -> StdResult<()> {
+    let x = vec![
+        1u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 96u8, 180u8, 94u8, 195u8, 0u8, 0u8, 0u8,
+        1u8, 0u8, 3u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 38u8, 229u8,
+        4u8, 215u8, 149u8, 163u8, 42u8, 54u8, 156u8, 236u8, 173u8, 168u8, 72u8, 220u8, 100u8, 90u8,
+        154u8, 159u8, 160u8, 215u8, 0u8, 91u8, 48u8, 44u8, 48u8, 44u8, 51u8, 44u8, 48u8, 44u8,
+        48u8, 44u8, 48u8, 44u8, 48u8, 44u8, 48u8, 44u8, 48u8, 44u8, 48u8, 44u8, 48u8, 44u8, 48u8,
+        44u8, 48u8, 44u8, 48u8, 44u8, 48u8, 44u8, 53u8, 55u8, 44u8, 52u8, 54u8, 44u8, 50u8, 53u8,
+        53u8, 44u8, 53u8, 48u8, 44u8, 50u8, 52u8, 51u8, 44u8, 49u8, 48u8, 54u8, 44u8, 49u8, 50u8,
+        50u8, 44u8, 49u8, 49u8, 48u8, 44u8, 49u8, 50u8, 53u8, 44u8, 56u8, 56u8, 44u8, 55u8, 51u8,
+        44u8, 49u8, 56u8, 57u8, 44u8, 50u8, 48u8, 55u8, 44u8, 49u8, 48u8, 52u8, 44u8, 56u8, 51u8,
+        44u8, 49u8, 49u8, 57u8, 44u8, 49u8, 50u8, 55u8, 44u8, 49u8, 57u8, 50u8, 44u8, 49u8, 52u8,
+        55u8, 44u8, 56u8, 57u8, 44u8, 48u8, 44u8, 48u8, 44u8, 48u8, 44u8, 48u8, 44u8, 48u8, 44u8,
+        48u8, 44u8, 48u8, 44u8, 48u8, 44u8, 48u8, 44u8, 48u8, 44u8, 48u8, 44u8, 48u8, 44u8, 48u8,
+        44u8, 48u8, 44u8, 48u8, 44u8, 48u8, 44u8, 48u8, 44u8, 48u8, 44u8, 48u8, 44u8, 48u8, 44u8,
+        48u8, 44u8, 48u8, 44u8, 48u8, 44u8, 48u8, 44u8, 48u8, 44u8, 48u8, 44u8, 48u8, 44u8, 48u8,
+        44u8, 48u8, 44u8, 48u8, 44u8, 51u8, 44u8, 50u8, 51u8, 50u8, 44u8, 48u8, 44u8, 51u8, 44u8,
+        48u8, 44u8, 48u8, 44u8, 48u8, 44u8, 48u8, 44u8, 48u8, 44u8, 48u8, 44u8, 48u8, 44u8, 48u8,
+        44u8, 48u8, 44u8, 48u8, 44u8, 48u8, 44u8, 48u8, 44u8, 53u8, 51u8, 44u8, 49u8, 49u8, 54u8,
+        44u8, 52u8, 56u8, 44u8, 49u8, 49u8, 54u8, 44u8, 49u8, 52u8, 57u8, 44u8, 49u8, 48u8, 56u8,
+        44u8, 49u8, 49u8, 51u8, 44u8, 56u8, 44u8, 48u8, 44u8, 50u8, 51u8, 50u8, 44u8, 52u8, 57u8,
+        44u8, 49u8, 53u8, 50u8, 44u8, 49u8, 44u8, 50u8, 56u8, 44u8, 50u8, 48u8, 51u8, 44u8, 50u8,
+        49u8, 50u8, 44u8, 50u8, 50u8, 49u8, 44u8, 50u8, 52u8, 49u8, 44u8, 56u8, 53u8, 44u8, 49u8,
+        48u8, 57u8, 93u8,
+    ];
+    let b = Binary::from(x.clone());
+    let y: Vec<u8> = b.into();
+    assert_eq!(x, y);
+    Ok(())
+}
+
+#[test]
+fn build_native_and_asset_ids() -> StdResult<()> {
+    let external_id_uluna = ExternalTokenId::from_bank_token(&"uluna".to_string())?;
+
+    let expected_external_id: [u8; 32] = [1, 250, 108, 111, 188, 54, 216, 194, 69, 176, 168, 82, 164, 62, 181, 214, 68, 232, 180, 196, 119, 178, 123, 250, 185, 83, 124, 16, 148, 89, 57, 218];
+    assert_eq!(
+        &external_id_uluna.serialize(),
+        &expected_external_id,
+        "external_id != expected"
+    );
+
+    // weth
+    let token_address = "000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2";
+    let token_address: [u8; 32] = hex::decode(token_address)
+        .unwrap()
+        .as_slice()
+        .try_into()
+        .unwrap();
+    let external_id_weth = ExternalTokenId::from_foreign_token(token_address);
+
+    let expected_asset_id: [u8; 32] = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 192, 42, 170, 57, 178, 35, 254, 141, 10, 14, 92, 79, 39, 234, 217, 8, 60, 117, 108, 194];
+    assert_eq!(
+        &external_id_weth.serialize(),
+        &expected_asset_id,
+        "asset_id != expected"
+    );
+    Ok(())
+}
+
+#[test]
+fn deserialize_transfer_vaa() -> StdResult<()> {
+    let signed_vaa = "\
+        010000000001003f3179d5bb17b6f2ecc13741ca3f78d922043e99e09975e390\
+        4332d2418bb3f16d7ac93ca8401f8bed1cf9827bc806ecf7c5a283340f033bf4\
+        72724abf1d274f00000000000000000000010000000000000000000000000000\
+        00000000000000000000000000000000ffff0000000000000000000100000000\
+        00000000000000000000000000000000000000000000000005f5e10001000000\
+        0000000000000000000000000000000000000000000000007575736400030000\
+        00000000000000000000f7f7dde848e7450a029cd0a9bd9bdae4b5147db30003\
+        00000000000000000000000000000000000000000000000000000000000f4240";
+    let signed_vaa = hex::decode(signed_vaa).unwrap();
+
+    let parsed = ParsedVAA::deserialize(signed_vaa.as_slice())?;
+    let message = TokenBridgeMessage::deserialize(&parsed.payload)?;
+    assert_eq!(
+        message.action,
+        Action::TRANSFER,
+        "message.action != expected"
+    );
+
+    let info = TransferInfo::deserialize(&message.payload)?;
+
+    let amount = (0u128, 100_000_000u128);
+    assert_eq!(info.amount, amount, "info.amount != expected");
+
+    let token_address = "0100000000000000000000000000000000000000000000000000000075757364";
+    let token_address = hex::decode(token_address).unwrap();
+    assert_eq!(
+        info.token_address.serialize().to_vec(),
+        token_address,
+        "info.token_address != expected"
+    );
+
+    let token_chain = 3u16;
+    assert_eq!(
+        info.token_chain, token_chain,
+        "info.token_chain != expected"
+    );
+
+    let recipient = "000000000000000000000000f7f7dde848e7450a029cd0a9bd9bdae4b5147db3";
+    let recipient = hex::decode(recipient).unwrap();
+    assert_eq!(
+        info.recipient.to_vec(),
+        recipient,
+        "info.recipient != expected"
+    );
+
+    let recipient_chain = 3u16;
+    assert_eq!(
+        info.recipient_chain, recipient_chain,
+        "info.recipient_chain != expected"
+    );
+
+    let fee = (0u128, 1_000_000u128);
+    assert_eq!(info.fee, fee, "info.fee != expected");
+
+    Ok(())
+}
+
+#[test]
+fn deserialize_transfer_with_payload_vaa() -> StdResult<()> {
+
+// ┌──────────────────────────────────────────────────────────────────────────────┐
+// │ Wormhole VAA v1         │ nonce: 2080370133       │ time: 0                  │
+// │ guardian set #0         │ #4568529024235897313    │ consistency: 32          │
+// ├──────────────────────────────────────────────────────────────────────────────┤
+// │ Signature:                                                                   │
+// │   #0: 2565e7ae10421624fd81118855acda893e752aeeef31c13fbfc417591ada...        │
+// ├──────────────────────────────────────────────────────────────────────────────┤
+// │ Emitter: 11111111111111111111111111111115 (Solana)                           │
+// ╞══════════════════════════════════════════════════════════════════════════════╡
+// │ Token transfer with payload (aka payload 3)                                  │
+// │ Amount: 1.0                                                                  │
+// │ Token: terra1qqqqqqqqqqqqqqqqqqqqqqqqqp6h2umyswfh6y (Terra)                  │
+// │ Recipient: terra13nkgqrfymug724h8pprpexqj9h629sa3ncw7sh (Terra)              │
+// │ From: 1399a4e782b935d2bb36b97586d3df8747b07dc66902d807eed0ae99e00ed256       │
+// ╞══════════════════════════════════════════════════════════════════════════════╡
+// │ Custom payload:                                                              │
+// │ Length: 30 (0x1e) bytes                                                      │
+// │ 0000:   41 6c 6c 20  79 6f 75 72  20 62 61 73  65 20 61 72   All your base ar│
+// │ 0010:   65 20 62 65  6c 6f 6e 67  20 74 6f 20  75 73         e belong to us  │
+// └──────────────────────────────────────────────────────────────────────────────┘
+
+    let signed_vaa = "\
+        010000000001002565e7ae10421624fd81118855acda893e752aeeef31c13fbf\
+        c417591ada039822195a1321a72cc4bac1c6031e0595f1c1361ca2a30d941a41\
+        95fad8020d43d500000000007bffedd500010000000000000000000000000000\
+        0000000000000000000000000000000000043f66acf143a481e1200300000000\
+        00000000000000000000000000000000000000000000000005f5e10000000000\
+        0000000000000000000000000000000000000000000000007575736400030000\
+        000000000000000000008cec800d24df11e556e708461c98122df4a2c3b10003\
+        1399a4e782b935d2bb36b97586d3df8747b07dc66902d807eed0ae99e00ed256\
+        416c6c20796f75722062617365206172652062656c6f6e6720746f207573";
+    let signed_vaa = hex::decode(signed_vaa).unwrap();
+
+    let parsed = ParsedVAA::deserialize(signed_vaa.as_slice())?;
+    let message = TokenBridgeMessage::deserialize(&parsed.payload)?;
+    assert_eq!(
+        message.action,
+        Action::TRANSFER_WITH_PAYLOAD,
+        "message.action != expected"
+    );
+
+    let info = TransferWithPayloadInfo::deserialize(&message.payload)?;
+
+    let amount = (0u128, 100_000_000u128);
+    assert_eq!(info.amount, amount, "info.amount != expected");
+
+    let token_address = "0000000000000000000000000000000000000000000000000000000075757364";
+    let token_address = hex::decode(token_address).unwrap();
+    assert_eq!(
+        info.token_address.serialize().to_vec(),
+        token_address,
+        "info.token_address != expected"
+    );
+
+    let token_chain = 3u16;
+    assert_eq!(
+        info.token_chain, token_chain,
+        "info.token_chain != expected"
+    );
+
+    let recipient = "0000000000000000000000008cec800d24df11e556e708461c98122df4a2c3b1";
+    let recipient = hex::decode(recipient).unwrap();
+    assert_eq!(
+        info.recipient.to_vec(),
+        recipient,
+        "info.recipient != expected"
+    );
+
+    let sender = "1399a4e782b935d2bb36b97586d3df8747b07dc66902d807eed0ae99e00ed256";
+    let sender = hex::decode(sender).unwrap();
+    assert_eq!(
+        info.sender_address.to_vec(),
+        sender,
+        "info.sender != expected"
+    );
+
+    let recipient_chain = 3u16;
+    assert_eq!(
+        info.recipient_chain, recipient_chain,
+        "info.recipient_chain != expected"
+    );
+
+
+    let transfer_payload = "All your base are belong to us";
+    let transfer_payload = transfer_payload.as_bytes();
+    assert_eq!(
+        info.payload.as_slice(),
+        transfer_payload,
+        "info.payload != expected"
+    );
+
+    Ok(())
+}

--- a/cosmwasm/contracts/shutdown-token-bridge/src/token_address.rs
+++ b/cosmwasm/contracts/shutdown-token-bridge/src/token_address.rs
@@ -1,0 +1,226 @@
+use cosmwasm_std::{
+    Addr,
+    StdError,
+    StdResult,
+    Storage,
+};
+
+use schemars::JsonSchema;
+use serde::{
+    Deserialize,
+    Serialize,
+};
+use sha3::{
+    Digest,
+    Keccak256,
+};
+
+use crate::state::{
+    bank_token_hashes,
+    bank_token_hashes_read,
+    config_read,
+    native_c20_hashes,
+    native_c20_hashes_read,
+};
+
+/// Represent the external view of a token address.
+/// This is the value that goes into the VAA.
+///
+/// When given an external 32 byte address, there are 3 options:
+/// I. This is a token native to this chain
+///     a. it's a token managed by the Bank cosmos module
+///     (e.g. the staking denom "uluna" on Terra)
+///     b. it's a CW20 token
+/// II. This is a token address from another chain
+///
+/// Thus, interpreting an external token id requires knowing whether the token
+/// in question originates from this chain, or another chain. This information
+/// will always be available from the context.
+///
+/// I. //////////////////////////////////////////////////////////////////////////
+///
+/// In the first case (native tokens), the layout of is the following:
+///
+///  | 1 byte |                          31 bytes                               |
+///  +--------+-----------------------------------------------------------------+
+///  | MARKER |                           HASH                                  |
+///  +--------+-----------------------------------------------------------------+
+///
+/// The left-most byte (MARKER) tells us whether it's a Bank token (1), or a CW20 (0).
+/// Since denom names can be arbitarily long, and CW20 addresses are 32 byes, we
+/// cannot directly encode them into the remaining 31 bytes. Instead, we hash
+/// the data (either the denom or the CW20 address), and put the last 31 bytes
+/// of the hash into the address (HASH). In particular, this choice reduces the
+/// space of the hash function by 8 bits, but assuming the hash is resistant to
+/// differential attacks, we consider giving up on these 8 bits safe.
+///
+/// In order to be able to recover the denom and the contract address later, we
+/// store a mapping from these 32 bytes (MARKER+HASH) to denoms and CW20
+/// addresses (c.f. [`native_cw20_hashes`] & [`bank_token_hashes`] in state.rs)
+///
+/// II. /////////////////////////////////////////////////////////////////////////
+///
+/// In the second case (foreign tokens), the whole 32 bytes correspond to the
+/// external token address. In this case, the corresponding token will be a
+/// wrapped asset, whose address is stored in storage as a mapping (c.f.
+/// [`wrapped_asset`] in state.rs)
+///
+///    (chain_id, external_id) => wrapped_asset_address
+///
+/// For internal consumption of these addresses, we first convert them to
+/// [`TokenId`] (see below).
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[repr(transparent)]
+pub struct ExternalTokenId {
+    bytes: [u8; 32],
+}
+
+/// The intention is that [`ExternalTokenId`] should always be converted to/from
+/// [`TokenId`] through the functions defined in this module. This is why its
+/// internal contents are private. The following functions are called
+/// [`serialize`] and [`deserialize`] to signify that they should only be used
+/// when converting back and forth the wire format.
+impl ExternalTokenId {
+    pub fn serialize(&self) -> [u8; 32] {
+        self.bytes
+    }
+
+    pub fn deserialize(data: [u8; 32]) -> Self {
+        Self { bytes: data }
+    }
+}
+
+impl ExternalTokenId {
+    pub fn to_token_id(&self, storage: &dyn Storage, origin_chain: u16) -> StdResult<TokenId> {
+        let state = config_read(storage).load()?;
+        if origin_chain == state.chain_id {
+            let marker_byte = self.bytes[0];
+            match marker_byte {
+                1 => {
+                    let denom = bank_token_hashes_read(storage).load(&self.bytes)?;
+                    Ok(TokenId::Bank { denom })
+                }
+                0 => {
+                    let human_address = native_c20_hashes_read(storage).load(&self.bytes)?;
+                    Ok(TokenId::Contract(ContractId::NativeCW20 {
+                        contract_address: human_address,
+                    }))
+                }
+                b => Err(StdError::generic_err(format!("Unknown marker byte: {}", b))),
+            }
+        } else {
+            Ok(TokenId::Contract(ContractId::ForeignToken {
+                chain_id: origin_chain,
+                foreign_address: self.bytes,
+            }))
+        }
+    }
+
+    pub fn from_native_cw20(contract_address: &Addr) -> StdResult<ExternalTokenId> {
+        let mut hash = hash(contract_address.as_bytes());
+        // override first byte with marker byte
+        hash[0] = 0;
+        Ok(ExternalTokenId { bytes: hash })
+    }
+
+    pub fn from_foreign_token(foreign_address: [u8; 32]) -> ExternalTokenId {
+        ExternalTokenId {
+            bytes: foreign_address,
+        }
+    }
+
+    pub fn from_bank_token(denom: &String) -> StdResult<ExternalTokenId> {
+        let mut hash = hash(&denom.as_bytes());
+        // override first byte with marker byte
+        hash[0] = 1;
+        Ok(ExternalTokenId { bytes: hash })
+    }
+
+    pub fn from_token_id(token_id: &TokenId) -> StdResult<ExternalTokenId> {
+        match token_id {
+            TokenId::Bank { denom } => Self::from_bank_token(denom),
+            TokenId::Contract(contract) => match contract {
+                ContractId::NativeCW20 { contract_address } => {
+                    Self::from_native_cw20(contract_address)
+                }
+                ContractId::ForeignToken {
+                    chain_id: _,
+                    foreign_address,
+                } => Ok(Self::from_foreign_token(*foreign_address)),
+            },
+        }
+    }
+}
+
+/// Internal view of an address. This type is similar to [`AssetInfo`], but more
+/// granular. We do differentiate between bank tokens and CW20 tokens, but in
+/// the latter case, we further differentiate between native CW20s and wrapped
+/// CW20s (see [`ContractId`]).
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub enum TokenId {
+    Bank { denom: String },
+    Contract(ContractId),
+}
+
+impl TokenId {
+    /// Given a [`TokenId`], we can always directly construct an
+    /// [`ExternalTokenId`], but the converse is not true, since the
+    /// construction of external ids involves hashing, and is thus irreversible.
+    /// To maintain the bijection (modulo hash collisions), we store the hash
+    /// preimages in storage, so given an external id, the necessary information
+    /// can always be queried to reconstruct the token id.
+    /// This information must be stored when the token id is first converted to
+    /// an external id, i.e. when an attestation is generated for the token.
+    pub fn store(&self, storage: &mut dyn Storage) -> StdResult<ExternalTokenId> {
+        let external_id = ExternalTokenId::from_token_id(self)?;
+        match self {
+            TokenId::Bank { denom } => bank_token_hashes(storage).save(&external_id.bytes, denom),
+            TokenId::Contract(contract) => match contract {
+                ContractId::NativeCW20 { contract_address } => {
+                    native_c20_hashes(storage).save(&external_id.bytes, &contract_address)
+                }
+                ContractId::ForeignToken {
+                    chain_id: _,
+                    foreign_address: _,
+                } => Err(StdError::generic_err(
+                    "Foreign tokens are not stored in storage",
+                )),
+            },
+        }?;
+        Ok(external_id)
+    }
+}
+
+/// A contract id is either a native cw20 address, or a foreign token. The
+/// reason we represent the foreign address here instead of storing the wrapped
+/// CW20 contract's address directly is that the wrapped asset might not be
+/// deployed yet.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub enum ContractId {
+    NativeCW20 {
+        contract_address: Addr,
+    },
+    /// A wrapped token might not exist yet.
+    ForeignToken {
+        chain_id: u16,
+        foreign_address: [u8; 32],
+    },
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[repr(transparent)]
+pub struct WrappedCW20 {
+    pub human_address: Addr,
+}
+
+impl WrappedCW20 {
+    pub fn into_string(self) -> String {
+        self.human_address.into_string()
+    }
+}
+
+fn hash(bytes: &[u8]) -> [u8; 32] {
+    let mut hasher = Keccak256::new();
+    hasher.update(bytes);
+    hasher.finalize().into()
+}

--- a/cosmwasm/contracts/shutdown-wormhole/.cargo/config
+++ b/cosmwasm/contracts/shutdown-wormhole/.cargo/config
@@ -1,0 +1,5 @@
+[alias]
+wasm = "build --release --target wasm32-unknown-unknown"
+wasm-debug = "build --target wasm32-unknown-unknown"
+unit-test = "test --lib --features backtraces"
+integration-test = "test --test integration"

--- a/cosmwasm/contracts/shutdown-wormhole/Cargo.toml
+++ b/cosmwasm/contracts/shutdown-wormhole/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "shutdown-wormhole-bridge-terra-2"
+version = "0.1.0"
+authors = ["Yuriy Savchenko <yuriy.savchenko@gmail.com>"]
+edition = "2018"
+description = "Shutdown Wormhole contract"
+
+[lib]
+name = "shutdown_wormhole"
+crate-type = ["cdylib", "rlib"]
+
+[features]
+backtraces = ["cosmwasm-std/backtraces"]
+# use library feature to disable all init/handle/query exports
+library = []
+
+[dependencies]
+cosmwasm-std = { version = "1.0.0" }
+cosmwasm-storage = { version = "1.0.0" }
+schemars = "0.8.8"
+serde = { version = "1.0.137", default-features = false, features = ["derive"] }
+cw20 = "0.13.2"
+cw20-base = { version = "0.13.2", features = ["library"] }
+cw20-wrapped-2 = { path = "../cw20-wrapped", features = ["library"] }
+thiserror = { version = "1.0.31" }
+k256 = { version = "0.9.4", default-features = false, features = ["ecdsa"] }
+getrandom = { version = "0.2", features = ["custom"] }
+sha3 = { version = "0.9.1", default-features = false }
+generic-array = { version = "0.14.4" }
+hex = "0.4.2"
+lazy_static = "1.4.0"
+
+[dev-dependencies]
+serde_json = "1.0"

--- a/cosmwasm/contracts/shutdown-wormhole/src/byte_utils.rs
+++ b/cosmwasm/contracts/shutdown-wormhole/src/byte_utils.rs
@@ -1,0 +1,101 @@
+use cosmwasm_std::CanonicalAddr;
+
+pub trait ByteUtils {
+    fn get_u8(&self, index: usize) -> u8;
+    fn get_u16(&self, index: usize) -> u16;
+    fn get_u32(&self, index: usize) -> u32;
+    fn get_u64(&self, index: usize) -> u64;
+
+    fn get_u128_be(&self, index: usize) -> u128;
+    /// High 128 then low 128
+    fn get_u256(&self, index: usize) -> (u128, u128);
+    fn get_address(&self, index: usize) -> CanonicalAddr;
+    fn get_bytes32(&self, index: usize) -> &[u8];
+    fn get_bytes(&self, index: usize, bytes: usize) -> &[u8];
+    fn get_const_bytes<const N: usize>(&self, index: usize) -> [u8; N];
+}
+
+impl ByteUtils for &[u8] {
+    fn get_u8(&self, index: usize) -> u8 {
+        self[index]
+    }
+    fn get_u16(&self, index: usize) -> u16 {
+        let mut bytes: [u8; 16 / 8] = [0; 16 / 8];
+        bytes.copy_from_slice(&self[index..index + 2]);
+        u16::from_be_bytes(bytes)
+    }
+    fn get_u32(&self, index: usize) -> u32 {
+        let mut bytes: [u8; 32 / 8] = [0; 32 / 8];
+        bytes.copy_from_slice(&self[index..index + 4]);
+        u32::from_be_bytes(bytes)
+    }
+    fn get_u64(&self, index: usize) -> u64 {
+        let mut bytes: [u8; 64 / 8] = [0; 64 / 8];
+        bytes.copy_from_slice(&self[index..index + 8]);
+        u64::from_be_bytes(bytes)
+    }
+    fn get_u128_be(&self, index: usize) -> u128 {
+        let mut bytes: [u8; 128 / 8] = [0; 128 / 8];
+        bytes.copy_from_slice(&self[index..index + 128 / 8]);
+        u128::from_be_bytes(bytes)
+    }
+    fn get_u256(&self, index: usize) -> (u128, u128) {
+        (self.get_u128_be(index), self.get_u128_be(index + 128 / 8))
+    }
+    fn get_address(&self, index: usize) -> CanonicalAddr {
+        // 32 bytes are reserved for addresses, but wasmd uses both 32 and 20 bytes
+        // https://github.com/CosmWasm/wasmd/blob/ac92fdcf37388cc8dc24535f301f64395f8fb3da/x/wasm/types/types.go#L325
+        if self.get_u128_be(index) >> 32 == 0 {
+            return CanonicalAddr::from(&self[index + 12..index + 32])    
+        }
+        return CanonicalAddr::from(&self[index..index + 32])
+    }
+    fn get_bytes32(&self, index: usize) -> &[u8] {
+        &self[index..index + 32]
+    }
+
+    fn get_bytes(&self, index: usize, bytes: usize) -> &[u8] {
+        &self[index..index + bytes]
+    }
+
+    fn get_const_bytes<const N: usize>(&self, index: usize) -> [u8; N] {
+        let mut bytes: [u8; N] = [0; N];
+        bytes.copy_from_slice(&self[index..index + N]);
+        bytes
+    }
+}
+
+/// Left-pad a <= 32 byte address with 0s
+pub fn extend_address_to_32(addr: &CanonicalAddr) -> Vec<u8> {
+    extend_address_to_32_array(addr).to_vec()
+}
+
+pub fn extend_address_to_32_array(addr: &CanonicalAddr) -> [u8; 32] {
+    let mut v: Vec<u8> = vec![0; 32 - addr.len()];
+    v.extend(addr.as_slice());
+    let mut result: [u8; 32] = [0; 32];
+    result.copy_from_slice(&v);
+    result
+}
+
+/// Turn a string into a fixed length array. If the string is shorter than the
+/// resulting array, it gets padded with \0s on the right. If longer, it gets
+/// truncated.
+pub fn string_to_array<const N: usize>(s: &str) -> [u8; N] {
+    let bytes = s.as_bytes();
+    let len = usize::min(N, bytes.len());
+    let zeros = vec![0; N - len];
+    let padded = [bytes[..len].to_vec(), zeros].concat();
+    let mut result: [u8; N] = [0; N];
+    result.copy_from_slice(&padded);
+    result
+}
+
+pub fn extend_string_to_32(s: &str) -> Vec<u8> {
+    string_to_array::<32>(s).to_vec()
+}
+
+pub fn get_string_from_32(v: &[u8]) -> String {
+    let s = String::from_utf8_lossy(v);
+    s.chars().filter(|c| c != &'\0').collect()
+}

--- a/cosmwasm/contracts/shutdown-wormhole/src/contract.rs
+++ b/cosmwasm/contracts/shutdown-wormhole/src/contract.rs
@@ -1,0 +1,358 @@
+use cosmwasm_std::{
+    to_binary,
+    Binary,
+    Coin,
+    CosmosMsg,
+    Deps,
+    DepsMut,
+    Env,
+    MessageInfo,
+    Response,
+    StdError,
+    StdResult,
+    Storage,
+    WasmMsg,
+};
+
+#[cfg(not(feature = "library"))]
+use cosmwasm_std::entry_point;
+
+use crate::{
+    byte_utils::{
+        extend_address_to_32,
+        ByteUtils,
+    },
+    error::ContractError,
+    msg::{
+        ExecuteMsg,
+        GetAddressHexResponse,
+        GuardianSetInfoResponse,
+        InstantiateMsg,
+        MigrateMsg,
+        QueryMsg,
+    },
+    state::{
+        config,
+        config_read,
+        guardian_set_get,
+        guardian_set_set,
+        vaa_archive_add,
+        vaa_archive_check,
+        ConfigInfo,
+        ContractUpgrade,
+        GovernancePacket,
+        GuardianAddress,
+        GuardianSetInfo,
+        GuardianSetUpgrade,
+        ParsedVAA,
+    },
+};
+
+use k256::{
+    ecdsa::{
+        recoverable::{
+            Id as RecoverableId,
+            Signature as RecoverableSignature,
+        },
+        Signature,
+        VerifyingKey,
+    },
+    EncodedPoint,
+};
+use sha3::{
+    Digest,
+    Keccak256,
+};
+
+use generic_array::GenericArray;
+use std::convert::TryFrom;
+
+type HumanAddr = String;
+
+// Lock assets fee amount and denomination
+const FEE_AMOUNT: u128 = 0;
+
+/// Migration code that runs the next time the contract is upgraded.
+/// This function will contain ephemeral code that we want to run once, and thus
+/// can (and should be) safely deleted after the upgrade happened successfully.
+///
+/// Most upgrades won't require any special migration logic. In those cases,
+/// this function can safely be implemented as:
+/// ```ignore
+/// Ok(Response::default())
+/// ```
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn migrate(_deps: DepsMut, _env: Env, _msg: MigrateMsg) -> StdResult<Response> {
+    Ok(Response::default())
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn instantiate(
+    deps: DepsMut,
+    _env: Env,
+    _info: MessageInfo,
+    msg: InstantiateMsg,
+) -> StdResult<Response> {
+    // Save general wormhole info
+    let state = ConfigInfo {
+        gov_chain: msg.gov_chain,
+        gov_address: msg.gov_address.as_slice().to_vec(),
+        guardian_set_index: 0,
+        guardian_set_expirity: msg.guardian_set_expirity,
+        fee: Coin::new(FEE_AMOUNT, &msg.fee_denom),
+        chain_id: msg.chain_id,
+        fee_denom: msg.fee_denom,
+    };
+    config(deps.storage).save(&state)?;
+
+    // Add initial guardian set to storage
+    guardian_set_set(
+        deps.storage,
+        state.guardian_set_index,
+        &msg.initial_guardian_set,
+    )?;
+
+    Ok(Response::default())
+}
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> StdResult<Response> {
+    match msg {
+        ExecuteMsg::SubmitVAA { vaa } => handle_submit_vaa(deps, env, info, vaa.as_slice()),
+    }
+}
+
+/// Process VAA message signed by quardians
+fn handle_submit_vaa(
+    deps: DepsMut,
+    env: Env,
+    _info: MessageInfo,
+    data: &[u8],
+) -> StdResult<Response> {
+    let state = config_read(deps.storage).load()?;
+
+    let vaa = parse_and_verify_vaa(deps.storage, data, env.block.time.seconds())?;
+    vaa_archive_add(deps.storage, vaa.hash.as_slice())?;
+
+    if state.gov_chain == vaa.emitter_chain && state.gov_address == vaa.emitter_address {
+        if state.guardian_set_index != vaa.guardian_set_index {
+            return Err(StdError::generic_err(
+                "governance VAAs must be signed by the current guardian set",
+            ));
+        }
+        return handle_governance_payload(deps, env, &vaa.payload);
+    }
+
+    ContractError::InvalidVAAAction.std_err()
+}
+
+fn handle_governance_payload(deps: DepsMut, env: Env, data: &[u8]) -> StdResult<Response> {
+    let gov_packet = GovernancePacket::deserialize(data)?;
+    let state = config_read(deps.storage).load()?;
+
+    let module = String::from_utf8(gov_packet.module).unwrap();
+    let module: String = module.chars().filter(|c| c != &'\0').collect();
+
+    if module != "Core" {
+        return Err(StdError::generic_err("this is not a valid module"));
+    }
+
+    if gov_packet.chain != 0 && gov_packet.chain != state.chain_id {
+        return Err(StdError::generic_err(
+            "the governance VAA is for another chain",
+        ));
+    }
+
+    match gov_packet.action {
+        1u8 => vaa_update_contract(deps, env, &gov_packet.payload),
+        2u8 => vaa_update_guardian_set(deps, env, &gov_packet.payload),
+        _ => ContractError::InvalidVAAAction.std_err(),
+    }
+}
+
+/// Parses raw VAA data into a struct and verifies whether it contains sufficient signatures of an
+/// active guardian set i.e. is valid according to Wormhole consensus rules
+fn parse_and_verify_vaa(
+    storage: &dyn Storage,
+    data: &[u8],
+    block_time: u64,
+) -> StdResult<ParsedVAA> {
+    let vaa = ParsedVAA::deserialize(data)?;
+
+    if vaa.version != 1 {
+        return ContractError::InvalidVersion.std_err();
+    }
+
+    // Check if VAA with this hash was already accepted
+    if vaa_archive_check(storage, vaa.hash.as_slice()) {
+        return ContractError::VaaAlreadyExecuted.std_err();
+    }
+
+    // Load and check guardian set
+    let guardian_set = guardian_set_get(storage, vaa.guardian_set_index);
+    let guardian_set: GuardianSetInfo =
+        guardian_set.or_else(|_| ContractError::InvalidGuardianSetIndex.std_err())?;
+
+    if guardian_set.expiration_time != 0 && guardian_set.expiration_time < block_time {
+        return ContractError::GuardianSetExpired.std_err();
+    }
+    if (vaa.len_signers as usize) < guardian_set.quorum() {
+        return ContractError::NoQuorum.std_err();
+    }
+
+    // Verify guardian signatures
+    let mut last_index: i32 = -1;
+    let mut pos = ParsedVAA::HEADER_LEN;
+
+    for _ in 0..vaa.len_signers {
+        if pos + ParsedVAA::SIGNATURE_LEN > data.len() {
+            return ContractError::InvalidVAA.std_err();
+        }
+        let index = data.get_u8(pos) as i32;
+        if index <= last_index {
+            return ContractError::WrongGuardianIndexOrder.std_err();
+        }
+        last_index = index;
+
+        let signature = Signature::try_from(
+            &data[pos + ParsedVAA::SIG_DATA_POS
+                ..pos + ParsedVAA::SIG_DATA_POS + ParsedVAA::SIG_DATA_LEN],
+        )
+        .or_else(|_| ContractError::CannotDecodeSignature.std_err())?;
+        let id = RecoverableId::new(data.get_u8(pos + ParsedVAA::SIG_RECOVERY_POS))
+            .or_else(|_| ContractError::CannotDecodeSignature.std_err())?;
+        let recoverable_signature = RecoverableSignature::new(&signature, id)
+            .or_else(|_| ContractError::CannotDecodeSignature.std_err())?;
+
+        let verify_key = recoverable_signature
+            .recover_verify_key_from_digest_bytes(GenericArray::from_slice(vaa.hash.as_slice()))
+            .or_else(|_| ContractError::CannotRecoverKey.std_err())?;
+
+        let index = index as usize;
+        if index >= guardian_set.addresses.len() {
+            return ContractError::TooManySignatures.std_err();
+        }
+        if !keys_equal(&verify_key, &guardian_set.addresses[index]) {
+            return ContractError::GuardianSignatureError.std_err();
+        }
+        pos += ParsedVAA::SIGNATURE_LEN;
+    }
+
+    Ok(vaa)
+}
+
+fn vaa_update_guardian_set(deps: DepsMut, env: Env, data: &[u8]) -> StdResult<Response> {
+    /* Payload format
+    0   uint32 new_index
+    4   uint8 len(keys)
+    5   [][20]uint8 guardian addresses
+    */
+
+    let mut state = config_read(deps.storage).load()?;
+
+    let GuardianSetUpgrade {
+        new_guardian_set_index,
+        new_guardian_set,
+    } = GuardianSetUpgrade::deserialize(data)?;
+
+    if new_guardian_set_index != state.guardian_set_index + 1 {
+        return ContractError::GuardianSetIndexIncreaseError.std_err();
+    }
+
+    let old_guardian_set_index = state.guardian_set_index;
+
+    state.guardian_set_index = new_guardian_set_index;
+
+    guardian_set_set(deps.storage, state.guardian_set_index, &new_guardian_set)?;
+
+    config(deps.storage).save(&state)?;
+
+    let mut old_guardian_set = guardian_set_get(deps.storage, old_guardian_set_index)?;
+    old_guardian_set.expiration_time = env.block.time.seconds() + state.guardian_set_expirity;
+    guardian_set_set(deps.storage, old_guardian_set_index, &old_guardian_set)?;
+
+    Ok(Response::new()
+        .add_attribute("action", "guardian_set_change")
+        .add_attribute("old", old_guardian_set_index.to_string())
+        .add_attribute("new", state.guardian_set_index.to_string()))
+}
+
+fn vaa_update_contract(_deps: DepsMut, env: Env, data: &[u8]) -> StdResult<Response> {
+    /* Payload format
+    0   [][32]uint8 new_contract
+    */
+
+    let ContractUpgrade { new_contract } = ContractUpgrade::deserialize(data)?;
+
+    Ok(Response::new()
+        .add_message(CosmosMsg::Wasm(WasmMsg::Migrate {
+            contract_addr: env.contract.address.to_string(),
+            new_code_id: new_contract,
+            msg: to_binary(&MigrateMsg {})?,
+        }))
+        .add_attribute("action", "contract_upgrade"))
+}
+
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
+    match msg {
+        QueryMsg::GuardianSetInfo {} => to_binary(&query_guardian_set_info(deps)?),
+        QueryMsg::VerifyVAA { vaa, block_time } => to_binary(&query_parse_and_verify_vaa(
+            deps,
+            vaa.as_slice(),
+            block_time,
+        )?),
+        // QueryMsg::GetState {} => to_binary(&query_state(deps)?),
+        QueryMsg::QueryAddressHex { address } => to_binary(&query_address_hex(deps, &address)?),
+    }
+}
+
+pub fn query_guardian_set_info(deps: Deps) -> StdResult<GuardianSetInfoResponse> {
+    let state = config_read(deps.storage).load()?;
+    let guardian_set = guardian_set_get(deps.storage, state.guardian_set_index)?;
+    let res = GuardianSetInfoResponse {
+        guardian_set_index: state.guardian_set_index,
+        addresses: guardian_set.addresses,
+    };
+    Ok(res)
+}
+
+pub fn query_parse_and_verify_vaa(
+    deps: Deps,
+    data: &[u8],
+    block_time: u64,
+) -> StdResult<ParsedVAA> {
+    parse_and_verify_vaa(deps.storage, data, block_time)
+}
+
+// returns the hex of the 32 byte address we use for some address on this chain
+pub fn query_address_hex(deps: Deps, address: &HumanAddr) -> StdResult<GetAddressHexResponse> {
+    Ok(GetAddressHexResponse {
+        hex: hex::encode(extend_address_to_32(&deps.api.addr_canonicalize(address)?)),
+    })
+}
+
+fn keys_equal(a: &VerifyingKey, b: &GuardianAddress) -> bool {
+    let mut hasher = Keccak256::new();
+
+    let point = if let Some(p) = EncodedPoint::from(a).decompress() {
+        p
+    } else {
+        return false;
+    };
+
+    hasher.update(&point.as_bytes()[1..]);
+    let a = &hasher.finalize()[12..];
+
+    let b = &b.bytes;
+    if a.len() != b.len() {
+        return false;
+    }
+    for (ai, bi) in a.iter().zip(b.as_slice().iter()) {
+        if ai != bi {
+            return false;
+        }
+    }
+    true
+}

--- a/cosmwasm/contracts/shutdown-wormhole/src/contract.rs
+++ b/cosmwasm/contracts/shutdown-wormhole/src/contract.rs
@@ -303,7 +303,6 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
             vaa.as_slice(),
             block_time,
         )?),
-        // QueryMsg::GetState {} => to_binary(&query_state(deps)?),
         QueryMsg::QueryAddressHex { address } => to_binary(&query_address_hex(deps, &address)?),
     }
 }

--- a/cosmwasm/contracts/shutdown-wormhole/src/error.rs
+++ b/cosmwasm/contracts/shutdown-wormhole/src/error.rs
@@ -1,0 +1,113 @@
+use cosmwasm_std::StdError;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum ContractError {
+    /// Invalid VAA version
+    #[error("InvalidVersion")]
+    InvalidVersion,
+
+    /// Guardian set with this index does not exist
+    #[error("InvalidGuardianSetIndex")]
+    InvalidGuardianSetIndex,
+
+    /// Guardian set expiration date is zero or in the past
+    #[error("GuardianSetExpired")]
+    GuardianSetExpired,
+
+    /// Not enough signers on the VAA
+    #[error("NoQuorum")]
+    NoQuorum,
+
+    /// Wrong guardian index order, order must be ascending
+    #[error("WrongGuardianIndexOrder")]
+    WrongGuardianIndexOrder,
+
+    /// Some problem with signature decoding from bytes
+    #[error("CannotDecodeSignature")]
+    CannotDecodeSignature,
+
+    /// Some problem with public key recovery from the signature
+    #[error("CannotRecoverKey")]
+    CannotRecoverKey,
+
+    /// Recovered pubkey from signature does not match guardian address
+    #[error("GuardianSignatureError")]
+    GuardianSignatureError,
+
+    /// VAA action code not recognized
+    #[error("InvalidVAAAction")]
+    InvalidVAAAction,
+
+    /// VAA guardian set is not current
+    #[error("NotCurrentGuardianSet")]
+    NotCurrentGuardianSet,
+
+    /// Only 128-bit amounts are supported
+    #[error("AmountTooHigh")]
+    AmountTooHigh,
+
+    /// Amount should be higher than zero
+    #[error("AmountTooLow")]
+    AmountTooLow,
+
+    /// Source and target chain ids must be different
+    #[error("SameSourceAndTarget")]
+    SameSourceAndTarget,
+
+    /// Target chain id must be the same as the current CHAIN_ID
+    #[error("WrongTargetChain")]
+    WrongTargetChain,
+
+    /// Wrapped asset init hook sent twice for the same asset id
+    #[error("AssetAlreadyRegistered")]
+    AssetAlreadyRegistered,
+
+    /// Guardian set must increase in steps of 1
+    #[error("GuardianSetIndexIncreaseError")]
+    GuardianSetIndexIncreaseError,
+
+    /// VAA was already executed
+    #[error("VaaAlreadyExecuted")]
+    VaaAlreadyExecuted,
+
+    /// Message sender not permitted to execute this operation
+    #[error("PermissionDenied")]
+    PermissionDenied,
+
+    /// Could not decode target address from canonical to human-readable form
+    #[error("WrongTargetAddressFormat")]
+    WrongTargetAddressFormat,
+
+    /// More signatures than active guardians found
+    #[error("TooManySignatures")]
+    TooManySignatures,
+
+    /// Wrapped asset not found in the registry
+    #[error("AssetNotFound")]
+    AssetNotFound,
+
+    /// Generic error when there is a problem with VAA structure
+    #[error("InvalidVAA")]
+    InvalidVAA,
+
+    /// Thrown when fee is enabled for the action, but was not sent with the transaction
+    #[error("FeeTooLow")]
+    FeeTooLow,
+
+    /// Registering asset outside of the wormhole
+    #[error("RegistrationForbidden")]
+    RegistrationForbidden,
+}
+
+impl ContractError {
+    pub fn std(&self) -> StdError {
+        StdError::GenericErr {
+            msg: format!("{}", self),
+        }
+    }
+
+    pub fn std_err<T>(&self) -> Result<T, StdError> {
+        Err(self.std())
+    }
+}

--- a/cosmwasm/contracts/shutdown-wormhole/src/lib.rs
+++ b/cosmwasm/contracts/shutdown-wormhole/src/lib.rs
@@ -1,0 +1,10 @@
+pub mod byte_utils;
+pub mod contract;
+pub mod error;
+pub mod msg;
+pub mod state;
+
+pub use crate::error::ContractError;
+
+#[cfg(test)]
+mod testing;

--- a/cosmwasm/contracts/shutdown-wormhole/src/msg.rs
+++ b/cosmwasm/contracts/shutdown-wormhole/src/msg.rs
@@ -34,7 +34,6 @@ pub struct InstantiateMsg {
 #[serde(rename_all = "snake_case")]
 pub enum ExecuteMsg {
     SubmitVAA { vaa: Binary },
-    // PostMessage { message: Binary, nonce: u32 },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -47,7 +46,6 @@ pub struct MigrateMsg {
 pub enum QueryMsg {
     GuardianSetInfo {},
     VerifyVAA { vaa: Binary, block_time: u64 },
-    // GetState {},
     QueryAddressHex { address: HumanAddr },
 }
 

--- a/cosmwasm/contracts/shutdown-wormhole/src/msg.rs
+++ b/cosmwasm/contracts/shutdown-wormhole/src/msg.rs
@@ -1,0 +1,77 @@
+use cosmwasm_std::{
+    Binary,
+    Coin,
+};
+use schemars::JsonSchema;
+use serde::{
+    Deserialize,
+    Serialize,
+};
+
+use crate::state::{
+    GuardianAddress,
+    GuardianSetInfo,
+};
+
+type HumanAddr = String;
+
+/// The instantiation parameters of the token bridge contract. See
+/// [`crate::state::ConfigInfo`] for more details on what these fields mean.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct InstantiateMsg {
+    pub gov_chain: u16,
+    pub gov_address: Binary,
+
+    /// Guardian set to initialise the contract with.
+    pub initial_guardian_set: GuardianSetInfo,
+    pub guardian_set_expirity: u64,
+
+    pub chain_id: u16,
+    pub fee_denom: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecuteMsg {
+    SubmitVAA { vaa: Binary },
+    // PostMessage { message: Binary, nonce: u32 },
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct MigrateMsg {
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum QueryMsg {
+    GuardianSetInfo {},
+    VerifyVAA { vaa: Binary, block_time: u64 },
+    // GetState {},
+    QueryAddressHex { address: HumanAddr },
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct GuardianSetInfoResponse {
+    pub guardian_set_index: u32,         // Current guardian set index
+    pub addresses: Vec<GuardianAddress>, // List of querdian addresses
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct WrappedRegistryResponse {
+    pub address: HumanAddr,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct GetStateResponse {
+    pub fee: Coin,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct GetAddressHexResponse {
+    pub hex: String,
+}

--- a/cosmwasm/contracts/shutdown-wormhole/src/state.rs
+++ b/cosmwasm/contracts/shutdown-wormhole/src/state.rs
@@ -1,0 +1,424 @@
+use schemars::JsonSchema;
+use serde::{
+    Deserialize,
+    Serialize,
+};
+
+use cosmwasm_std::{
+    Binary,
+    CanonicalAddr,
+    Coin,
+    StdResult,
+    Storage,
+    Uint128,
+};
+use cosmwasm_storage::{
+    bucket,
+    bucket_read,
+    singleton,
+    singleton_read,
+    Bucket,
+    ReadonlyBucket,
+    ReadonlySingleton,
+    Singleton,
+};
+
+use crate::{
+    byte_utils::ByteUtils,
+    error::ContractError,
+};
+
+use sha3::{
+    Digest,
+    Keccak256,
+};
+
+type HumanAddr = String;
+
+pub static CONFIG_KEY: &[u8] = b"config";
+pub static GUARDIAN_SET_KEY: &[u8] = b"guardian_set";
+pub static SEQUENCE_KEY: &[u8] = b"sequence";
+pub static WRAPPED_ASSET_KEY: &[u8] = b"wrapped_asset";
+pub static WRAPPED_ASSET_ADDRESS_KEY: &[u8] = b"wrapped_asset_address";
+
+/// Legacy version of [`ConfigInfo`]. Required for the migration.  In
+/// particular, the last two fields of [`ConfigInfo`] have been added after the
+/// Terra2 contract's deployment, which means that Terra2 needs to be migrated.
+/// See [`crate::contract::migrate`] for details on why this is necessary.
+/// Once the migration has been executed, this struct (and the corresponding
+/// migration logic) can be deleted.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct ConfigInfoLegacy {
+    /// Current active guardian set
+    pub guardian_set_index: u32,
+
+    /// Period for which a guardian set stays active after it has been replaced.
+    /// The typo is an easter egg.
+    pub guardian_set_expirity: u64,
+
+    /// Governance chain (typically Solana, i.e. chain id 1)
+    pub gov_chain: u16,
+
+    /// Address of governance contract (typically 0x0000000000000000000000000000000000000000000000000000000000000004)
+    pub gov_address: Vec<u8>,
+
+    // Message sending fee
+    pub fee: Coin,
+}
+
+/// Information about this contract's general parameters.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct ConfigInfo {
+    /// Current active guardian set
+    pub guardian_set_index: u32,
+
+    /// Period for which a guardian set stays active after it has been replaced.
+    /// The typo is an easter egg.
+    pub guardian_set_expirity: u64,
+
+    /// Governance chain (typically Solana, i.e. chain id 1)
+    pub gov_chain: u16,
+
+    /// Address of governance contract (typically 0x0000000000000000000000000000000000000000000000000000000000000004)
+    pub gov_address: Vec<u8>,
+
+    // Message sending fee
+    pub fee: Coin,
+
+    /// The wormhole id of the current chain.
+    pub chain_id: u16,
+
+    /// The denom in which transaction fees and wormhole fees are paid.
+    /// Typically the native denom of the current chain.
+    pub fee_denom: String,
+}
+
+// Validator Action Approval(VAA) data
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct ParsedVAA {
+    pub version: u8,
+    pub guardian_set_index: u32,
+    pub timestamp: u32,
+    pub nonce: u32,
+    pub len_signers: u8,
+
+    pub emitter_chain: u16,
+    pub emitter_address: Vec<u8>,
+    pub sequence: u64,
+    pub consistency_level: u8,
+    pub payload: Vec<u8>,
+
+    pub hash: Vec<u8>,
+}
+
+impl ParsedVAA {
+    /* VAA format:
+
+    header (length 6):
+    0   uint8   version (0x01)
+    1   uint32  guardian set index
+    5   uint8   len signatures
+
+    per signature (length 66):
+    0   uint8       index of the signer (in guardian keys)
+    1   [65]uint8   signature
+
+    body:
+    0   uint32      timestamp (unix in seconds)
+    4   uint32      nonce
+    8   uint16      emitter_chain
+    10  [32]uint8   emitter_address
+    42  uint64      sequence
+    50  uint8       consistency_level
+    51  []uint8     payload
+    */
+
+    pub const HEADER_LEN: usize = 6;
+    pub const SIGNATURE_LEN: usize = 66;
+
+    pub const GUARDIAN_SET_INDEX_POS: usize = 1;
+    pub const LEN_SIGNER_POS: usize = 5;
+
+    pub const VAA_NONCE_POS: usize = 4;
+    pub const VAA_EMITTER_CHAIN_POS: usize = 8;
+    pub const VAA_EMITTER_ADDRESS_POS: usize = 10;
+    pub const VAA_SEQUENCE_POS: usize = 42;
+    pub const VAA_CONSISTENCY_LEVEL_POS: usize = 50;
+    pub const VAA_PAYLOAD_POS: usize = 51;
+
+    // Signature data offsets in the signature block
+    pub const SIG_DATA_POS: usize = 1;
+    // Signature length minus recovery id at the end
+    pub const SIG_DATA_LEN: usize = 64;
+    // Recovery byte is last after the main signature
+    pub const SIG_RECOVERY_POS: usize = Self::SIG_DATA_POS + Self::SIG_DATA_LEN;
+
+    pub fn deserialize(data: &[u8]) -> StdResult<Self> {
+        let version = data.get_u8(0);
+
+        // Load 4 bytes starting from index 1
+        let guardian_set_index: u32 = data.get_u32(Self::GUARDIAN_SET_INDEX_POS);
+        let len_signers = data.get_u8(Self::LEN_SIGNER_POS) as usize;
+        let body_offset: usize = Self::HEADER_LEN + Self::SIGNATURE_LEN * len_signers as usize;
+
+        // Hash the body
+        if body_offset >= data.len() {
+            return ContractError::InvalidVAA.std_err();
+        }
+        let body = &data[body_offset..];
+        let mut hasher = Keccak256::new();
+        hasher.update(body);
+        let hash = hasher.finalize().to_vec();
+
+        // Rehash the hash
+        let mut hasher = Keccak256::new();
+        hasher.update(hash);
+        let hash = hasher.finalize().to_vec();
+
+        // Signatures valid, apply VAA
+        if body_offset + Self::VAA_PAYLOAD_POS > data.len() {
+            return ContractError::InvalidVAA.std_err();
+        }
+
+        let timestamp = data.get_u32(body_offset);
+        let nonce = data.get_u32(body_offset + Self::VAA_NONCE_POS);
+        let emitter_chain = data.get_u16(body_offset + Self::VAA_EMITTER_CHAIN_POS);
+        let emitter_address = data
+            .get_bytes32(body_offset + Self::VAA_EMITTER_ADDRESS_POS)
+            .to_vec();
+        let sequence = data.get_u64(body_offset + Self::VAA_SEQUENCE_POS);
+        let consistency_level = data.get_u8(body_offset + Self::VAA_CONSISTENCY_LEVEL_POS);
+        let payload = data[body_offset + Self::VAA_PAYLOAD_POS..].to_vec();
+
+        Ok(ParsedVAA {
+            version,
+            guardian_set_index,
+            timestamp,
+            nonce,
+            len_signers: len_signers as u8,
+            emitter_chain,
+            emitter_address,
+            sequence,
+            consistency_level,
+            payload,
+            hash,
+        })
+    }
+}
+
+// Guardian address
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct GuardianAddress {
+    pub bytes: Binary, // 20-byte addresses
+}
+
+#[cfg(test)]
+use hex;
+
+#[cfg(test)]
+impl GuardianAddress {
+    pub fn from(string: &str) -> GuardianAddress {
+        GuardianAddress {
+            bytes: hex::decode(string).expect("Decoding failed").into(),
+        }
+    }
+}
+
+// Guardian set information
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct GuardianSetInfo {
+    pub addresses: Vec<GuardianAddress>,
+    // List of guardian addresses
+    pub expiration_time: u64, // Guardian set expiration time
+}
+
+impl GuardianSetInfo {
+    pub fn quorum(&self) -> usize {
+        // allow quorum of 0 for testing purposes...
+        if self.addresses.is_empty() {
+            return 0;
+        }
+        ((self.addresses.len() * 10 / 3) * 2) / 10 + 1
+    }
+}
+
+// Wormhole contract generic information
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct WormholeInfo {
+    // Period for which a guardian set stays active after it has been replaced
+    pub guardian_set_expirity: u64,
+}
+
+pub fn config(storage: &mut dyn Storage) -> Singleton<ConfigInfo> {
+    singleton(storage, CONFIG_KEY)
+}
+
+pub fn config_read(storage: &dyn Storage) -> ReadonlySingleton<ConfigInfo> {
+    singleton_read(storage, CONFIG_KEY)
+}
+
+pub fn config_read_legacy(storage: &dyn Storage) -> ReadonlySingleton<ConfigInfoLegacy> {
+    singleton_read(storage, CONFIG_KEY)
+}
+
+pub fn guardian_set_set(
+    storage: &mut dyn Storage,
+    index: u32,
+    data: &GuardianSetInfo,
+) -> StdResult<()> {
+    bucket(storage, GUARDIAN_SET_KEY).save(&index.to_be_bytes(), data)
+}
+
+pub fn guardian_set_get(storage: &dyn Storage, index: u32) -> StdResult<GuardianSetInfo> {
+    bucket_read(storage, GUARDIAN_SET_KEY).load(&index.to_be_bytes())
+}
+
+pub fn sequence_set(storage: &mut dyn Storage, emitter: &[u8], sequence: u64) -> StdResult<()> {
+    bucket(storage, SEQUENCE_KEY).save(emitter, &sequence)
+}
+
+pub fn sequence_read(storage: &dyn Storage, emitter: &[u8]) -> u64 {
+    bucket_read(storage, SEQUENCE_KEY)
+        .load(emitter)
+        .or::<u64>(Ok(0))
+        .unwrap()
+}
+
+pub fn vaa_archive_add(storage: &mut dyn Storage, hash: &[u8]) -> StdResult<()> {
+    bucket(storage, GUARDIAN_SET_KEY).save(hash, &true)
+}
+
+pub fn vaa_archive_check(storage: &dyn Storage, hash: &[u8]) -> bool {
+    bucket_read(storage, GUARDIAN_SET_KEY)
+        .load(hash)
+        .or::<bool>(Ok(false))
+        .unwrap()
+}
+
+pub fn wrapped_asset(storage: &mut dyn Storage) -> Bucket<HumanAddr> {
+    bucket(storage, WRAPPED_ASSET_KEY)
+}
+
+pub fn wrapped_asset_read(storage: &dyn Storage) -> ReadonlyBucket<HumanAddr> {
+    bucket_read(storage, WRAPPED_ASSET_KEY)
+}
+
+pub fn wrapped_asset_address(storage: &mut dyn Storage) -> Bucket<Vec<u8>> {
+    bucket(storage, WRAPPED_ASSET_ADDRESS_KEY)
+}
+
+pub fn wrapped_asset_address_read(storage: &dyn Storage) -> ReadonlyBucket<Vec<u8>> {
+    bucket_read(storage, WRAPPED_ASSET_ADDRESS_KEY)
+}
+
+pub struct GovernancePacket {
+    pub module: Vec<u8>,
+    pub action: u8,
+    pub chain: u16,
+    pub payload: Vec<u8>,
+}
+
+impl GovernancePacket {
+    pub fn deserialize(data: &[u8]) -> StdResult<Self> {
+        let module = data.get_bytes32(0).to_vec();
+        let action = data.get_u8(32);
+        let chain = data.get_u16(33);
+        let payload = data[35..].to_vec();
+
+        Ok(GovernancePacket {
+            module,
+            action,
+            chain,
+            payload,
+        })
+    }
+}
+
+// action 1
+pub struct ContractUpgrade  {
+    pub new_contract: u64,
+}
+
+// action 2
+pub struct GuardianSetUpgrade {
+    pub new_guardian_set_index: u32,
+    pub new_guardian_set: GuardianSetInfo,
+}
+
+impl ContractUpgrade {
+    pub fn deserialize(data: &[u8]) -> StdResult<Self> {
+        let new_contract = data.get_u64(24);
+        Ok(ContractUpgrade {
+            new_contract,
+        })
+    }
+}
+
+impl GuardianSetUpgrade {
+    pub fn deserialize(data: &[u8]) -> StdResult<Self> {
+        const ADDRESS_LEN: usize = 20;
+
+        let new_guardian_set_index = data.get_u32(0);
+
+        let n_guardians = data.get_u8(4);
+
+        let mut addresses = vec![];
+
+        for i in 0..n_guardians {
+            let pos = 5 + (i as usize) * ADDRESS_LEN;
+            if pos + ADDRESS_LEN > data.len() {
+                return ContractError::InvalidVAA.std_err();
+            }
+
+            addresses.push(GuardianAddress {
+                bytes: data[pos..pos + ADDRESS_LEN].to_vec().into(),
+            });
+        }
+
+        let new_guardian_set = GuardianSetInfo {
+            addresses,
+            expiration_time: 0,
+        };
+
+        Ok(GuardianSetUpgrade {
+            new_guardian_set_index,
+            new_guardian_set,
+        })
+    }
+}
+
+// action 3
+pub struct SetFee {
+    pub fee: Coin,
+}
+
+impl SetFee {
+    pub fn deserialize(data: &[u8], fee_denom: String) -> StdResult<Self> {
+        let (_, amount) = data.get_u256(0);
+        let fee = Coin {
+            denom: fee_denom,
+            amount: Uint128::new(amount),
+        };
+        Ok(SetFee { fee })
+    }
+}
+
+// action 4
+pub struct TransferFee {
+    pub amount: Coin,
+    pub recipient: CanonicalAddr,
+}
+
+impl TransferFee {
+    pub fn deserialize(data: &[u8], fee_denom: String) -> StdResult<Self> {
+        let recipient = data.get_address(0);
+
+        let (_, amount) = data.get_u256(32);
+        let amount = Coin {
+            denom: fee_denom,
+            amount: Uint128::new(amount),
+        };
+        Ok(TransferFee { amount, recipient })
+    }
+}
+

--- a/cosmwasm/contracts/shutdown-wormhole/src/testing/mod.rs
+++ b/cosmwasm/contracts/shutdown-wormhole/src/testing/mod.rs
@@ -1,0 +1,1 @@
+mod tests;

--- a/cosmwasm/contracts/shutdown-wormhole/src/testing/tests.rs
+++ b/cosmwasm/contracts/shutdown-wormhole/src/testing/tests.rs
@@ -1,0 +1,162 @@
+use cosmwasm_std::StdResult;
+
+use crate::state::{GuardianAddress, GuardianSetInfo, ParsedVAA};
+
+#[test]
+fn quardian_set_quorum() {
+    let num_guardians_trials: Vec<usize> = vec![
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 20, 25, 100,
+    ];
+
+    let expected_quorums: Vec<usize> = vec![
+        1, 2, 3, 3, 4, 5, 5, 6, 7, 7, 8, 9, 14, 17, 67,
+    ];
+
+    let make_guardian_set = |n: usize| -> GuardianSetInfo {
+        let mut addresses = Vec::with_capacity(n);
+        for _ in 0..n {
+            addresses.push(
+                GuardianAddress {
+                    bytes: Vec::new().into(),
+                }
+            );
+        }
+        GuardianSetInfo {
+            addresses,
+            expiration_time: 0,
+        }
+    };
+
+    for (i, &num_guardians) in num_guardians_trials.iter().enumerate() {
+        let quorum = make_guardian_set(num_guardians).quorum();
+        assert_eq!(quorum, expected_quorums[i], "quorum != expected");
+    }
+}
+
+#[test]
+fn deserialize_round_1() -> StdResult<()> {
+    let signed_vaa = "\
+        080000000901007bfa71192f886ab6819fa4862e34b4d178962958d9b2e3d943\
+        7338c9e5fde1443b809d2886eaa69e0f0158ea517675d96243c9209c3fe1d94d\
+        5b19866654c6980000000b150000000500020001020304000000000000000000\
+        000000000000000000000000000000000000000000000000000a0261626364";
+    let signed_vaa = hex::decode(signed_vaa).unwrap();
+
+    let parsed = ParsedVAA::deserialize(signed_vaa.as_slice())?;
+
+    let version = 8u8;
+    assert_eq!(parsed.version, version, "parsed.version != expected");
+
+    let guardian_set_index = 9u32;
+    assert_eq!(parsed.guardian_set_index, guardian_set_index, "parsed.guardian_set_index != expected");
+
+    let timestamp = 2837u32;
+    assert_eq!(parsed.timestamp, timestamp, "parsed.timestamp != expected");
+
+    let nonce = 5u32;
+    assert_eq!(parsed.nonce, nonce, "parsed.nonce != expected");
+    
+    let len_signers = 1u8;
+    assert_eq!(parsed.len_signers, len_signers, "parsed.len_signers != expected");
+    
+    let emitter_chain = 2u16;
+    assert_eq!(parsed.emitter_chain, emitter_chain, "parsed.emitter_chain != expected");
+
+    let emitter_address = "0001020304000000000000000000000000000000000000000000000000000000";
+    let emitter_address = hex::decode(emitter_address).unwrap();
+    assert_eq!(parsed.emitter_address, emitter_address, "parsed.emitter_address != expected");
+
+    let sequence = 10u64;
+    assert_eq!(parsed.sequence, sequence, "parsed.sequence != expected");
+
+    let consistency_level = 2u8;
+    assert_eq!(parsed.consistency_level, consistency_level, "parsed.consistency_level != expected");
+
+    let payload = vec![97u8, 98u8, 99u8, 100u8];
+    assert_eq!(parsed.payload, payload, "parsed.payload != expected");
+
+    let hash = vec![
+        164u8,  44u8,  82u8, 103u8,  33u8, 170u8, 183u8, 178u8,
+        188u8, 204u8,  35u8,  53u8,  78u8, 148u8, 160u8, 153u8,
+        122u8, 252u8,  84u8, 211u8,  26u8, 204u8, 128u8, 215u8,
+         37u8, 232u8, 222u8, 186u8, 222u8, 186u8,  98u8,  94u8,
+    ];
+    assert_eq!(parsed.hash, hash, "parsed.hash != expected");
+
+    Ok(())
+}
+
+#[test]
+fn deserialize_round_2() -> StdResult<()> {
+    let signed_vaa = "\
+        010000000001003f3179d5bb17b6f2ecc13741ca3f78d922043e99e09975e390\
+        4332d2418bb3f16d7ac93ca8401f8bed1cf9827bc806ecf7c5a283340f033bf4\
+        72724abf1d274f00000000000000000000010000000000000000000000000000\
+        00000000000000000000000000000000ffff0000000000000000000100000000\
+        00000000000000000000000000000000000000000000000005f5e10001000000\
+        0000000000000000000000000000000000000000000000007575736400030000\
+        00000000000000000000f7f7dde848e7450a029cd0a9bd9bdae4b5147db30003\
+        00000000000000000000000000000000000000000000000000000000000f4240";
+    let signed_vaa = hex::decode(signed_vaa).unwrap();
+
+    let parsed = ParsedVAA::deserialize(signed_vaa.as_slice())?;
+
+    let version = 1u8;
+    assert_eq!(parsed.version, version, "parsed.version != expected");
+
+    let guardian_set_index = 0u32;
+    assert_eq!(parsed.guardian_set_index, guardian_set_index, "parsed.guardian_set_index != expected");
+
+    let timestamp = 0u32;
+    assert_eq!(parsed.timestamp, timestamp, "parsed.timestamp != expected");
+
+    let nonce = 0u32;
+    assert_eq!(parsed.nonce, nonce, "parsed.nonce != expected");
+    
+    let len_signers = 1u8;
+    assert_eq!(parsed.len_signers, len_signers, "parsed.len_signers != expected");
+    
+    let emitter_chain = 1u16;
+    assert_eq!(parsed.emitter_chain, emitter_chain, "parsed.emitter_chain != expected");
+
+    let emitter_address = "000000000000000000000000000000000000000000000000000000000000ffff";
+    let emitter_address = hex::decode(emitter_address).unwrap();
+    assert_eq!(parsed.emitter_address, emitter_address, "parsed.emitter_address != expected");
+    
+    let sequence = 0u64;
+    assert_eq!(parsed.sequence, sequence, "parsed.sequence != expected");
+
+    let consistency_level = 0u8;
+    assert_eq!(parsed.consistency_level, consistency_level, "parsed.consistency_level != expected");
+
+    let payload = vec![
+          1u8,   0u8,   0u8,   0u8,   0u8,   0u8,   0u8,   0u8,
+          0u8,   0u8,   0u8,   0u8,   0u8,   0u8,   0u8,   0u8,
+          0u8,   0u8,   0u8,   0u8,   0u8,   0u8,   0u8,   0u8,
+          0u8,   0u8,   0u8,   0u8,   0u8,   5u8, 245u8, 225u8,
+          0u8,   1u8,   0u8,   0u8,   0u8,   0u8,   0u8,   0u8,
+          0u8,   0u8,   0u8,   0u8,   0u8,   0u8,   0u8,   0u8,
+          0u8,   0u8,   0u8,   0u8,   0u8,   0u8,   0u8,   0u8,
+          0u8,   0u8,   0u8,   0u8,   0u8, 117u8, 117u8, 115u8,
+        100u8,   0u8,   3u8,   0u8,   0u8,   0u8,   0u8,   0u8,
+          0u8,   0u8,   0u8,   0u8,   0u8,   0u8,   0u8, 247u8,
+        247u8, 221u8, 232u8,  72u8, 231u8,  69u8,  10u8,   2u8,
+        156u8, 208u8, 169u8, 189u8, 155u8, 218u8, 228u8, 181u8,
+         20u8, 125u8, 179u8,   0u8,   3u8,   0u8,   0u8,   0u8,
+          0u8,   0u8,   0u8,   0u8,   0u8,   0u8,   0u8,   0u8,
+          0u8,   0u8,   0u8,   0u8,   0u8,   0u8,   0u8,   0u8,
+          0u8,   0u8,   0u8,   0u8,   0u8,   0u8,   0u8,   0u8,
+          0u8,   0u8,  15u8,  66u8,  64u8,
+    ];
+    assert_eq!(parsed.payload, payload, "parsed.payload != expected");
+
+    let hash = vec![
+        114u8, 108u8, 111u8,  78u8, 204u8,  83u8, 150u8, 170u8,
+        240u8,  15u8, 193u8, 176u8, 165u8,  87u8, 174u8, 230u8,
+         94u8, 222u8, 106u8, 206u8, 179u8, 203u8, 193u8, 187u8,
+          1u8, 148u8,  17u8,  40u8, 248u8, 214u8, 147u8,  68u8,
+    ];
+    assert_eq!(parsed.hash, hash, "parsed.hash != expected");
+
+    Ok(())
+}

--- a/cosmwasm/contracts/shutdown-wormhole/tests/integration.rs
+++ b/cosmwasm/contracts/shutdown-wormhole/tests/integration.rs
@@ -1,0 +1,82 @@
+use cosmwasm_std::{
+    from_slice,
+    testing::{
+        mock_dependencies,
+        mock_env,
+        mock_info,
+        MockApi,
+        MockQuerier,
+        MockStorage,
+    },
+    Coin,
+    OwnedDeps,
+    Response,
+    Storage,
+};
+use cosmwasm_storage::to_length_prefixed;
+
+use wormhole::{
+    contract::instantiate,
+    msg::InstantiateMsg,
+    state::{
+        ConfigInfo,
+        GuardianAddress,
+        GuardianSetInfo,
+        CONFIG_KEY,
+    },
+};
+
+use hex;
+
+static INITIALIZER: &str = "initializer";
+static GOV_ADDR: &[u8] = b"GOVERNANCE_ADDRESS";
+
+fn get_config_info<S: Storage>(storage: &S) -> ConfigInfo {
+    let key = to_length_prefixed(CONFIG_KEY);
+    let data = storage.get(&key).expect("data should exist");
+    from_slice(&data).expect("invalid data")
+}
+
+fn do_init(guardians: &[GuardianAddress]) -> OwnedDeps<MockStorage, MockApi, MockQuerier> {
+    let mut deps = mock_dependencies();
+    let init_msg = InstantiateMsg {
+        gov_chain: 0,
+        gov_address: GOV_ADDR.into(),
+        initial_guardian_set: GuardianSetInfo {
+            addresses: guardians.to_vec(),
+            expiration_time: 100,
+        },
+        guardian_set_expirity: 50,
+        chain_id: 18,
+        fee_denom: "uluna".to_string(),
+    };
+    let env = mock_env();
+    let info = mock_info(INITIALIZER, &[]);
+    let res: Response = instantiate(deps.as_mut(), env, info, init_msg).unwrap();
+    assert_eq!(0, res.messages.len());
+
+    // query the store directly
+    assert_eq!(
+        get_config_info(&deps.storage),
+        ConfigInfo {
+            guardian_set_index: 0,
+            guardian_set_expirity: 50,
+            gov_chain: 0,
+            gov_address: GOV_ADDR.to_vec(),
+            fee: Coin::new(0, "uluna"),
+            chain_id: 18,
+            fee_denom: "uluna".to_string(),
+        }
+    );
+    deps
+}
+
+#[test]
+fn init_works() {
+    let guardians = [GuardianAddress::from(GuardianAddress {
+        bytes: hex::decode("beFA429d57cD18b7F8A4d91A2da9AB4AF05d0FBe")
+            .expect("Decoding failed")
+            .into(),
+    })];
+    let _deps = do_init(&guardians);
+}

--- a/cosmwasm/contracts/token-bridge/src/contract.rs
+++ b/cosmwasm/contracts/token-bridge/src/contract.rs
@@ -89,7 +89,6 @@ use crate::{
         bridge_deposit,
         config,
         config_read,
-        config_read_legacy,
         is_wrapped_asset,
         is_wrapped_asset_read,
         receive_native,
@@ -102,7 +101,6 @@ use crate::{
         Action,
         AssetMeta,
         ConfigInfo,
-        ConfigInfoLegacy,
         RegisterChain,
         TokenBridgeMessage,
         TransferInfo,
@@ -135,44 +133,7 @@ pub enum TransferType<A> {
 /// Ok(Response::default())
 /// ```
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> StdResult<Response> {
-    // This migration adds a new field to the [`ConfigInfo`] struct. The
-    // state stored on chain has the old version, so we first parse it as
-    // [`ConfigInfoLegacy`], then add the new fields, and write it back as [`ConfigInfo`].
-    // Since the only place the contract with the legacy state is deployed is
-    // terra2, we just hardcode the new value here for that chain.
-
-    // 1. make sure this contract doesn't already have the new ConfigInfo struct
-    // in storage. Note that this check is not strictly necessary, as the
-    // upgrade will only be issued for terra2, and no new chains. However, it is
-    // good practice to ensure that migration code cannot be run twice, which
-    // this check achieves.
-    if config_read(deps.storage).load().is_ok() {
-        return Err(StdError::generic_err(
-            "Can't migrate; this contract already has a new ConfigInfo struct",
-        ));
-    }
-
-    // 2. parse old state
-    let ConfigInfoLegacy {
-        gov_chain,
-        gov_address,
-        wormhole_contract,
-        wrapped_asset_code_id,
-    } = config_read_legacy(deps.storage).load()?;
-
-    // 3. store new state with terra2 values hardcoded
-    let chain_id = 18;
-
-    let config_info = ConfigInfo {
-        gov_chain,
-        gov_address,
-        wormhole_contract,
-        wrapped_asset_code_id,
-        chain_id,
-    };
-
-    config(deps.storage).save(&config_info)?;
+pub fn migrate(_deps: DepsMut, _env: Env, _msg: MigrateMsg) -> StdResult<Response> {
     Ok(Response::default())
 }
 

--- a/cosmwasm/contracts/wormhole/src/contract.rs
+++ b/cosmwasm/contracts/wormhole/src/contract.rs
@@ -37,7 +37,6 @@ use crate::{
     state::{
         config,
         config_read,
-        config_read_legacy,
         guardian_set_get,
         guardian_set_set,
         sequence_read,
@@ -45,7 +44,6 @@ use crate::{
         vaa_archive_add,
         vaa_archive_check,
         ConfigInfo,
-        ConfigInfoLegacy,
         ContractUpgrade,
         GovernancePacket,
         GuardianAddress,
@@ -91,53 +89,8 @@ const FEE_AMOUNT: u128 = 0;
 /// Ok(Response::default())
 /// ```
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> StdResult<Response> {
-    // This migration adds two new fields to the [`ConfigInfo`] struct. The
-    // state stored on chain has the old version, so we first parse it as
-    // [`ConfigInfoLegacy`], then add the new fields, and write it back as [`ConfigInfo`].
-    // Since the only place the contract with the legacy state is deployed is
-    // terra2, we just hardcode the new values here for that chain.
-
-    // 1. make sure this contract doesn't already have the new ConfigInfo struct
-    // in storage. Note that this check is not strictly necessary, as the
-    // upgrade will only be issued for terra2, and no new chains. However, it is
-    // good practice to ensure that migration code cannot be run twice, which
-    // this check achieves.
-    if config_read(deps.storage).load().is_ok() {
-        return Err(StdError::generic_err(
-            "Can't migrate; this contract already has a new ConfigInfo struct",
-        ));
-    }
-
-    // 2. parse old state
-    let ConfigInfoLegacy {
-        guardian_set_index,
-        guardian_set_expirity,
-        gov_chain,
-        gov_address,
-        fee,
-    } = config_read_legacy(deps.storage).load()?;
-
-    // 3. store new state with terra2 values hardcoded
-    let chain_id = 18;
-    let fee_denom = "uluna".to_string();
-
-    let config_info = ConfigInfo {
-        guardian_set_index,
-        guardian_set_expirity,
-        gov_chain,
-        gov_address,
-        fee,
-        chain_id,
-        fee_denom,
-    };
-
-    config(deps.storage).save(&config_info)?;
+pub fn migrate(_deps: DepsMut, _env: Env, _msg: MigrateMsg) -> StdResult<Response> {
     Ok(Response::default())
-    // NOTE: once this migration has successfully completed, the contents of
-    // this (`migrate`) function should be deleted, along with the
-    // [`ConfigInfoLegacy`] struct, since it will not be necessary in the
-    // future.
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/cosmwasm/tools/deploy.js
+++ b/cosmwasm/tools/deploy.js
@@ -20,6 +20,8 @@ const artifacts = [
   "cw20_wrapped_2.wasm",
   "cw20_base.wasm",
   "mock_bridge_integration_2.wasm",
+  "shutdown_wormhole.wasm",
+  "shutdown_token_bridge_terra_2.wasm",
 ];
 
 /* Check that the artifact folder contains all the wasm files we expect and nothing else */

--- a/near/devnet_deploy.ts
+++ b/near/devnet_deploy.ts
@@ -81,7 +81,7 @@ async function initNear() {
       let resp = await masterAccount.createAccount(
           "devnet.test.near",
           da.publicKey,
-          new BN(10).pow(new BN(25))
+          new BN(10).pow(new BN(27))
       );
 
       console.log("devnet.test.near funded");


### PR DESCRIPTION
Added shutdown contracts and remove migrate functionality.
Basically, copied the wormhole and token bridge contracts and stripped out functionality.
You might be better off diff'ing the shutdown contracts with the base contracts to see what was removed.  
A directory diff would work well.