### PR TITLE
Sui: dynamic child object setup, treasury.move, TreasuryCapStore, CoinStore

### DIFF
--- a/sui/token_bridge/README.md
+++ b/sui/token_bridge/README.md
@@ -2,6 +2,12 @@
 
 The Token Bridge is responsible for storing treasury caps and locked tokens and exposing functions for initiating and completing transfers, which are gated behind VAAs. It also supports token attestations from foreign chains (which must be done once prior to transfer), contract upgrades, and chain registration.
 
+## Token Attestation
+
+Right now it is unclear how to do token attestation.
+
+There doesn't seem to be a standardized way to store info about a coin. One way is to create a `CoinInfo` object containing the name, symbol, decimals of the token, and `transfer::freeze_object` it.
+
 ## Creating new Coin Types
 We emulate the transferable witness pattern to allow users to call into the token bridge contract and prompt it to create a new currency representing a wrapped asset.
 

--- a/sui/token_bridge/README.md
+++ b/sui/token_bridge/README.md
@@ -4,7 +4,7 @@ The Token Bridge is responsible for storing treasury caps and locked tokens and 
 
 ## Token Attestation
 
-Right now it is unclear how to do token attestation.
+Right now it is unclear how to do token attestation, because Mysten Labs is still working on a token metadata standard, like ERC20.
 
 There doesn't seem to be a standardized way to store info about a coin. One way is to create a `CoinInfo` object containing the name, symbol, decimals of the token, and `transfer::freeze_object` it.
 

--- a/sui/token_bridge/sources/attest_token.move
+++ b/sui/token_bridge/sources/attest_token.move
@@ -1,0 +1,143 @@
+l// module token_bridge::attest_token {
+//     use aptos_framework::aptos_coin::{AptosCoin};
+//     use aptos_framework::coin::{Self, Coin};
+
+ea//     use token_bridge::asset_meta::{Self, AssetMeta};
+//     use token_bridge::state;
+//     use token_bridge::token_hash;
+//     use token_bridge::string32;
+
+//     const E_COIN_IS_NOT_INITIALIZED: u64 = 0;
+//     /// Wrapped assets can't be attested
+//     const E_WRAPPED_ASSET: u64 = 1;
+
+//     public fun attest_token_with_signer<CoinType>(user: &signer): u64 {
+//         let message_fee = wormhole::state::get_message_fee();
+//         let fee_coins = coin::withdraw<AptosCoin>(user, message_fee);
+//         attest_token<CoinType>(fee_coins)
+//     }
+
+//     public fun attest_token<CoinType>(fee_coins: Coin<AptosCoin>): u64 {
+//         let asset_meta: AssetMeta = attest_token_internal<CoinType>();
+//         let payload: vector<u8> = asset_meta::encode(asset_meta);
+//         let nonce = 0;
+//         state::publish_message(
+//             nonce,
+//             payload,
+//             fee_coins
+//         )
+//     }
+
+//     #[test_only]
+//     public fun attest_token_test<CoinType>(): AssetMeta {
+//         attest_token_internal<CoinType>()
+//     }
+
+//     fun attest_token_internal<CoinType>(): AssetMeta {
+//         // wrapped assets and uninitialised type can't be attested.
+//         assert!(!state::is_wrapped_asset<CoinType>(), E_WRAPPED_ASSET);
+//         assert!(coin::is_coin_initialized<CoinType>(), E_COIN_IS_NOT_INITIALIZED); // not tested
+
+//         let token_address = token_hash::derive<CoinType>();
+//         if (!state::is_registered_native_asset<CoinType>()) {
+//             // if native asset is not registered, register it in the reverse look-up map
+//             state::set_native_asset_type_info<CoinType>();
+//         };
+//         let token_chain = wormhole::state::get_chain_id();
+//         let decimals = coin::decimals<CoinType>();
+//         let symbol = string32::from_string(&coin::symbol<CoinType>());
+//         let name = string32::from_string(&coin::name<CoinType>());
+//         asset_meta::create(
+//             token_hash::get_external_address(&token_address),
+//             token_chain,
+//             decimals,
+//             symbol,
+//             name
+//         )
+//     }
+// }
+
+// #[test_only]
+// module token_bridge::attest_token_test {
+//     use aptos_framework::coin;
+//     use aptos_framework::string::utf8;
+//     use aptos_framework::type_info::type_of;
+
+//     use token_bridge::token_bridge::{Self as bridge};
+//     use token_bridge::state;
+//     use token_bridge::attest_token;
+//     use token_bridge::token_hash;
+//     use token_bridge::asset_meta;
+//     use token_bridge::string32;
+//     use token_bridge::wrapped_test;
+
+//     struct MyCoin has key {}
+
+//     fun setup(
+//         token_bridge: &signer,
+//         deployer: &signer,
+//     ) {
+//         // we initialise the bridge with zero fees to avoid having to mint fee
+//         // tokens in these tests. The wormolhe fee handling is already tested
+//         // in wormhole.move, so it's unnecessary here.
+//         wormhole::wormhole_test::setup(0);
+//         bridge::init_test(deployer);
+
+//         init_my_token(token_bridge);
+//     }
+
+//     fun init_my_token(admin: &signer) {
+//         let name = utf8(b"Some test coin");
+//         let symbol = utf8(b"TEST");
+//         let decimals = 10;
+//         let monitor_supply = true;
+//         let (burn_cap, freeze_cap, mint_cap) = coin::initialize<MyCoin>(admin, name, symbol, decimals, monitor_supply);
+//         coin::destroy_burn_cap(burn_cap);
+//         coin::destroy_freeze_cap(freeze_cap);
+//         coin::destroy_mint_cap(mint_cap);
+//     }
+
+//     #[test(token_bridge=@token_bridge, deployer=@deployer)]
+//     fun test_attest_token(token_bridge: &signer, deployer: &signer) {
+//         use std::string;
+
+//         setup(token_bridge, deployer);
+//         let asset_meta = attest_token::attest_token_test<MyCoin>();
+
+//         let token_address = asset_meta::get_token_address(&asset_meta);
+//         let token_chain = asset_meta::get_token_chain(&asset_meta);
+//         let decimals = asset_meta::get_decimals(&asset_meta);
+//         let symbol = string32::to_string(&asset_meta::get_symbol(&asset_meta));
+//         let name = string32::to_string(&asset_meta::get_name(&asset_meta));
+
+//         assert!(token_address == token_hash::get_external_address(&token_hash::derive<MyCoin>()), 0);
+//         assert!(token_chain == wormhole::u16::from_u64(22), 0);
+//         assert!(decimals == 10, 0);
+//         assert!(name == string::utf8(b"Some test coin"), 0);
+//         assert!(symbol == string::utf8(b"TEST"), 0);
+//     }
+
+//     #[test(token_bridge=@token_bridge, deployer=@deployer)]
+//     #[expected_failure(abort_code = 1)]
+//     fun test_attest_wrapped_token(token_bridge: &signer, deployer: &signer) {
+//         setup(token_bridge, deployer);
+//         wrapped_test::init_wrapped_token();
+//         // this should fail because T is a wrapped asset
+//         let _asset_meta = attest_token::attest_token_test<wrapped_coin::coin::T>();
+//     }
+
+//     #[test(token_bridge=@token_bridge, deployer=@deployer)]
+//     fun test_attest_token_with_signer(token_bridge: &signer, deployer: &signer) {
+//         setup(token_bridge, deployer);
+//         let asset_meta1 = attest_token::attest_token_test<MyCoin>();
+
+//         // check that native asset is registered with State
+//         let token_address = token_hash::derive<MyCoin>();
+//         assert!(state::native_asset_info(token_address) == type_of<MyCoin>(), 0);
+
+//         // attest same token a second time, should have no change in behavior
+//         let asset_meta2 = attest_token::attest_token_test<MyCoin>();
+//         assert!(asset_meta1 == asset_meta2, 0);
+//         assert!(state::native_asset_info(token_address) == type_of<MyCoin>(), 0);
+//     }
+// }

--- a/sui/token_bridge/sources/attest_token.move
+++ b/sui/token_bridge/sources/attest_token.move
@@ -1,8 +1,11 @@
-l// module token_bridge::attest_token {
+// TODO - implement attest token when Sui token standard is available,
+//        code for Aptos attest token is below
+
+// module token_bridge::attest_token {
 //     use aptos_framework::aptos_coin::{AptosCoin};
 //     use aptos_framework::coin::{Self, Coin};
 
-ea//     use token_bridge::asset_meta::{Self, AssetMeta};
+//     use token_bridge::asset_meta::{Self, AssetMeta};
 //     use token_bridge::state;
 //     use token_bridge::token_hash;
 //     use token_bridge::string32;

--- a/sui/token_bridge/sources/bridge_state.move
+++ b/sui/token_bridge/sources/bridge_state.move
@@ -2,7 +2,7 @@ module token_bridge::bridge_state {
    //use std::vector::{Self};
    use std::option::{Self, Option};
 
-   //use sui::object::{UID};
+   use sui::object::{UID};
    //use sui::coin::TreasuryCap;
    use sui::vec_map::{Self, VecMap};
    use sui::vec_set::{Self, VecSet};
@@ -16,6 +16,7 @@ module token_bridge::bridge_state {
    const E_WRAPPED_ASSET_NOT_INITIALIZED: u64 = 3;
 
    friend token_bridge::vaa;
+   friend token_bridge::register_chain;
 
    /// The origin chain and address of a token.  In case of native tokens
    /// (where the chain is aptos), the token_address is the hash of the token
@@ -25,7 +26,8 @@ module token_bridge::bridge_state {
       token_address: ExternalAddress,
    }
 
-   struct BridgeState {
+   struct BridgeState has key {
+      id: UID,
       governance_chain_id: U16,
       governance_contract: ExternalAddress,
 
@@ -84,19 +86,6 @@ module token_bridge::bridge_state {
       }
    }
 
-   // }
-
-   // // given the hash of the TypeInfo of a Coin, this tells us if it is registered with Token Bridge
-   // public fun is_registered_native_asset<CoinType>(): bool acquires State {
-   //    let token = token_hash::derive<CoinType>();
-   //    let native_infos = &borrow_global<State>(@token_bridge).native_infos;
-   //    !is_wrapped_asset<CoinType>() && table::contains(native_infos, token)
-   // }
-
-   // public fun is_wrapped_asset<CoinType>(): bool {
-   //    exists<OriginInfo>(type_info::account_address(&type_of<CoinType>()))
-   // }
-
    // setters
 
    public(friend) fun set_vaa_consumed(state: &mut BridgeState, hash: vector<u8>) {
@@ -109,5 +98,9 @@ module token_bridge::bridge_state {
 
    public(friend) fun set_governance_contract(state: &mut BridgeState, governance_contract: ExternalAddress) {
       state.governance_contract = governance_contract;
+   }
+
+   public (friend) fun set_registered_emitter(state: &mut BridgeState, chain_id: U16, emitter: ExternalAddress) {
+      vec_map::insert<U16, ExternalAddress>(&mut state.registered_emitters, chain_id, emitter);
    }
 }

--- a/sui/token_bridge/sources/bridge_state.move
+++ b/sui/token_bridge/sources/bridge_state.move
@@ -3,7 +3,6 @@ module token_bridge::bridge_state {
    use std::option::{Self, Option};
 
    use sui::object::{UID};
-   //use sui::coin::TreasuryCap;
    use sui::vec_map::{Self, VecMap};
    use sui::vec_set::{Self, VecSet};
 
@@ -26,7 +25,7 @@ module token_bridge::bridge_state {
       token_address: ExternalAddress,
    }
 
-   struct BridgeState has key {
+   struct BridgeState has key, store {
       id: UID,
       governance_chain_id: U16,
       governance_contract: ExternalAddress,

--- a/sui/token_bridge/sources/complete_transfer.move
+++ b/sui/token_bridge/sources/complete_transfer.move
@@ -1,0 +1,4 @@
+module token_bridge::complete_transfer {
+
+
+}

--- a/sui/token_bridge/sources/register_chain.move
+++ b/sui/token_bridge/sources/register_chain.move
@@ -1,0 +1,165 @@
+module token_bridge::register_chain {
+
+    use sui::tx_context::TxContext;
+
+    use wormhole::myu16::{Self as u16, U16};
+    use wormhole::cursor;
+    use wormhole::deserialize;
+    use wormhole::myvaa::{Self as corevaa};
+    use wormhole::external_address::{Self, ExternalAddress};
+    use wormhole::state::{State as WormholeState};
+
+    use token_bridge::vaa as token_bridge_vaa;
+    use token_bridge::bridge_state::{Self as bridge_state, BridgeState};
+
+    /// "TokenBridge" (left padded)
+    const TOKEN_BRIDGE: vector<u8> = x"000000000000000000000000000000000000000000546f6b656e427269646765";
+
+    const E_INVALID_MODULE: u64 = 0;
+    const E_INVALID_ACTION: u64 = 1;
+    const E_INVALID_TARGET: u64 = 2;
+
+    struct RegisterChain has copy, drop {
+        /// Chain ID
+        emitter_chain_id: U16,
+        /// Emitter address. Left-zero-padded if shorter than 32 bytes
+        emitter_address: ExternalAddress,
+    }
+
+    #[test_only]
+    public fun parse_payload_test(payload: vector<u8>): RegisterChain {
+        parse_payload(payload)
+    }
+
+    fun parse_payload(payload: vector<u8>): RegisterChain {
+        let cur = cursor::cursor_init(payload);
+        let target_module = deserialize::deserialize_vector(&mut cur, 32);
+
+        assert!(target_module == TOKEN_BRIDGE, E_INVALID_MODULE);
+
+        let action = deserialize::deserialize_u8(&mut cur);
+        assert!(action == 0x01, E_INVALID_ACTION);
+
+        // TODO(csongor): should we also accept a VAA targeting aptos directly?
+        // why would a registration VAA target a specific chain?
+        let target_chain = deserialize::deserialize_u16(&mut cur);
+        assert!(target_chain == u16::from_u64(0x0), E_INVALID_TARGET);
+
+        let emitter_chain_id = deserialize::deserialize_u16(&mut cur);
+
+        let emitter_address = external_address::deserialize(&mut cur);
+
+        cursor::destroy_empty(cur);
+
+        RegisterChain { emitter_chain_id, emitter_address }
+    }
+
+    // TODO - make this an entry fun?
+    public entry fun submit_vaa(wormhole_state: &mut WormholeState, bridge_state: &mut BridgeState, vaa: vector<u8>, ctx: &mut TxContext) {
+        let vaa = corevaa::parse_and_verify(wormhole_state, vaa, ctx);
+        corevaa::assert_governance(wormhole_state, &vaa); // not tested
+        token_bridge_vaa::replay_protect(bridge_state, &vaa);
+
+        let RegisterChain { emitter_chain_id, emitter_address } = parse_payload(corevaa::destroy(vaa));
+
+        bridge_state::set_registered_emitter(bridge_state, emitter_chain_id, emitter_address);
+    }
+
+    public fun get_emitter_chain_id(a: &RegisterChain): U16 {
+        a.emitter_chain_id
+    }
+
+    public fun get_emitter_address(a: &RegisterChain): ExternalAddress {
+        a.emitter_address
+    }
+
+}
+
+// #[test_only]
+// module token_bridge::register_chain_test {
+//     use std::option;
+//     use wormhole::u16;
+//     use token_bridge::register_chain;
+//     use wormhole::vaa;
+//     use wormhole::wormhole;
+//     use wormhole::external_address;
+//     use token_bridge::token_bridge;
+//     use token_bridge::state;
+
+//     /// Registration VAA for the etheruem token bridge 0xdeadbeef
+//     const ETHEREUM_TOKEN_REG: vector<u8> = x"0100000000010015d405c74be6d93c3c33ed6b48d8db70dfb31e0981f8098b2a6c7583083e0c3343d4a1abeb3fc1559674fa067b0c0e2e9de2fafeaecdfeae132de2c33c9d27cc0100000001000000010001000000000000000000000000000000000000000000000000000000000000000400000000016911ae00000000000000000000000000000000000000000000546f6b656e427269646765010000000200000000000000000000000000000000000000000000000000000000deadbeef";
+
+//     /// Another registration VAA for the ethereum token bridge, 0xbeefface
+//     const ETHEREUM_TOKEN_REG_2:vector<u8> = x"01000000000100c2157fa1c14957dff26d891e4ad0d993ad527f1d94f603e3d2bb1e37541e2fbe45855ffda1efc7eb2eb24009a1585fa25a267815db97e4a9d4a5eb31987b5fb40100000001000000010001000000000000000000000000000000000000000000000000000000000000000400000000017ca43300000000000000000000000000000000000000000000546f6b656e427269646765010000000200000000000000000000000000000000000000000000000000000000beefface";
+
+//     /// Registration VAA for the etheruem NFT bridge 0xdeadbeef
+//     const ETHEREUM_NFT_REG: vector<u8> = x"0100000000010066cce2cb12d88c97d4975cba858bb3c35d6430003e97fced46a158216f3ca01710fd16cc394441a08fef978108ed80c653437f43bb2ca039226974d9512298b10000000001000000010001000000000000000000000000000000000000000000000000000000000000000400000000018483540000000000000000000000000000000000000000000000004e4654427269646765010000000200000000000000000000000000000000000000000000000000000000deadbeef";
+
+//     const ETH_ID: u64 = 2;
+
+//     fun setup(deployer: &signer) {
+//         let aptos_framework = std::account::create_account_for_test(@aptos_framework);
+//         std::timestamp::set_time_has_started_for_testing(&aptos_framework);
+//         wormhole::init_test(
+//             22,
+//             1,
+//             x"0000000000000000000000000000000000000000000000000000000000000004",
+//             x"beFA429d57cD18b7F8A4d91A2da9AB4AF05d0FBe",
+//             0
+//         );
+//         token_bridge::init_test(deployer);
+//     }
+
+//     #[test]
+//     public fun test_parse() {
+//         let vaa = vaa::parse_test(ETHEREUM_TOKEN_REG);
+//         let register_chain = register_chain::parse_payload_test(vaa::destroy(vaa));
+//         let chain = register_chain::get_emitter_chain_id(&register_chain);
+//         let address = register_chain::get_emitter_address(&register_chain);
+
+//         assert!(chain == u16::from_u64(ETH_ID), 0);
+//         assert!(address == external_address::from_bytes(x"deadbeef"), 0);
+
+//     }
+
+//     #[test]
+//     #[expected_failure(abort_code = 0)]
+//     public fun test_parse_fail() {
+//         let vaa = vaa::parse_test(ETHEREUM_NFT_REG);
+//         // this should fail because it's an NFT registration
+//         let _register_chain = register_chain::parse_payload_test(vaa::destroy(vaa));
+
+//     }
+
+//     #[test(deployer = @deployer)]
+//     public fun test_registration(deployer: &signer) {
+//         setup(deployer);
+
+//         register_chain::submit_vaa(ETHEREUM_TOKEN_REG);
+//         let address = state::get_registered_emitter(u16::from_u64(ETH_ID));
+//         assert!(address == option::some(external_address::from_bytes(x"deadbeef")), 0);
+//     }
+
+//     #[test(deployer = @deployer)]
+//     #[expected_failure(abort_code = 25607)]
+//     public fun test_replay_protect(deployer: &signer) {
+//         setup(deployer);
+
+//         register_chain::submit_vaa(ETHEREUM_TOKEN_REG);
+//         register_chain::submit_vaa(ETHEREUM_TOKEN_REG);
+//     }
+
+//     #[test(deployer = @deployer)]
+//     public fun test_re_registration(deployer: &signer) {
+//         test_registration(deployer);
+
+//         // TODO(csongor): we register ethereum again, which overrides the
+//         // previous one. This deviates from other chains (where this is
+//         // rejected), but I think this is the right behaviour.
+//         // Easy to change, should be discussed.
+//         register_chain::submit_vaa(ETHEREUM_TOKEN_REG_2);
+//         let address = state::get_registered_emitter(u16::from_u64(ETH_ID));
+//         assert!(address == option::some(external_address::from_bytes(x"beefface")), 0);
+//     }
+
+// }

--- a/sui/token_bridge/sources/treasury.move
+++ b/sui/token_bridge/sources/treasury.move
@@ -1,0 +1,80 @@
+// This module defines stores for TreasuryCaps and Coins
+// owned by the Token Bridge, as well as related functions
+// like minting and burning wrapped tokens.
+
+// TODO: full support dynamic child object access pattern when available:
+//       https://github.com/MystenLabs/sui/issues/4203
+
+module token_bridge::treasury {
+    use sui::tx_context::{TxContext};
+    use sui::object::{Self, UID};
+    use sui::coin::{Self, TreasuryCap, Coin};
+    //use sui::balance::{Self};
+    use sui::transfer::{Self};
+
+    use token_bridge::bridge_state::{BridgeState};
+
+    friend token_bridge::wrapped;
+
+    struct TreasuryCapStore<phantom CoinType> has key, store {
+        id: UID,
+        cap: TreasuryCap<CoinType>,
+    }
+
+    struct UnparametrizedObject has key, store {id: UID}
+
+    struct CoinStore<phantom CoinType> has key, store {
+        id: UID,
+        coins: Coin<CoinType>,
+    }
+
+    #[test_only]
+    public entry fun init_unparametrized_object(bridge_state: &mut BridgeState, ctx: &mut TxContext){
+        transfer::transfer_to_object<UnparametrizedObject, BridgeState>(UnparametrizedObject{id: object::new(ctx)}, bridge_state);
+    }
+
+    public(friend) fun create_treasury_cap_store<CoinType>(bridge_state: &mut BridgeState, cap: TreasuryCap<CoinType>, ctx: &mut TxContext) { //
+        let store = TreasuryCapStore<CoinType> { id: object::new(ctx), cap: cap };
+        transfer::transfer_to_object<TreasuryCapStore<CoinType>,BridgeState>(store, bridge_state);
+    }
+
+    public(friend) fun create_coin_store<CoinType>(bridge_state: &mut BridgeState, ctx: &mut TxContext) {
+        let store = CoinStore<CoinType> { id: object::new(ctx), coins: coin::zero<CoinType>(ctx) };
+        transfer::transfer_to_object<CoinStore<CoinType>,BridgeState>(store, bridge_state);
+    }
+
+    // One can only call mint in complete_transfer when minting wrapped assets is necessary
+    // TODO: get instead of passing in TreasuryCapStore, we should pass in BridgeState,
+    //       and get the child TreasuryCapStore object dynamically
+    public(friend) fun mint<T: drop>(
+        cap_container: &mut TreasuryCapStore<T>,
+        value: u64,
+        ctx: &mut TxContext,
+    ): Coin<T> {
+        coin::mint<T>(&mut cap_container.cap, value, ctx)
+    }
+
+    public(friend) fun burn<T: drop>(
+        cap_container: &mut TreasuryCapStore<T>,
+        coin: Coin<T>,
+    ) {
+        coin::burn<T>(&mut cap_container.cap, coin);
+    }
+
+    //public(friend) fun deposit<CoinType>(_bridge_state: &mut BridgeState, _coin: Coin<CoinType>) {
+        // TODO: detect if CoinStore<CoinType> exists as a child object of bridge_state
+        //        if it is not a child object, initialize a CoinStore and transfer it to bridge
+        //        if it is, obtain a reference to it
+        // TODO: coin::join<CoinType>(&mut coin_store, coin);
+    //}
+
+    //public(friend) fun withdraw<phantom CoinType>(_bridge_state: &mut BridgeState, value: u64, ctx: &mut TxContext) { //: Coin<CoinType> {
+        // TODO: detect if CoinStore<CoinType> exists as a child object of bridge_state
+        //        if it is not a child object, initialize a CoinStore and transfer it to bridge
+        //        if it is, obtain a reference to it
+
+        //let balance_mut = coins::balance_mut<CoinType>(&mut store.coins, ctx);
+        //coin::take<CoinType>(balance_mut, value, ctx)
+    //}
+
+}

--- a/sui/token_bridge/sources/wrapped.move
+++ b/sui/token_bridge/sources/wrapped.move
@@ -28,9 +28,6 @@ module token_bridge::wrapped {
         let treasury_cap = coin::create_currency<T>(witness, ctx);
         // TODO - assert emitter is registered, extract decimals, token name, symbol, etc. from asset meta
         // TODO - figure out where to store name, symbol, etc.
-        // let native_token_address = asset_meta::get_token_address(&asset_meta);
-        // let native_token_chain = asset_meta::get_token_chain(&asset_meta);
-        // let origin_info = state::create_origin_info(native_token_chain, native_token_address);
         transfer::share_object(TreasuryCapContainer{id: object::new(ctx), t: treasury_cap});
     }
 

--- a/sui/token_bridge/sources/wrapped.move
+++ b/sui/token_bridge/sources/wrapped.move
@@ -1,20 +1,22 @@
 module token_bridge::wrapped {
     use sui::tx_context::TxContext;
-    use sui::object::{Self, UID};
-    use sui::coin::{Self, Coin, TreasuryCap};
-    use sui::transfer::{Self};
+    //use sui::object::{Self, UID};
+    use sui::coin::{Self};
+    //use sui::coin::{Self, Coin, TreasuryCap};
+    //use sui::transfer::{Self};
 
     use token_bridge::bridge_state::{BridgeState};
     use token_bridge::vaa::{Self as token_bridge_vaa};
     use token_bridge::asset_meta::{AssetMeta, Self};
+    use token_bridge::treasury::{Self};
 
     use wormhole::state::{State as WormholeState};
     use wormhole::myvaa::{Self as corevaa};
 
-    struct TreasuryCapContainer<phantom CoinType> has key, store {
-        id: UID,
-        t: TreasuryCap<CoinType>,
-    }
+    // struct TreasuryCapContainer<phantom CoinType> has key, store {
+    //     id: UID,
+    //     t: TreasuryCap<CoinType>,
+    // }
 
     public fun create_wrapped_coin<T: drop>(
         state: &mut WormholeState,
@@ -28,15 +30,6 @@ module token_bridge::wrapped {
         let treasury_cap = coin::create_currency<T>(witness, ctx);
         // TODO - assert emitter is registered, extract decimals, token name, symbol, etc. from asset meta
         // TODO - figure out where to store name, symbol, etc.
-        transfer::share_object(TreasuryCapContainer{id: object::new(ctx), t: treasury_cap});
-    }
-
-    // One can only call mint in complete_transfer when minting wrapped assets is necessary
-    public(friend) fun mint<T: drop>(
-        cap_container: &mut TreasuryCapContainer<T>,
-        value: u64,
-        ctx: &mut TxContext,
-    ): Coin<T> {
-        coin::mint<T>(&mut cap_container.t, value, ctx)
+        treasury::create_treasury_cap_store<T>(bridge_state, treasury_cap, ctx);
     }
 }

--- a/sui/wormhole/Move.toml
+++ b/sui/wormhole/Move.toml
@@ -6,4 +6,4 @@ version = "0.0.1"
 Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework", rev = "devnet" }
 
 [addresses]
-wormhole = "0xd3361388d6c9df295c98e91ae258267dbce7c8e7"
+wormhole = "0x0"

--- a/sui/wormhole/Move.toml
+++ b/sui/wormhole/Move.toml
@@ -6,4 +6,4 @@ version = "0.0.1"
 Sui = { git = "https://github.com/MystenLabs/sui.git", subdir = "crates/sui-framework", rev = "devnet" }
 
 [addresses]
-wormhole = "0x0"
+wormhole = "0x4769931c1f0d0bc45efabdf8b33f4953f672a88f"


### PR DESCRIPTION
- Implement more of the token bridge, including `treasury.move`, which contains `TreasuryCapStore`, `CoinStore`, and related functions like minting and burning wrapped assets
- Tailored design to the dynamic Child object access pattern, we will be able to use it in `complete_transfer` and `transfer_tokens`, they will only need to take `BridgeState` as an arg, instead of the IDs of `TreasuryCapStore<CoinType>` or `CoinStore<CoinType>`
- RegisterChain.move
- README comments