### PR TITLE
Tilt / CI improvements

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -249,6 +249,14 @@ def build_node_yaml():
                     "wormhole.test.near"
                 ]
 
+            if wormchain:
+                container["command"] += [
+                    "--wormchainWS",
+                    "ws://guardian-validator:26657/websocket",
+                    "--wormchainLCD",
+                    "http://guardian-validator:1317"
+                ]
+
     return encode_yaml_stream(node_yaml)
 
 k8s_yaml_with_ns(build_node_yaml())

--- a/Tiltfile
+++ b/Tiltfile
@@ -159,6 +159,8 @@ def build_node_yaml():
                 container["command"] = command_with_dlv(container["command"])
                 container["command"] += ["--logLevel=debug"]
                 print(container["command"])
+            elif ci:
+                container["command"] += ["--logLevel=warn"]
 
             if explorer:
                 container["command"] += [

--- a/algorand/sandbox-algorand/images/algod/Dockerfile
+++ b/algorand/sandbox-algorand/images/algod/Dockerfile
@@ -39,7 +39,7 @@ COPY . /tmp
 RUN /tmp/images/algod/install.sh \
     -d "${BIN_DIR}" \
     -u "https://github.com/algorand/go-algorand" \
-    -b "v3.9.2-stable" \
+    -b "v3.11.2-stable" \
     -s ""
 
 # Configure network

--- a/cosmwasm/devnet/config/config.toml
+++ b/cosmwasm/devnet/config/config.toml
@@ -47,7 +47,7 @@ db_backend = "goleveldb"
 db_dir = "data"
 
 # Output level for logging, including package level options
-log_level = "info"
+log_level = "warn"
 
 # Output format: 'plain' (colored text) or 'json'
 log_format = "plain"

--- a/devnet/eth-devnet.yaml
+++ b/devnet/eth-devnet.yaml
@@ -36,6 +36,7 @@ spec:
           command:
             - npx
             - ganache-cli
+            - -q
             - -e 10000
             - --deterministic
             - --time="1970-01-01T00:00:00+00:00"
@@ -66,3 +67,4 @@ spec:
             - -c
             - "npx truffle exec mine.js"
 ---
+

--- a/devnet/eth-devnet2.yaml
+++ b/devnet/eth-devnet2.yaml
@@ -37,6 +37,7 @@ spec:
           command:
             - npx
             - ganache-cli
+            - -q
             - -e 10000
             - --deterministic
             - --time="1970-01-01T00:00:00+00:00"

--- a/devnet/near-devnet.yaml
+++ b/devnet/near-devnet.yaml
@@ -32,10 +32,15 @@ spec:
       containers:
         - name: near-node
           image: near-node
+          env:
+            # this still results in DEBUG logs from "stats", but `warn,stats=warn` didn't work
+            - name: RUST_LOG
+              value: warn
           command:
             - /bin/sh
             - -c
-            - /tmp/start_node.sh
+            # because the above still left logs, redirecting stderr
+            - "/tmp/start_node.sh 2> /dev/null"
           ports:
             - containerPort: 3030
               name: node
@@ -57,6 +62,5 @@ spec:
               port: 3030
             periodSeconds: 1
             initialDelaySeconds: 15
-            periodSeconds: 5
 
       restartPolicy: Always

--- a/devnet/node.yaml
+++ b/devnet/node.yaml
@@ -93,10 +93,10 @@ spec:
             - ws://eth-devnet:8545
             - --neonRPC
             - ws://eth-devnet:8545
-            - --wormchainWS
-            - ws://guardian-validator:26657/websocket
-            - --wormchainLCD
-            - http://guardian-validator:1317
+            # - --wormchainWS
+            # - ws://guardian-validator:26657/websocket
+            # - --wormchainLCD
+            # - http://guardian-validator:1317
             # - --terraWS
             # - ws://terra-terrad:26657/websocket
             # - --terraLCD

--- a/devnet/solana-devnet.yaml
+++ b/devnet/solana-devnet.yaml
@@ -56,7 +56,8 @@ spec:
             - --bpf-program
             - Ex9bCdVMSfx7EzB3pgSi2R4UHwJAXvTw18rBQm5YQ8gK
             - /opt/solana/deps/wormhole_migration.so
-            - --log
+            # - --log
+            - -q
           ports:
             - containerPort: 8001
               name: gossip

--- a/devnet/terra-devnet.yaml
+++ b/devnet/terra-devnet.yaml
@@ -140,8 +140,10 @@ spec:
       containers:
         - image: terramoney/fcd:bombay
           name: fcd-collector
-          args:
-            - collector
+          command:
+            - sh
+            - -c
+            - "sed -i \"s/level: \\'info\\'/level: \\'warn\\'/g\" src/lib/logger.ts && ./entrypoint.sh collector"
           resources: {}
           env:
             - name: CHAIN_ID
@@ -170,8 +172,10 @@ spec:
               value: "src/orm/*Entity.ts"
         - image: terramoney/fcd:bombay
           name: fcd-api
-          args:
-            - start
+          command:
+            - sh
+            - -c
+            - "sed -i \"s/level: \\'info\\'/level: \\'warn\\'/g\" src/lib/logger.ts && ./entrypoint.sh start"
           resources: {}
           ports:
             - containerPort: 3060

--- a/devnet/terra2-devnet.yaml
+++ b/devnet/terra2-devnet.yaml
@@ -140,8 +140,10 @@ spec:
       containers:
         - image: terramoney/fcd:2.0.5
           name: fcd-collector
-          args:
-            - collector
+          command:
+            - sh
+            - -c
+            - "sed -i \"s/level: \\'info\\'/level: \\'warn\\'/g\" src/lib/logger.ts && ./entrypoint.sh collector"
           resources: {}
           env:
             - name: CHAIN_ID
@@ -170,8 +172,10 @@ spec:
               value: "src/orm/*Entity.ts"
         - image: terramoney/fcd:2.0.5
           name: fcd-api
-          args:
-            - start
+          command:
+            - sh
+            - -c
+            - "sed -i \"s/level: \\'info\\'/level: \\'warn\\'/g\" src/lib/logger.ts && ./entrypoint.sh start"
           resources: {}
           ports:
             - containerPort: 3060

--- a/ethereum/mine.js
+++ b/ethereum/mine.js
@@ -27,7 +27,7 @@ function sleep(ms) {
 module.exports = function(callback) {
     const fn = async () => {
         while (true) {
-            console.log(await advanceBlock());
+            await advanceBlock();
             await sleep(1000);
         }
     }

--- a/node/pkg/watchers/algorand/watcher.go
+++ b/node/pkg/watchers/algorand/watcher.go
@@ -239,7 +239,6 @@ func (e *Watcher) Run(ctx context.Context) error {
 					}
 					e.next_round = e.next_round + 1
 
-					readiness.SetReady(common.ReadinessAlgorandSyncing)
 					currentAlgorandHeight.Set(float64(e.next_round))
 					p2p.DefaultRegistry.SetNetworkStats(vaa.ChainIDAlgorand, &gossipv1.Heartbeat_Network{
 						Height:          int64(e.next_round),
@@ -251,6 +250,7 @@ func (e *Watcher) Run(ctx context.Context) error {
 					}
 				}
 			}
+			readiness.SetReady(common.ReadinessAlgorandSyncing)
 		}
 	}
 }

--- a/terra/devnet/config/config.toml
+++ b/terra/devnet/config/config.toml
@@ -47,7 +47,7 @@ db_backend = "goleveldb"
 db_dir = "data"
 
 # Output level for logging, including package level options
-log_level = "info"
+log_level = "warn"
 
 # Output format: 'plain' (colored text) or 'json'
 log_format = "plain"

--- a/testing/sdk.sh
+++ b/testing/sdk.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 set -e
+while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' guardian:6060/readyz)" != "200" ]]; do sleep 5; done
 while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' spy:6060/metrics)" != "200" ]]; do sleep 5; done
 CI=true npm --prefix ../sdk/js run test-ci

--- a/testing/spydk.sh
+++ b/testing/spydk.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 set -e
+while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' guardian:6060/readyz)" != "200" ]]; do sleep 5; done
 while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' spy:6060/metrics)" != "200" ]]; do sleep 5; done
 CI=true npm --prefix ../spydk/js run test-ci

--- a/wormchain/validators/first_validator/config/config.toml
+++ b/wormchain/validators/first_validator/config/config.toml
@@ -47,7 +47,7 @@ db_backend = "goleveldb"
 db_dir = "../../build/data"
 
 # Output level for logging, including package level options
-log_level = "info"
+log_level = "warn"
 
 # Output format: 'plain' (colored text) or 'json'
 log_format = "plain"

--- a/wormchain/validators/kubernetes/wormchain-guardian-devnet.yaml
+++ b/wormchain/validators/kubernetes/wormchain-guardian-devnet.yaml
@@ -43,7 +43,7 @@ spec:
             - --home
             - /app/validators/first_validator
             - --log_level
-            - info
+            - warn
           ports:
             - containerPort: 26657
               name: tendermint

--- a/wormchain/validators/kubernetes/wormchain-validator2-devnet.yaml
+++ b/wormchain/validators/kubernetes/wormchain-validator2-devnet.yaml
@@ -43,7 +43,7 @@ spec:
             - --home
             - /app/validators/second_validator
             - --log_level
-            - info
+            - warn
           ports:
             - containerPort: 26657
               name: tendermint

--- a/wormchain/validators/second_validator/config/config.toml
+++ b/wormchain/validators/second_validator/config/config.toml
@@ -47,7 +47,7 @@ db_backend = "goleveldb"
 db_dir = "../../build/data"
 
 # Output level for logging, including package level options
-log_level = "info"
+log_level = "warn"
 
 # Output format: 'plain' (colored text) or 'json'
 log_format = "plain"


### PR DESCRIPTION
This should resolve the minimal tilt guardian from not becoming ready without `--wormchain`
Also the test logs were very annoying to debug with all the info statements, so this PR aims to make the test logs more meaningful and not stream infinitely intermingled with the real errors.