### PR TITLE
sdk/js - add getSignedBatchVAA and bump version

### DIFF
--- a/sdk/js/package-lock.json
+++ b/sdk/js/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@certusone/wormhole-sdk",
-  "version": "0.6.1",
+  "version": "0.6.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@certusone/wormhole-sdk",
-      "version": "0.6.1",
+      "version": "0.6.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@certusone/wormhole-sdk-proto-web": "^0.0.3",
+        "@certusone/wormhole-sdk-proto-web": "^0.0.5",
         "@certusone/wormhole-sdk-wasm": "^0.0.1",
         "@solana/spl-token": "^0.1.8",
         "@solana/web3.js": "^1.24.0",
@@ -641,9 +641,9 @@
       "dev": true
     },
     "node_modules/@certusone/wormhole-sdk-proto-web": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk-proto-web/-/wormhole-sdk-proto-web-0.0.3.tgz",
-      "integrity": "sha512-O8gx8dLTcgF5jbmWjRiyZAn1LozslhWqDo6Q6QJfRiL6DWySV5TOXqgaEfQ4UGEM4uqM76HWZpwfEWUjaRhJ/A==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk-proto-web/-/wormhole-sdk-proto-web-0.0.5.tgz",
+      "integrity": "sha512-shZo7FG2Idu2RCTBU4f4KXQpzmSgb4ymtstTQrCDmIG0NPhGfraDMjESqMHtPd+aCcLrEnq/k2JBIeUKb0ThvQ==",
       "dependencies": {
         "@improbable-eng/grpc-web": "^0.15.0",
         "protobufjs": "^7.0.0",
@@ -667,9 +667,9 @@
       "integrity": "sha512-9RTUNjK60eJbx3uz+TEGF7fUr29ZDxR5QzXcyDpeSfeH28S9ycINflOgOlppit5U+4kNTe83KQnMEerw7GmE8w=="
     },
     "node_modules/@certusone/wormhole-sdk-proto-web/node_modules/protobufjs": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.0.0.tgz",
-      "integrity": "sha512-ffNIEm+quOcYtQvHdW406v1NQmZSuqVklxsXk076BtuFnlYZfigLU+JOMrTD8TUOyqHYbRI/fSVNvgd25YeN3w==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.1.1.tgz",
+      "integrity": "sha512-d0nMQqS/aT3lfV8bKi9Gbg73vPd2LcDdTDOu6RE/M+h9DY8g1EmDzk3ADPccthEWfTBjkR2oxNdx9Gs8YubT+g==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -682,7 +682,6 @@
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.1",
         "@types/node": ">=13.7.0",
         "long": "^5.0.0"
       },
@@ -12190,9 +12189,9 @@
       "dev": true
     },
     "@certusone/wormhole-sdk-proto-web": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk-proto-web/-/wormhole-sdk-proto-web-0.0.3.tgz",
-      "integrity": "sha512-O8gx8dLTcgF5jbmWjRiyZAn1LozslhWqDo6Q6QJfRiL6DWySV5TOXqgaEfQ4UGEM4uqM76HWZpwfEWUjaRhJ/A==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk-proto-web/-/wormhole-sdk-proto-web-0.0.5.tgz",
+      "integrity": "sha512-shZo7FG2Idu2RCTBU4f4KXQpzmSgb4ymtstTQrCDmIG0NPhGfraDMjESqMHtPd+aCcLrEnq/k2JBIeUKb0ThvQ==",
       "requires": {
         "@improbable-eng/grpc-web": "^0.15.0",
         "protobufjs": "^7.0.0",
@@ -12213,9 +12212,9 @@
           "integrity": "sha512-9RTUNjK60eJbx3uz+TEGF7fUr29ZDxR5QzXcyDpeSfeH28S9ycINflOgOlppit5U+4kNTe83KQnMEerw7GmE8w=="
         },
         "protobufjs": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.0.0.tgz",
-          "integrity": "sha512-ffNIEm+quOcYtQvHdW406v1NQmZSuqVklxsXk076BtuFnlYZfigLU+JOMrTD8TUOyqHYbRI/fSVNvgd25YeN3w==",
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.1.1.tgz",
+          "integrity": "sha512-d0nMQqS/aT3lfV8bKi9Gbg73vPd2LcDdTDOu6RE/M+h9DY8g1EmDzk3ADPccthEWfTBjkR2oxNdx9Gs8YubT+g==",
           "requires": {
             "@protobufjs/aspromise": "^1.1.2",
             "@protobufjs/base64": "^1.1.2",
@@ -12227,7 +12226,6 @@
             "@protobufjs/path": "^1.1.2",
             "@protobufjs/pool": "^1.1.0",
             "@protobufjs/utf8": "^1.1.0",
-            "@types/long": "^4.0.1",
             "@types/node": ">=13.7.0",
             "long": "^5.0.0"
           }

--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@certusone/wormhole-sdk",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "SDK for interacting with Wormhole",
   "homepage": "https://wormhole.com",
   "main": "./lib/cjs/index.js",
@@ -56,7 +56,7 @@
     "web3": "^1.6.1"
   },
   "dependencies": {
-    "@certusone/wormhole-sdk-proto-web": "^0.0.3",
+    "@certusone/wormhole-sdk-proto-web": "^0.0.5",
     "@certusone/wormhole-sdk-wasm": "^0.0.1",
     "@solana/spl-token": "^0.1.8",
     "@solana/web3.js": "^1.24.0",

--- a/sdk/js/src/rpc/getSignedBatchVAA.ts
+++ b/sdk/js/src/rpc/getSignedBatchVAA.ts
@@ -1,0 +1,19 @@
+import { ChainId, ChainName, coalesceChainId } from "../utils/consts";
+import { publicrpc } from "@certusone/wormhole-sdk-proto-web";
+const { GrpcWebImpl, PublicRPCServiceClientImpl } = publicrpc;
+
+export async function getSignedBatchVAA(
+  host: string,
+  emitterChain: ChainId | ChainName,
+  transactionId: string,
+  extraGrpcOpts = {}
+) {
+  const rpc = new GrpcWebImpl(host, extraGrpcOpts);
+  const api = new PublicRPCServiceClientImpl(rpc);
+  return await api.GetSignedBatchVAA({
+    batchId: {
+      emitterChain: coalesceChainId(emitterChain),
+      txId: transactionId,
+    },
+  });
+}

--- a/sdk/js/src/rpc/getSignedBatchVAAWithRetry.ts
+++ b/sdk/js/src/rpc/getSignedBatchVAAWithRetry.ts
@@ -1,0 +1,35 @@
+import { ChainId, ChainName, getSignedBatchVAA } from "..";
+import { coalesceChainId } from "../utils";
+
+export async function getSignedBatchVAAWithRetry(
+  hosts: string[],
+  emitterChain: ChainId | ChainName,
+  transactionId: string,
+  extraGrpcOpts = {},
+  retryTimeout = 1000,
+  retryAttempts?: number
+) {
+  let currentWormholeRpcHost = -1;
+  const getNextRpcHost = () => ++currentWormholeRpcHost % hosts.length;
+  let result;
+  let attempts = 0;
+  while (!result) {
+    attempts++;
+    await new Promise((resolve) => setTimeout(resolve, retryTimeout));
+    try {
+      result = await getSignedBatchVAA(
+        hosts[getNextRpcHost()],
+        coalesceChainId(emitterChain),
+        transactionId,
+        extraGrpcOpts
+      );
+    } catch (e) {
+      if (retryAttempts !== undefined && attempts > retryAttempts) {
+        throw e;
+      }
+    }
+  }
+  return result;
+}
+
+export default getSignedBatchVAAWithRetry;

--- a/sdk/js/src/rpc/index.ts
+++ b/sdk/js/src/rpc/index.ts
@@ -1,4 +1,6 @@
 export * from "./getSignedVAA";
 export { getSignedVAAWithRetry } from "./getSignedVAAWithRetry";
+export * from "./getSignedBatchVAA";
+export { getSignedBatchVAAWithRetry } from "./getSignedBatchVAAWithRetry";
 export * from "./getGovernorIsVAAEnqueued";
 export * from "./getGovernorIsVAAEnqueuedWithRetry";


### PR DESCRIPTION
- Pulled in the latest version of `js-proto-web` that has the BatchVAA protos.
- Added new RPC methods `getSignedBatchVAA` & `getSignedBatchVAAWithRetry`.
- Bumped the version of the sdk.