### PR TITLE
Node: Arbitrum poller failling without details

### DIFF
--- a/node/pkg/watchers/evm/connectors/poller.go
+++ b/node/pkg/watchers/evm/connectors/poller.go
@@ -67,10 +67,11 @@ func (b *BlockPollConnector) run(ctx context.Context) error {
 					break
 				}
 				logger.Error("polling encountered an error", zap.Error(err))
+				time.Sleep(b.Delay)
 			}
 
 			if err != nil {
-				b.errFeed.Send("polling encountered an error")
+				b.errFeed.Send(fmt.Sprint("polling encountered an error: ", err))
 			}
 			timer.Reset(b.Delay)
 		}

--- a/node/pkg/watchers/evm/connectors/poller.go
+++ b/node/pkg/watchers/evm/connectors/poller.go
@@ -67,6 +67,9 @@ func (b *BlockPollConnector) run(ctx context.Context) error {
 					break
 				}
 				logger.Error("polling encountered an error", zap.Error(err))
+
+				// Wait an interval before trying again. We stay in this loop so that we
+				// try up to three times before causing the watcher to restart.
 				time.Sleep(b.Delay)
 			}
 


### PR DESCRIPTION
The Arbitrum poller is occasionally failing, but the error text is not getting logged when the runnable dies. 

Additionally, the poller retries three times before dying, but we are not seeing the log error from any of them. Adding a 250 ms delay between retries.

Change-Id: Id067d0be18a7c391ef90a82cc78f0684c72ab2ad