### PR TITLE
cosmwasm: support natives over 8 decimals

### DIFF
--- a/cosmwasm/contracts/token-bridge/src/contract.rs
+++ b/cosmwasm/contracts/token-bridge/src/contract.rs
@@ -135,50 +135,50 @@ pub enum TransferType<A> {
 /// Ok(Response::default())
 /// ```
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> StdResult<Response> {
-    // This migration adds a new field to the [`ConfigInfo`] struct. The
-    // state stored on chain has the old version, so we first parse it as
-    // [`ConfigInfoLegacy`], then add the new fields, and write it back as [`ConfigInfo`].
-    // Since the only place the contract with the legacy state is deployed is
-    // terra2, we just hardcode the new value here for that chain.
+pub fn migrate(_deps: DepsMut, _env: Env, _msg: MigrateMsg) -> StdResult<Response> {
+    // // This migration adds a new field to the [`ConfigInfo`] struct. The
+    // // state stored on chain has the old version, so we first parse it as
+    // // [`ConfigInfoLegacy`], then add the new fields, and write it back as [`ConfigInfo`].
+    // // Since the only place the contract with the legacy state is deployed is
+    // // terra2, we just hardcode the new value here for that chain.
 
-    // 1. make sure this contract doesn't already have the new ConfigInfo struct
-    // in storage. Note that this check is not strictly necessary, as the
-    // upgrade will only be issued for terra2, and no new chains. However, it is
-    // good practice to ensure that migration code cannot be run twice, which
-    // this check achieves.
-    if config_read(deps.storage).load().is_ok() {
-        return Err(StdError::generic_err(
-            "Can't migrate; this contract already has a new ConfigInfo struct",
-        ));
-    }
+    // // 1. make sure this contract doesn't already have the new ConfigInfo struct
+    // // in storage. Note that this check is not strictly necessary, as the
+    // // upgrade will only be issued for terra2, and no new chains. However, it is
+    // // good practice to ensure that migration code cannot be run twice, which
+    // // this check achieves.
+    // if config_read(deps.storage).load().is_ok() {
+    //     return Err(StdError::generic_err(
+    //         "Can't migrate; this contract already has a new ConfigInfo struct",
+    //     ));
+    // }
 
-    // 2. parse old state
-    let ConfigInfoLegacy {
-        gov_chain,
-        gov_address,
-        wormhole_contract,
-        wrapped_asset_code_id,
-    } = config_read_legacy(deps.storage).load()?;
+    // // 2. parse old state
+    // let ConfigInfoLegacy {
+    //     gov_chain,
+    //     gov_address,
+    //     wormhole_contract,
+    //     wrapped_asset_code_id,
+    // } = config_read_legacy(deps.storage).load()?;
     
-    // 3. store new state with terra2 values hardcoded
-    let chain_id = 18;
-    let native_denom = "uluna".to_string();
-    let native_symbol = "LUNA".to_string();
-    let native_decimals = 6;
+    // // 3. store new state with terra2 values hardcoded
+    // let chain_id = 18;
+    // let native_denom = "uluna".to_string();
+    // let native_symbol = "LUNA".to_string();
+    // let native_decimals = 6;
 
-    let config_info = ConfigInfo {
-        gov_chain,
-        gov_address,
-        wormhole_contract,
-        wrapped_asset_code_id,
-        chain_id,
-        native_denom,
-        native_symbol,
-        native_decimals
-    };
+    // let config_info = ConfigInfo {
+    //     gov_chain,
+    //     gov_address,
+    //     wormhole_contract,
+    //     wrapped_asset_code_id,
+    //     chain_id,
+    //     native_denom,
+    //     native_symbol,
+    //     native_decimals
+    // };
 
-    config(deps.storage).save(&config_info)?;
+    // config(deps.storage).save(&config_info)?;
     Ok(Response::default())
 }
 

--- a/cosmwasm/contracts/token-bridge/src/contract.rs
+++ b/cosmwasm/contracts/token-bridge/src/contract.rs
@@ -89,6 +89,7 @@ use crate::{
         bridge_deposit,
         config,
         config_read,
+        config_read_legacy,
         is_wrapped_asset,
         is_wrapped_asset_read,
         receive_native,
@@ -101,6 +102,7 @@ use crate::{
         Action,
         AssetMeta,
         ConfigInfo,
+        ConfigInfoLegacy,
         RegisterChain,
         TokenBridgeMessage,
         TransferInfo,
@@ -133,8 +135,50 @@ pub enum TransferType<A> {
 /// Ok(Response::default())
 /// ```
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn migrate(_deps: DepsMut, _env: Env, _msg: MigrateMsg) -> StdResult<Response> {
-    // This migration is not, currently, needed as the upgrade has happened successfully.
+pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> StdResult<Response> {
+    // This migration adds a new field to the [`ConfigInfo`] struct. The
+    // state stored on chain has the old version, so we first parse it as
+    // [`ConfigInfoLegacy`], then add the new fields, and write it back as [`ConfigInfo`].
+    // Since the only place the contract with the legacy state is deployed is
+    // terra2, we just hardcode the new value here for that chain.
+
+    // 1. make sure this contract doesn't already have the new ConfigInfo struct
+    // in storage. Note that this check is not strictly necessary, as the
+    // upgrade will only be issued for terra2, and no new chains. However, it is
+    // good practice to ensure that migration code cannot be run twice, which
+    // this check achieves.
+    if config_read(deps.storage).load().is_ok() {
+        return Err(StdError::generic_err(
+            "Can't migrate; this contract already has a new ConfigInfo struct",
+        ));
+    }
+
+    // 2. parse old state
+    let ConfigInfoLegacy {
+        gov_chain,
+        gov_address,
+        wormhole_contract,
+        wrapped_asset_code_id,
+    } = config_read_legacy(deps.storage).load()?;
+    
+    // 3. store new state with terra2 values hardcoded
+    let chain_id = 18;
+    let native_denom = "uluna".to_string();
+    let native_symbol = "LUNA".to_string();
+    let native_decimals = 6;
+
+    let config_info = ConfigInfo {
+        gov_chain,
+        gov_address,
+        wormhole_contract,
+        wrapped_asset_code_id,
+        chain_id,
+        native_denom,
+        native_symbol,
+        native_decimals
+    };
+
+    config(deps.storage).save(&config_info)?;
     Ok(Response::default())
 }
 
@@ -152,6 +196,9 @@ pub fn instantiate(
         wormhole_contract: msg.wormhole_contract,
         wrapped_asset_code_id: msg.wrapped_asset_code_id,
         chain_id: msg.chain_id,
+        native_denom: msg.native_denom,
+        native_symbol: msg.native_symbol,
+        native_decimals: msg.native_decimals,
     };
     config(deps.storage).save(&state)?;
 
@@ -593,16 +640,19 @@ fn handle_create_asset_meta_native_token(
 ) -> StdResult<Response> {
     let cfg = config_read(deps.storage).load()?;
 
-    let symbol = format_native_denom_symbol(&denom);
+    if denom != cfg.native_denom {
+        return Err(StdError::generic_err("unsupported native token"));
+    }
+
     let token_id = TokenId::Bank { denom };
     let external_id = token_id.store(deps.storage)?;
 
     let meta: AssetMeta = AssetMeta {
         token_chain: cfg.chain_id,
         token_address: external_id.clone(),
-        decimals: 6,
-        symbol: extend_string_to_32(&symbol),
-        name: extend_string_to_32(&symbol),
+        decimals: cfg.native_decimals,
+        symbol: extend_string_to_32(&cfg.native_symbol),
+        name: extend_string_to_32(&cfg.native_symbol),
     };
     let token_bridge_message = TokenBridgeMessage {
         action: Action::ATTEST_META,
@@ -619,7 +669,7 @@ fn handle_create_asset_meta_native_token(
             funds: info.funds,
         }))
         .add_attribute("meta.token_chain", cfg.chain_id.to_string())
-        .add_attribute("meta.symbol", symbol)
+        .add_attribute("meta.symbol", cfg.native_symbol)
         .add_attribute("meta.asset_id", hex::encode(external_id.serialize()))
         .add_attribute("meta.nonce", nonce.to_string())
         .add_attribute("meta.block_time", env.block.time.seconds().to_string()))
@@ -1016,7 +1066,7 @@ fn handle_complete_transfer_token_native(
     };
 
     let (not_supported_amount, mut amount) = transfer_info.amount;
-    let (not_supported_fee, fee) = transfer_info.fee;
+    let (not_supported_fee, mut fee) = transfer_info.fee;
 
     amount = amount.checked_sub(fee).unwrap();
 
@@ -1027,6 +1077,12 @@ fn handle_complete_transfer_token_native(
 
     let external_address = ExternalTokenId::from_bank_token(&denom)?;
     receive_native(deps.storage, &external_address, Uint128::new(amount + fee))?;
+
+    // undo normalization to 8 decimals
+    let decimals = cfg.native_decimals;
+    let multiplier = 10u128.pow((max(decimals, 8u8) - 8u8) as u32);
+    amount = amount.checked_mul(multiplier).unwrap();
+    fee = fee.checked_mul(multiplier).unwrap();
 
     let mut messages = vec![CosmosMsg::Bank(BankMsg::Send {
         to_address: recipient.to_string(),
@@ -1329,30 +1385,24 @@ fn handle_initiate_transfer_token(
         .add_attribute("transfer.block_time", env.block.time.seconds().to_string()))
 }
 
-fn format_native_denom_symbol(denom: &str) -> String {
-    if denom == "uluna" {
-        return "LUNA".to_string();
-    } else if denom == "axpla" {
-        return "XPLA".to_string();
-    }
-    //TODO: is there better formatting to do here?
-    denom.to_uppercase()
-}
-
 #[allow(clippy::too_many_arguments)]
 fn handle_initiate_transfer_native_token(
     deps: DepsMut,
     env: Env,
     info: MessageInfo,
     denom: String,
-    amount: Uint128,
+    mut amount: Uint128,
     recipient_chain: u16,
     recipient: [u8; 32],
-    fee: Uint128,
+    mut fee: Uint128,
     transfer_type: TransferType<Vec<u8>>,
     nonce: u32,
 ) -> StdResult<Response> {
     let cfg = config_read(deps.storage).load()?;
+
+    if denom != cfg.native_denom {
+        return Err(StdError::generic_err("unsupported native token"));
+    }
 
     if recipient_chain == cfg.chain_id {
         return ContractError::SameSourceAndTarget.std_err();
@@ -1363,6 +1413,23 @@ fn handle_initiate_transfer_native_token(
     if fee > amount {
         return Err(StdError::generic_err("fee greater than sent amount"));
     }
+
+    let decimals = cfg.native_decimals;
+    let multiplier = 10u128.pow((max(decimals, 8u8) - 8u8) as u32);
+
+    // chop off dust
+    amount = Uint128::new(
+        amount
+            .u128()
+            .checked_sub(amount.u128().checked_rem(multiplier).unwrap())
+            .unwrap(),
+    );
+
+    fee = Uint128::new(
+        fee.u128()
+            .checked_sub(fee.u128().checked_rem(multiplier).unwrap())
+            .unwrap(),
+    );
 
     let deposit_key = format!("{}:{}", info.sender, denom);
     bridge_deposit(deps.storage).update(deposit_key.as_bytes(), |current: Option<Uint128>| {
@@ -1377,6 +1444,10 @@ fn handle_initiate_transfer_native_token(
     let asset_chain: u16 = cfg.chain_id;
     // we store here just in case the token is transferred out before it's attested
     let asset_address = TokenId::Bank { denom }.store(deps.storage)?;
+
+    // convert to normalized amounts before recording & posting vaa
+    amount = Uint128::new(amount.u128().checked_div(multiplier).unwrap());
+    fee = Uint128::new(fee.u128().checked_div(multiplier).unwrap());
 
     send_native(deps.storage, &asset_address, amount)?;
 

--- a/cosmwasm/contracts/token-bridge/src/msg.rs
+++ b/cosmwasm/contracts/token-bridge/src/msg.rs
@@ -30,6 +30,9 @@ pub struct InstantiateMsg {
     pub wrapped_asset_code_id: u64,
 
     pub chain_id: u16,
+    pub native_denom: String,
+    pub native_symbol: String,
+    pub native_decimals: u8,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/cosmwasm/contracts/token-bridge/src/state.rs
+++ b/cosmwasm/contracts/token-bridge/src/state.rs
@@ -79,6 +79,12 @@ pub struct ConfigInfo {
 
     /// The wormhole id of the current chain.
     pub chain_id: u16,
+
+    /// The native denom info of the current chain
+    /// Other tokens will not be allowed to be attested
+    pub native_denom: String,
+    pub native_symbol: String,
+    pub native_decimals: u8,
 }
 
 pub fn config(storage: &mut dyn Storage) -> Singleton<ConfigInfo> {

--- a/cosmwasm/test/src/__tests__/bridge.ts
+++ b/cosmwasm/test/src/__tests__/bridge.ts
@@ -185,6 +185,9 @@ test("Deploy Contracts", (done) => {
           wormhole_contract: wormhole,
           wrapped_asset_code_id: wrappedAssetCodeId,
           chain_id: 18,
+          native_denom: "uluna",
+          native_symbol: "LUNA",
+          native_decimals: 6,
         },
         "tokenBridge",
         tokenBridge_code

--- a/cosmwasm/tools/deploy.js
+++ b/cosmwasm/tools/deploy.js
@@ -181,6 +181,9 @@ addresses["token_bridge_terra_2.wasm"] = await instantiate(
     wormhole_contract: addresses["wormhole.wasm"],
     wrapped_asset_code_id: codeIds["cw20_wrapped_2.wasm"],
     chain_id: 18,
+    native_denom: "uluna",
+    native_symbol: "LUNA",
+    native_decimals: 6,
   },
   "tokenBridge"
 );

--- a/cosmwasm/tools/deploy_xpla.js
+++ b/cosmwasm/tools/deploy_xpla.js
@@ -198,6 +198,9 @@ addresses["token_bridge_terra_2.wasm"] = await instantiate(
     wormhole_contract: addresses["wormhole.wasm"],
     wrapped_asset_code_id: codeIds["cw20_wrapped_2.wasm"],
     chain_id: 28,
+    native_denom: "axpla",
+    native_symbol: "XPLA",
+    native_decimals: 18,
   },
   "tokenBridge"
 );


### PR DESCRIPTION
Previously, the cosmwasm contracts only had to handle Terra Classic or Terra 2, both of which natives have 6 decimals. But with more cosmwasm chains on the horizon (like XPLA) with larger decimal sizes (18 in the [axpla case](https://docs.xpla.io/docs/develop/core-modules/#conventions)), the code needs to handle normalization to 8 decimals on the way out and in.