### PR TITLE
aptos: prove

### DIFF
--- a/aptos/token_bridge/sources/contract_upgrade.move
+++ b/aptos/token_bridge/sources/contract_upgrade.move
@@ -13,13 +13,13 @@
 /// upgraded to for whatever reason, the governance VAA won't be possible to
 /// replay in the future, since the commit transaction replay protects it.
 module token_bridge::contract_upgrade {
-    use std::aptos_hash;
     use std::vector;
     use aptos_framework::code;
     use wormhole::deserialize;
     use wormhole::cursor;
     use wormhole::vaa;
     use wormhole::state as core;
+    use wormhole::keccak256::keccak256;
 
     use token_bridge::vaa as token_bridge_vaa;
     use token_bridge::state;
@@ -106,7 +106,7 @@ module token_bridge::contract_upgrade {
         vector::reverse(&mut c);
         let a = vector::empty<u8>();
         while (!vector::is_empty(&c)) vector::append(&mut a, vector::pop_back(&mut c));
-        assert!(aptos_hash::keccak256(a) == hash, E_UNEXPECTED_HASH);
+        assert!(keccak256(a) == hash, E_UNEXPECTED_HASH);
 
         let token_bridge = state::token_bridge_signer();
         code::publish_package_txn(&token_bridge, metadata_serialized, code);

--- a/aptos/token_bridge/sources/newtypes/string32.move
+++ b/aptos/token_bridge/sources/newtypes/string32.move
@@ -18,6 +18,10 @@ module token_bridge::string32 {
        string: String
     }
 
+    spec String32 {
+        invariant string::length(string) == 32;
+    }
+
     /// Right-pads a `String` to a `String32` with 0 bytes.
     /// Aborts if the string is longer than 32 bytes.
     public fun right_pad(s: &String): String32 {
@@ -25,7 +29,12 @@ module token_bridge::string32 {
         assert!(length <= 32, E_STRING_TOO_LONG);
         let string = *string::bytes(s);
         let zeros = 32 - length;
-        while (zeros > 0) {
+        while ({
+            spec {
+                invariant zeros + vector::length(string) == 32;
+            };
+            zeros > 0
+        }) {
             vector::push_back(&mut string, 0);
             zeros = zeros - 1;
         };

--- a/aptos/wormhole/sources/contract_upgrade.move
+++ b/aptos/wormhole/sources/contract_upgrade.move
@@ -13,13 +13,13 @@
 /// upgraded to for whatever reason, the governance VAA won't be possible to
 /// replay in the future, since the commit transaction replay protects it.
 module wormhole::contract_upgrade {
-    use std::aptos_hash;
     use std::vector;
     use aptos_framework::code;
     use wormhole::deserialize;
     use wormhole::cursor;
     use wormhole::vaa;
     use wormhole::state;
+    use wormhole::keccak256::keccak256;
 
     /// "Core" (left padded)
     const CORE: vector<u8> = x"00000000000000000000000000000000000000000000000000000000436f7265";
@@ -105,7 +105,7 @@ module wormhole::contract_upgrade {
         vector::reverse(&mut c);
         let a = vector::empty<u8>();
         while (!vector::is_empty(&c)) vector::append(&mut a, vector::pop_back(&mut c));
-        assert!(aptos_hash::keccak256(a) == hash, E_UNEXPECTED_HASH);
+        assert!(keccak256(a) == hash, E_UNEXPECTED_HASH);
 
         let wormhole = state::wormhole_signer();
         code::publish_package_txn(&wormhole, metadata_serialized, code);

--- a/aptos/wormhole/sources/deserialize.move
+++ b/aptos/wormhole/sources/deserialize.move
@@ -14,7 +14,7 @@ module wormhole::deserialize {
         let i = 0;
         while (i < 2) {
             let b = cursor::poke(cur);
-            res = (res << 8) | (b as u64);
+            res = (res << 8) + (b as u64);
             i = i + 1;
         };
         u16::from_u64(res)
@@ -25,7 +25,7 @@ module wormhole::deserialize {
         let i = 0;
         while (i < 4) {
             let b = cursor::poke(cur);
-            res = (res << 8) | (b as u64);
+            res = (res << 8) + (b as u64);
             i = i + 1;
         };
         u32::from_u64(res)
@@ -36,7 +36,7 @@ module wormhole::deserialize {
         let i = 0;
         while (i < 8) {
             let b = cursor::poke(cur);
-            res = (res << 8) | (b as u64);
+            res = (res << 8) + (b as u64);
             i = i + 1;
         };
         res
@@ -47,7 +47,7 @@ module wormhole::deserialize {
         let i = 0;
         while (i < 16) {
             let b = cursor::poke(cur);
-            res = (res << 8) | (b as u128);
+            res = (res << 8) + (b as u128);
             i = i + 1;
         };
         res

--- a/aptos/wormhole/sources/guardian_pubkey.move
+++ b/aptos/wormhole/sources/guardian_pubkey.move
@@ -8,8 +8,8 @@ module wormhole::guardian_pubkey {
         ecdsa_raw_public_key_to_bytes,
         ecdsa_recover,
     };
-    use 0x1::aptos_hash;
     use 0x1::vector;
+    use wormhole::keccak256::keccak256;
 
     /// An error occurred while deserializing, for example due to wrong input size.
     const E_DESERIALIZE: u64 = 1;
@@ -28,7 +28,7 @@ module wormhole::guardian_pubkey {
     /// Computes the address from a 64 byte public key.
     public fun from_pubkey(pubkey: &ECDSARawPublicKey): Address {
         let bytes = ecdsa_raw_public_key_to_bytes(pubkey);
-        let hash = aptos_hash::keccak256(bytes);
+        let hash = keccak256(bytes);
         let address = vector::empty<u8>();
         let i = 0;
         while (i < 20) {

--- a/aptos/wormhole/sources/keccak256.move
+++ b/aptos/wormhole/sources/keccak256.move
@@ -1,0 +1,16 @@
+module wormhole::keccak256 {
+    use aptos_framework::aptos_hash;
+
+    spec module {
+        pragma verify=false;
+    }
+
+    public fun keccak256(bytes: vector<u8>): vector<u8> {
+        aptos_hash::keccak256(bytes)
+    }
+
+    spec keccak256 {
+        pragma opaque;
+    }
+
+}

--- a/aptos/wormhole/sources/u16.move
+++ b/aptos/wormhole/sources/u16.move
@@ -24,8 +24,8 @@ module wormhole::u16 {
 
     public fun split_u8(number: U16): (u8, u8) {
         let U16 { number } = number;
-        let v0: u8 = (number >> 8 & 0xFF as u8);
-        let v1: u8 = (number & 0xFF as u8);
+        let v0: u8 = ((number >> 8) % (0xFF + 1) as u8);
+        let v1: u8 = (number        % (0xFF + 1) as u8);
         (v0, v1)
     }
 

--- a/aptos/wormhole/sources/u32.move
+++ b/aptos/wormhole/sources/u32.move
@@ -24,10 +24,10 @@ module wormhole::u32 {
 
     public fun split_u8(number: U32): (u8, u8, u8, u8) {
         let U32 { number } = number;
-        let v0: u8 = (number >> 24 & 0xFF as u8);
-        let v1: u8 = (number >> 16 & 0xFF as u8);
-        let v2: u8 = (number >> 8 & 0xFF as u8);
-        let v3: u8 = (number & 0xFF as u8);
+        let v0: u8 = ((number >> 24) % (0xFF + 1) as u8);
+        let v1: u8 = ((number >> 16) % (0xFF + 1) as u8);
+        let v2: u8 = ((number >> 8)  % (0xFF + 1) as u8);
+        let v3: u8 = (number         % (0xFF + 1) as u8);
         (v0, v1, v2, v3)
     }
 

--- a/aptos/wormhole/sources/vaa.move
+++ b/aptos/wormhole/sources/vaa.move
@@ -1,7 +1,6 @@
 module wormhole::vaa {
     use 0x1::vector;
     use 0x1::secp256k1;
-    use 0x1::aptos_hash;
 
     use wormhole::u16::{U16};
     use wormhole::u32::{U32};
@@ -19,6 +18,7 @@ module wormhole::vaa {
     };
     use wormhole::state;
     use wormhole::external_address::{Self, ExternalAddress};
+    use wormhole::keccak256::keccak256;
 
     friend wormhole::guardian_set_upgrade;
     friend wormhole::contract_upgrade;
@@ -80,7 +80,7 @@ module wormhole::vaa {
         };
 
         let body = cursor::rest(cur);
-        let hash = aptos_hash::keccak256(aptos_hash::keccak256(body));
+        let hash = keccak256(keccak256(body));
 
         let cur = cursor::init(body);
 

--- a/aptos/wormhole/sources/wormhole.move
+++ b/aptos/wormhole/sources/wormhole.move
@@ -131,8 +131,8 @@ module wormhole::wormhole {
 #[test_only]
 module wormhole::wormhole_test {
     use 0x1::hash;
-    use 0x1::aptos_hash;
     use wormhole::wormhole;
+    use wormhole::keccak256::keccak256;
     use aptos_framework::aptos_coin::{Self};
     use aptos_framework::coin;
 
@@ -152,7 +152,7 @@ module wormhole::wormhole_test {
     #[test]
     public fun test_hash() {
         assert!(hash::sha3_256(vector[0]) == x"5d53469f20fef4f8eab52b88044ede69c77a6a68a60728609fc4a65ff531e7d0", 0);
-        assert!(aptos_hash::keccak256(vector[0]) == x"bc36789e7a1e281436464229828f817d6612f7b477d66591ff96a9e064bcc98a", 0);
+        assert!(keccak256(vector[0]) == x"bc36789e7a1e281436464229828f817d6612f7b477d66591ff96a9e064bcc98a", 0);
     }
 
     #[test(aptos_framework = @aptos_framework)]


### PR DESCRIPTION
This PR sets up the code to support formal verification by the move prover. The prover can't reason about bitwise operations (and just bails when the project contains them), so I did some changes to replace them with supported numeric operations.

For now, there is a single invariant proven, namely that
```rust
    spec String32 {
        invariant string::length(string) == 32;
    }
```

i.e. that `String32` indeed always contains 32 characters. The prover neatly understands the semantics of move modules, and requires that each constructor of `String32` (and each mutable borrow in the `String32` module) holds this invariant. This required adding a loop invariant to `right_pad`.

Currently the prover doesn't get executed in CI, trying to think what the best way is to set it up, I've built a docker image that has all the dependencies in it, but it's 10G in size, so would like to shrink it before pushing it. Having installed the dependencies natively on macOS, the prover just hangs 🤷 