### PR TITLE
docker: fix guardiand build action

### DIFF
--- a/Dockerfile.node
+++ b/Dockerfile.node
@@ -34,7 +34,6 @@ FROM scratch as export
 COPY --from=build /bin/* /bin/
 COPY --from=build /lib/* /lib/
 COPY --from=build /lib64/* /lib64/
-COPY --from=build /usr/lib/libwasmvm.so /usr/lib/
 
 # finally copy the guardian executable
 COPY --from=build /guardiand .


### PR DESCRIPTION
Looks like this action has been failing for a while. https://github.com/wormhole-foundation/wormhole/actions/runs/3239158698/jobs/5308206975
I expect this change will fix it.