### PR TITLE
sdk/vaa: add verify function to vaa

### DIFF
--- a/node/pkg/processor/cleanup.go
+++ b/node/pkg/processor/cleanup.go
@@ -107,7 +107,7 @@ func (p *Processor) handleCleanup(ctx context.Context) {
 			}
 
 			hasSigs := len(s.signatures)
-			wantSigs := CalculateQuorum(len(gs.Keys))
+			wantSigs := vaa.CalculateQuorum(len(gs.Keys))
 			quorum := hasSigs >= wantSigs
 
 			var chain vaa.ChainID
@@ -211,7 +211,7 @@ func (p *Processor) handleCleanup(ctx context.Context) {
 				// network reached consensus without us. We don't know the correct guardian
 				// set, so we simply use the most recent one.
 				hasSigs := len(s.signatures)
-				wantSigs := CalculateQuorum(len(p.gs.Keys))
+				wantSigs := vaa.CalculateQuorum(len(p.gs.Keys))
 
 				p.logger.Info("expiring unsubmitted nil observation",
 					zap.String("digest", hash),

--- a/node/pkg/processor/observation_test.go
+++ b/node/pkg/processor/observation_test.go
@@ -75,13 +75,13 @@ func TestHandleInboundSignedVAAWithQuorum(t *testing.T) {
 		{label: "GuardianSetNoKeys", keyOrder: []*ecdsa.PrivateKey{}, indexOrder: []uint8{}, addrs: []ethcommon.Address{},
 			errString: "dropping SignedVAAWithQuorum message since we have a guardian set without keys"},
 		{label: "VAANoSignatures", keyOrder: []*ecdsa.PrivateKey{}, indexOrder: []uint8{0}, addrs: []ethcommon.Address{goodAddr1},
-			errString: "received SignedVAAWithQuorum message with no VAA signatures"},
+			errString: "dropping SignedVAAWithQuorum message because it failed verification: VAA was not signed"},
 		{label: "VAAInvalidSignatures", keyOrder: []*ecdsa.PrivateKey{badPrivateKey1}, indexOrder: []uint8{0}, addrs: []ethcommon.Address{goodAddr1},
-			errString: "received SignedVAAWithQuorum message with invalid VAA signatures"},
+			errString: "dropping SignedVAAWithQuorum message because it failed verification: VAA had bad signatures"},
 		{label: "DuplicateGoodSignaturesNonMonotonic", keyOrder: []*ecdsa.PrivateKey{goodPrivateKey1, goodPrivateKey1, goodPrivateKey1, goodPrivateKey1}, indexOrder: []uint8{0, 0, 0, 0}, addrs: []ethcommon.Address{goodAddr1},
-			errString: "received SignedVAAWithQuorum message with invalid VAA signatures"},
+			errString: "dropping SignedVAAWithQuorum message because it failed verification: VAA had bad signatures"},
 		{label: "DuplicateGoodSignaturesMonotonic", keyOrder: []*ecdsa.PrivateKey{goodPrivateKey1, goodPrivateKey1, goodPrivateKey1, goodPrivateKey1}, indexOrder: []uint8{0, 1, 2, 3}, addrs: []ethcommon.Address{goodAddr1},
-			errString: "received SignedVAAWithQuorum message with invalid VAA signatures"},
+			errString: "dropping SignedVAAWithQuorum message because it failed verification: VAA had bad signatures"},
 	}
 
 	for _, tc := range tests {

--- a/node/pkg/processor/quorum_test.go
+++ b/node/pkg/processor/quorum_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/wormhole-foundation/wormhole/sdk/vaa"
 )
 
 func TestCalculateQuorum(t *testing.T) {
@@ -31,7 +32,7 @@ func TestCalculateQuorum(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(fmt.Sprint(tc.have), func(t *testing.T) {
-			assert.Equal(t, tc.want, CalculateQuorum(tc.have))
+			assert.Equal(t, tc.want, vaa.CalculateQuorum(tc.have))
 		})
 	}
 }

--- a/sdk/vaa/quorum.go
+++ b/sdk/vaa/quorum.go
@@ -1,4 +1,4 @@
-package processor
+package vaa
 
 // CalculateQuorum returns the minimum number of guardians that need to sign a VAA for a given guardian set.
 //


### PR DESCRIPTION
This addresses issue https://github.com/wormhole-foundation/wormhole/issues/1764
The relevant pieces of node/pkg/processor/observation.go::handleInboundSignedVAAWithQuorum() were pulled into
sdk/vaa/structs.go:Verify()

Downside:  CalculateQuorum() was copied from node/pkg/processor/quorum.go to sdk/vaa/structs.go.  Should be a better way than copying functions.

Resolution:
Moving CalculateQuorum() to a new file in the sdk and making sure test run correctly.