### PR TITLE
tob-worm-4-panics: using options rather than unwrap & tob-worm-9: cosmwasm test build

### DIFF
--- a/cosmwasm/Makefile
+++ b/cosmwasm/Makefile
@@ -59,6 +59,7 @@ test/node_modules: test/package-lock.json
 unit-test:
 	cargo test -p wormhole-bridge-terra-2
 	cargo test -p token-bridge-terra-2
+	cargo test -p cw20-wrapped-2
 
 .PHONY: test
 ## Run unit and integration tests

--- a/cosmwasm/contracts/cw20-wrapped/src/contract.rs
+++ b/cosmwasm/contracts/cw20-wrapped/src/contract.rs
@@ -315,7 +315,7 @@ mod tests {
 
     #[test]
     fn can_mint_by_minter() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         let minter = HumanAddr::from("minter");
         let recipient = HumanAddr::from("recipient");
         let amount = Uint128::new(222_222_222);
@@ -324,7 +324,7 @@ mod tests {
 
     #[test]
     fn others_cannot_mint() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         let minter = HumanAddr::from("minter");
         let recipient = HumanAddr::from("recipient");
         do_init(deps.as_mut(), &minter);
@@ -347,7 +347,7 @@ mod tests {
 
     #[test]
     fn transfer_balance_success() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         let minter = HumanAddr::from("minter");
         let owner = HumanAddr::from("owner");
         let amount_initial = Uint128::new(222_222_222);
@@ -371,7 +371,7 @@ mod tests {
 
     #[test]
     fn transfer_balance_not_enough() {
-        let mut deps = mock_dependencies(&[]);
+        let mut deps = mock_dependencies();
         let minter = HumanAddr::from("minter");
         let owner = HumanAddr::from("owner");
         let amount_initial = Uint128::new(222_221);

--- a/cosmwasm/contracts/token-bridge/src/contract.rs
+++ b/cosmwasm/contracts/token-bridge/src/contract.rs
@@ -924,7 +924,7 @@ fn handle_complete_transfer_token(
 
     amount = amount
         .checked_sub(fee)
-        .ok_or_else(|| StdError::generic_err("Insufficient funds"))?;
+        .ok_or(StdError::generic_err("Insufficient funds"))?;
 
     // Check high 128 bit of amount value to be empty
     if not_supported_amount != 0 || not_supported_fee != 0 {
@@ -1072,7 +1072,7 @@ fn handle_complete_transfer_token_native(
 
     amount = amount
         .checked_sub(fee)
-        .ok_or_else(|| StdError::generic_err("Insufficient funds"))?;
+        .ok_or(StdError::generic_err("Insufficient funds"))?;
 
     // Check high 128 bit of amount value to be empty
     if not_supported_amount != 0 || not_supported_fee != 0 {
@@ -1272,14 +1272,14 @@ fn handle_initiate_transfer_token(
                 .checked_rem(multiplier)
                 .and_then(|rem| amount.u128().checked_sub(rem))
                 .map(Uint128::new)
-                .ok_or_else(|| StdError::generic_err("Insufficient funds"))?;
+                .ok_or(StdError::generic_err("Insufficient funds"))?;
 
             fee = fee
                 .u128()
                 .checked_rem(multiplier)
                 .and_then(|rem| fee.u128().checked_sub(rem))
                 .map(Uint128::new)
-                .ok_or_else(|| StdError::generic_err("Invalid fee"))?;
+                .ok_or(StdError::generic_err("Invalid fee"))?;
 
             // This is a regular asset, transfer its balance
             submessages.push(SubMsg::reply_on_success(

--- a/solana/migration/src/api/add_liquidity.rs
+++ b/solana/migration/src/api/add_liquidity.rs
@@ -97,11 +97,11 @@ pub fn add_liquidity(
     let share_amount = if accs.from_mint.decimals > accs.to_mint.decimals {
         data.amount
             .checked_mul(10u64.pow((accs.from_mint.decimals - accs.to_mint.decimals) as u32))
-            .ok_or(Result::Err(SolitaireError::InsufficientFunds))?
+            .ok_or(SolitaireError::InsufficientFunds)?
     } else {
         data.amount
             .checked_div(10u64.pow((accs.to_mint.decimals - accs.from_mint.decimals) as u32))
-            .ok_or(Result::Err(SolitaireError::InsufficientFunds))?
+            .ok_or(SolitaireError::InsufficientFunds)?
     };
 
     // Mint LP shares

--- a/solana/migration/src/api/add_liquidity.rs
+++ b/solana/migration/src/api/add_liquidity.rs
@@ -97,11 +97,11 @@ pub fn add_liquidity(
     let share_amount = if accs.from_mint.decimals > accs.to_mint.decimals {
         data.amount
             .checked_mul(10u64.pow((accs.from_mint.decimals - accs.to_mint.decimals) as u32))
-            .ok_or_else(|| Result::Err(SolitaireError::InsufficientFunds))?
+            .ok_or(Result::Err(SolitaireError::InsufficientFunds))?
     } else {
         data.amount
             .checked_div(10u64.pow((accs.to_mint.decimals - accs.from_mint.decimals) as u32))
-            .ok_or_else(|| Result::Err(SolitaireError::InsufficientFunds))?
+            .ok_or(Result::Err(SolitaireError::InsufficientFunds))?
     };
 
     // Mint LP shares

--- a/solana/migration/src/api/add_liquidity.rs
+++ b/solana/migration/src/api/add_liquidity.rs
@@ -95,19 +95,13 @@ pub fn add_liquidity(
 
     // The share amount should be equal to the amount of from tokens an lp would be getting
     let share_amount = if accs.from_mint.decimals > accs.to_mint.decimals {
-        match data.amount
+        data.amount
             .checked_mul(10u64.pow((accs.from_mint.decimals - accs.to_mint.decimals) as u32))
-        {
-            None => return Result::Err(SolitaireError::InsufficientFunds),
-            Some(value) => value
-        }
+            .ok_or_else(|| Result::Err(SolitaireError::InsufficientFunds))?
     } else {
-        match data.amount
+        data.amount
             .checked_div(10u64.pow((accs.to_mint.decimals - accs.from_mint.decimals) as u32))
-        {
-            None => return Result::Err(SolitaireError::InsufficientFunds),
-            Some(value) => value
-        }
+            .ok_or_else(|| Result::Err(SolitaireError::InsufficientFunds))?
     };
 
     // Mint LP shares

--- a/solana/migration/src/api/add_liquidity.rs
+++ b/solana/migration/src/api/add_liquidity.rs
@@ -95,13 +95,19 @@ pub fn add_liquidity(
 
     // The share amount should be equal to the amount of from tokens an lp would be getting
     let share_amount = if accs.from_mint.decimals > accs.to_mint.decimals {
-        data.amount
+        match data.amount
             .checked_mul(10u64.pow((accs.from_mint.decimals - accs.to_mint.decimals) as u32))
-            .unwrap()
+        {
+            None => return Result::Err(SolitaireError::InsufficientFunds),
+            Some(value) => value
+        }
     } else {
-        data.amount
+        match data.amount
             .checked_div(10u64.pow((accs.to_mint.decimals - accs.from_mint.decimals) as u32))
-            .unwrap()
+        {
+            None => return Result::Err(SolitaireError::InsufficientFunds),
+            Some(value) => value
+        }
     };
 
     // Mint LP shares

--- a/solana/migration/src/api/migrate_tokens.rs
+++ b/solana/migration/src/api/migrate_tokens.rs
@@ -99,11 +99,11 @@ pub fn migrate_tokens(
     let out_amount = if accs.from_mint.decimals > accs.to_mint.decimals {
         data.amount
             .checked_div(10u64.pow((accs.from_mint.decimals - accs.to_mint.decimals) as u32))
-            .ok_or_else(|| Result::Err(SolitaireError::InsufficientFunds))?
+            .ok_or(Result::Err(SolitaireError::InsufficientFunds))?
     } else {
         data.amount
             .checked_mul(10u64.pow((accs.to_mint.decimals - accs.from_mint.decimals) as u32))
-            .ok_or_else(|| Result::Err(SolitaireError::InsufficientFunds))?
+            .ok_or(Result::Err(SolitaireError::InsufficientFunds))?
     };
 
     // Transfer out-tokens to user

--- a/solana/migration/src/api/migrate_tokens.rs
+++ b/solana/migration/src/api/migrate_tokens.rs
@@ -97,13 +97,19 @@ pub fn migrate_tokens(
 
     // The out amount needs to be decimal adjusted
     let out_amount = if accs.from_mint.decimals > accs.to_mint.decimals {
-        data.amount
+        match data.amount
             .checked_div(10u64.pow((accs.from_mint.decimals - accs.to_mint.decimals) as u32))
-            .unwrap()
+        {
+            None => return Result::Err(SolitaireError::InsufficientFunds),
+            Some(value) => value
+        }
     } else {
-        data.amount
+        match data.amount
             .checked_mul(10u64.pow((accs.to_mint.decimals - accs.from_mint.decimals) as u32))
-            .unwrap()
+        {
+            None => return Result::Err(SolitaireError::InsufficientFunds),
+            Some(value) => value
+        }
     };
 
     // Transfer out-tokens to user

--- a/solana/migration/src/api/migrate_tokens.rs
+++ b/solana/migration/src/api/migrate_tokens.rs
@@ -99,11 +99,11 @@ pub fn migrate_tokens(
     let out_amount = if accs.from_mint.decimals > accs.to_mint.decimals {
         data.amount
             .checked_div(10u64.pow((accs.from_mint.decimals - accs.to_mint.decimals) as u32))
-            .ok_or(Result::Err(SolitaireError::InsufficientFunds))?
+            .ok_or(SolitaireError::InsufficientFunds)?
     } else {
         data.amount
             .checked_mul(10u64.pow((accs.to_mint.decimals - accs.from_mint.decimals) as u32))
-            .ok_or(Result::Err(SolitaireError::InsufficientFunds))?
+            .ok_or(SolitaireError::InsufficientFunds)?
     };
 
     // Transfer out-tokens to user

--- a/solana/migration/src/api/migrate_tokens.rs
+++ b/solana/migration/src/api/migrate_tokens.rs
@@ -97,19 +97,13 @@ pub fn migrate_tokens(
 
     // The out amount needs to be decimal adjusted
     let out_amount = if accs.from_mint.decimals > accs.to_mint.decimals {
-        match data.amount
+        data.amount
             .checked_div(10u64.pow((accs.from_mint.decimals - accs.to_mint.decimals) as u32))
-        {
-            None => return Result::Err(SolitaireError::InsufficientFunds),
-            Some(value) => value
-        }
+            .ok_or_else(|| Result::Err(SolitaireError::InsufficientFunds))?
     } else {
-        match data.amount
+        data.amount
             .checked_mul(10u64.pow((accs.to_mint.decimals - accs.from_mint.decimals) as u32))
-        {
-            None => return Result::Err(SolitaireError::InsufficientFunds),
-            Some(value) => value
-        }
+            .ok_or_else(|| Result::Err(SolitaireError::InsufficientFunds))?
     };
 
     // Transfer out-tokens to user

--- a/solana/migration/src/api/remove_liquidity.rs
+++ b/solana/migration/src/api/remove_liquidity.rs
@@ -84,11 +84,11 @@ pub fn remove_liquidity(
     let out_amount = if accs.from_mint.decimals > accs.to_mint.decimals {
         data.amount
             .checked_div(10u64.pow((accs.from_mint.decimals - accs.to_mint.decimals) as u32))
-            .ok_or_else(|| Result::Err(SolitaireError::InsufficientFunds))?
+            .ok_or(Result::Err(SolitaireError::InsufficientFunds))?
     } else {
         data.amount
             .checked_mul(10u64.pow((accs.to_mint.decimals - accs.from_mint.decimals) as u32))
-            .ok_or_else(|| Result::Err(SolitaireError::InsufficientFunds))?
+            .ok_or(Result::Err(SolitaireError::InsufficientFunds))?
     };
 
     // Transfer removed liquidity to LP

--- a/solana/migration/src/api/remove_liquidity.rs
+++ b/solana/migration/src/api/remove_liquidity.rs
@@ -82,19 +82,13 @@ pub fn remove_liquidity(
 
     // The out amount needs to be decimal adjusted
     let out_amount = if accs.from_mint.decimals > accs.to_mint.decimals {
-        match data.amount
+        data.amount
             .checked_div(10u64.pow((accs.from_mint.decimals - accs.to_mint.decimals) as u32))
-        {
-            None => return Result::Err(SolitaireError::InsufficientFunds),
-            Some(value) => value
-        }
+            .ok_or_else(|| Result::Err(SolitaireError::InsufficientFunds))?
     } else {
-        match data.amount
+        data.amount
             .checked_mul(10u64.pow((accs.to_mint.decimals - accs.from_mint.decimals) as u32))
-        {
-            None => return Result::Err(SolitaireError::InsufficientFunds),
-            Some(value) => value
-        }
+            .ok_or_else(|| Result::Err(SolitaireError::InsufficientFunds))?
     };
 
     // Transfer removed liquidity to LP

--- a/solana/migration/src/api/remove_liquidity.rs
+++ b/solana/migration/src/api/remove_liquidity.rs
@@ -84,11 +84,11 @@ pub fn remove_liquidity(
     let out_amount = if accs.from_mint.decimals > accs.to_mint.decimals {
         data.amount
             .checked_div(10u64.pow((accs.from_mint.decimals - accs.to_mint.decimals) as u32))
-            .ok_or(Result::Err(SolitaireError::InsufficientFunds))?
+            .ok_or(SolitaireError::InsufficientFunds)?
     } else {
         data.amount
             .checked_mul(10u64.pow((accs.to_mint.decimals - accs.from_mint.decimals) as u32))
-            .ok_or(Result::Err(SolitaireError::InsufficientFunds))?
+            .ok_or(SolitaireError::InsufficientFunds)?
     };
 
     // Transfer removed liquidity to LP

--- a/solana/migration/src/api/remove_liquidity.rs
+++ b/solana/migration/src/api/remove_liquidity.rs
@@ -82,13 +82,19 @@ pub fn remove_liquidity(
 
     // The out amount needs to be decimal adjusted
     let out_amount = if accs.from_mint.decimals > accs.to_mint.decimals {
-        data.amount
+        match data.amount
             .checked_div(10u64.pow((accs.from_mint.decimals - accs.to_mint.decimals) as u32))
-            .unwrap()
+        {
+            None => return Result::Err(SolitaireError::InsufficientFunds),
+            Some(value) => value
+        }
     } else {
-        data.amount
+        match data.amount
             .checked_mul(10u64.pow((accs.to_mint.decimals - accs.from_mint.decimals) as u32))
-            .unwrap()
+        {
+            None => return Result::Err(SolitaireError::InsufficientFunds),
+            Some(value) => value
+        }
     };
 
     // Transfer removed liquidity to LP

--- a/solana/modules/token_bridge/program/src/api/complete_transfer.rs
+++ b/solana/modules/token_bridge/program/src/api/complete_transfer.rs
@@ -242,7 +242,8 @@ pub fn complete_wrapped(
 
     claim::consume(ctx, accs.payer.key, &mut accs.claim, &accs.vaa)?;
 
-    let token_amount: u64 = accs.vaa
+    let token_amount: u64 = accs
+        .vaa
         .amount
         .as_u64()
         .checked_sub(accs.vaa.fee.as_u64())

--- a/solana/modules/token_bridge/program/src/api/complete_transfer.rs
+++ b/solana/modules/token_bridge/program/src/api/complete_transfer.rs
@@ -131,7 +131,7 @@ pub fn complete_native(
 
     let token_amount = amount
         .checked_sub(fee)
-        .ok_or_else(|| Result::Err(SolitaireError::InsufficientFunds))?;
+        .ok_or(Result::Err(SolitaireError::InsufficientFunds))?;
 
     // Transfer tokens
     let transfer_ix = spl_token::instruction::transfer(
@@ -247,7 +247,7 @@ pub fn complete_wrapped(
         .amount
         .as_u64()
         .checked_sub(accs.vaa.fee.as_u64())
-        .ok_or_else(|| Result::Err(SolitaireError::InsufficientFunds))?;
+        .ok_or(Result::Err(SolitaireError::InsufficientFunds))?;
 
     // Mint tokens
     let mint_ix = spl_token::instruction::mint_to(

--- a/solana/modules/token_bridge/program/src/api/complete_transfer.rs
+++ b/solana/modules/token_bridge/program/src/api/complete_transfer.rs
@@ -131,7 +131,7 @@ pub fn complete_native(
 
     let token_amount = amount
         .checked_sub(fee)
-        .ok_or(Result::Err(SolitaireError::InsufficientFunds))?;
+        .ok_or(SolitaireError::InsufficientFunds)?;
 
     // Transfer tokens
     let transfer_ix = spl_token::instruction::transfer(
@@ -247,7 +247,7 @@ pub fn complete_wrapped(
         .amount
         .as_u64()
         .checked_sub(accs.vaa.fee.as_u64())
-        .ok_or(Result::Err(SolitaireError::InsufficientFunds))?;
+        .ok_or(SolitaireError::InsufficientFunds)?;
 
     // Mint tokens
     let mint_ix = spl_token::instruction::mint_to(

--- a/solana/modules/token_bridge/program/src/api/complete_transfer.rs
+++ b/solana/modules/token_bridge/program/src/api/complete_transfer.rs
@@ -129,10 +129,9 @@ pub fn complete_native(
         fee *= 10u64.pow((accs.mint.decimals - 8) as u32);
     }
 
-    let token_amount = match amount.checked_sub(fee) {
-        None => return Result::Err(SolitaireError::InsufficientFunds),
-        Some(value) => value
-    };
+    let token_amount = amount
+        .checked_sub(fee)
+        .ok_or_else(|| Result::Err(SolitaireError::InsufficientFunds))?;
 
     // Transfer tokens
     let transfer_ix = spl_token::instruction::transfer(
@@ -243,14 +242,11 @@ pub fn complete_wrapped(
 
     claim::consume(ctx, accs.payer.key, &mut accs.claim, &accs.vaa)?;
 
-    let token_amount: u64 = match accs.vaa
+    let token_amount: u64 = accs.vaa
         .amount
         .as_u64()
         .checked_sub(accs.vaa.fee.as_u64())
-    {
-        None => return Result::Err(SolitaireError::InsufficientFunds),
-        Some(value) => value
-    };
+        .ok_or_else(|| Result::Err(SolitaireError::InsufficientFunds))?;
 
     // Mint tokens
     let mint_ix = spl_token::instruction::mint_to(

--- a/solana/solitaire/program/src/error.rs
+++ b/solana/solitaire/program/src/error.rs
@@ -50,6 +50,9 @@ pub enum SolitaireError {
     UnknownInstruction(u8),
 
     Custom(u64),
+
+    /// User does not have sufficient funds for the tx
+    InsufficientFunds,
 }
 
 impl From<ProgramError> for SolitaireError {


### PR DESCRIPTION
4. Use of panics on invalid inputs
Description In several places, the code panics when an arithmetic overflow or underflow occurs. Panics should be reserved for programmer errors (e.g., assertion violations). Panicking on user errors dilutes the utility of the panic operation. An example appears in figure 4.1. Thecomplete_nativefunction useschecked_subto verify that the transfer includes sufficient funds to cover the fee. However, complete_nativepanics if there are insufficient funds.Thus, the function could panic on either a programmer error or a user error.

Also added 9. cw20-wrapped tests do not build
**for tob-9**
Removed the arguments and ran cargo test. Works seamlessly