### PR TITLE
SDK: Remove support for Ropsten

### DIFF
--- a/sdk/js/CHANGELOG.md
+++ b/sdk/js/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## 0.10.0
-
-### Removed
-
-Removed support for Ropsten since the chain has been deprecated.
-
 ## 0.9.0
 
 ### Added
@@ -31,6 +25,8 @@ Use FQTs in Aptos SDK
 ### Removed
 
 Dependency: @certusone/wormhole-sdk-wasm
+
+Removed support for Ropsten since the chain has been deprecated.
 
 ## 0.8.0
 

--- a/sdk/js/CHANGELOG.md
+++ b/sdk/js/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.10.0
+
+### Removed
+
+Removed support for Ropsten since the chain has been deprecated.
+
 ## 0.9.0
 
 ### Added

--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@certusone/wormhole-sdk",
-  "version": "0.10.0",
+  "version": "0.9.0",
   "description": "SDK for interacting with Wormhole",
   "homepage": "https://wormhole.com",
   "main": "./lib/cjs/index.js",

--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@certusone/wormhole-sdk",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "SDK for interacting with Wormhole",
   "homepage": "https://wormhole.com",
   "main": "./lib/cjs/index.js",

--- a/sdk/js/src/utils/consts.ts
+++ b/sdk/js/src/utils/consts.ts
@@ -27,7 +27,6 @@ export const CHAINS = {
   gnosis: 25,
   pythnet: 26,
   xpla: 28,
-  ropsten: 10001,
   wormchain: 3104,
 } as const;
 
@@ -55,7 +54,7 @@ export type EVMChainName =
   | "arbitrum"
   | "optimism"
   | "gnosis"
-  | "ropsten";
+  ;
 
 /**
  *
@@ -222,11 +221,6 @@ const MAINNET = {
       "xpla137w0wfch2dfmz7jl2ap8pcmswasj8kg06ay4dtjzw7tzkn77ufxqfw7acv",
     nft_bridge: undefined,
   },
-  ropsten: {
-    core: undefined,
-    token_bridge: undefined,
-    nft_bridge: undefined,
-  },
   wormchain: {
     core: undefined,
     token_bridge: undefined,
@@ -378,11 +372,6 @@ const TESTNET = {
       "xpla1kek6zgdaxcsu35nqfsyvs2t9vs87dqkkq6hjdgczacysjn67vt8sern93x",
     nft_bridge: undefined,
   },
-  ropsten: {
-    core: "0x210c5F5e2AF958B4defFe715Dc621b7a3BA888c5",
-    token_bridge: "0xF174F9A837536C449321df1Ca093Bb96948D5386",
-    nft_bridge: "0x2b048Da40f69c8dc386a56705915f8E966fe1eba",
-  },
   wormchain: {
     core: undefined,
     token_bridge: undefined,
@@ -533,11 +522,6 @@ const DEVNET = {
     token_bridge: undefined,
     nft_bridge: undefined,
   },
-  ropsten: {
-    core: undefined,
-    token_bridge: undefined,
-    nft_bridge: undefined,
-  },
   wormchain: {
     core: "wormhole1ap5vgur5zlgys8whugfegnn43emka567dtq0jl",
     token_bridge: "wormhole1zugu6cajc4z7ue29g9wnes9a5ep9cs7yu7rn3z",
@@ -611,7 +595,6 @@ export const CHAIN_ID_OPTIMISM = CHAINS["optimism"];
 export const CHAIN_ID_GNOSIS = CHAINS["gnosis"];
 export const CHAIN_ID_PYTHNET = CHAINS["pythnet"];
 export const CHAIN_ID_XPLA = CHAINS["xpla"];
-export const CHAIN_ID_ETHEREUM_ROPSTEN = CHAINS["ropsten"];
 export const CHAIN_ID_WORMCHAIN = CHAINS["wormchain"];
 
 // This inverts the [[CHAINS]] object so that we can look up a chain by id
@@ -742,8 +725,7 @@ export function isEVMChain(
     chainId === CHAIN_ID_NEON ||
     chainId === CHAIN_ID_ARBITRUM ||
     chainId === CHAIN_ID_OPTIMISM ||
-    chainId === CHAIN_ID_GNOSIS ||
-    chainId === CHAIN_ID_ETHEREUM_ROPSTEN
+    chainId === CHAIN_ID_GNOSIS
   ) {
     return isEVM(chainId);
   } else {


### PR DESCRIPTION
Remove Ropsten support from the SDK. 

Once this PR has been merged and the SDK released, a separate PR will be used to remove support from client/js and the relayer.

Additionally, PR 1818 is removing support from the node / guardian code.