### PR TITLE
sdk/js - include nonce in GetSignedBatchVAA call

### DIFF
--- a/sdk/js-proto-node/.npmrc
+++ b/sdk/js-proto-node/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/sdk/js-proto-web/.npmrc
+++ b/sdk/js-proto-web/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/sdk/js/.npmrc
+++ b/sdk/js/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/sdk/js/package-lock.json
+++ b/sdk/js/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@certusone/wormhole-sdk",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@certusone/wormhole-sdk",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@certusone/wormhole-sdk-proto-web": "^0.0.5",
+        "@certusone/wormhole-sdk-proto-web": "0.0.6",
         "@certusone/wormhole-sdk-wasm": "^0.0.1",
         "@injectivelabs/sdk-ts": "^1.0.211",
         "@project-serum/anchor": "^0.25.0",
@@ -692,9 +692,9 @@
       "dev": true
     },
     "node_modules/@certusone/wormhole-sdk-proto-web": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk-proto-web/-/wormhole-sdk-proto-web-0.0.5.tgz",
-      "integrity": "sha512-shZo7FG2Idu2RCTBU4f4KXQpzmSgb4ymtstTQrCDmIG0NPhGfraDMjESqMHtPd+aCcLrEnq/k2JBIeUKb0ThvQ==",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk-proto-web/-/wormhole-sdk-proto-web-0.0.6.tgz",
+      "integrity": "sha512-LTyjsrWryefx5WmkoBP6FQ2EjLxhMExAGxLkloHUhufVQZdrbGh0htBBUviP+HaDSJBCMPMtulNFwkBJV6muqQ==",
       "dependencies": {
         "@improbable-eng/grpc-web": "^0.15.0",
         "protobufjs": "^7.0.0",
@@ -14507,9 +14507,9 @@
       "dev": true
     },
     "@certusone/wormhole-sdk-proto-web": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk-proto-web/-/wormhole-sdk-proto-web-0.0.5.tgz",
-      "integrity": "sha512-shZo7FG2Idu2RCTBU4f4KXQpzmSgb4ymtstTQrCDmIG0NPhGfraDMjESqMHtPd+aCcLrEnq/k2JBIeUKb0ThvQ==",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk-proto-web/-/wormhole-sdk-proto-web-0.0.6.tgz",
+      "integrity": "sha512-LTyjsrWryefx5WmkoBP6FQ2EjLxhMExAGxLkloHUhufVQZdrbGh0htBBUviP+HaDSJBCMPMtulNFwkBJV6muqQ==",
       "requires": {
         "@improbable-eng/grpc-web": "^0.15.0",
         "protobufjs": "^7.0.0",

--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@certusone/wormhole-sdk",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "SDK for interacting with Wormhole",
   "homepage": "https://wormhole.com",
   "main": "./lib/cjs/index.js",
@@ -61,7 +61,7 @@
     "web3": "^1.6.1"
   },
   "dependencies": {
-    "@certusone/wormhole-sdk-proto-web": "^0.0.5",
+    "@certusone/wormhole-sdk-proto-web": "0.0.6",
     "@certusone/wormhole-sdk-wasm": "^0.0.1",
     "@injectivelabs/sdk-ts": "^1.0.211",
     "@project-serum/anchor": "^0.25.0",

--- a/sdk/js/src/rpc/getSignedBatchVAA.ts
+++ b/sdk/js/src/rpc/getSignedBatchVAA.ts
@@ -5,7 +5,8 @@ const { GrpcWebImpl, PublicRPCServiceClientImpl } = publicrpc;
 export async function getSignedBatchVAA(
   host: string,
   emitterChain: ChainId | ChainName,
-  transactionId: string,
+  transactionId: Uint8Array,
+  nonce: number,
   extraGrpcOpts = {}
 ) {
   const rpc = new GrpcWebImpl(host, extraGrpcOpts);
@@ -14,6 +15,7 @@ export async function getSignedBatchVAA(
     batchId: {
       emitterChain: coalesceChainId(emitterChain),
       txId: transactionId,
+      nonce,
     },
   });
 }

--- a/sdk/js/src/rpc/getSignedBatchVAAWithRetry.ts
+++ b/sdk/js/src/rpc/getSignedBatchVAAWithRetry.ts
@@ -4,7 +4,8 @@ import { coalesceChainId } from "../utils";
 export async function getSignedBatchVAAWithRetry(
   hosts: string[],
   emitterChain: ChainId | ChainName,
-  transactionId: string,
+  transactionId: Uint8Array,
+  nonce: number,
   extraGrpcOpts = {},
   retryTimeout = 1000,
   retryAttempts?: number
@@ -21,6 +22,7 @@ export async function getSignedBatchVAAWithRetry(
         hosts[getNextRpcHost()],
         coalesceChainId(emitterChain),
         transactionId,
+        nonce,
         extraGrpcOpts
       );
     } catch (e) {


### PR DESCRIPTION
This updates the SDK method to include `nonce` when calling the guardian's publicrpc endpoint to get a BatchVAA.

I also added `.npmrc`s to the js modules, to make npm save exact package versions (no `^`).

Part of https://github.com/wormhole-foundation/wormhole/issues/1893 & https://github.com/wormhole-foundation/wormhole/issues/1679