### PR TITLE
sdk/js: add SequenceTracker

### DIFF
--- a/sdk/js/src/solana/wormhole/accounts/emitter.ts
+++ b/sdk/js/src/solana/wormhole/accounts/emitter.ts
@@ -1,5 +1,15 @@
-import { PublicKey, PublicKeyInitData } from "@solana/web3.js";
+import {
+  Commitment,
+  Connection,
+  PublicKey,
+  PublicKeyInitData,
+} from "@solana/web3.js";
 import { deriveAddress } from "../../utils";
+import {
+  deriveEmitterSequenceKey,
+  getSequenceTracker,
+  SequenceTracker,
+} from "./sequence";
 
 export interface EmitterAccounts {
   emitter: PublicKey;
@@ -12,16 +22,6 @@ export function deriveWormholeEmitterKey(
   return deriveAddress([Buffer.from("emitter")], emitterProgramId);
 }
 
-export function deriveEmitterSequenceKey(
-  emitter: PublicKeyInitData,
-  wormholeProgramId: PublicKeyInitData
-): PublicKey {
-  return deriveAddress(
-    [Buffer.from("Sequence"), new PublicKey(emitter).toBytes()],
-    wormholeProgramId
-  );
-}
-
 export function getEmitterKeys(
   emitterProgramId: PublicKeyInitData,
   wormholeProgramId: PublicKeyInitData
@@ -31,4 +31,18 @@ export function getEmitterKeys(
     emitter,
     sequence: deriveEmitterSequenceKey(emitter, wormholeProgramId),
   };
+}
+
+export async function getProgramSequenceTracker(
+  connection: Connection,
+  emitterProgramId: PublicKeyInitData,
+  wormholeProgramId: PublicKeyInitData,
+  commitment?: Commitment
+): Promise<SequenceTracker> {
+  return getSequenceTracker(
+    connection,
+    deriveWormholeEmitterKey(emitterProgramId),
+    wormholeProgramId,
+    commitment
+  );
 }

--- a/sdk/js/src/solana/wormhole/accounts/index.ts
+++ b/sdk/js/src/solana/wormhole/accounts/index.ts
@@ -4,5 +4,6 @@ export * from "./emitter";
 export * from "./feeCollector";
 export * from "./guardianSet";
 export * from "./postedVaa";
+export * from "./sequence";
 export * from "./signatureSet";
 export * from "./upgrade";

--- a/sdk/js/src/solana/wormhole/accounts/sequence.ts
+++ b/sdk/js/src/solana/wormhole/accounts/sequence.ts
@@ -1,0 +1,50 @@
+import {
+  Connection,
+  PublicKey,
+  Commitment,
+  PublicKeyInitData,
+} from "@solana/web3.js";
+import { deriveAddress, getAccountData } from "../../utils";
+
+export function deriveEmitterSequenceKey(
+  emitter: PublicKeyInitData,
+  wormholeProgramId: PublicKeyInitData
+): PublicKey {
+  return deriveAddress(
+    [Buffer.from("Sequence"), new PublicKey(emitter).toBytes()],
+    wormholeProgramId
+  );
+}
+
+export async function getSequenceTracker(
+  connection: Connection,
+  emitter: PublicKeyInitData,
+  wormholeProgramId: PublicKeyInitData,
+  commitment?: Commitment
+): Promise<SequenceTracker> {
+  return connection
+    .getAccountInfo(
+      deriveEmitterSequenceKey(emitter, wormholeProgramId),
+      commitment
+    )
+    .then((info) => SequenceTracker.deserialize(getAccountData(info)));
+}
+
+export class SequenceTracker {
+  sequence: bigint;
+
+  constructor(sequence: bigint) {
+    this.sequence = sequence;
+  }
+
+  static deserialize(data: Buffer): SequenceTracker {
+    if (data.length != 8) {
+      throw new Error("data.length != 8");
+    }
+    return new SequenceTracker(data.readBigUInt64LE(0));
+  }
+
+  value(): bigint {
+    return this.sequence;
+  }
+}

--- a/testing/solana-test-validator/sdk-tests/2_token_bridge.ts
+++ b/testing/solana-test-validator/sdk-tests/2_token_bridge.ts
@@ -58,6 +58,7 @@ import {
   deriveWormholeEmitterKey,
   getPostedMessage,
   getPostedVaa,
+  getProgramSequenceTracker,
 } from "../../../sdk/js/src/solana/wormhole";
 import {
   parseGovernanceVaa,
@@ -1082,6 +1083,13 @@ describe("Token Bridge", () => {
         expect(assetMeta.decimals).to.equal(9);
         expect(assetMeta.symbol).to.equal("");
         expect(assetMeta.name).to.equal("");
+
+        const sequenceTracker = await getProgramSequenceTracker(
+          connection,
+          TOKEN_BRIDGE_ADDRESS,
+          CORE_BRIDGE_ADDRESS
+        );
+        expect(sequenceTracker.value()).to.equal(messageData.sequence + 1n);
       });
 
       //   it("Attest Mint With Metadata", async () => {
@@ -1183,6 +1191,13 @@ describe("Token Bridge", () => {
           Buffer.compare(tokenTransfer.tokenAddress, mint.toBuffer())
         ).to.equal(0);
         expect(tokenTransfer.tokenChain).to.equal(1);
+
+        const sequenceTracker = await getProgramSequenceTracker(
+          connection,
+          TOKEN_BRIDGE_ADDRESS,
+          CORE_BRIDGE_ADDRESS
+        );
+        expect(sequenceTracker.value()).to.equal(messageData.sequence + 1n);
       });
 
       it("Receive Token", async () => {
@@ -1409,6 +1424,13 @@ describe("Token Bridge", () => {
         expect(
           Buffer.compare(tokenTransfer.tokenTransferPayload, transferPayload)
         ).to.equal(0);
+
+        const sequenceTracker = await getProgramSequenceTracker(
+          connection,
+          TOKEN_BRIDGE_ADDRESS,
+          CORE_BRIDGE_ADDRESS
+        );
+        expect(sequenceTracker.value()).to.equal(messageData.sequence + 1n);
       });
     });
 
@@ -1744,6 +1766,13 @@ describe("Token Bridge", () => {
           Buffer.compare(tokenTransfer.tokenAddress, tokenAddress)
         ).to.equal(0);
         expect(tokenTransfer.tokenChain).to.equal(tokenChain);
+
+        const sequenceTracker = await getProgramSequenceTracker(
+          connection,
+          TOKEN_BRIDGE_ADDRESS,
+          CORE_BRIDGE_ADDRESS
+        );
+        expect(sequenceTracker.value()).to.equal(messageData.sequence + 1n);
       });
 
       it("Send Token With Payload", async () => {
@@ -1846,6 +1875,13 @@ describe("Token Bridge", () => {
         expect(
           Buffer.compare(tokenTransfer.tokenTransferPayload, transferPayload)
         ).to.equal(0);
+
+        const sequenceTracker = await getProgramSequenceTracker(
+          connection,
+          TOKEN_BRIDGE_ADDRESS,
+          CORE_BRIDGE_ADDRESS
+        );
+        expect(sequenceTracker.value()).to.equal(messageData.sequence + 1n);
       });
     });
   });


### PR DESCRIPTION
In PR #1375 I forgot to add SequenceTracker deserialization found in [sequence.rs](https://github.com/wormhole-foundation/wormhole/blob/dev.v2/solana/bridge/program/src/accounts/sequence.rs).

This adds a way to deserialize this account and corresponding tests to verify the account data.