### PR TITLE
node: prevent reobservation of unreliable messages

### DIFF
--- a/node/pkg/common/chainlock.go
+++ b/node/pkg/common/chainlock.go
@@ -21,6 +21,10 @@ type MessagePublication struct {
 	EmitterChain     vaa.ChainID
 	EmitterAddress   vaa.Address
 	Payload          []byte
+
+	// Unreliable indicates if this message can be reobserved. If a message is considered unreliable it cannot be
+	// reobserved.
+	Unreliable bool
 }
 
 func (msg *MessagePublication) MessageID() []byte {

--- a/node/pkg/processor/cleanup.go
+++ b/node/pkg/processor/cleanup.go
@@ -177,12 +177,19 @@ func (p *Processor) handleCleanup(ctx context.Context) {
 			aggregationStateTimeout.Inc()
 		case !s.submitted && delta.Minutes() >= 5:
 			// Poor observation has been unsubmitted for five minutes - clearly, something went wrong.
-			// If we have previously submitted an observation, we can make another attempt to get it over
-			// the finish line by sending a re-observation request to the network and rebroadcasting our
+			// If we have previously submitted an observation, and it was reliable, we can make another attempt to get
+			// it over the finish line by sending a re-observation request to the network and rebroadcasting our
 			// sig. If we do not have an observation, it means we either never observed it, or it got
 			// revived by a malfunctioning guardian node, in which case, we can't do anything about it
 			// and just delete it to keep our state nice and lean.
 			if s.ourMsg != nil {
+				// Unreliable observations cannot be resubmitted and can be considered failed after 5 minutes
+				if !s.ourObservation.IsReliable() {
+					p.logger.Info("expiring unsubmitted unreliable observation", zap.String("digest", hash), zap.Duration("delta", delta))
+					delete(p.state.signatures, hash)
+					aggregationStateTimeout.Inc()
+					break
+				}
 				p.logger.Info("resubmitting observation",
 					zap.String("digest", hash),
 					zap.Duration("delta", delta),

--- a/node/pkg/processor/message.go
+++ b/node/pkg/processor/message.go
@@ -80,6 +80,7 @@ func (p *Processor) handleMessage(ctx context.Context, k *common.MessagePublicat
 			Sequence:         k.Sequence,
 			ConsistencyLevel: k.ConsistencyLevel,
 		},
+		Unreliable: k.Unreliable,
 	}
 
 	// A governance message should never be emitted on-chain

--- a/node/pkg/processor/processor.go
+++ b/node/pkg/processor/processor.go
@@ -31,6 +31,8 @@ type (
 		// SigningMsg returns the hash of the signing body of the observation. This is used
 		// for signature generation and verification.
 		SigningMsg() ethcommon.Hash
+		// IsReliable returns whether this message is considered reliable meaning it can be reobserved.
+		IsReliable() bool
 		// HandleQuorum finishes processing the observation once a quorum of signatures have
 		// been received for it.
 		HandleQuorum(sigs []*vaa.Signature, hash string, p *Processor)

--- a/node/pkg/processor/vaa.go
+++ b/node/pkg/processor/vaa.go
@@ -9,6 +9,7 @@ import (
 
 type VAA struct {
 	vaa.VAA
+	Unreliable bool
 }
 
 func (v *VAA) HandleQuorum(sigs []*vaa.Signature, hash string, p *Processor) {
@@ -44,4 +45,8 @@ func (v *VAA) HandleQuorum(sigs []*vaa.Signature, hash string, p *Processor) {
 	p.broadcastSignedVAA(signed)
 	p.attestationEvents.ReportVAAQuorum(signed)
 	p.state.signatures[hash].submitted = true
+}
+
+func (v *VAA) IsReliable() bool {
+	return !v.Unreliable
 }


### PR DESCRIPTION
Given solana unreliable messages overwrite the account, they cannot be reobserved. 
This change prevents sending reobservation requests for unreliable messages.