### PR TITLE
Protect token implementation for arbitrum&optimism

### DIFF
--- a/ethereum/contracts/bridge/BridgeImplementation.sol
+++ b/ethereum/contracts/bridge/BridgeImplementation.sol
@@ -18,43 +18,26 @@ contract BridgeImplementation is Bridge {
     function initialize() initializer public virtual {
         // this function needs to be exposed for an upgrade to pass
         address tokenContract;
-        uint256 evmChainId;
-        uint16 chain = chainId();
+        uint256 chain = chainId();
 
-        // Wormhole chain ids explicitly enumerated
-        if        (chain == 2)  { evmChainId = 1;          // ethereum
-            setFinality(1);
-            tokenContract = 0x0fD04a68d3c3A692d6Fa30384D1A87Ef93554eE6;
-        } else if (chain == 4)  { evmChainId = 56;         // bsc
-            tokenContract = 0x7f8C5e730121657E17E452c5a1bA3fA1eF96f22a;
-        } else if (chain == 5)  { evmChainId = 137;        // polygon
-            tokenContract = 0x7C9Fc5741288cDFdD83CeB07f3ea7e22618D79D2;
-        } else if (chain == 6)  { evmChainId = 43114;      // avalanche
-            tokenContract = 0xe07548528D7c0C470251CF1374eF762345f298eE;
-        } else if (chain == 7)  { evmChainId = 42262;      // oasis
-            tokenContract = 0x75d520ed7fE263b96cCC7165aCe270097bC11721;
-        } else if (chain == 9)  { evmChainId = 1313161554; // aurora
-            tokenContract = 0x20F989Ad4C3B6ddcd940A66013d45f45d5c15463;
-        } else if (chain == 10) { evmChainId = 250;        // fantom
-            tokenContract = 0x99A3385C5AA40B184F6F6898daeBcD752C4b11F8;
-        } else if (chain == 11) { evmChainId = 686;        // karura
-            tokenContract = 0x7C9Fc5741288cDFdD83CeB07f3ea7e22618D79D2;
-        } else if (chain == 12) { evmChainId = 787;        // acala
-        } else if (chain == 13) { evmChainId = 8217;       // klaytn
-            tokenContract = 0x7Ec2f3742F5D7ecF85817D67Ae3f89fa70164e8F;
-        } else if (chain == 14) { evmChainId = 42220;      // celo
-            tokenContract = 0x1a81c975d0e69206a45584BB98520f25dEEC7b6C;
-        } else if (chain == 16) { evmChainId = 1284;       // moonbeam
-            tokenContract = 0xddA94dA500AF7DCd8DE53482a39eD55d4aA3B392;
-        } else if (chain == 17) { evmChainId = 245022934;  // neon
-        } else if (chain == 23) { evmChainId = 42161;      // arbitrum
-        } else if (chain == 24) { evmChainId = 10;         // optimism
-        } else if (chain == 25) { evmChainId = 100;        // gnosis
+        // A previous upgrade
+        // (https://github.com/wormhole-foundation/wormhole/commit/cb161db5e01970cc92d80fc679e506db054f8368)
+        // set the token contract implementations for a number of chains,
+        // excluding arbitrum and optimism, both of which were deployed with
+        // that `initialize` contract, meaning there's a potential for a
+        // temporary DoS.
+        //
+        // Performing this upgrade closes that DoS window.
+        //
+        // *insert rant about implicit variable initialisation*
+        if        (chain == 23) { // arbitrum
+            tokenContract = 0x53B56de645B9de6e5a40acE047D1c74E8B42Eccb;
+        } else if (chain == 24) { // optimism
+            tokenContract = 0xb91e3638F82A1fACb28690b37e3aAE45d2c33808;
         } else {
-            revert("Unknown chain id.");
+            revert("Chain not handled.");
         }
 
-        setEvmChainId(evmChainId);
         setTokenImplementation(tokenContract);
     }
 

--- a/ethereum/contracts/bridge/BridgeSetters.sol
+++ b/ethereum/contracts/bridge/BridgeSetters.sol
@@ -35,6 +35,7 @@ contract BridgeSetters is BridgeState {
     }
 
     function setTokenImplementation(address impl) internal {
+        require(impl != address(0), "invalid implementation address");
         _state.tokenImplementation = impl;
     }
 

--- a/ethereum/contracts/nft/NFTBridgeSetters.sol
+++ b/ethereum/contracts/nft/NFTBridgeSetters.sol
@@ -35,6 +35,7 @@ contract NFTBridgeSetters is NFTBridgeState {
     }
 
     function setTokenImplementation(address impl) internal {
+        require(impl != address(0), "invalid implementation address");
         _state.tokenImplementation = impl;
     }
 

--- a/scripts/contract-upgrade-governance.sh
+++ b/scripts/contract-upgrade-governance.sh
@@ -174,6 +174,16 @@ case "$chain_name" in
     chain=15
     explorer="https://explorer.near.org/accounts/"
     ;;
+  arbitrum)
+    chain=23
+    explorer="https://arbiscan.io/address/"
+    evm=true
+    ;;
+  optimism)
+    chain=24
+    explorer="https://optimistic.etherscan.io/address/"
+    evm=true
+    ;;
   *)
     echo "Unknown chain: $chain_name" >&2
     exit 1


### PR DESCRIPTION
This PR protects from a temporary DoS risk arising from the `initialize()` function only partially defining the `tokenContract` variable, combined with the fact that `initialize()` is public. This PR fixes the immediate issue, will follow up with a proposal to eliminate this class of bugs in due course.

The EVM upgrade test is expected to fail for this one, because it simulates an upgrade against ethereum, which in this case is expected to revert (since this upgrade targets arbitrum and optimism exclusively).

The token implementations in question are:
https://arbiscan.io/address/0x53b56de645b9de6e5a40ace047d1c74e8b42eccb
https://optimistic.etherscan.io/address/0xb91e3638f82a1facb28690b37e3aae45d2c33808