### PR TITLE
spy_relayer: Enable docker-compose usage

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -439,8 +439,7 @@ if spy_relayer:
 
     docker_build(
         ref = "spy-relay-image",
-        context = ".",
-        only = ["./relayer/spy_relayer"],
+        context = "relayer/spy_relayer",
         dockerfile = "relayer/spy_relayer/Dockerfile",
         live_update = []
     )

--- a/devnet/spy-listener.yaml
+++ b/devnet/spy-listener.yaml
@@ -41,7 +41,7 @@ spec:
             - npm
             - run
             - --prefix
-            - /app/relayer/spy_relayer/
+            - /app
             - tilt_listener
           tty: true
           readinessProbe:

--- a/devnet/spy-relayer.yaml
+++ b/devnet/spy-relayer.yaml
@@ -41,7 +41,7 @@ spec:
             - npm
             - run
             - --prefix
-            - /app/relayer/spy_relayer/
+            - /app
             - tilt_relayer
           ports:
             - containerPort: 8083

--- a/devnet/spy-wallet-monitor.yaml
+++ b/devnet/spy-wallet-monitor.yaml
@@ -41,7 +41,7 @@ spec:
             - npm
             - run
             - --prefix
-            - /app/relayer/spy_relayer/
+            - /app
             - tilt_wallet_monitor
           ports:
             - containerPort: 8084

--- a/relayer/spy_relayer/.dockerignore
+++ b/relayer/spy_relayer/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/relayer/spy_relayer/.env.docker.sample
+++ b/relayer/spy_relayer/.env.docker.sample
@@ -1,0 +1,14 @@
+SUPPORTED_CHAINS=[{"chainId":1,"chainName":"Solana","nodeUrl":"http://localhost:8899","nativeCurrencySymbol":"SOL","tokenBridgeAddress":"B6RHG3mfcckmrYN1UhmJzyS1XX3fZKbkeUcpJe9Sy3FE","bridgeAddress":"Bridge1p5gheXUvJ6jGWGeCsgPKgnE3YgdGKRVCMY9o","wrappedAsset":"So11111111111111111111111111111111111111112"},{"chainId":2,"chainName":"ETH","nativeCurrencySymbol":"ETH","nodeUrl":"http://localhost:8545","tokenBridgeAddress":"0x0290FB167208Af455bB137780163b7B7a9a10C16","wrappedAsset":"0xDDb64fE46a91D46ee29420539FC25FD07c5FEa3E"},{"chainId":3,"chainName":"Terra","isTerraClassic":true,"nativeCurrencySymbol":"LUNA","nodeUrl":"http://localhost:1317","tokenBridgeAddress":"terra10pyejy66429refv3g35g2t7am0was7ya7kz2a4","terraName":"localterra","terraChainId":"localterra","terraCoin":"uluna","terraGasPriceUrl":"http://localhost:3060/v1/txs/gas_prices"},{"chainId":4,"chainName":"BSC","nativeCurrencySymbol":"BNB","nodeUrl":"http://localhost:8545","tokenBridgeAddress":"0x0290FB167208Af455bB137780163b7B7a9a10C16","wrappedAsset":"0xDDb64fE46a91D46ee29420539FC25FD07c5FEa3E"}]
+REDIS_HOST=redis
+REDIS_PORT=6379
+PROM_PORT=8083
+REST_PORT=4201
+READINESS_PORT=2000
+CLEAR_REDIS_ON_INIT=true
+DEMOTE_WORKING_ON_INIT=true
+LOG_LEVEL=debug
+SUPPORTED_TOKENS=[{"chainId":1,"address":"So11111111111111111111111111111111111111112"},{"chainId":1,"address":"2WDq7wSs9zYrpx2kbHDA4RUTRch2CCTP6ZWaH4GNfnQQ"},{"chainId":2,"address":"0xDDb64fE46a91D46ee29420539FC25FD07c5FEa3E"},{"chainId":2,"address":"0x2D8BE6BF0baA74e0A907016679CaE9190e80dD0A"},{"chainId":3,"address":"uluna"},{"chainId":4,"address":"0xDDb64fE46a91D46ee29420539FC25FD07c5FEa3E"}]
+PRIVATE_KEYS=[{"chainId":1,"privateKeys":[[14,173,153,4,176,224,201,111,32,237,183,185,159,247,22,161,89,84,215,209,212,137,10,92,157,49,29,192,101,164,152,70,87,65,8,174,214,157,175,126,98,90,54,24,100,177,247,77,19,112,47,44,165,109,233,102,14,86,109,29,134,145,132,141]]},{"chainId":2,"privateKeys":["0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d"]},{"chainId":3,"privateKeys":["notice oak worry limit wrap speak medal online prefer cluster roof addict wrist behave treat actual wasp year salad speed social layer crew genius"]},{"chainId":4,"privateKeys":["0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d"]}]
+SPY_SERVICE_HOST=guardian-spy:7073
+SPY_SERVICE_FILTERS=[{"chainId":1,"emitterAddress":"B6RHG3mfcckmrYN1UhmJzyS1XX3fZKbkeUcpJe9Sy3FE"},{"chainId":2,"emitterAddress":"0x0290FB167208Af455bB137780163b7B7a9a10C16"},{"chainId":3,"emitterAddress":"terra10pyejy66429refv3g35g2t7am0was7ya7kz2a4"},{"chainId":4,"emitterAddress":"0x0290FB167208Af455bB137780163b7B7a9a10C16"}]
+SPY_NUM_WORKERS=5

--- a/relayer/spy_relayer/Dockerfile
+++ b/relayer/spy_relayer/Dockerfile
@@ -14,7 +14,7 @@ COPY package-lock.json package-lock.json
 COPY tsconfig.json tsconfig.json
 COPY jestconfig.json jestconfig.json
 
-FROM base as builder
+FROM base AS builder
 
 RUN --mount=type=cache,target=/root/.npm \
     npm ci
@@ -22,12 +22,15 @@ RUN --mount=type=cache,target=/root/.npm \
 COPY src src
 RUN npm run build && npm prune --production
 
-FROM base as application
+FROM base AS application
 
 LABEL org.opencontainers.image.source="https://github.com/wormhole-foundation/wormhole/tree/dev.v2/relayer/spy_relayer#readme"
 
 COPY --from=builder /app/node_modules node_modules
 COPY --from=builder /app/lib lib
+COPY .env.tilt.listener /app/
+COPY .env.tilt.relayer /app/
+COPY .env.tilt.wallet-monitor /app/
 
 CMD [ "node", "lib/main.js" ]
 

--- a/relayer/spy_relayer/Dockerfile
+++ b/relayer/spy_relayer/Dockerfile
@@ -14,8 +14,6 @@ COPY . .
 
 LABEL org.opencontainers.image.source="https://github.com/wormhole-foundation/wormhole/tree/dev.v2/relayer/spy_relayer#readme"
 
-WORKDIR ./relayer/spy_relayer
-
 RUN npm ci && \
     npm run build
 

--- a/relayer/spy_relayer/Dockerfile
+++ b/relayer/spy_relayer/Dockerfile
@@ -1,21 +1,35 @@
 # syntax=docker.io/docker/dockerfile:1.3@sha256:42399d4635eddd7a9b8a24be879d2f9a930d0ed040a61324cfdf59ef1357b3b2
 
-FROM node:lts-alpine3.15@sha256:a2c7f8ebdec79619fba306cec38150db44a45b48380d09603d3602139c5a5f92
+FROM node:lts-alpine3.15@sha256:a2c7f8ebdec79619fba306cec38150db44a45b48380d09603d3602139c5a5f92 as base
 
 RUN mkdir -p /app
 WORKDIR /app
 
 RUN apk add python3 \
-        make \
-        g++ 
+    make \
+    g++
 
-COPY . .
+COPY package.json package.json
+COPY package-lock.json package-lock.json
+COPY tsconfig.json tsconfig.json
+COPY jestconfig.json jestconfig.json
 
+FROM base as builder
+
+RUN --mount=type=cache,target=/root/.npm \
+    npm ci
+
+COPY src src
+RUN npm run build && npm prune --production
+
+FROM base as application
 
 LABEL org.opencontainers.image.source="https://github.com/wormhole-foundation/wormhole/tree/dev.v2/relayer/spy_relayer#readme"
 
-RUN npm ci && \
-    npm run build
+COPY --from=builder /app/node_modules node_modules
+COPY --from=builder /app/lib lib
+
+CMD [ "node", "lib/main.js" ]
 
 #TODO don't hardcode for tilt but accept env file
 # RUN --mount=type=cache,uid=1000,gid=1000,target=/home/node/.npm \

--- a/relayer/spy_relayer/docker-compose.yml
+++ b/relayer/spy_relayer/docker-compose.yml
@@ -1,0 +1,29 @@
+version: "3.5"
+
+services:
+  redis:
+    image: redis:7.0
+    command: redis-server --save 60 1 --loglevel warning
+    volumes:
+      - redis-data:/data
+
+  guardian-spy:
+    image: ghcr.io/wormhole-foundation/guardiand:dev.v2
+    entrypoint: /guardiand
+    command: ${GUARDIAN_SPY_COMMAND:-spy --nodeKey /node.key --spyRPC "[::]:7073" --network /wormhole/testnet/2/1 --bootstrap /dns4/wormhole-testnet-v2-bootstrap.certus.one/udp/8999/quic/p2p/12D3KooWBY9ty9CXLBXGQzMuqkziLntsVcyz4pk1zWaJRvJn6Mmt}
+
+  spy-relayer:
+    build:
+      context: .
+    image: wormhole-relayer:latest
+    command: ${SPY_RELAYER_COMMAND:-npm run spy_relay}
+    environment:
+      - SPY_RELAY_CONFIG=/app/.env.docker.sample
+    ports:
+      - 8083:8083
+      - 4201:4201
+    volumes:
+      - .env.docker.sample:/app/.env.docker.sample
+
+volumes:
+  redis-data:

--- a/relayer/spy_relayer/docker-compose.yml
+++ b/relayer/spy_relayer/docker-compose.yml
@@ -15,7 +15,8 @@ services:
   spy-relayer:
     build:
       context: .
-    image: wormhole-relayer:latest
+      target: application
+    image: wormhole-relayer:dev.v2
     command: ${SPY_RELAYER_COMMAND:-npm run spy_relay}
     environment:
       - SPY_RELAY_CONFIG=/app/.env.docker.sample

--- a/scripts/check-docker-pin.sh
+++ b/scripts/check-docker-pin.sh
@@ -11,7 +11,7 @@
 #   - We ignore scratch because it's literally the docker base image
 #   - We ignore solana AS (builder|ci_tests) because it's a relative reference to another FROM call
 #
-git ls-files | grep "Dockerfile*" | xargs grep -s "FROM" | egrep -v 'sha256|scratch|solana|aptos AS (builder|ci_tests|tests)'
+git ls-files | grep "Dockerfile*" | xargs grep -s "FROM" | egrep -v 'sha256|scratch|solana|aptos|base AS (application|base|builder|ci_tests|tests)'
 if [ $? -eq 0 ]; then
    echo "[!] Unpinned docker files" >&2
    exit 1


### PR DESCRIPTION
This PR enables spy_relayer stack to be run using docker-compose.

For basic usage, you just run `docker-compose up` and it will run the whole stack written on README.md.

https://github.com/wormhole-foundation/wormhole/tree/dev.v2/relayer/spy_relayer#run-the-apps