### PR TITLE
sdk/js - pin injective module to working version

### DIFF
--- a/sdk/js/package-lock.json
+++ b/sdk/js/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "@certusone/wormhole-sdk",
-  "version": "0.6.3",
+  "version": "0.6.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@certusone/wormhole-sdk",
-      "version": "0.6.3",
+      "version": "0.6.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@certusone/wormhole-sdk-proto-web": "^0.0.5",
         "@certusone/wormhole-sdk-wasm": "^0.0.1",
-        "@injectivelabs/sdk-ts": "^1.0.75",
+        "@injectivelabs/indexer-api": "1.0.2",
+        "@injectivelabs/sdk-ts": "1.0.75",
         "@solana/spl-token": "^0.1.8",
         "@solana/web3.js": "^1.24.0",
         "@terra-money/terra.js": "^3.1.3",
@@ -23,8 +24,8 @@
       },
       "devDependencies": {
         "@improbable-eng/grpc-web-node-http-transport": "^0.15.0",
-        "@injectivelabs/networks": "^1.0.12",
-        "@injectivelabs/tx-ts": "^1.0.22",
+        "@injectivelabs/networks": "1.0.12",
+        "@injectivelabs/tx-ts": "1.0.22",
         "@openzeppelin/contracts": "^4.2.0",
         "@typechain/ethers-v5": "^7.0.1",
         "@types/jest": "^27.0.2",

--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@certusone/wormhole-sdk",
-  "version": "0.6.3",
+  "version": "0.6.5",
   "description": "SDK for interacting with Wormhole",
   "homepage": "https://wormhole.com",
   "main": "./lib/cjs/index.js",
@@ -39,8 +39,8 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@improbable-eng/grpc-web-node-http-transport": "^0.15.0",
-    "@injectivelabs/networks": "^1.0.12",
-    "@injectivelabs/tx-ts": "^1.0.22",
+    "@injectivelabs/networks": "1.0.12",
+    "@injectivelabs/tx-ts": "1.0.22",
     "@openzeppelin/contracts": "^4.2.0",
     "@typechain/ethers-v5": "^7.0.1",
     "@types/jest": "^27.0.2",
@@ -60,7 +60,8 @@
   "dependencies": {
     "@certusone/wormhole-sdk-proto-web": "^0.0.5",
     "@certusone/wormhole-sdk-wasm": "^0.0.1",
-    "@injectivelabs/sdk-ts": "^1.0.75",
+    "@injectivelabs/indexer-api": "1.0.2",
+    "@injectivelabs/sdk-ts": "1.0.75",
     "@solana/spl-token": "^0.1.8",
     "@solana/web3.js": "^1.24.0",
     "@terra-money/terra.js": "^3.1.3",


### PR DESCRIPTION
I found the latest version of `@injectivelabs/sdk-ts` is broken, it requires a dependency that it does not supply. I filed an [issue](https://github.com/InjectiveLabs/injective-ts/issues/81).

They have carrots `^` on their dependencies, so I had to add a working version of `@injectivelabs/indexer-api` to our package.json to get it working.

Found this while publishing to expose the new batchVAA functions.