### PR TITLE
node: support for heartbeat spying fixes #1768

### DIFF
--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -801,7 +801,7 @@ func runNode(cmd *cobra.Command, args []string) {
 	injectC := make(chan *vaa.VAA)
 
 	// Guardian set state managed by processor
-	gst := common.NewGuardianSetState()
+	gst := common.NewGuardianSetState(nil)
 
 	// Per-chain observation requests
 	chainObsvReqC := make(map[vaa.ChainID]chan *gossipv1.ObservationRequest)

--- a/node/cmd/spy/spy.go
+++ b/node/cmd/spy/spy.go
@@ -257,7 +257,7 @@ func runSpy(cmd *cobra.Command, args []string) {
 	signedInC := make(chan *gossipv1.SignedVAAWithQuorum, 50)
 
 	// Guardian set state managed by processor
-	gst := common.NewGuardianSetState()
+	gst := common.NewGuardianSetState(nil)
 
 	// RPC server
 	s := newSpyServer(logger)

--- a/node/pkg/common/guardianset_test.go
+++ b/node/pkg/common/guardianset_test.go
@@ -57,7 +57,7 @@ func TestKeysAsHexStrings(t *testing.T) {
 }
 
 func TestNewGuardianSetState(t *testing.T) {
-	gss := NewGuardianSetState()
+	gss := NewGuardianSetState(nil)
 	assert.NotNil(t, gss)
 	assert.Nil(t, gss.current)
 	assert.Nil(t, gss.Get())
@@ -72,7 +72,7 @@ func TestSet(t *testing.T) {
 		Index: 1,
 	}
 
-	gss := NewGuardianSetState()
+	gss := NewGuardianSetState(nil)
 	assert.Nil(t, gss.current)
 	gss.Set(&gs)
 	assert.Equal(t, gss.current, &gs)
@@ -87,7 +87,7 @@ func TestGet(t *testing.T) {
 		Index: 1,
 	}
 
-	gss := NewGuardianSetState()
+	gss := NewGuardianSetState(nil)
 	assert.Nil(t, gss.Get())
 	gss.Set(&gs)
 	assert.Equal(t, gss.Get(), &gs)


### PR DESCRIPTION
This commit adds support for observing heartbeat updates to a GuardianSetState via a channel. See #1768 for more details on motivation.