### PR TITLE
Node: Don't log "Transaction failed" in solana

### DIFF
--- a/node/pkg/watchers/solana/client.go
+++ b/node/pkg/watchers/solana/client.go
@@ -307,7 +307,11 @@ func (s *SolanaWatcher) fetchBlock(ctx context.Context, logger *zap.Logger, slot
 OUTER:
 	for txNum, txRpc := range out.Transactions {
 		if txRpc.Meta.Err != nil {
-			logger.Info("Transaction failed, skipping it", zap.Int("txNum", txNum))
+			logger.Debug("Transaction failed, skipping it",
+				zap.Uint64("slot", slot),
+				zap.Int("txNum", txNum),
+				zap.String("err", fmt.Sprint(txRpc.Meta.Err)),
+			)
 			continue
 		}
 		tx, err := txRpc.GetTransaction()


### PR DESCRIPTION
The "Transaction failed, skipping it" message comes out a lot in mainnet! Looking at the failures, they look legit, so changing the message to a debug to reduce logging.

Change-Id: I31ed7c57102dbdcd5956270e99859b9bdeaafb13