### PR TITLE
ethereum: deploy test token nonce race condition fix

### DIFF
--- a/ethereum/scripts/deploy_test_token.js
+++ b/ethereum/scripts/deploy_test_token.js
@@ -16,18 +16,13 @@ const interateToStandardTransactionCount = async () => {
   );
 
   const transactionsToBurn = 32 - transactionCount;
-  const promises = [];
   for (let i = 0; i < transactionsToBurn; i++) {
-    promises.push(
-      web3.eth.sendTransaction({
-        to: accounts[0],
-        from: accounts[0],
-        value: 530,
-      })
-    );
+    await web3.eth.sendTransaction({
+      to: accounts[0],
+      from: accounts[0],
+      value: 530,
+    })
   }
-
-  await Promise.all(promises);
 
   const burnCount = await web3.eth.getTransactionCount(accounts[0], "latest");
 
@@ -36,7 +31,7 @@ const interateToStandardTransactionCount = async () => {
   return Promise.resolve();
 };
 
-module.exports = async function(callback) {
+module.exports = async function (callback) {
   try {
     const accounts = await web3.eth.getAccounts();
 


### PR DESCRIPTION
Noticed this error happening in tilt sometimes:

[tests] Error: Returned error: VM Exception while processing transaction: the tx doesn't have the correct nonce. account has nonce of: 17 tx has nonce of: 16

It's not safe to submit txs in parallel, because the nonce can get out of sync. Instead we should submit them serially.