### PR TITLE
sdk/js: add .skip

### DIFF
--- a/sdk/js/src/cosmwasm/query.testnet.test.ts
+++ b/sdk/js/src/cosmwasm/query.testnet.test.ts
@@ -311,7 +311,8 @@ test.skip("testnet - injective get foreign asset", async () => {
 
   expect(result?.length).toBeGreaterThan(0);
 });
-test("testnet - injective submit a vaa", async () => {
+// TODO: fix ALGO_MNEMONIC
+test.skip("testnet - injective submit a vaa", async () => {
   try {
     // Set up Algorand side
     const algodToken = "";


### PR DESCRIPTION
The purpose of this PR is to intentionally skip the `testnet - injective submit a vaa` sdk-ci test because it breaks the Tilt integration tests due to `ALGO_MNEMONIC` being unset.