### PR TITLE
ci: unscoped package check robustness improvements

### DIFF
--- a/scripts/check-docker-pin.sh
+++ b/scripts/check-docker-pin.sh
@@ -11,7 +11,10 @@
 #   - We ignore scratch because it's literally the docker base image
 #   - We ignore solana AS (builder|ci_tests) because it's a relative reference to another FROM call
 #
-git ls-files | grep "Dockerfile*" | xargs grep -s "FROM" | egrep -v 'sha256|scratch|solana|aptos AS (builder|ci_tests|tests)'
+# original command:
+# git ls-files | grep "Dockerfile*" | xargs grep -s "FROM" | egrep -v 'sha256|scratch|solana|aptos AS (builder|ci_tests|tests)'
+# update (works with spaces in directories but includes files outside of 'git ls-files':
+find . -type f -name 'Dockerfile*' -print0 | xargs -r -0 grep -s "FROM" | egrep -v 'sha256|scratch|solana|aptos AS (builder|ci_tests|tests)'
 if [ $? -eq 0 ]; then
    echo "[!] Unpinned docker files" >&2
    exit 1

--- a/scripts/check-npm-package-scopes.sh
+++ b/scripts/check-npm-package-scopes.sh
@@ -2,7 +2,7 @@
 
 # This script checks to ensure that all our NPM packages have an appropriate scope.
 #
-git ls-files | grep "package.json" | xargs grep -s "\"name\":" | egrep -v '@certusone/|@wormhole-foundation/'
+find . -type f -name 'package.json' -print0 | xargs -n1 -r -0 /bin/bash -c 'printf "[$@]"; jq  ".name" "$@";' '' | egrep -v "^\[.*\]null$" | egrep -v '^\[.*\]"(@certusone/|@wormhole-foundation/)'
 if [ $? -eq 0 ]; then
    echo "[!] Unscoped npm packages" >&2
    exit 1


### PR DESCRIPTION
This change tries to improve the previous bash script by
1) supporting spaces and other special characters in file paths
2) using jq instead of a simple grep to parse the json
3) being more restrictive in the regexes on what to allow to pass through

Would like to get the feedback from the bash wiz though 