### PR TITLE
aptos: include metadata in upgrade hash

### DIFF
--- a/aptos/scripts/upgrade
+++ b/aptos/scripts/upgrade
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -euo pipefail
+set -eo pipefail
 
 function usage() {
 cat <<EOF >&2
@@ -60,7 +60,6 @@ case "$MODULE" in
 esac
 
 HASH=$(worm aptos hash-contracts $DIR)
-# devnet guardian secret..
 CONTRACT_ADDR=$(worm contract "$NETWORK" aptos "$MODULE")
 VAA=$(worm generate upgrade -c aptos -a "$HASH" -m "$MODULE" -g $GUARDIAN_SECRET)
 

--- a/aptos/token_bridge/sources/contract_upgrade.move
+++ b/aptos/token_bridge/sources/contract_upgrade.move
@@ -12,6 +12,11 @@
 /// This two-phase process has the advantage that even if the bytecode can't be
 /// upgraded to for whatever reason, the governance VAA won't be possible to
 /// replay in the future, since the commit transaction replay protects it.
+///
+/// Additionally, there is an optional migration step that may include one-off
+/// logic to be executed after the upgrade. This has to be done in a separate
+/// transaction, because the transaction that uploads bytecode cannot execute
+/// it.
 module token_bridge::contract_upgrade {
     use std::vector;
     use aptos_framework::code;
@@ -122,9 +127,24 @@ module token_bridge::contract_upgrade {
 
     struct Migrating has key {}
 
+    public fun is_migrating(): bool {
+        exists<Migrating>(@token_bridge)
+    }
+
     public entry fun migrate() acquires Migrating {
         assert!(exists<Migrating>(@token_bridge), E_NOT_MIGRATING);
         let Migrating { } = move_from<Migrating>(@token_bridge);
+
+        // NOTE: put any one-off migration logic here.
+        // Most upgrades likely won't need to do anything, in which case the
+        // rest of this function's body may be empty.
+        // Make sure to delete it after the migration has gone through
+        // successfully.
+        // WARNING: the migration does *not* proceed atomically with the
+        // upgrade (as they are done in separate transactions).
+        // If the nature of your migration absolutely requires the migration to
+        // happen before certain other functionality is available, then guard
+        // that functionality with `assert!(!is_migrating())` (from above).
     }
 }
 

--- a/aptos/token_bridge/sources/contract_upgrade.move
+++ b/aptos/token_bridge/sources/contract_upgrade.move
@@ -107,10 +107,13 @@ module token_bridge::contract_upgrade {
         assert!(exists<UpgradeAuthorized>(@token_bridge), E_UPGRADE_UNAUTHORIZED);
         let UpgradeAuthorized { hash } = move_from<UpgradeAuthorized>(@token_bridge);
 
+        // we compute the hash of hashes of the metadata and the bytecodes.
+        // the aptos framework appears to perform no validation of the metadata,
+        // so we check it here too.
         let c = copy code;
         vector::reverse(&mut c);
-        let a = vector::empty<u8>();
-        while (!vector::is_empty(&c)) vector::append(&mut a, vector::pop_back(&mut c));
+        let a = keccak256(metadata_serialized);
+        while (!vector::is_empty(&c)) vector::append(&mut a, keccak256(vector::pop_back(&mut c)));
         assert!(keccak256(a) == hash, E_UNEXPECTED_HASH);
 
         let token_bridge = state::token_bridge_signer();

--- a/aptos/wormhole/sources/contract_upgrade.move
+++ b/aptos/wormhole/sources/contract_upgrade.move
@@ -106,10 +106,13 @@ module wormhole::contract_upgrade {
         assert!(exists<UpgradeAuthorized>(@wormhole), E_UPGRADE_UNAUTHORIZED);
         let UpgradeAuthorized { hash } = move_from<UpgradeAuthorized>(@wormhole);
 
+        // we compute the hash of hashes of the metadata and the bytecodes.
+        // the aptos framework appears to perform no validation of the metadata,
+        // so we check it here too.
         let c = copy code;
         vector::reverse(&mut c);
-        let a = vector::empty<u8>();
-        while (!vector::is_empty(&c)) vector::append(&mut a, vector::pop_back(&mut c));
+        let a = keccak256(metadata_serialized);
+        while (!vector::is_empty(&c)) vector::append(&mut a, keccak256(vector::pop_back(&mut c)));
         assert!(keccak256(a) == hash, E_UNEXPECTED_HASH);
 
         let wormhole = state::wormhole_signer();

--- a/clients/js/cmds/aptos.ts
+++ b/clients/js/cmds/aptos.ts
@@ -375,11 +375,12 @@ function serializePackage(p: Package): PackageBCS {
   modules.forEach(module => serializer.serializeBytes(module));
   const serializedModules = serializer.getBytes();
 
-  const codeHash = Buffer.from(sha3.keccak256(Buffer.concat(modules)), "hex")
+  const hashes = [metaBytes].concat(modules).map((x) => Buffer.from(sha3.keccak256(x), "hex"));
+  const codeHash = Buffer.from(sha3.keccak256(Buffer.concat(hashes)), "hex")
 
   return {
     meta: serializedPackageMetadata,
     bytecodes: serializedModules,
-    codeHash: codeHash
+    codeHash
   }
 }


### PR DESCRIPTION
In addition to the bytecodes, now we also include the metadata file's content in the upgrade hash. This is more of a sanity thing, as there's no reason not to include it, even if there's no immediately apparent attack vector without it.