### PR TITLE
Node: Delete PYTHNET log messages

### DIFF
--- a/node/pkg/processor/cleanup.go
+++ b/node/pkg/processor/cleanup.go
@@ -230,7 +230,6 @@ func (p *Processor) handleCleanup(ctx context.Context) {
 	oldestTime := time.Now().Add(-time.Hour)
 	for key, pe := range p.pythnetVaas {
 		if pe.updateTime.Before(oldestTime) {
-			p.logger.Debug("PYTHNET: dropping old pythnet vaa", zap.String("message_id", key), zap.Stringer("updateTime", pe.updateTime))
 			delete(p.pythnetVaas, key)
 		}
 	}

--- a/node/pkg/processor/cleanup.go
+++ b/node/pkg/processor/cleanup.go
@@ -230,7 +230,7 @@ func (p *Processor) handleCleanup(ctx context.Context) {
 	oldestTime := time.Now().Add(-time.Hour)
 	for key, pe := range p.pythnetVaas {
 		if pe.updateTime.Before(oldestTime) {
-			p.logger.Info("PYTHNET: dropping old pythnet vaa", zap.String("message_id", key), zap.Stringer("updateTime", pe.updateTime))
+			p.logger.Debug("PYTHNET: dropping old pythnet vaa", zap.String("message_id", key), zap.Stringer("updateTime", pe.updateTime))
 			delete(p.pythnetVaas, key)
 		}
 	}

--- a/node/pkg/processor/processor.go
+++ b/node/pkg/processor/processor.go
@@ -235,7 +235,6 @@ func (p *Processor) Run(ctx context.Context) error {
 func (p *Processor) storeSignedVAA(v *vaa.VAA) error {
 	if v.EmitterChain == vaa.ChainIDPythNet {
 		key := fmt.Sprintf("%v/%v", v.EmitterAddress, v.Sequence)
-		p.logger.Debug("PYTHNET: storing pythnet vaa", zap.String("message_id", key))
 		p.pythnetVaas[key] = PythNetVaaEntry{v: v, updateTime: time.Now()}
 		return nil
 	}
@@ -247,11 +246,9 @@ func (p *Processor) getSignedVAA(id db.VAAID) (*vaa.VAA, error) {
 		key := fmt.Sprintf("%v/%v", id.EmitterAddress, id.Sequence)
 		ret, exists := p.pythnetVaas[key]
 		if exists {
-			p.logger.Debug("PYTHNET: found pythnet vaa", zap.String("message_id", key))
 			return ret.v, nil
 		}
 
-		p.logger.Debug("PYTHNET: did not find pythnet vaa", zap.String("message_id", key))
 		return nil, db.ErrVAANotFound
 	}
 

--- a/node/pkg/processor/processor.go
+++ b/node/pkg/processor/processor.go
@@ -235,7 +235,7 @@ func (p *Processor) Run(ctx context.Context) error {
 func (p *Processor) storeSignedVAA(v *vaa.VAA) error {
 	if v.EmitterChain == vaa.ChainIDPythNet {
 		key := fmt.Sprintf("%v/%v", v.EmitterAddress, v.Sequence)
-		p.logger.Info("PYTHNET: storing pythnet vaa", zap.String("message_id", key))
+		p.logger.Debug("PYTHNET: storing pythnet vaa", zap.String("message_id", key))
 		p.pythnetVaas[key] = PythNetVaaEntry{v: v, updateTime: time.Now()}
 		return nil
 	}
@@ -247,11 +247,11 @@ func (p *Processor) getSignedVAA(id db.VAAID) (*vaa.VAA, error) {
 		key := fmt.Sprintf("%v/%v", id.EmitterAddress, id.Sequence)
 		ret, exists := p.pythnetVaas[key]
 		if exists {
-			p.logger.Info("PYTHNET: found pythnet vaa", zap.String("message_id", key))
+			p.logger.Debug("PYTHNET: found pythnet vaa", zap.String("message_id", key))
 			return ret.v, nil
 		}
 
-		p.logger.Info("PYTHNET: did not find pythnet vaa", zap.String("message_id", key))
+		p.logger.Debug("PYTHNET: did not find pythnet vaa", zap.String("message_id", key))
 		return nil, db.ErrVAANotFound
 	}
 


### PR DESCRIPTION
These messages were added when we stopped writing PythNet messages to the DB. Since things have been working smoothly, these can be changed to debugs to reduce unnecessary logging.