### PR TITLE
tilt: shorten terra block time

### DIFF
--- a/cosmwasm/devnet/config/config.toml
+++ b/cosmwasm/devnet/config/config.toml
@@ -370,7 +370,7 @@ timeout_precommit_delta = "500ms"
 # How long we wait after committing a block, before starting on the new
 # height (this gives us a chance to receive some more precommits, even
 # though we already have +2/3).
-timeout_commit = "5s"
+timeout_commit = "0.5s"
 
 # How many blocks to look back to check existence of the node's consensus votes before joining consensus
 # When non-zero, the node will panic upon restart

--- a/terra/devnet/config/config.toml
+++ b/terra/devnet/config/config.toml
@@ -47,7 +47,7 @@ db_backend = "goleveldb"
 db_dir = "data"
 
 # Output level for logging, including package level options
-log_level = "debug"
+log_level = "info"
 
 # Output format: 'plain' (colored text) or 'json'
 log_format = "plain"
@@ -335,7 +335,7 @@ timeout_precommit_delta = "500ms"
 # How long we wait after committing a block, before starting on the new
 # height (this gives us a chance to receive some more precommits, even
 # though we already have +2/3).
-timeout_commit = "5s"
+timeout_commit = "0.5s"
 
 # How many blocks to look back to check existence of the node's consensus votes before joining consensus
 # When non-zero, the node will panic upon restart

--- a/terra/tools/deploy.js
+++ b/terra/tools/deploy.js
@@ -15,13 +15,7 @@ function sleep(ms) {
 }
 
 async function broadcastAndWait(terra, tx) {
-  const response = await terra.tx.broadcast(tx);
-  let currentHeight = (await terra.tendermint.blockInfo()).block.header.height;
-  while (currentHeight <= response.height) {
-    await sleep(100);
-    currentHeight = (await terra.tendermint.blockInfo()).block.header.height;
-  }
-  return response;
+  return await terra.tx.broadcast(tx);
 }
 
 /*


### PR DESCRIPTION
Reducing terra block times helps tilt startup times as transactions are sent block by block.

I intentionally did not set `skip_timeout_commit` to `true` as this would create blocks as fast as possible and `create_empty_blocks = false` is not an option as the ABCI apphash changes every block on terra which forces block creation.