### PR TITLE
scripts: uppercase digest in governance generator

### DIFF
--- a/scripts/contract-upgrade-governance.sh
+++ b/scripts/contract-upgrade-governance.sh
@@ -323,6 +323,11 @@ echo "$rest" >> "$gov_msg_file"
 verify=$(guardiand admin governance-vaa-verify "$gov_msg_file" 2>&1)
 digest=$(echo "$verify" | grep "VAA with digest" | cut -d' ' -f6 | sed 's/://g')
 
+# massage the digest into the same format that the inject command prints it
+digest=$(echo "$digest" | awk '{print toupper($0)}' | sed 's/^0X//')
+# we use the first 7 characters of the digest as an identifier for the prototxt file
+gov_id=$(echo "$digest" | cut -c1-7)
+
 ################################################################################
 # Print vote command and expected digests
 
@@ -333,12 +338,12 @@ cat <<-EOD
 	Shell command for voting:
 
 	\`\`\`shell
-	cat << EOF > governance.prototxt
+	cat << EOF > governance-$gov_id.prototxt
 	$(cat "$gov_msg_file")
 
 	EOF
 
-	guardiand admin governance-vaa-inject --socket /path/to/admin.sock governance.prototxt
+	guardiand admin governance-vaa-inject --socket /path/to/admin.sock governance-$gov_id.prototxt
 	\`\`\`
 
 	Expected digest(s):

--- a/scripts/register-chain-governance.sh
+++ b/scripts/register-chain-governance.sh
@@ -153,6 +153,11 @@ echo "$rest" >> "$gov_msg_file"
 verify=$(guardiand admin governance-vaa-verify "$gov_msg_file" 2>&1)
 digest=$(echo "$verify" | grep "VAA with digest" | cut -d' ' -f6 | sed 's/://g')
 
+# massage the digest into the same format that the inject command prints it
+digest=$(echo "$digest" | awk '{print toupper($0)}' | sed 's/^0X//')
+# we use the first 7 characters of the digest as an identifier for the prototxt file
+gov_id=$(echo "$digest" | cut -c1-7)
+
 ################################################################################
 # Print vote command and expected digests
 
@@ -163,12 +168,12 @@ cat <<-EOD
 	Shell command for voting:
 
 	\`\`\`shell
-	cat << EOF > governance.prototxt
+	cat << EOF > governance-$gov_id.prototxt
 	$(cat "$gov_msg_file")
 
 	EOF
 
-	guardiand admin governance-vaa-inject --socket /path/to/admin.sock governance.prototxt
+	guardiand admin governance-vaa-inject --socket /path/to/admin.sock governance-$gov_id.prototxt
 	\`\`\`
 
 	Expected digest(s):


### PR DESCRIPTION
the injection command prints out in this format, so it's easier to read for guardians this way