### PR TITLE
aptos: testnet

### DIFF
--- a/aptos/deployer/sources/deployer.move
+++ b/aptos/deployer/sources/deployer.move
@@ -86,10 +86,36 @@ module deployer::deployer {
         metadata_serialized: vector<u8>,
         code: vector<vector<u8>>,
         seed: vector<u8>
-    ) {
-        let (resource_signer, signer_cap) = account::create_resource_account(deployer, seed);
-        let deployer = signer::address_of(deployer);
-        move_to(&resource_signer, DeployingSignerCapability { signer_cap, deployer });
+    ) acquires DeployingSignerCapability {
+        let deployer_address = signer::address_of(deployer);
+        let resource = account::create_resource_address(&deployer_address, seed);
+        let resource_signer: signer;
+        if (exists<DeployingSignerCapability>(resource)) {
+            // if the deploying signer capability already exists, it means that
+            // the resource account hasn't claimed it. This code path allows the
+            // deployer to upgrade the resource account's contract, but only
+            // before the resource account is initialised.
+            // You might think that this is a very niche use-case, but this
+            // happened when trying to deploy wormhole to aptos testnet, as the
+            // bytecode we published had been compiled with an older version of
+            // the stdlib, and had native dependency issues. These are checked
+            // lazily (i.e. at runtime, and not deployment time), which meant
+            // that the contract was effectively broken, i.e. unable to
+            // initialise itself, and therefore unable to upgrade.
+            let deploying_cap = borrow_global<DeployingSignerCapability>(resource);
+            resource_signer = account::create_signer_with_capability(&deploying_cap.signer_cap);
+        } else {
+            // if it doesn't exist, it means that either
+            // a) the account hasn't been created yet at all
+            // b) the account has already claimed the signer capability
+            //
+            // in the case of a), we just create it. In case of b), the account
+            // creation will fail, since the resource account already exist,
+            // effectively providing replay protection.
+            let signer_cap: account::SignerCapability;
+            (resource_signer, signer_cap) = account::create_resource_account(deployer, seed);
+            move_to(&resource_signer, DeployingSignerCapability { signer_cap, deployer: deployer_address });
+        };
         code::publish_package_txn(&resource_signer, metadata_serialized, code);
     }
 

--- a/aptos/scripts/deploy_testnet
+++ b/aptos/scripts/deploy_testnet
@@ -13,7 +13,7 @@ NAMED_ADDRS="wormhole=$WORMHOLE_ADDR,deployer=$DEPLOYER_ADDR,token_bridge=$TOKEN
 
 # STEP 1) if deployer address is not funded with Aptos tokens,
 #         first fund it using a faucet script or the Aptos CLI
-worm aptos faucet --rpc 'https://fullnode.devnet.aptoslabs.com' --account $DEPLOYER_ADDR --faucet 'https://faucet.devnet.aptoslabs.com'
+worm aptos faucet --rpc 'https://fullnode.testnet.aptoslabs.com/v1' --account $DEPLOYER_ADDR --faucet 'https://faucet.testnet.aptoslabs.com'
 
 #================================================================================================
 

--- a/aptos/token_bridge/sources/deploy_coin.move
+++ b/aptos/token_bridge/sources/deploy_coin.move
@@ -19,10 +19,10 @@
 // TODO: find out if we need to update the source_digest in the package metadata as well
 
 module token_bridge::deploy_coin {
-    use 0x1::signer::{Self};
-    use 0x1::vector::{Self};
-    use 0x1::code::{publish_package_txn};
-    use 0x1::bcs::{Self};
+    use std::signer::{Self};
+    use std::vector::{Self};
+    use std::code::{publish_package_txn};
+    use std::bcs::{Self};
 
     public entry fun deploy_coin(deployer: &signer) {
         let addr = signer::address_of(deployer);

--- a/aptos/token_bridge/sources/structs/asset_meta.move
+++ b/aptos/token_bridge/sources/structs/asset_meta.move
@@ -1,5 +1,5 @@
 module token_bridge::asset_meta {
-    use 0x1::vector::{Self};
+    use std::vector::{Self};
     use wormhole::serialize::{serialize_u8, serialize_u16, serialize_vector};
     use wormhole::deserialize::{deserialize_u8, deserialize_u16, deserialize_vector};
     use wormhole::cursor::{Self};

--- a/aptos/wormhole/sources/cursor.move
+++ b/aptos/wormhole/sources/cursor.move
@@ -1,5 +1,5 @@
 module wormhole::cursor {
-    use 0x1::vector::{Self};
+    use std::vector;
 
     /// A cursor allows consuming a vector incrementally for parsing operations.
     /// It has no drop ability, and the only way to deallocate it is by calling the

--- a/aptos/wormhole/sources/deserialize.move
+++ b/aptos/wormhole/sources/deserialize.move
@@ -1,5 +1,5 @@
 module wormhole::deserialize {
-    use 0x1::vector::{Self};
+    use std::vector;
     use wormhole::cursor::{Self, Cursor};
     use wormhole::u16::{Self, U16};
     use wormhole::u32::{Self, U32};

--- a/aptos/wormhole/sources/emitter.move
+++ b/aptos/wormhole/sources/emitter.move
@@ -13,7 +13,7 @@ module wormhole::emitter {
     friend wormhole::emitter_test;
 
     struct EmitterRegistry has store {
-        next_id: u128
+        next_id: u64
     }
 
     // TODO(csongor): document that this has to be globally unique.
@@ -35,7 +35,7 @@ module wormhole::emitter {
 
     struct EmitterCapability has store {
         /// Unique identifier of the emitter
-        emitter: u128,
+        emitter: u64,
         /// Sequence number of the next wormhole message
         sequence: u64
     }
@@ -48,7 +48,7 @@ module wormhole::emitter {
         let EmitterCapability { emitter: _, sequence: _ } = emitter_cap;
     }
 
-    public fun get_emitter(emitter_cap: &EmitterCapability): u128 {
+    public fun get_emitter(emitter_cap: &EmitterCapability): u64 {
         emitter_cap.emitter
     }
 
@@ -57,7 +57,7 @@ module wormhole::emitter {
     /// The 16 byte (u128) emitter id left-padded to u256
     public fun get_external_address(emitter_cap: &EmitterCapability): ExternalAddress {
         let emitter_bytes = vector<u8>[];
-        serialize::serialize_u128(&mut emitter_bytes, emitter_cap.emitter);
+        serialize::serialize_u64(&mut emitter_bytes, emitter_cap.emitter);
         external_address::from_bytes(emitter_bytes)
     }
 

--- a/aptos/wormhole/sources/external_address.move
+++ b/aptos/wormhole/sources/external_address.move
@@ -1,7 +1,7 @@
 /// 32 byte, left-padded address representing an arbitrary address, to be used in VAAs to
 /// refer to addresses.
 module wormhole::external_address {
-    use aptos_framework::vector;
+    use std::vector;
 
     use wormhole::cursor::Cursor;
     use wormhole::deserialize;

--- a/aptos/wormhole/sources/guardian_pubkey.move
+++ b/aptos/wormhole/sources/guardian_pubkey.move
@@ -2,13 +2,13 @@
 /// That is, they are computed by taking the last 20 bytes of the keccak256
 /// hash of their 64 byte secp256k1 public key.
 module wormhole::guardian_pubkey {
-    use 0x1::secp256k1::{
+    use aptos_std::secp256k1::{
         ECDSARawPublicKey,
         ECDSASignature,
         ecdsa_raw_public_key_to_bytes,
         ecdsa_recover,
     };
-    use 0x1::vector;
+    use std::vector;
     use wormhole::keccak256::keccak256;
 
     /// An error occurred while deserializing, for example due to wrong input size.
@@ -55,7 +55,7 @@ module wormhole::guardian_pubkey {
 #[test_only]
 module wormhole::guardian_pubkey_test {
     use wormhole::guardian_pubkey;
-    use 0x1::secp256k1::{
+    use aptos_std::secp256k1::{
         ecdsa_raw_public_key_from_64_bytes,
         ecdsa_signature_from_bytes
     };

--- a/aptos/wormhole/sources/guardian_set_upgrade.move
+++ b/aptos/wormhole/sources/guardian_set_upgrade.move
@@ -10,7 +10,7 @@ module wormhole::guardian_set_upgrade {
     };
     use wormhole::u32::{Self,U32};
     use wormhole::u16;
-    use 0x1::vector::{Self};
+    use std::vector;
 
     const E_WRONG_GUARDIAN_LEN: u64 = 0x0;
     const E_NO_GUARDIAN_SET: u64 = 0x1;
@@ -98,7 +98,7 @@ module wormhole::guardian_set_upgrade_test {
     use wormhole::guardian_set_upgrade;
     use wormhole::wormhole;
     use wormhole::state;
-    use 0x1::vector;
+    use std::vector;
     use wormhole::structs::{create_guardian};
     use wormhole::u32;
 

--- a/aptos/wormhole/sources/serialize.move
+++ b/aptos/wormhole/sources/serialize.move
@@ -1,5 +1,5 @@
 module wormhole::serialize {
-    use 0x1::vector;
+    use std::vector;
     use wormhole::u16::{Self, U16};
     use wormhole::u32::{Self, U32};
     use wormhole::u256::U256;
@@ -57,7 +57,7 @@ module wormhole::test_serialize {
     use wormhole::u32;
     use wormhole::u16;
     use wormhole::u256;
-    use 0x1::vector;
+    use std::vector;
 
     #[test]
     fun test_serialize_u8(){

--- a/aptos/wormhole/sources/state.move
+++ b/aptos/wormhole/sources/state.move
@@ -21,7 +21,7 @@ module wormhole::state {
     }
 
     struct WormholeMessage has store, drop {
-        sender: u128,
+        sender: u64,
         sequence: u64,
         nonce: u64,
         payload: vector<u8>,
@@ -110,7 +110,7 @@ module wormhole::state {
     }
 
     public(friend) entry fun publish_event(
-        sender: u128,
+        sender: u64,
         sequence: u64,
         nonce: u64,
         payload: vector<u8>,

--- a/aptos/wormhole/sources/vaa.move
+++ b/aptos/wormhole/sources/vaa.move
@@ -1,6 +1,6 @@
 module wormhole::vaa {
-    use 0x1::vector;
-    use 0x1::secp256k1;
+    use std::vector;
+    use aptos_std::secp256k1;
 
     use wormhole::u16::{U16};
     use wormhole::u32::{U32};

--- a/aptos/wormhole/sources/wormhole.move
+++ b/aptos/wormhole/sources/wormhole.move
@@ -130,7 +130,7 @@ module wormhole::wormhole {
 
 #[test_only]
 module wormhole::wormhole_test {
-    use 0x1::hash;
+    use std::hash;
     use wormhole::wormhole;
     use wormhole::keccak256::keccak256;
     use aptos_framework::aptos_coin::{Self};

--- a/clients/js/networks.ts
+++ b/clients/js/networks.ts
@@ -216,7 +216,7 @@ const TESTNET = {
     key: undefined,
   },
   aptos: {
-    rpc: "https://fullnode.devnet.aptoslabs.com/v1",
+    rpc: "https://fullnode.testnet.aptoslabs.com/v1",
     key: get_env_var("APTOS_TESTNET"),
   },
   sui: {


### PR DESCRIPTION
The contracts are now deployed on the long-lived testnet.

Emitter addresses are now represented as u64 instead of u128, this is to streamline the watcher component (will be a separate PR).

There was a fun issue with deployment. I first deployed the contract bytecodes, but the init functions were failing with a `MISSING_DEPENDENCY` runtime error. It turns out that vector operations are not native functions, but implemented as Move VM opcodes directly (whereas natives are implemented by the backend as magic). There's a rewriter pass in the move compiler that replaces vector operations with the opcodes, defined here: https://github.com/move-language/move/blob/main/language/move-compiler/src/naming/fake_natives.rs#L99-L116. Notice that the rewriter matches on the AST _before_ address substitution is performed, which means that only calls to `std::vector` will be picked up, but not `0x1::vector`. So after replacing the `0x1::vector` imports with `std::vector` imports, I managed to successfully upgrade and initialise the contracts.

Why did this only fail now, and not before? Until recently, the aptos native function table was populated with the vector operations, but this PR removed that: https://github.com/aptos-labs/aptos-core/pull/4621.

Why did this only fail _after_ deployment, not during deployment, or better, at compile time? It turns out that native dependencies are resolved lazily, i.e. at runtime, as opposed to linking (deployment) time. This created a scenario where the contracts had already been deployed, but unable to execute. The normal contract upgrade flow thus didn't work, because that goes through the contract itself, which in this case was not initialised yet properly. I thus made changes to the deployer module to allow the deployer account to perform upgrades of resource account modules as long as the resource account hasn't been initialised yet (that is, hasn't claimed the signer capability). This is actually nicer behaviour, because it allows deploying to a resource account and performing upgrades by the deployer, and only at a later stage transfer authority to the contract itself.