### PR TITLE
ci: unscoped npm package check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,8 +119,8 @@ jobs:
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-            toolchain: ${{ steps.toolchain.outputs.version }}
-            components: "clippy,rustfmt"
+          toolchain: ${{ steps.toolchain.outputs.version }}
+          components: "clippy,rustfmt"
 
       - name: Cache rust packages
         uses: actions/cache@v3
@@ -139,11 +139,11 @@ jobs:
 
       - name: Run `cargo check`
         run: cargo check --workspace --tests --manifest-path solana/Cargo.toml
-             --features "nft-bridge/instructions token-bridge/instructions wormhole-bridge-solana/instructions"
+          --features "nft-bridge/instructions token-bridge/instructions wormhole-bridge-solana/instructions"
 
       - name: Run `cargo clippy`
         run: cargo clippy --workspace --tests --manifest-path solana/Cargo.toml
-             --features "nft-bridge/instructions token-bridge/instructions wormhole-bridge-solana/instructions"
+          --features "nft-bridge/instructions token-bridge/instructions wormhole-bridge-solana/instructions"
 
       - name: Cache solana tools
         id: cache-solana
@@ -233,7 +233,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.19.0'
+          go-version: "1.19.0"
       - run: curl https://get.ignite.com/cli@v0.23.0 | bash && mv ignite /usr/local/bin/
       - run: cd wormhole_chain && make proto -B && make test
 
@@ -302,3 +302,10 @@ jobs:
         uses: actions/checkout@v2
       - run: chmod 755 ./scripts/check-docker-pin.sh
       - run: ./scripts/check-docker-pin.sh
+  npm-packages:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v2
+      - run: chmod 755 ./scripts/check-npm-package-scopes.sh
+      - run: ./scripts/check-npm-package-scopes.sh

--- a/aptos/scripts/package.json
+++ b/aptos/scripts/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "scripts",
-  "version": "1.0.0",
+  "name": "@wormhole-foundation/scripts-aptos",
+  "version": "0.0.1",
   "main": "index.js",
   "license": "MIT",
   "dependencies": {

--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "wormhole-client",
-  "version": "1.0.0",
+  "name": "@wormhole-foundation/wormhole-client",
+  "version": "0.0.1",
   "dependencies": {
     "@celo-tools/celo-ethers-wrapper": "^0.1.0",
     "@certusone/wormhole-sdk": "^0.7.1",

--- a/cosmwasm/test/package.json
+++ b/cosmwasm/test/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "test",
-  "version": "0.1.0",
+  "name": "@wormhole-foundation/tests-cosmwasm",
+  "version": "0.0.1",
   "description": "",
   "type": "module",
   "scripts": {

--- a/cosmwasm/tools/package.json
+++ b/cosmwasm/tools/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "tools",
-  "version": "1.0.0",
+  "name": "@wormhole-foundation/tools-cosmwasm",
+  "version": "0.0.1",
   "description": "",
   "main": "deploy.js",
   "type": "module",

--- a/ethereum/package.json
+++ b/ethereum/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "wormhole",
-  "version": "1.0.0",
+  "name": "@wormhole-foundation/contracts-ethereum",
+  "version": "0.0.1",
   "description": "",
   "main": "networks.js",
   "devDependencies": {

--- a/lp_ui/package.json
+++ b/lp_ui/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "lp_ui",
-  "version": "0.1.0",
+  "name": "@wormhole-foundation/ui-lp",
+  "version": "0.0.1",
   "private": true,
   "dependencies": {
     "@certusone/wormhole-sdk": "^0.1.1",

--- a/near/package.json
+++ b/near/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
-  "name": "wormhole-near",
-  "version": "1.0.0",
+  "name": "@wormhole-foundation/scripts-near",
+  "version": "0.0.1",
   "description": "Wormhole near support code",
   "keywords": [
     "near-protocol",

--- a/node/hack/governor/package.json
+++ b/node/hack/governor/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "cgov_token_gen",
-  "version": "1.0.0",
+  "name": "@wormhole-foundation/scripts-governor-token-generation",
+  "version": "0.0.1",
   "description": "Chain Governor Token Generator",
   "main": "index.ts",
   "scripts": {

--- a/relayer/spy_relayer/package.json
+++ b/relayer/spy_relayer/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "spy_relay",
-  "version": "1.0.0",
+  "name": "@wormhole-foundation/spy-relay",
+  "version": "0.0.1",
   "description": "Spy listener and relayer",
   "main": "spy_relay.js",
   "scripts": {

--- a/scripts/check-npm-package-scopes.sh
+++ b/scripts/check-npm-package-scopes.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# This script checks to ensure that all our NPM packages have an appropriate scope.
+#
+git ls-files | grep "package.json" | xargs grep -s "\"name\":" | egrep -v '@certusone/|@wormhole-foundation/'
+if [ $? -eq 0 ]; then
+   echo "[!] Unscoped npm packages" >&2
+   exit 1
+else
+   echo "[+] No unscoped npm packages"
+fi

--- a/terra/test/package.json
+++ b/terra/test/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "test",
-  "version": "0.1.0",
+  "name": "@wormhole-foundation/tests-terra",
+  "version": "0.0.1",
   "description": "",
   "type": "module",
   "scripts": {

--- a/terra/tools/package.json
+++ b/terra/tools/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "tools",
-  "version": "1.0.0",
+  "name": "@wormhole-foundation/tools-terra",
+  "version": "0.0.1",
   "description": "",
   "main": "deploy.js",
   "type": "module",

--- a/testing/contract-integrations/package.json
+++ b/testing/contract-integrations/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "contract-integration-tests",
-  "version": "1.0.0",
+  "name": "@wormhole-foundation/tests-contract-integration",
+  "version": "0.0.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/testing/rollback/package.json
+++ b/testing/rollback/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "rollback-test",
+  "name": "@wormhole-foundation/tests-rollback",
   "version": "0.0.1",
   "private": true,
   "dependencies": {

--- a/testing/weth-switch/package.json
+++ b/testing/weth-switch/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "rollback-test",
+  "name": "@wormhole-foundation/tests-weth-switch",
   "version": "0.0.1",
   "private": true,
   "dependencies": {

--- a/tools/package.json
+++ b/tools/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "tools",
-  "version": "1.0.0",
+  "name": "@wormhole-foundation/tools-protobuf",
+  "version": "0.0.1",
   "description": "tooling for building web code from protobufs",
   "devDependencies": {
     "ts-proto": "^1.82.3"

--- a/wormhole_chain/testing/js/package-lock.json
+++ b/wormhole_chain/testing/js/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "wormhole-chain-tests",
-  "version": "0.0.0",
+  "name": "@wormhole-foundation/tests-wormhole-chain",
+  "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "wormhole-chain-tests",
-      "version": "0.0.0",
+      "name": "@wormhole-foundation/tests-wormhole-chain",
+      "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
         "@certusone/wormhole-sdk": "^0.2.0",
@@ -15,6 +15,7 @@
         "@cosmjs/proto-signing": "^0.27.1",
         "@cosmjs/stargate": "^0.27.1",
         "@cosmjs/tendermint-rpc": "^0.27.1",
+        "@wormhole-foundation/wormhole-chain-sdk": "file:../../ts-sdk",
         "axios": "^0.26.0",
         "bech32": "^2.0.0",
         "elliptic": "^6.5.4",
@@ -23,16 +24,15 @@
         "ts-jest": "^27.1.3",
         "ts-node": "^10.7.0",
         "tslint": "^6.1.3",
-        "typescript": "^4.5.5",
-        "wormhole-chain-sdk": "file:../../ts-sdk"
+        "typescript": "^4.5.5"
       },
       "devDependencies": {
         "jest": "^27.5.1"
       }
     },
     "../../ts-sdk": {
-      "name": "wormhole-chain-sdk",
-      "version": "0.0.0",
+      "name": "@wormhole-foundation/wormhole-chain-sdk",
+      "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
         "@certusone/wormhole-sdk": "^0.2.0",
@@ -2241,6 +2241,10 @@
       "version": "20.2.1",
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.1.tgz",
       "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw=="
+    },
+    "node_modules/@wormhole-foundation/wormhole-chain-sdk": {
+      "resolved": "../../ts-sdk",
+      "link": true
     },
     "node_modules/abab": {
       "version": "2.0.5",
@@ -6124,10 +6128,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/wormhole-chain-sdk": {
-      "resolved": "../../ts-sdk",
-      "link": true
-    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -7887,6 +7887,29 @@
       "version": "20.2.1",
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.1.tgz",
       "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw=="
+    },
+    "@wormhole-foundation/wormhole-chain-sdk": {
+      "version": "file:../../ts-sdk",
+      "requires": {
+        "@certusone/wormhole-sdk": "^0.2.0",
+        "@cosmjs/cosmwasm-stargate": "^0.27.1",
+        "@cosmjs/launchpad": "^0.27.1",
+        "@cosmjs/math": "^0.27.1",
+        "@cosmjs/proto-signing": "^0.27.1",
+        "@cosmjs/stargate": "^0.27.1",
+        "@cosmjs/tendermint-rpc": "^0.27.1",
+        "axios": "^0.26.0",
+        "bech32": "^2.0.0",
+        "elliptic": "^6.5.4",
+        "ethers": "^5.5.4",
+        "jest": "^27.5.1",
+        "keccak256": "^1.0.6",
+        "node-fetch": "^2.6.7",
+        "protobufjs": "^6.11.2",
+        "ts-jest": "^27.1.3",
+        "tslint": "^6.1.3",
+        "typescript": "^4.5.5"
+      }
     },
     "abab": {
       "version": "2.0.5",
@@ -10799,29 +10822,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
-    },
-    "wormhole-chain-sdk": {
-      "version": "file:../../ts-sdk",
-      "requires": {
-        "@certusone/wormhole-sdk": "^0.2.0",
-        "@cosmjs/cosmwasm-stargate": "^0.27.1",
-        "@cosmjs/launchpad": "^0.27.1",
-        "@cosmjs/math": "^0.27.1",
-        "@cosmjs/proto-signing": "^0.27.1",
-        "@cosmjs/stargate": "^0.27.1",
-        "@cosmjs/tendermint-rpc": "^0.27.1",
-        "axios": "^0.26.0",
-        "bech32": "^2.0.0",
-        "elliptic": "^6.5.4",
-        "ethers": "^5.5.4",
-        "jest": "^27.5.1",
-        "keccak256": "^1.0.6",
-        "node-fetch": "^2.6.7",
-        "protobufjs": "^6.11.2",
-        "ts-jest": "^27.1.3",
-        "tslint": "^6.1.3",
-        "typescript": "^4.5.5"
-      }
     },
     "wrap-ansi": {
       "version": "7.0.0",

--- a/wormhole_chain/testing/js/package.json
+++ b/wormhole_chain/testing/js/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "wormhole-chain-tests",
-  "version": "0.0.0",
+  "name": "@wormhole-foundation/tests-wormhole-chain",
+  "version": "0.0.1",
   "description": "testing project for wormhole chain",
   "main": "index.js",
   "type": "module",
@@ -30,6 +30,7 @@
     "@cosmjs/proto-signing": "^0.27.1",
     "@cosmjs/stargate": "^0.27.1",
     "@cosmjs/tendermint-rpc": "^0.27.1",
+    "@wormhole-foundation/wormhole-chain-sdk": "file:../../ts-sdk",
     "axios": "^0.26.0",
     "bech32": "^2.0.0",
     "elliptic": "^6.5.4",
@@ -38,8 +39,7 @@
     "ts-jest": "^27.1.3",
     "ts-node": "^10.7.0",
     "tslint": "^6.1.3",
-    "typescript": "^4.5.5",
-    "wormhole-chain-sdk": "file:../../ts-sdk"
+    "typescript": "^4.5.5"
   },
   "devDependencies": {
     "jest": "^27.5.1"

--- a/wormhole_chain/testing/js/src/__tests__/basicTransfer.ts
+++ b/wormhole_chain/testing/js/src/__tests__/basicTransfer.ts
@@ -1,5 +1,5 @@
 import { expect, jest, test } from "@jest/globals";
-import { getAddress, getWallet } from "wormhole-chain-sdk";
+import { getAddress, getWallet } from "@wormhole-foundation/wormhole-chain-sdk";
 import { TEST_WALLET_MNEMONIC_1, TEST_WALLET_MNEMONIC_2 } from "../consts";
 import { getBalance, sendTokens } from "../utils/walletHelpers";
 

--- a/wormhole_chain/testing/js/src/__tests__/sdkTests.ts
+++ b/wormhole_chain/testing/js/src/__tests__/sdkTests.ts
@@ -9,7 +9,7 @@ import {
   toAccAddress,
   toBase64,
   toValAddress,
-} from "wormhole-chain-sdk";
+} from "@wormhole-foundation/wormhole-chain-sdk";
 import {
   GUARDIAN_VALIDATOR_BASE64_VALADDR,
   GUARDIAN_VALIDATOR_VALADDR,

--- a/wormhole_chain/testing/js/src/__tests__/validators.ts
+++ b/wormhole_chain/testing/js/src/__tests__/validators.ts
@@ -4,7 +4,7 @@ import {
   getWallet,
   getWormchainSigningClient,
   toValAddress,
-} from "wormhole-chain-sdk";
+} from "@wormhole-foundation/wormhole-chain-sdk";
 import { getZeroFee } from "../bootstrap";
 import {
   DEVNET_GUARDIAN_PRIVATE_KEY,

--- a/wormhole_chain/testing/js/src/bootstrap.ts
+++ b/wormhole_chain/testing/js/src/bootstrap.ts
@@ -3,13 +3,13 @@ import { DeliverTxResponse, StdFee } from "@cosmjs/stargate";
 import axios from "axios";
 import pkg from "protobufjs";
 const { Field, Type } = pkg;
-import * as sdk from "wormhole-chain-sdk";
+import * as sdk from "@wormhole-foundation/wormhole-chain-sdk";
 import {
   fromAccAddress,
   fromValAddress,
   toBase64,
   toValAddress,
-} from "wormhole-chain-sdk";
+} from "@wormhole-foundation/wormhole-chain-sdk";
 import {
   DEVNET_GUARDIAN2_PRIVATE_KEY,
   DEVNET_GUARDIAN2_PUBLIC_KEY,
@@ -26,7 +26,7 @@ import {
 } from "./consts.js";
 import { signValidatorAddress } from "./utils/walletHelpers.js";
 
-import fs from 'fs';
+import fs from "fs";
 
 const {
   getAddress,
@@ -59,37 +59,61 @@ async function fullBootstrapProcess() {
 
     //verify that guardian 1 is the only bonded validator
     const validators = await queryClient.staking.queryValidators({});
-    expectEqual("Initial bonded validators", validators.data.validators?.map((x) => x.operator_address), [GUARDIAN_VALIDATOR_VALADDR])
+    expectEqual(
+      "Initial bonded validators",
+      validators.data.validators?.map((x) => x.operator_address),
+      [GUARDIAN_VALIDATOR_VALADDR]
+    );
 
-    const Guardian1ValidatorAddress: string = getValidatorAddressBase64('../../validators/first_validator/config/priv_validator_key.json')
-    const Guardian2ValidatorAddress: string = getValidatorAddressBase64('../../validators/second_validator/config/priv_validator_key.json')
+    const Guardian1ValidatorAddress: string = getValidatorAddressBase64(
+      "../../validators/first_validator/config/priv_validator_key.json"
+    );
+    const Guardian2ValidatorAddress: string = getValidatorAddressBase64(
+      "../../validators/second_validator/config/priv_validator_key.json"
+    );
 
     //verify that guardian 1 is producing blocks
     let latestBlock = await getLatestBlock();
     let validatorSet = latestBlock.block.last_commit.signatures;
 
-    expectEqual("Signers on first block", validatorSet.map((sig: any) => sig.validator_address), [Guardian1ValidatorAddress])
+    expectEqual(
+      "Signers on first block",
+      validatorSet.map((sig: any) => sig.validator_address),
+      [Guardian1ValidatorAddress]
+    );
 
     //verify that guardian 1 is registered to test wallet 1.
     let response = await queryClient.core.queryGuardianValidatorAll();
     const guardianValidators = response.data.guardianValidator || [];
-    const tiltnetGuardian = {guardianKey: TILTNET_GUARDIAN_PUBKEY, validatorAddr: toBase64(fromValAddress(GUARDIAN_VALIDATOR_VALADDR))}
-    expectEqual("Initial guardian validators", guardianValidators.map((x) => ({guardianKey: x.guardianKey, validatorAddr: x.validatorAddr})), [tiltnetGuardian] )
+    const tiltnetGuardian = {
+      guardianKey: TILTNET_GUARDIAN_PUBKEY,
+      validatorAddr: toBase64(fromValAddress(GUARDIAN_VALIDATOR_VALADDR)),
+    };
+    expectEqual(
+      "Initial guardian validators",
+      guardianValidators.map((x) => ({
+        guardianKey: x.guardianKey,
+        validatorAddr: x.validatorAddr,
+      })),
+      [tiltnetGuardian]
+    );
 
     //verify that the latest guardian set is 1
     const response2 = await queryClient.core.queryLatestGuardianSetIndex();
     let index = response2.data.latestGuardianSetIndex;
-    expectEqual("Initial \"latest\" guardian set", index, 0)
+    expectEqual('Initial "latest" guardian set', index, 0);
 
     //verify that the consensus guardian set is 1
     const response3 = await queryClient.core.queryConsensusGuardianSetIndex();
     index = response3.data.ConsensusGuardianSetIndex?.index;
-    expectEqual("Initial consensus guardian set", index, 0)
+    expectEqual("Initial consensus guardian set", index, 0);
 
     //verify that the only guardian public key is guardian public key 1.
     const response4 = await queryClient.core.queryGuardianSet(0);
     const guardianSet = response4.data || null;
-    expectEqual("Guardian set 0", guardianSet.GuardianSet?.keys, [TILTNET_GUARDIAN_PUBKEY])
+    expectEqual("Guardian set 0", guardianSet.GuardianSet?.keys, [
+      TILTNET_GUARDIAN_PUBKEY,
+    ]);
 
     //process upgrade VAA
     const msg = signingClient.core.msgExecuteGovernanceVAA({
@@ -101,7 +125,7 @@ async function fullBootstrapProcess() {
       [msg],
       getZeroFee()
     );
-    expectTxSuccess("guardian set upgrade VAA", receipt)
+    expectTxSuccess("guardian set upgrade VAA", receipt);
 
     const guardianKey2base64 = Buffer.from(
       DEVNET_GUARDIAN2_PUBLIC_KEY,
@@ -111,22 +135,28 @@ async function fullBootstrapProcess() {
     //verify only guardian 2 is in guardian set 1.
     const response7 = await queryClient.core.queryGuardianSet(1);
     const guardianSet7 = response7.data || null;
-    expectEqual("Guardian set 1", guardianSet7.GuardianSet?.keys, [guardianKey2base64])
+    expectEqual("Guardian set 1", guardianSet7.GuardianSet?.keys, [
+      guardianKey2base64,
+    ]);
 
     //verify latest guardian set is 1
     const response5 = await queryClient.core.queryLatestGuardianSetIndex();
     let index5 = response5.data.latestGuardianSetIndex || null;
-    expectEqual("Latest guardian set after upgrade", index5, 1)
+    expectEqual("Latest guardian set after upgrade", index5, 1);
 
     //verify consensus guardian set is 0
     const response6 = await queryClient.core.queryConsensusGuardianSetIndex();
     let index6 = response6.data.ConsensusGuardianSetIndex?.index;
-    expectEqual("Consensus guardian set after upgrade", index6, 0)
+    expectEqual("Consensus guardian set after upgrade", index6, 0);
 
     //verify guardian 1 is still producing blocks
     let latestBlock2 = await getLatestBlock();
     let validatorSet2 = latestBlock2.block.last_commit.signatures;
-    expectEqual("Validators after upgrade", validatorSet2.map((sig: any) => sig.validator_address), [Guardian1ValidatorAddress])
+    expectEqual(
+      "Validators after upgrade",
+      validatorSet2.map((sig: any) => sig.validator_address),
+      [Guardian1ValidatorAddress]
+    );
 
     //TODO attempt to register guardian2 to validator2, exception because validator2 is not bonded.
 
@@ -163,15 +193,26 @@ async function fullBootstrapProcess() {
       [bondMsg],
       getZeroFee()
     );
-    expectTxSuccess("second validator registration", createValidatorReceipt)
+    expectTxSuccess("second validator registration", createValidatorReceipt);
 
     //confirm validator2 is bonded
     const validators2 = await queryClient.staking.queryValidators({});
-    expectEqual("Second bonded validators", validators2.data.validators?.map((x) => x.operator_address).sort(), [GUARDIAN_VALIDATOR_VALADDR, toValAddress(fromAccAddress(TEST_WALLET_ADDRESS_2))].sort())
+    expectEqual(
+      "Second bonded validators",
+      validators2.data.validators?.map((x) => x.operator_address).sort(),
+      [
+        GUARDIAN_VALIDATOR_VALADDR,
+        toValAddress(fromAccAddress(TEST_WALLET_ADDRESS_2)),
+      ].sort()
+    );
 
     let latestBlock3 = await getLatestBlock();
     let validatorSet3 = latestBlock3.block.last_commit.signatures;
-    expectEqual("Signers after second validator bonded", validatorSet3.map((sig: any) => sig.validator_address), [Guardian1ValidatorAddress])
+    expectEqual(
+      "Signers after second validator bonded",
+      validatorSet3.map((sig: any) => sig.validator_address),
+      [Guardian1ValidatorAddress]
+    );
 
     //attempt to register guardian2 to validator2
     //TODO what encoding for the guardian key & how to sign the validator address?
@@ -188,27 +229,45 @@ async function fullBootstrapProcess() {
       [registerMsg],
       getZeroFee()
     );
-    expectTxSuccess("second guardian registration", registerMsgReceipe)
+    expectTxSuccess("second guardian registration", registerMsgReceipe);
 
     //confirm validator2 is also now registered as a guardian validator
     let guardianValResponse =
       await queryClient.core.queryGuardianValidatorAll();
     const guardianValidators2 =
       guardianValResponse.data.guardianValidator || [];
-    const secondGuardian = {guardianKey: Buffer.from(DEVNET_GUARDIAN2_PUBLIC_KEY, "hex").toString( "base64"), validatorAddr: toBase64(fromAccAddress(TEST_WALLET_ADDRESS_2))}
-    expectEqual("Updated guardian validators", guardianValidators2.map((x) => ({guardianKey: x.guardianKey, validatorAddr: x.validatorAddr})).sort(), [secondGuardian, tiltnetGuardian].sort())
+    const secondGuardian = {
+      guardianKey: Buffer.from(DEVNET_GUARDIAN2_PUBLIC_KEY, "hex").toString(
+        "base64"
+      ),
+      validatorAddr: toBase64(fromAccAddress(TEST_WALLET_ADDRESS_2)),
+    };
+    expectEqual(
+      "Updated guardian validators",
+      guardianValidators2
+        .map((x) => ({
+          guardianKey: x.guardianKey,
+          validatorAddr: x.validatorAddr,
+        }))
+        .sort(),
+      [secondGuardian, tiltnetGuardian].sort()
+    );
 
     //confirm consensus guardian set is now 2
     const conResponse = await queryClient.core.queryConsensusGuardianSetIndex();
     index = conResponse.data.ConsensusGuardianSetIndex?.index;
-    expectEqual("Updated consensus guardian set", index, 1)
+    expectEqual("Updated consensus guardian set", index, 1);
 
     //confirm blocks are only signed by validator2
-    console.log("Waiting 4 seconds for latest block...")
+    console.log("Waiting 4 seconds for latest block...");
     await new Promise((resolve) => setTimeout(resolve, 4000));
     latestBlock = await getLatestBlock();
     validatorSet = latestBlock.block.last_commit.signatures;
-    expectEqual("Signing validators on final block", validatorSet.map((sig: any) => sig.validator_address), [Guardian2ValidatorAddress])
+    expectEqual(
+      "Signing validators on final block",
+      validatorSet.map((sig: any) => sig.validator_address),
+      [Guardian2ValidatorAddress]
+    );
 
     console.log("Successfully completed bootstrap process.");
   } catch (e) {
@@ -253,52 +312,77 @@ const wait = async () => {
 wait();
 
 function getValidatorAddressBase64(file: string): string {
-  const validator_key_file = fs.readFileSync(file)
-  return Buffer.from(JSON.parse(validator_key_file.toString()).address, "hex").toString("base64")
+  const validator_key_file = fs.readFileSync(file);
+  return Buffer.from(
+    JSON.parse(validator_key_file.toString()).address,
+    "hex"
+  ).toString("base64");
 }
 
 function equal<T>(actual: T, expected: T): boolean {
   if (Array.isArray(actual) && Array.isArray(expected)) {
-    return actual.length === expected.length && actual.every((val, index) => equal(val, expected[index]));
+    return (
+      actual.length === expected.length &&
+      actual.every((val, index) => equal(val, expected[index]))
+    );
   } else if (typeof actual === "object" && typeof expected === "object") {
-    return JSON.stringify(actual) === JSON.stringify(expected)
+    return JSON.stringify(actual) === JSON.stringify(expected);
   } else {
-    return actual === expected
+    return actual === expected;
   }
 }
 
 function expectEqual<T>(msg: string, actual: T, expected: T): void {
   if (!equal(actual, expected)) {
-      eject(msg + ":\nExpected: " + green(stringify(expected)) + ", got: " + red(stringify(actual)))
+    eject(
+      msg +
+        ":\nExpected: " +
+        green(stringify(expected)) +
+        ", got: " +
+        red(stringify(actual))
+    );
   } else {
-    console.log(msg + ": " + green("PASS"))
+    console.log(msg + ": " + green("PASS"));
   }
 }
 
 function expectTxSuccess(msg: string, receipt: DeliverTxResponse): void {
   if (receipt.code !== 0) {
-    eject("Transaction " + msg + " failed. Transaction hash: " + red(receipt.transactionHash))
+    eject(
+      "Transaction " +
+        msg +
+        " failed. Transaction hash: " +
+        red(receipt.transactionHash)
+    );
   }
 
-  console.log("Transaction " + msg + ": " + green("PASS") + " (" + receipt.transactionHash + ")")
+  console.log(
+    "Transaction " +
+      msg +
+      ": " +
+      green("PASS") +
+      " (" +
+      receipt.transactionHash +
+      ")"
+  );
 }
 
 function stringify<T>(x: T): string {
   if (Array.isArray(x)) {
-    return "["+ x.map((x) => stringify(x)) + "]"
+    return "[" + x.map((x) => stringify(x)) + "]";
   } else if (typeof x === "object") {
-    return JSON.stringify(x)
+    return JSON.stringify(x);
   } else {
-    return "" + x
+    return "" + x;
   }
 }
 
 function red(str: string): string {
-  return '\x1b[31m' + str + '\x1b[0m'
+  return "\x1b[31m" + str + "\x1b[0m";
 }
 
 function green(str: string): string {
-  return '\x1b[32m' + str + '\x1b[0m'
+  return "\x1b[32m" + str + "\x1b[0m";
 }
 
 export default {};

--- a/wormhole_chain/testing/js/src/utils/walletHelpers.ts
+++ b/wormhole_chain/testing/js/src/utils/walletHelpers.ts
@@ -7,7 +7,7 @@ import {
   getWallet,
   getWormchainSigningClient,
   getWormholeQueryClient,
-} from "wormhole-chain-sdk";
+} from "@wormhole-foundation/wormhole-chain-sdk";
 import {
   WORM_DENOM,
   NODE_URL,
@@ -75,6 +75,9 @@ export function signValidatorAddress(valAddr: string, privKey: string) {
     Buffer.from(fromValAddress(valAddr).bytes)
   ).toString("hex");
   const signature = key.sign(valAddrHash, { canonical: true });
-  const hexString = signature.r.toString("hex").padStart(64, "0") + signature.s.toString("hex").padStart(64, "0") + signature.recoveryParam.toString(16).padStart(2, "0");
+  const hexString =
+    signature.r.toString("hex").padStart(64, "0") +
+    signature.s.toString("hex").padStart(64, "0") +
+    signature.recoveryParam.toString(16).padStart(2, "0");
   return Buffer.from(hexString, "hex");
 }

--- a/wormhole_chain/ts-sdk/package.json
+++ b/wormhole_chain/ts-sdk/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "wormhole-chain-sdk",
-  "version": "0.0.0",
+  "name": "@wormhole-foundation/wormhole-chain-sdk",
+  "version": "0.0.1",
   "description": "Typescript SDK for interating with the Wormhole chain",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Adding a check to ensure that packages in the repo are always scoped to the wormhole-foundation (or certusone, the current scope of the javasscript sdk and related packages) as is good practice.