### PR TITLE
node: don't require algorandIndexerToken

### DIFF
--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -648,9 +648,6 @@ func runNode(cmd *cobra.Command, args []string) {
 		if *algorandIndexerRPC == "" {
 			logger.Fatal("Please specify --algorandIndexerRPC")
 		}
-		if *algorandIndexerToken == "" {
-			logger.Fatal("Please specify --algorandIndexerToken")
-		}
 		if *algorandAlgodRPC == "" {
 			logger.Fatal("Please specify --algorandAlgodRPC")
 		}


### PR DESCRIPTION
I hear that not all indexers require tokens