### PR TITLE
Fix race condition in test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,7 +133,7 @@ jobs:
 
       # The go-ethereum and celo-blockchain packages both implement secp256k1 using the exact same header, but that causes duplicate symbols.
       - name: Run golang tests
-        run: cd node && go test -v -ldflags '-extldflags "-Wl,--allow-multiple-definition" ' ./...
+        run: cd node && go test -v -race -ldflags '-extldflags "-Wl,--allow-multiple-definition" ' ./...
 
   # Run Rust lints and tests
   rust-lint-and-tests:

--- a/node/pkg/common/obsvReqSendC_test.go
+++ b/node/pkg/common/obsvReqSendC_test.go
@@ -14,7 +14,7 @@ func TestObsvReqSendLimitEnforced(t *testing.T) {
 	obsvReqSendC := make(chan *gossipv1.ObservationRequest, ObsvReqChannelSize)
 
 	// If the channel overflows, the write hangs, so use a go routine with a timeout.
-	done := false
+	done := make(chan struct{})
 	go func() {
 		// Filling the queue up should work.
 		for count := 1; count <= ObsvReqChannelSize; count++ {
@@ -32,11 +32,13 @@ func TestObsvReqSendLimitEnforced(t *testing.T) {
 		err := PostObservationRequest(obsvReqSendC, req)
 		assert.ErrorIs(t, err, ErrChanFull)
 
-		done = true
+		done <- struct{}{}
 	}()
 
-	time.Sleep(time.Second)
-
-	// Make sure we didn't hang.
-	assert.Equal(t, true, done)
+	timeout := time.NewTimer(time.Second)
+	select {
+	case <-timeout.C:
+		assert.Fail(t, "timed out")
+	case <-done:
+	}
 }


### PR DESCRIPTION
Fix a racy test and enable data race detection when running unit tests in CI.