### PR TITLE
client/js: Remove support for Ropsten

### DIFF
--- a/clients/js/networks.ts
+++ b/clients/js/networks.ts
@@ -139,10 +139,6 @@ const MAINNET = {
     rpc: "https://rpc.gnosischain.com/",
     key: get_env_var("ETH_KEY"),
   },
-  ropsten: {
-    rpc: `https://rpc.ankr.com/eth_ropsten`,
-    key: get_env_var("ETH_KEY"),
-  },
 };
 
 const TESTNET = {
@@ -269,10 +265,6 @@ const TESTNET = {
     rpc: "https://sokol.poa.network/",
     key: get_env_var("ETH_KEY_TESTNET"),
   },
-  ropsten: {
-    rpc: `https://rpc.ankr.com/eth_ropsten`,
-    key: get_env_var("ETH_KEY_TESTNET"),
-  },
 };
 
 const DEVNET = {
@@ -397,10 +389,6 @@ const DEVNET = {
   gnosis: {
     rpc: undefined,
     key: undefined,
-  },
-  ropsten: {
-    rpc: undefined,
-    key: "0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d",
   },
 };
 

--- a/clients/js/package-lock.json
+++ b/clients/js/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@celo-tools/celo-ethers-wrapper": "^0.1.0",
-        "@certusone/wormhole-sdk": "^0.8.0",
+        "@certusone/wormhole-sdk": "^0.9.0",
         "@cosmjs/encoding": "^0.26.2",
         "@injectivelabs/networks": "^1.0.35",
         "@injectivelabs/sdk-ts": "^1.0.199",
@@ -524,21 +524,24 @@
       }
     },
     "node_modules/@certusone/wormhole-sdk": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk/-/wormhole-sdk-0.8.0.tgz",
-      "integrity": "sha512-0TMtLLXSbBgN2QdZASZNb8aDm6I1vawI7MLiIcgcuaEm/Ip8/mf6jWOMoptCyneNCFGuxQ8XIP43oReK6b4dyA==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk/-/wormhole-sdk-0.9.0.tgz",
+      "integrity": "sha512-RmMGQPvrySaJP6bjwW2m1NQ1b3QLhafvW33ZgkGRQlMNjw1Ph+CgZbE7y7xkctASLxFDYKCjpJhJWVOj/igGiw==",
       "dependencies": {
         "@certusone/wormhole-sdk-proto-web": "^0.0.5",
         "@certusone/wormhole-sdk-wasm": "^0.0.1",
         "@injectivelabs/sdk-ts": "^1.0.75",
-        "@solana/spl-token": "^0.1.8",
-        "@solana/web3.js": "^1.24.0",
+        "@project-serum/anchor": "^0.25.0",
+        "@solana/spl-token": "^0.3.5",
+        "@solana/web3.js": "^1.66.2",
         "@terra-money/terra.js": "^3.1.3",
         "@xpla/xpla.js": "^0.2.1",
         "algosdk": "^1.15.0",
         "aptos": "^1.3.16",
         "axios": "^0.24.0",
         "bech32": "^2.0.0",
+        "binary-parser": "^2.2.1",
+        "elliptic": "^6.5.4",
         "js-base64": "^3.6.1",
         "near-api-js": "^1.0.0"
       }
@@ -610,16 +613,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
       "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
-    },
-    "node_modules/@certusone/wormhole-sdk/node_modules/borsh": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.7.0.tgz",
-      "integrity": "sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==",
-      "dependencies": {
-        "bn.js": "^5.2.0",
-        "bs58": "^4.0.0",
-        "text-encoding-utf-8": "^1.0.2"
-      }
     },
     "node_modules/@certusone/wormhole-sdk/node_modules/depd": {
       "version": "2.0.0",
@@ -2870,6 +2863,17 @@
       "integrity": "sha512-/kSXhY692qiV1MXu6EeOZvg5nECLclxNXcKCxJ3cXQgYuRymRHpdx/t7JXfsK+JLjwA1e1c1/SBrlQYpusC29Q==",
       "dev": true
     },
+    "node_modules/@noble/ed25519": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.1.tgz",
+      "integrity": "sha512-Rk4SkJFaXZiznFyC/t77Q0NKS4FL7TLJJsVG2V2oiEq3kJVeTdxysEe/yRWSpnWMe808XRDJ+VFh5pt/FN5plw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
+    },
     "node_modules/@noble/hashes": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.3.tgz",
@@ -2885,13 +2889,65 @@
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.6.3.tgz",
       "integrity": "sha512-T04e4iTurVy7I8Sw4+c5OSN9/RkPlo1uKxAomtxQNLq8j1uPAqnsqG1bqvY3Jv7c13gyr6dui0zmh/I3+f/JaQ==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
           "url": "https://paulmillr.com/funding/"
         }
       ]
+    },
+    "node_modules/@project-serum/anchor": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@project-serum/anchor/-/anchor-0.25.0.tgz",
+      "integrity": "sha512-E6A5Y/ijqpfMJ5psJvbw0kVTzLZFUcOFgs6eSM2M2iWE1lVRF18T6hWZVNl6zqZsoz98jgnNHtVGJMs+ds9A7A==",
+      "dependencies": {
+        "@project-serum/borsh": "^0.2.5",
+        "@solana/web3.js": "^1.36.0",
+        "base64-js": "^1.5.1",
+        "bn.js": "^5.1.2",
+        "bs58": "^4.0.1",
+        "buffer-layout": "^1.2.2",
+        "camelcase": "^5.3.1",
+        "cross-fetch": "^3.1.5",
+        "crypto-hash": "^1.3.0",
+        "eventemitter3": "^4.0.7",
+        "js-sha256": "^0.9.0",
+        "pako": "^2.0.3",
+        "snake-case": "^3.0.4",
+        "superstruct": "^0.15.4",
+        "toml": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=11"
+      }
+    },
+    "node_modules/@project-serum/anchor/node_modules/cross-fetch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+      "dependencies": {
+        "node-fetch": "2.6.7"
+      }
+    },
+    "node_modules/@project-serum/anchor/node_modules/superstruct": {
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-0.15.5.tgz",
+      "integrity": "sha512-4AOeU+P5UuE/4nOUkmcQdW5y7i9ndt1cQd/3iUe+LTz3RxESf/W/5lg4B74HbDMMv8PHnPnGCQFH45kBcrQYoQ=="
+    },
+    "node_modules/@project-serum/borsh": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@project-serum/borsh/-/borsh-0.2.5.tgz",
+      "integrity": "sha512-UmeUkUoKdQ7rhx6Leve1SssMR/Ghv8qrEiyywyxSWg7ooV7StdpPBhciiy5eB3T0qU1BXvdRNC8TdrkxK7WC5Q==",
+      "dependencies": {
+        "bn.js": "^5.1.2",
+        "buffer-layout": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.2.0"
+      }
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -2991,8 +3047,9 @@
       }
     },
     "node_modules/@solana/buffer-layout": {
-      "version": "3.0.0",
-      "license": "MIT",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/buffer-layout/-/buffer-layout-4.0.0.tgz",
+      "integrity": "sha512-lR0EMP2HC3+Mxwd4YcnZb0smnaDw7Bl2IQWZiTevRH5ZZBZn6VRWn3/92E3qdU4SSImJkA6IDHawOHAnx/qUvQ==",
       "dependencies": {
         "buffer": "~6.0.3"
       },
@@ -3000,8 +3057,24 @@
         "node": ">=5.10"
       }
     },
+    "node_modules/@solana/buffer-layout-utils": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/buffer-layout-utils/-/buffer-layout-utils-0.2.0.tgz",
+      "integrity": "sha512-szG4sxgJGktbuZYDg2FfNmkMi0DYQoVjN2h7ta1W1hPrwzarcFLBq9UpX1UjNXsNpT9dn+chgprtWGioUAr4/g==",
+      "dependencies": {
+        "@solana/buffer-layout": "^4.0.0",
+        "@solana/web3.js": "^1.32.0",
+        "bigint-buffer": "^1.1.5",
+        "bignumber.js": "^9.0.1"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@solana/buffer-layout/node_modules/buffer": {
       "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
       "funding": [
         {
           "type": "github",
@@ -3016,26 +3089,25 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
       }
     },
     "node_modules/@solana/spl-token": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.1.8.tgz",
-      "integrity": "sha512-LZmYCKcPQDtJgecvWOgT/cnoIQPWjdH+QVyzPcFvyDUiT0DiRjZaam4aqNUyvchLFhzgunv3d9xOoyE34ofdoQ==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.3.6.tgz",
+      "integrity": "sha512-P9pTXjDIRvVbjr3J0mCnSamYqLnICeds7IoH1/Ro2R9OBuOHdp5pqKZoscfZ3UYrgnCWUc1bc9M2m/YPHjw+1g==",
       "dependencies": {
-        "@babel/runtime": "^7.10.5",
-        "@solana/web3.js": "^1.21.0",
-        "bn.js": "^5.1.0",
-        "buffer": "6.0.3",
-        "buffer-layout": "^1.2.0",
-        "dotenv": "10.0.0"
+        "@solana/buffer-layout": "^4.0.0",
+        "@solana/buffer-layout-utils": "^0.2.0",
+        "buffer": "^6.0.3"
       },
       "engines": {
-        "node": ">= 10"
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.47.4"
       }
     },
     "node_modules/@solana/spl-token/node_modules/buffer": {
@@ -3062,35 +3134,28 @@
       }
     },
     "node_modules/@solana/web3.js": {
-      "version": "1.34.0",
-      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.34.0.tgz",
-      "integrity": "sha512-6QvqN2DqEELvuV+5yUQM8P9fRiSG+6SzQ58HjumJqODu14r7eu5HXVWEymvKAvMLGME+0TmAdJHjw9xD5NgUWA==",
+      "version": "1.66.2",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.66.2.tgz",
+      "integrity": "sha512-RyaHMR2jGmaesnYP045VLeBGfR/gAW3cvZHzMFGg7bkO+WOYOYp1nEllf0/la4U4qsYGKCsO9eEevR5fhHiVHg==",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
-        "@ethersproject/sha2": "^5.5.0",
-        "@solana/buffer-layout": "^3.0.0",
+        "@noble/ed25519": "^1.7.0",
+        "@noble/hashes": "^1.1.2",
+        "@noble/secp256k1": "^1.6.3",
+        "@solana/buffer-layout": "^4.0.0",
+        "bigint-buffer": "^1.1.5",
         "bn.js": "^5.0.0",
-        "borsh": "^0.4.0",
+        "borsh": "^0.7.0",
         "bs58": "^4.0.1",
         "buffer": "6.0.1",
-        "cross-fetch": "^3.1.4",
+        "fast-stable-stringify": "^1.0.0",
         "jayson": "^3.4.4",
-        "js-sha3": "^0.8.0",
-        "rpc-websockets": "^7.4.2",
-        "secp256k1": "^4.0.2",
-        "superstruct": "^0.14.2",
-        "tweetnacl": "^1.0.0"
+        "node-fetch": "2",
+        "rpc-websockets": "^7.5.0",
+        "superstruct": "^0.14.2"
       },
       "engines": {
         "node": ">=12.20.0"
-      }
-    },
-    "node_modules/@solana/web3.js/node_modules/cross-fetch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
-      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
-      "dependencies": {
-        "node-fetch": "2.6.7"
       }
     },
     "node_modules/@terra-money/legacy.proto": {
@@ -3818,6 +3883,18 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/bigint-buffer": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/bigint-buffer/-/bigint-buffer-1.1.5.tgz",
+      "integrity": "sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "bindings": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/bignumber.js": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
@@ -3827,9 +3904,9 @@
       }
     },
     "node_modules/binary-parser": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/binary-parser/-/binary-parser-2.0.2.tgz",
-      "integrity": "sha512-F2JeaLmExQ0vOEbS5ERzkxePKWTPqJPV6Z04/owaXMQLlW1Kt9v2gUz3SocR40JQGtrUeZu3j6prZDeuEG8Dng==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/binary-parser/-/binary-parser-2.2.1.tgz",
+      "integrity": "sha512-5ATpz/uPDgq5GgEDxTB4ouXCde7q2lqAQlSdBRQVl/AJnxmQmhIfyxJx+0MGu//D5rHQifkfGbWWlaysG0o9NA==",
       "engines": {
         "node": ">=12"
       }
@@ -3908,20 +3985,13 @@
       "license": "MIT"
     },
     "node_modules/borsh": {
-      "version": "0.4.0",
-      "license": "Apache-2.0",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.7.0.tgz",
+      "integrity": "sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==",
       "dependencies": {
-        "@types/bn.js": "^4.11.5",
-        "bn.js": "^5.0.0",
+        "bn.js": "^5.2.0",
         "bs58": "^4.0.0",
         "text-encoding-utf-8": "^1.0.2"
-      }
-    },
-    "node_modules/borsh/node_modules/@types/bn.js": {
-      "version": "4.11.6",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/brace-expansion": {
@@ -4064,6 +4134,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/caniuse-lite": {
@@ -4367,6 +4445,17 @@
         "ripemd160-min": "0.0.6",
         "safe-buffer": "^5.2.0",
         "sha3": "^2.1.1"
+      }
+    },
+    "node_modules/crypto-hash": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/crypto-hash/-/crypto-hash-1.3.0.tgz",
+      "integrity": "sha512-lyAZ0EMyjDkVvz8WOeVnuCPvKVBXcMv1l5SVqO1yC7PzTwrD/pPje/BIRbWhMoPe436U+Y2nD7f5bFx0kt+Sbg==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/dashdash": {
@@ -6354,6 +6443,11 @@
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.8.tgz",
       "integrity": "sha512-lXatBjf3WPjmWD6DpIZxkeSsCOwqI0maYMpgDlx8g4U2qi4lbjA9oH/HD2a87G+KfsUmo5WbJFmqBZlPxtptag=="
     },
+    "node_modules/fast-stable-stringify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-stable-stringify/-/fast-stable-stringify-1.0.0.tgz",
+      "integrity": "sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag=="
+    },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -7507,16 +7601,6 @@
         "tweetnacl": "^1.0.1"
       }
     },
-    "node_modules/near-api-js/node_modules/borsh": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.7.0.tgz",
-      "integrity": "sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==",
-      "dependencies": {
-        "bn.js": "^5.2.0",
-        "bs58": "^4.0.0",
-        "text-encoding-utf-8": "^1.0.2"
-      }
-    },
     "node_modules/near-api-js/node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -7702,6 +7786,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg=="
     },
     "node_modules/parse-headers": {
       "version": "2.0.5",
@@ -8574,6 +8663,11 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/toml": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="
+    },
     "node_modules/tough-cookie": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
@@ -9410,21 +9504,24 @@
       "requires": {}
     },
     "@certusone/wormhole-sdk": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk/-/wormhole-sdk-0.8.0.tgz",
-      "integrity": "sha512-0TMtLLXSbBgN2QdZASZNb8aDm6I1vawI7MLiIcgcuaEm/Ip8/mf6jWOMoptCyneNCFGuxQ8XIP43oReK6b4dyA==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk/-/wormhole-sdk-0.9.0.tgz",
+      "integrity": "sha512-RmMGQPvrySaJP6bjwW2m1NQ1b3QLhafvW33ZgkGRQlMNjw1Ph+CgZbE7y7xkctASLxFDYKCjpJhJWVOj/igGiw==",
       "requires": {
         "@certusone/wormhole-sdk-proto-web": "^0.0.5",
         "@certusone/wormhole-sdk-wasm": "^0.0.1",
         "@injectivelabs/sdk-ts": "^1.0.75",
-        "@solana/spl-token": "^0.1.8",
-        "@solana/web3.js": "^1.24.0",
+        "@project-serum/anchor": "^0.25.0",
+        "@solana/spl-token": "^0.3.5",
+        "@solana/web3.js": "^1.66.2",
         "@terra-money/terra.js": "^3.1.3",
         "@xpla/xpla.js": "^0.2.1",
         "algosdk": "^1.15.0",
         "aptos": "^1.3.16",
         "axios": "^0.24.0",
         "bech32": "^2.0.0",
+        "binary-parser": "^2.2.1",
+        "elliptic": "^6.5.4",
         "js-base64": "^3.6.1",
         "near-api-js": "^1.0.0"
       },
@@ -9438,16 +9535,6 @@
           "version": "5.2.1",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
           "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
-        },
-        "borsh": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.7.0.tgz",
-          "integrity": "sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==",
-          "requires": {
-            "bn.js": "^5.2.0",
-            "bs58": "^4.0.0",
-            "text-encoding-utf-8": "^1.0.2"
-          }
         },
         "depd": {
           "version": "2.0.0",
@@ -11069,6 +11156,11 @@
       "integrity": "sha512-/kSXhY692qiV1MXu6EeOZvg5nECLclxNXcKCxJ3cXQgYuRymRHpdx/t7JXfsK+JLjwA1e1c1/SBrlQYpusC29Q==",
       "dev": true
     },
+    "@noble/ed25519": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.1.tgz",
+      "integrity": "sha512-Rk4SkJFaXZiznFyC/t77Q0NKS4FL7TLJJsVG2V2oiEq3kJVeTdxysEe/yRWSpnWMe808XRDJ+VFh5pt/FN5plw=="
+    },
     "@noble/hashes": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.3.tgz",
@@ -11077,8 +11169,53 @@
     "@noble/secp256k1": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.6.3.tgz",
-      "integrity": "sha512-T04e4iTurVy7I8Sw4+c5OSN9/RkPlo1uKxAomtxQNLq8j1uPAqnsqG1bqvY3Jv7c13gyr6dui0zmh/I3+f/JaQ==",
-      "dev": true
+      "integrity": "sha512-T04e4iTurVy7I8Sw4+c5OSN9/RkPlo1uKxAomtxQNLq8j1uPAqnsqG1bqvY3Jv7c13gyr6dui0zmh/I3+f/JaQ=="
+    },
+    "@project-serum/anchor": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@project-serum/anchor/-/anchor-0.25.0.tgz",
+      "integrity": "sha512-E6A5Y/ijqpfMJ5psJvbw0kVTzLZFUcOFgs6eSM2M2iWE1lVRF18T6hWZVNl6zqZsoz98jgnNHtVGJMs+ds9A7A==",
+      "requires": {
+        "@project-serum/borsh": "^0.2.5",
+        "@solana/web3.js": "^1.36.0",
+        "base64-js": "^1.5.1",
+        "bn.js": "^5.1.2",
+        "bs58": "^4.0.1",
+        "buffer-layout": "^1.2.2",
+        "camelcase": "^5.3.1",
+        "cross-fetch": "^3.1.5",
+        "crypto-hash": "^1.3.0",
+        "eventemitter3": "^4.0.7",
+        "js-sha256": "^0.9.0",
+        "pako": "^2.0.3",
+        "snake-case": "^3.0.4",
+        "superstruct": "^0.15.4",
+        "toml": "^3.0.0"
+      },
+      "dependencies": {
+        "cross-fetch": {
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+          "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+          "requires": {
+            "node-fetch": "2.6.7"
+          }
+        },
+        "superstruct": {
+          "version": "0.15.5",
+          "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-0.15.5.tgz",
+          "integrity": "sha512-4AOeU+P5UuE/4nOUkmcQdW5y7i9ndt1cQd/3iUe+LTz3RxESf/W/5lg4B74HbDMMv8PHnPnGCQFH45kBcrQYoQ=="
+        }
+      }
+    },
+    "@project-serum/borsh": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@project-serum/borsh/-/borsh-0.2.5.tgz",
+      "integrity": "sha512-UmeUkUoKdQ7rhx6Leve1SssMR/Ghv8qrEiyywyxSWg7ooV7StdpPBhciiy5eB3T0qU1BXvdRNC8TdrkxK7WC5Q==",
+      "requires": {
+        "bn.js": "^5.1.2",
+        "buffer-layout": "^1.2.0"
+      }
     },
     "@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -11160,13 +11297,17 @@
       }
     },
     "@solana/buffer-layout": {
-      "version": "3.0.0",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/buffer-layout/-/buffer-layout-4.0.0.tgz",
+      "integrity": "sha512-lR0EMP2HC3+Mxwd4YcnZb0smnaDw7Bl2IQWZiTevRH5ZZBZn6VRWn3/92E3qdU4SSImJkA6IDHawOHAnx/qUvQ==",
       "requires": {
         "buffer": "~6.0.3"
       },
       "dependencies": {
         "buffer": {
           "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
           "requires": {
             "base64-js": "^1.3.1",
             "ieee754": "^1.2.1"
@@ -11174,17 +11315,25 @@
         }
       }
     },
-    "@solana/spl-token": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.1.8.tgz",
-      "integrity": "sha512-LZmYCKcPQDtJgecvWOgT/cnoIQPWjdH+QVyzPcFvyDUiT0DiRjZaam4aqNUyvchLFhzgunv3d9xOoyE34ofdoQ==",
+    "@solana/buffer-layout-utils": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/buffer-layout-utils/-/buffer-layout-utils-0.2.0.tgz",
+      "integrity": "sha512-szG4sxgJGktbuZYDg2FfNmkMi0DYQoVjN2h7ta1W1hPrwzarcFLBq9UpX1UjNXsNpT9dn+chgprtWGioUAr4/g==",
       "requires": {
-        "@babel/runtime": "^7.10.5",
-        "@solana/web3.js": "^1.21.0",
-        "bn.js": "^5.1.0",
-        "buffer": "6.0.3",
-        "buffer-layout": "^1.2.0",
-        "dotenv": "10.0.0"
+        "@solana/buffer-layout": "^4.0.0",
+        "@solana/web3.js": "^1.32.0",
+        "bigint-buffer": "^1.1.5",
+        "bignumber.js": "^9.0.1"
+      }
+    },
+    "@solana/spl-token": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.3.6.tgz",
+      "integrity": "sha512-P9pTXjDIRvVbjr3J0mCnSamYqLnICeds7IoH1/Ro2R9OBuOHdp5pqKZoscfZ3UYrgnCWUc1bc9M2m/YPHjw+1g==",
+      "requires": {
+        "@solana/buffer-layout": "^4.0.0",
+        "@solana/buffer-layout-utils": "^0.2.0",
+        "buffer": "^6.0.3"
       },
       "dependencies": {
         "buffer": {
@@ -11199,34 +11348,25 @@
       }
     },
     "@solana/web3.js": {
-      "version": "1.34.0",
-      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.34.0.tgz",
-      "integrity": "sha512-6QvqN2DqEELvuV+5yUQM8P9fRiSG+6SzQ58HjumJqODu14r7eu5HXVWEymvKAvMLGME+0TmAdJHjw9xD5NgUWA==",
+      "version": "1.66.2",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.66.2.tgz",
+      "integrity": "sha512-RyaHMR2jGmaesnYP045VLeBGfR/gAW3cvZHzMFGg7bkO+WOYOYp1nEllf0/la4U4qsYGKCsO9eEevR5fhHiVHg==",
       "requires": {
         "@babel/runtime": "^7.12.5",
-        "@ethersproject/sha2": "^5.5.0",
-        "@solana/buffer-layout": "^3.0.0",
+        "@noble/ed25519": "^1.7.0",
+        "@noble/hashes": "^1.1.2",
+        "@noble/secp256k1": "^1.6.3",
+        "@solana/buffer-layout": "^4.0.0",
+        "bigint-buffer": "^1.1.5",
         "bn.js": "^5.0.0",
-        "borsh": "^0.4.0",
+        "borsh": "^0.7.0",
         "bs58": "^4.0.1",
         "buffer": "6.0.1",
-        "cross-fetch": "^3.1.4",
+        "fast-stable-stringify": "^1.0.0",
         "jayson": "^3.4.4",
-        "js-sha3": "^0.8.0",
-        "rpc-websockets": "^7.4.2",
-        "secp256k1": "^4.0.2",
-        "superstruct": "^0.14.2",
-        "tweetnacl": "^1.0.0"
-      },
-      "dependencies": {
-        "cross-fetch": {
-          "version": "3.1.5",
-          "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
-          "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
-          "requires": {
-            "node-fetch": "2.6.7"
-          }
-        }
+        "node-fetch": "2",
+        "rpc-websockets": "^7.5.0",
+        "superstruct": "^0.14.2"
       }
     },
     "@terra-money/legacy.proto": {
@@ -11850,15 +11990,23 @@
       "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.36.tgz",
       "integrity": "sha512-t70bfa7HYEA1D9idDbmuv7YbsbVkQ+Hp+8KFSul4aE5e/i1bjCNIRYJZlA8Q8p0r9T8cF/RVvwUgRA//FydEyg=="
     },
+    "bigint-buffer": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/bigint-buffer/-/bigint-buffer-1.1.5.tgz",
+      "integrity": "sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==",
+      "requires": {
+        "bindings": "^1.3.0"
+      }
+    },
     "bignumber.js": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
       "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
     },
     "binary-parser": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/binary-parser/-/binary-parser-2.0.2.tgz",
-      "integrity": "sha512-F2JeaLmExQ0vOEbS5ERzkxePKWTPqJPV6Z04/owaXMQLlW1Kt9v2gUz3SocR40JQGtrUeZu3j6prZDeuEG8Dng=="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/binary-parser/-/binary-parser-2.2.1.tgz",
+      "integrity": "sha512-5ATpz/uPDgq5GgEDxTB4ouXCde7q2lqAQlSdBRQVl/AJnxmQmhIfyxJx+0MGu//D5rHQifkfGbWWlaysG0o9NA=="
     },
     "bindings": {
       "version": "1.5.0",
@@ -11934,20 +12082,13 @@
       "version": "5.2.0"
     },
     "borsh": {
-      "version": "0.4.0",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.7.0.tgz",
+      "integrity": "sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==",
       "requires": {
-        "@types/bn.js": "^4.11.5",
-        "bn.js": "^5.0.0",
+        "bn.js": "^5.2.0",
         "bs58": "^4.0.0",
         "text-encoding-utf-8": "^1.0.2"
-      },
-      "dependencies": {
-        "@types/bn.js": {
-          "version": "4.11.6",
-          "requires": {
-            "@types/node": "*"
-          }
-        }
       }
     },
     "brace-expansion": {
@@ -12043,6 +12184,11 @@
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
       }
+    },
+    "camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
     },
     "caniuse-lite": {
       "version": "1.0.30001425",
@@ -12304,6 +12450,11 @@
         "safe-buffer": "^5.2.0",
         "sha3": "^2.1.1"
       }
+    },
+    "crypto-hash": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/crypto-hash/-/crypto-hash-1.3.0.tgz",
+      "integrity": "sha512-lyAZ0EMyjDkVvz8WOeVnuCPvKVBXcMv1l5SVqO1yC7PzTwrD/pPje/BIRbWhMoPe436U+Y2nD7f5bFx0kt+Sbg=="
     },
     "dashdash": {
       "version": "1.14.1",
@@ -13733,6 +13884,11 @@
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.8.tgz",
       "integrity": "sha512-lXatBjf3WPjmWD6DpIZxkeSsCOwqI0maYMpgDlx8g4U2qi4lbjA9oH/HD2a87G+KfsUmo5WbJFmqBZlPxtptag=="
     },
+    "fast-stable-stringify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-stable-stringify/-/fast-stable-stringify-1.0.0.tgz",
+      "integrity": "sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag=="
+    },
     "file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -14663,16 +14819,6 @@
         "tweetnacl": "^1.0.1"
       },
       "dependencies": {
-        "borsh": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.7.0.tgz",
-          "integrity": "sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==",
-          "requires": {
-            "bn.js": "^5.2.0",
-            "bs58": "^4.0.0",
-            "text-encoding-utf-8": "^1.0.2"
-          }
-        },
         "depd": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -14830,6 +14976,11 @@
           }
         }
       }
+    },
+    "pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg=="
     },
     "parse-headers": {
       "version": "2.0.5",
@@ -15495,6 +15646,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+    },
+    "toml": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="
     },
     "tough-cookie": {
       "version": "2.5.0",

--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "dependencies": {
     "@celo-tools/celo-ethers-wrapper": "^0.1.0",
-    "@certusone/wormhole-sdk": "^0.8.0",
+    "@certusone/wormhole-sdk": "^0.9.0",
     "@cosmjs/encoding": "^0.26.2",
     "@injectivelabs/networks": "^1.0.35",
     "@injectivelabs/sdk-ts": "^1.0.199",

--- a/clients/js/solana.ts
+++ b/clients/js/solana.ts
@@ -4,7 +4,7 @@ import { impossible, Payload, VAA } from "./vaa";
 import base58 from "bs58";
 import { CHAINS, CONTRACTS, SolanaChainName } from '@certusone/wormhole-sdk/lib/cjs/utils/consts';
 import { importCoreWasm, importNftWasm, importTokenWasm } from '@certusone/wormhole-sdk/lib/cjs/solana/wasm';
-import { ixFromRust, postVaaSolanaWithRetry } from '@certusone/wormhole-sdk/lib/cjs/solana';
+import { postVaaSolanaWithRetry } from '@certusone/wormhole-sdk/lib/cjs/solana';
 
 export async function execute_solana(
   v: VAA<Payload>,
@@ -108,7 +108,7 @@ export async function execute_solana(
     bridge_id.toString(), from.publicKey.toString(), vaa, 5)
 
   // Then do the actual thing
-  let transaction = new web3s.Transaction().add(ixFromRust(ix))
+  let transaction = new web3s.Transaction().add(ix)
 
   let signature = await web3s.sendAndConfirmTransaction(
     connection,

--- a/ethereum/truffle-config.js
+++ b/ethereum/truffle-config.js
@@ -45,15 +45,6 @@ module.exports = {
       },
       network_id: "5",
     },
-    ropsten_testnet: {
-      provider: () => {
-        return new HDWalletProvider(
-          process.env.MNEMONIC,
-          "https://rpc.ankr.com/eth_ropsten"
-        );
-      },
-      network_id: "3",
-    },
     bsc: {
       provider: () => {
         return new HDWalletProvider(


### PR DESCRIPTION
This PR updates the client/js code to remove support for Ropsten since it is deprecated. 

Note that it removes a call to ixFromRust() because it no longer exists in the SDK. I did a test submit on Solana and it seemed to work.

This PR partially fixes issue 1770.

Change-Id: I314c2299fb00be0c1647729dc3016c9dd34beb3a