### PR TITLE
cosmwasm: Override local deps at the workspace level

### DIFF
--- a/cosmwasm/Cargo.toml
+++ b/cosmwasm/Cargo.toml
@@ -18,3 +18,9 @@ codegen-units = 1
 panic = 'abort'
 incremental = false
 overflow-checks = true
+
+[patch.crates-io]
+cw20-wrapped-2 = { path = "contracts/cw20-wrapped" }
+token-bridge-terra-2 = { path = "contracts/token-bridge" }
+wormhole-bridge-terra-2 = { path = "contracts/wormhole" }
+

--- a/cosmwasm/contracts/mock-bridge-integration/Cargo.toml
+++ b/cosmwasm/contracts/mock-bridge-integration/Cargo.toml
@@ -19,7 +19,7 @@ schemars = "0.8.8"
 serde = { version = "1.0.137", default-features = false, features = ["derive"] }
 cw20 = "0.13.2"
 cw20-base = { version = "0.13.2", features = ["library"] }
-cw20-wrapped-2 = { path = "../cw20-wrapped", features = ["library"] }
+cw20-wrapped-2 = { version = "0.1.0", features = ["library"] }
 terraswap = "2.6.1"
 thiserror = { version = "1.0.31" }
 k256 = { version = "0.9.4", default-features = false, features = ["ecdsa"] }
@@ -29,8 +29,8 @@ hex = "0.4.2"
 lazy_static = "1.4.0"
 bigint = "4"
 
-wormhole-bridge-terra-2 = { path = "../wormhole", features = ["library"] }
-token-bridge-terra-2 = { path = "../token-bridge", features = ["library"] }
+wormhole-bridge-terra-2 = { version = "0.1.0", features = ["library"] }
+token-bridge-terra-2 = { version = "0.1.0", features = ["library"] }
 
 [dev-dependencies]
 cosmwasm-vm = { version = "1.0.0", default-features = false }

--- a/cosmwasm/contracts/shutdown-token-bridge/Cargo.toml
+++ b/cosmwasm/contracts/shutdown-token-bridge/Cargo.toml
@@ -9,4 +9,4 @@ description = "Shutdown Wormhole token bridge on cosmwasm"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-token-bridge-terra-2 = { path = "../token-bridge", default-features = false }
+token-bridge-terra-2 = { version = "0.1.0", default-features = false }

--- a/cosmwasm/contracts/shutdown-wormhole/Cargo.toml
+++ b/cosmwasm/contracts/shutdown-wormhole/Cargo.toml
@@ -9,4 +9,4 @@ description = "Shutdown Wormhole core bridge on cosmwasm"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-wormhole-bridge-terra-2 = { path = "../wormhole", default-features = false }
+wormhole-bridge-terra-2 = { version = "0.1.0", default-features = false }

--- a/cosmwasm/contracts/token-bridge/Cargo.toml
+++ b/cosmwasm/contracts/token-bridge/Cargo.toml
@@ -24,9 +24,9 @@ schemars = "0.8.8"
 serde = { version = "1.0.137", default-features = false, features = ["derive"] }
 cw20 = "0.13.2"
 cw20-base = { version = "0.13.2", features = ["library"] }
-cw20-wrapped-2 = { path = "../cw20-wrapped", features = ["library"] }
+cw20-wrapped-2 = { version = "0.1.0", features = ["library"] }
 terraswap = "2.6.1"
-wormhole-bridge-terra-2 = { path = "../wormhole", default-features = false, features = ["library"] }
+wormhole-bridge-terra-2 = { version = "0.1.0", default-features = false, features = ["library"] }
 thiserror = { version = "1.0.31" }
 k256 = { version = "0.9.4", default-features = false, features = ["ecdsa"] }
 sha3 = { version = "0.9.1", default-features = false }

--- a/cosmwasm/contracts/wormhole/Cargo.toml
+++ b/cosmwasm/contracts/wormhole/Cargo.toml
@@ -25,7 +25,7 @@ schemars = "0.8.8"
 serde = { version = "1.0.137", default-features = false, features = ["derive"] }
 cw20 = "0.13.2"
 cw20-base = { version = "0.13.2", features = ["library"] }
-cw20-wrapped-2 = { path = "../cw20-wrapped", features = ["library"] }
+cw20-wrapped-2 = { version = "0.1.0", features = ["library"] }
 thiserror = { version = "1.0.31" }
 k256 = { version = "0.9.4", default-features = false, features = ["ecdsa"] }
 getrandom = { version = "0.2", features = ["custom"] }


### PR DESCRIPTION
 Put all the local overrides at the workspace level rather than having
 to specify the path in each individual crate.  This will also make it
 easier for us to publish to crates.io when that time comes.
