### PR TITLE
Node: update governor limits for Moonbeam

### DIFF
--- a/node/pkg/governor/mainnet_chains.go
+++ b/node/pkg/governor/mainnet_chains.go
@@ -26,7 +26,7 @@ func chainList() []chainConfigEntry {
 		chainConfigEntry{emitterChainID: vaa.ChainIDCelo, dailyLimit: 5_000_000, bigTransactionSize: 500_000},
 		chainConfigEntry{emitterChainID: vaa.ChainIDNear, dailyLimit: 5_000_000, bigTransactionSize: 500_000},
 		chainConfigEntry{emitterChainID: vaa.ChainIDTerra2, dailyLimit: 500_000, bigTransactionSize: 50_000},
-		chainConfigEntry{emitterChainID: vaa.ChainIDMoonbeam, dailyLimit: 500_000, bigTransactionSize: 50_000},
+		chainConfigEntry{emitterChainID: vaa.ChainIDMoonbeam, dailyLimit: 5_000_000, bigTransactionSize: 500_000},
 		chainConfigEntry{emitterChainID: vaa.ChainIDAptos, dailyLimit: 1_000_000, bigTransactionSize: 100_000},
 		chainConfigEntry{emitterChainID: vaa.ChainIDXpla, dailyLimit: 200_000, bigTransactionSize: 20_000},
 	}


### PR DESCRIPTION
Moonbeam limits are exhausted daily and now that multiple DEXs are accepting wrapped assets from chains with $5m notional limits, it would be keen to up the Moonbeam limits to match.