### PR TITLE
node: don't store pythnet VAAs in the database

### DIFF
--- a/node/pkg/processor/cleanup.go
+++ b/node/pkg/processor/cleanup.go
@@ -81,7 +81,7 @@ func (p *Processor) handleCleanup(ctx context.Context) {
 					p.logger.Info("Expiring late VAA", zap.String("digest", hash), zap.Duration("delta", delta))
 					aggregationStateLate.Inc()
 					delete(p.state.signatures, hash)
-					break
+					continue
 				} else if err != db.ErrVAANotFound {
 					p.logger.Error("failed to look up VAA in database",
 						zap.String("digest", hash),

--- a/node/pkg/processor/cleanup.go
+++ b/node/pkg/processor/cleanup.go
@@ -75,7 +75,7 @@ func (p *Processor) handleCleanup(ctx context.Context) {
 			if ourVaa, ok := s.ourObservation.(*VAA); ok {
 				if ourVaa.VAA.EmitterChain == vaa.ChainIDPythNet {
 					if p.deletePythNetVAA(&ourVaa.VAA) {
-						p.logger.Info("Expiring late pythnet VAA", zap.String("digest", hash), zap.Duration("delta", delta))
+						p.logger.Info("PYTHNET: expiring late pythnet VAA", zap.String("message_id", ourVaa.MessageID()), zap.Duration("delta", delta))
 					}
 				} else {
 					if _, err := p.db.GetSignedVAABytes(*db.VaaIDFromVAA(&ourVaa.VAA)); err == nil {
@@ -236,7 +236,7 @@ func (p *Processor) handleCleanup(ctx context.Context) {
 	oldestTime := time.Now().Add(-time.Hour)
 	for key, pe := range p.pythnetVaas {
 		if pe.updateTime.Before(oldestTime) {
-			p.logger.Info("dropping old pythnet vaa", zap.String("key", key), zap.Stringer("updateTime", pe.updateTime))
+			p.logger.Info("PYTHNET: dropping old pythnet vaa", zap.String("message_id", key), zap.Stringer("updateTime", pe.updateTime))
 			delete(p.pythnetVaas, key)
 		}
 	}

--- a/node/pkg/processor/message.go
+++ b/node/pkg/processor/message.go
@@ -101,36 +101,57 @@ func (p *Processor) handleMessage(ctx context.Context, k *common.MessagePublicat
 	//
 	// Exception: if an observation is made within the settlement time (30s), we'll
 	// process it so other nodes won't consider it a miss.
-	if vb, err := p.db.GetSignedVAABytes(*db.VaaIDFromVAA(&v.VAA)); err == nil {
-		// unmarshal vaa
-		var existing *vaa.VAA
-		if existing, err = vaa.Unmarshal(vb); err != nil {
-			panic("failed to unmarshal VAA from db")
-		}
 
-		if k.Timestamp.Sub(existing.Timestamp) > settlementTime {
-			p.logger.Info("ignoring observation since we already have a quorum VAA for it",
+	if v.VAA.EmitterChain == vaa.ChainIDPythNet {
+		existing, exists := p.getPythNetVAA(&v.VAA)
+		if exists {
+			if k.Timestamp.Sub(existing.Timestamp) > settlementTime {
+				p.logger.Info("ignoring pythnet observation since we already have a quorum VAA for it",
+					zap.Stringer("emitter_chain", k.EmitterChain),
+					zap.Stringer("emitter_address", k.EmitterAddress),
+					zap.String("emitter_address_b58", base58.Encode(k.EmitterAddress.Bytes())),
+					zap.Uint32("nonce", k.Nonce),
+					zap.Stringer("txhash", k.TxHash),
+					zap.String("txhash_b58", base58.Encode(k.TxHash.Bytes())),
+					zap.Time("timestamp", k.Timestamp),
+					zap.String("message_id", v.MessageID()),
+					zap.Duration("settlement_time", settlementTime),
+				)
+				return
+			}
+		}
+	} else {
+		if vb, err := p.db.GetSignedVAABytes(*db.VaaIDFromVAA(&v.VAA)); err == nil {
+			// unmarshal vaa
+			var existing *vaa.VAA
+			if existing, err = vaa.Unmarshal(vb); err != nil {
+				panic("failed to unmarshal VAA from db")
+			}
+
+			if k.Timestamp.Sub(existing.Timestamp) > settlementTime {
+				p.logger.Info("ignoring observation since we already have a quorum VAA for it",
+					zap.Stringer("emitter_chain", k.EmitterChain),
+					zap.Stringer("emitter_address", k.EmitterAddress),
+					zap.String("emitter_address_b58", base58.Encode(k.EmitterAddress.Bytes())),
+					zap.Uint32("nonce", k.Nonce),
+					zap.Stringer("txhash", k.TxHash),
+					zap.String("txhash_b58", base58.Encode(k.TxHash.Bytes())),
+					zap.Time("timestamp", k.Timestamp),
+					zap.String("message_id", v.MessageID()),
+					zap.Duration("settlement_time", settlementTime),
+				)
+				return
+			}
+		} else if err != db.ErrVAANotFound {
+			p.logger.Error("failed to get VAA from db",
 				zap.Stringer("emitter_chain", k.EmitterChain),
 				zap.Stringer("emitter_address", k.EmitterAddress),
-				zap.String("emitter_address_b58", base58.Encode(k.EmitterAddress.Bytes())),
 				zap.Uint32("nonce", k.Nonce),
 				zap.Stringer("txhash", k.TxHash),
-				zap.String("txhash_b58", base58.Encode(k.TxHash.Bytes())),
 				zap.Time("timestamp", k.Timestamp),
-				zap.String("message_id", v.MessageID()),
-				zap.Duration("settlement_time", settlementTime),
+				zap.Error(err),
 			)
-			return
 		}
-	} else if err != db.ErrVAANotFound {
-		p.logger.Error("failed to get VAA from db",
-			zap.Stringer("emitter_chain", k.EmitterChain),
-			zap.Stringer("emitter_address", k.EmitterAddress),
-			zap.Uint32("nonce", k.Nonce),
-			zap.Stringer("txhash", k.TxHash),
-			zap.Time("timestamp", k.Timestamp),
-			zap.Error(err),
-		)
 	}
 
 	// Generate digest of the unsigned VAA.

--- a/node/pkg/processor/message.go
+++ b/node/pkg/processor/message.go
@@ -106,14 +106,7 @@ func (p *Processor) handleMessage(ctx context.Context, k *common.MessagePublicat
 		existing, exists := p.getPythNetVAA(&v.VAA)
 		if exists {
 			if k.Timestamp.Sub(existing.Timestamp) > settlementTime {
-				p.logger.Info("ignoring pythnet observation since we already have a quorum VAA for it",
-					zap.Stringer("emitter_chain", k.EmitterChain),
-					zap.Stringer("emitter_address", k.EmitterAddress),
-					zap.String("emitter_address_b58", base58.Encode(k.EmitterAddress.Bytes())),
-					zap.Uint32("nonce", k.Nonce),
-					zap.Stringer("txhash", k.TxHash),
-					zap.String("txhash_b58", base58.Encode(k.TxHash.Bytes())),
-					zap.Time("timestamp", k.Timestamp),
+				p.logger.Info("PYTHNET: ignoring pythnet observation since we already have a quorum VAA for it",
 					zap.String("message_id", v.MessageID()),
 					zap.Duration("settlement_time", settlementTime),
 				)

--- a/node/pkg/processor/message.go
+++ b/node/pkg/processor/message.go
@@ -102,49 +102,30 @@ func (p *Processor) handleMessage(ctx context.Context, k *common.MessagePublicat
 	// Exception: if an observation is made within the settlement time (30s), we'll
 	// process it so other nodes won't consider it a miss.
 
-	if v.VAA.EmitterChain == vaa.ChainIDPythNet {
-		existing, exists := p.getPythNetVAA(&v.VAA)
-		if exists {
-			if k.Timestamp.Sub(existing.Timestamp) > settlementTime {
-				p.logger.Info("PYTHNET: ignoring pythnet observation since we already have a quorum VAA for it",
-					zap.String("message_id", v.MessageID()),
-					zap.Duration("settlement_time", settlementTime),
-				)
-				return
-			}
-		}
-	} else {
-		if vb, err := p.db.GetSignedVAABytes(*db.VaaIDFromVAA(&v.VAA)); err == nil {
-			// unmarshal vaa
-			var existing *vaa.VAA
-			if existing, err = vaa.Unmarshal(vb); err != nil {
-				panic("failed to unmarshal VAA from db")
-			}
-
-			if k.Timestamp.Sub(existing.Timestamp) > settlementTime {
-				p.logger.Info("ignoring observation since we already have a quorum VAA for it",
-					zap.Stringer("emitter_chain", k.EmitterChain),
-					zap.Stringer("emitter_address", k.EmitterAddress),
-					zap.String("emitter_address_b58", base58.Encode(k.EmitterAddress.Bytes())),
-					zap.Uint32("nonce", k.Nonce),
-					zap.Stringer("txhash", k.TxHash),
-					zap.String("txhash_b58", base58.Encode(k.TxHash.Bytes())),
-					zap.Time("timestamp", k.Timestamp),
-					zap.String("message_id", v.MessageID()),
-					zap.Duration("settlement_time", settlementTime),
-				)
-				return
-			}
-		} else if err != db.ErrVAANotFound {
-			p.logger.Error("failed to get VAA from db",
+	if existing, err := p.getSignedVAA(*db.VaaIDFromVAA(&v.VAA)); err == nil {
+		if k.Timestamp.Sub(existing.Timestamp) > settlementTime {
+			p.logger.Info("ignoring observation since we already have a quorum VAA for it",
 				zap.Stringer("emitter_chain", k.EmitterChain),
 				zap.Stringer("emitter_address", k.EmitterAddress),
+				zap.String("emitter_address_b58", base58.Encode(k.EmitterAddress.Bytes())),
 				zap.Uint32("nonce", k.Nonce),
 				zap.Stringer("txhash", k.TxHash),
+				zap.String("txhash_b58", base58.Encode(k.TxHash.Bytes())),
 				zap.Time("timestamp", k.Timestamp),
-				zap.Error(err),
+				zap.String("message_id", v.MessageID()),
+				zap.Duration("settlement_time", settlementTime),
 			)
+			return
 		}
+	} else if err != db.ErrVAANotFound {
+		p.logger.Error("failed to get VAA from db",
+			zap.Stringer("emitter_chain", k.EmitterChain),
+			zap.Stringer("emitter_address", k.EmitterAddress),
+			zap.Uint32("nonce", k.Nonce),
+			zap.Stringer("txhash", k.TxHash),
+			zap.Time("timestamp", k.Timestamp),
+			zap.Error(err),
+		)
 	}
 
 	// Generate digest of the unsigned VAA.

--- a/node/pkg/processor/observation.go
+++ b/node/pkg/processor/observation.go
@@ -289,18 +289,11 @@ func (p *Processor) handleInboundSignedVAAWithQuorum(ctx context.Context, m *gos
 	if v.EmitterChain == vaa.ChainIDPythNet {
 		_, exists := p.getPythNetVAA(v)
 		if exists {
-			p.logger.Debug("ignored SignedVAAWithQuorum message for pythnet VAA we already store",
-				zap.String("digest", hash),
-			)
+			p.logger.Debug("PYTHNET: ignored SignedVAAWithQuorum message for pythnet VAA we already store", zap.String("message_id", v.MessageID()))
 			return
 		}
 
-		p.logger.Info("storing inbound signed pythnet VAA with quorum",
-			zap.String("digest", hash),
-			zap.Any("vaa", v),
-			zap.String("bytes", hex.EncodeToString(m.Vaa)),
-			zap.String("message_id", v.MessageID()))
-
+		p.logger.Info("PYTHNET: storing inbound signed pythnet VAA with quorum", zap.String("message_id", v.MessageID()))
 		p.storePythNetVAA(v)
 	} else { // Not PythNet
 		_, err = p.db.GetSignedVAABytes(*db.VaaIDFromVAA(v))

--- a/node/pkg/processor/observation.go
+++ b/node/pkg/processor/observation.go
@@ -286,41 +286,30 @@ func (p *Processor) handleInboundSignedVAAWithQuorum(ctx context.Context, m *gos
 	//  - enough signatures are present for the VAA to reach quorum
 
 	// Check if we already store this VAA
-	if v.EmitterChain == vaa.ChainIDPythNet {
-		_, exists := p.getPythNetVAA(v)
-		if exists {
-			p.logger.Debug("PYTHNET: ignored SignedVAAWithQuorum message for pythnet VAA we already store", zap.String("message_id", v.MessageID()))
-			return
-		}
-
-		p.logger.Info("PYTHNET: storing inbound signed pythnet VAA with quorum", zap.String("message_id", v.MessageID()))
-		p.storePythNetVAA(v)
-	} else { // Not PythNet
-		_, err = p.db.GetSignedVAABytes(*db.VaaIDFromVAA(v))
-		if err == nil {
-			p.logger.Debug("ignored SignedVAAWithQuorum message for VAA we already store",
-				zap.String("digest", hash),
-			)
-			return
-		} else if err != db.ErrVAANotFound {
-			p.logger.Error("failed to look up VAA in database",
-				zap.String("digest", hash),
-				zap.Error(err),
-			)
-			return
-		}
-
-		// Store signed VAA in database.
-		p.logger.Info("storing inbound signed VAA with quorum",
+	_, err = p.getSignedVAA(*db.VaaIDFromVAA(v))
+	if err == nil {
+		p.logger.Debug("ignored SignedVAAWithQuorum message for VAA we already store",
 			zap.String("digest", hash),
-			zap.Any("vaa", v),
-			zap.String("bytes", hex.EncodeToString(m.Vaa)),
-			zap.String("message_id", v.MessageID()))
+		)
+		return
+	} else if err != db.ErrVAANotFound {
+		p.logger.Error("failed to look up VAA in database",
+			zap.String("digest", hash),
+			zap.Error(err),
+		)
+		return
+	}
 
-		if err := p.db.StoreSignedVAA(v); err != nil {
-			p.logger.Error("failed to store signed VAA", zap.Error(err))
-			return
-		}
+	// Store signed VAA in database.
+	p.logger.Info("storing inbound signed VAA with quorum",
+		zap.String("digest", hash),
+		zap.Any("vaa", v),
+		zap.String("bytes", hex.EncodeToString(m.Vaa)),
+		zap.String("message_id", v.MessageID()))
+
+	if err := p.storeSignedVAA(v); err != nil {
+		p.logger.Error("failed to store signed VAA", zap.Error(err))
+		return
 	}
 	p.attestationEvents.ReportVAAQuorum(v)
 }

--- a/node/pkg/processor/processor.go
+++ b/node/pkg/processor/processor.go
@@ -3,6 +3,7 @@ package processor
 import (
 	"context"
 	"crypto/ecdsa"
+	"fmt"
 	"time"
 
 	"github.com/certusone/wormhole/node/pkg/notify/discord"
@@ -73,6 +74,11 @@ type (
 	}
 )
 
+type PythNetVaaEntry struct {
+	v          *vaa.VAA
+	updateTime time.Time // Used for determining when to delete entries
+}
+
 type Processor struct {
 	// lockC is a channel of observed emitted messages
 	lockC chan *common.MessagePublication
@@ -122,8 +128,9 @@ type Processor struct {
 	// cleanup triggers periodic state cleanup
 	cleanup *time.Ticker
 
-	notifier *discord.DiscordNotifier
-	governor *governor.ChainGovernor
+	notifier    *discord.DiscordNotifier
+	governor    *governor.ChainGovernor
+	pythnetVaas map[string]PythNetVaaEntry
 }
 
 func NewProcessor(
@@ -165,10 +172,11 @@ func NewProcessor(
 
 		notifier: notifier,
 
-		logger:   supervisor.Logger(ctx),
-		state:    &aggregationState{observationMap{}},
-		ourAddr:  crypto.PubkeyToAddress(gk.PublicKey),
-		governor: g,
+		logger:      supervisor.Logger(ctx),
+		state:       &aggregationState{observationMap{}},
+		ourAddr:     crypto.PubkeyToAddress(gk.PublicKey),
+		governor:    g,
+		pythnetVaas: make(map[string]PythNetVaaEntry),
 	}
 }
 
@@ -217,4 +225,22 @@ func (p *Processor) Run(ctx context.Context) error {
 			}
 		}
 	}
+}
+
+func (p *Processor) storePythNetVAA(v *vaa.VAA) {
+	key := fmt.Sprintf("%v/%v", v.EmitterAddress, v.Sequence)
+	p.pythnetVaas[key] = PythNetVaaEntry{v: v, updateTime: time.Now()}
+}
+
+func (p *Processor) getPythNetVAA(v *vaa.VAA) (*vaa.VAA, bool) {
+	key := fmt.Sprintf("%v/%v", v.EmitterAddress, v.Sequence)
+	ret, exists := p.pythnetVaas[key]
+	return ret.v, exists
+}
+
+func (p *Processor) deletePythNetVAA(v *vaa.VAA) bool {
+	key := fmt.Sprintf("%v/%v", v.EmitterAddress, v.Sequence)
+	_, exists := p.pythnetVaas[key]
+	delete(p.pythnetVaas, key)
+	return exists
 }

--- a/node/pkg/processor/processor.go
+++ b/node/pkg/processor/processor.go
@@ -256,7 +256,7 @@ func (p *Processor) getSignedVAA(id db.VAAID) (*vaa.VAA, error) {
 	}
 
 	vaa, err := vaa.Unmarshal(vb)
-	if err == nil {
+	if err != nil {
 		panic("failed to unmarshal VAA from db")
 	}
 

--- a/node/pkg/processor/vaa.go
+++ b/node/pkg/processor/vaa.go
@@ -38,8 +38,12 @@ func (v *VAA) HandleQuorum(sigs []*vaa.Signature, hash string, p *Processor) {
 		zap.String("bytes", hex.EncodeToString(vaaBytes)),
 		zap.String("message_id", signed.MessageID()))
 
-	if err := p.db.StoreSignedVAA(signed); err != nil {
-		p.logger.Error("failed to store signed VAA", zap.Error(err))
+	if signed.EmitterChain == vaa.ChainIDPythNet {
+		p.storePythNetVAA(signed)
+	} else {
+		if err := p.db.StoreSignedVAA(signed); err != nil {
+			p.logger.Error("failed to store signed VAA", zap.Error(err))
+		}
 	}
 
 	p.broadcastSignedVAA(signed)

--- a/node/pkg/processor/vaa.go
+++ b/node/pkg/processor/vaa.go
@@ -32,15 +32,16 @@ func (v *VAA) HandleQuorum(sigs []*vaa.Signature, hash string, p *Processor) {
 	}
 
 	// Store signed VAA in database.
-	p.logger.Info("signed VAA with quorum",
-		zap.String("digest", hash),
-		zap.Any("vaa", signed),
-		zap.String("bytes", hex.EncodeToString(vaaBytes)),
-		zap.String("message_id", signed.MessageID()))
-
 	if signed.EmitterChain == vaa.ChainIDPythNet {
+		p.logger.Info("PYTHNET: storing signed VAA with quorum for pythnet", zap.String("message_id", signed.MessageID()))
 		p.storePythNetVAA(signed)
 	} else {
+		p.logger.Info("signed VAA with quorum",
+			zap.String("digest", hash),
+			zap.Any("vaa", signed),
+			zap.String("bytes", hex.EncodeToString(vaaBytes)),
+			zap.String("message_id", signed.MessageID()))
+
 		if err := p.db.StoreSignedVAA(signed); err != nil {
 			p.logger.Error("failed to store signed VAA", zap.Error(err))
 		}

--- a/node/pkg/processor/vaa.go
+++ b/node/pkg/processor/vaa.go
@@ -32,19 +32,14 @@ func (v *VAA) HandleQuorum(sigs []*vaa.Signature, hash string, p *Processor) {
 	}
 
 	// Store signed VAA in database.
-	if signed.EmitterChain == vaa.ChainIDPythNet {
-		p.logger.Info("PYTHNET: storing signed VAA with quorum for pythnet", zap.String("message_id", signed.MessageID()))
-		p.storePythNetVAA(signed)
-	} else {
-		p.logger.Info("signed VAA with quorum",
-			zap.String("digest", hash),
-			zap.Any("vaa", signed),
-			zap.String("bytes", hex.EncodeToString(vaaBytes)),
-			zap.String("message_id", signed.MessageID()))
+	p.logger.Info("signed VAA with quorum",
+		zap.String("digest", hash),
+		zap.Any("vaa", signed),
+		zap.String("bytes", hex.EncodeToString(vaaBytes)),
+		zap.String("message_id", signed.MessageID()))
 
-		if err := p.db.StoreSignedVAA(signed); err != nil {
-			p.logger.Error("failed to store signed VAA", zap.Error(err))
-		}
+	if err := p.storeSignedVAA(signed); err != nil {
+		p.logger.Error("failed to store signed VAA", zap.Error(err))
 	}
 
 	p.broadcastSignedVAA(signed)


### PR DESCRIPTION
This PR stores PythNet VAAs in memory rather than writing them to the guardiand database. It does this for ChainID == Pythnet rather than using the new IsUnreliable flag because that flag is not present in the SignedVAAWithQuorum gossip message (and changing that message might break various things).

Change-Id: Ief4357ab4c909d25dc9182490c322ef253ac23d3