### PR TITLE
Governor: Increase the CoinGecko interval

### DIFF
--- a/node/pkg/governor/governor.go
+++ b/node/pkg/governor/governor.go
@@ -301,7 +301,9 @@ func (gov *ChainGovernor) ProcessMsgForTime(msg *common.MessagePublication, now 
 
 	// If we don't care about this chain, the VAA can be published.
 	if !exists {
-		gov.logger.Info("cgov: ignoring vaa because the emitter chain is not configured", zap.String("msgID", msg.MessageIDString()))
+		if msg.EmitterChain != vaa.ChainIDPythNet {
+			gov.logger.Info("cgov: ignoring vaa because the emitter chain is not configured", zap.String("msgID", msg.MessageIDString()))
+		}
 		return true, nil
 	}
 


### PR DESCRIPTION
In mainnet, we are seeing some guardians getting rate limited by CoinGecko. This PR changes the CoinGecko limit from every five minutes to every 15 minutes. It also improves handling when the query fails, so it only logs a single error and prints the actual error text.

Change-Id: I4f97a012284c75d544a1fe7d43e5914210c4b441