### PR TITLE
node: add channel read/write type constraints

### DIFF
--- a/node/cmd/guardiand/adminserver.go
+++ b/node/cmd/guardiand/adminserver.go
@@ -41,9 +41,9 @@ type nodePrivilegedService struct {
 	nodev1.UnimplementedNodePrivilegedServiceServer
 	db              *db.Database
 	injectC         chan<- *vaa.VAA
-	obsvReqSendC    chan *gossipv1.ObservationRequest
+	obsvReqSendC    chan<- *gossipv1.ObservationRequest
 	logger          *zap.Logger
-	signedInC       chan *gossipv1.SignedVAAWithQuorum
+	signedInC       chan<- *gossipv1.SignedVAAWithQuorum
 	governor        *governor.ChainGovernor
 	evmConnector    connectors.Connector
 	gsCache         sync.Map
@@ -397,8 +397,19 @@ func (s *nodePrivilegedService) FindMissingMessages(ctx context.Context, req *no
 	}, nil
 }
 
-func adminServiceRunnable(logger *zap.Logger, socketPath string, injectC chan<- *vaa.VAA, signedInC chan *gossipv1.SignedVAAWithQuorum, obsvReqSendC chan *gossipv1.ObservationRequest,
-	db *db.Database, gst *common.GuardianSetState, gov *governor.ChainGovernor, gk *ecdsa.PrivateKey, ethRpc *string, ethContract *string) (supervisor.Runnable, error) {
+func adminServiceRunnable(
+	logger *zap.Logger,
+	socketPath string,
+	injectC chan<- *vaa.VAA,
+	signedInC chan<- *gossipv1.SignedVAAWithQuorum,
+	obsvReqSendC chan<- *gossipv1.ObservationRequest,
+	db *db.Database,
+	gst *common.GuardianSetState,
+	gov *governor.ChainGovernor,
+	gk *ecdsa.PrivateKey,
+	ethRpc *string,
+	ethContract *string,
+) (supervisor.Runnable, error) {
 	// Delete existing UNIX socket, if present.
 	fi, err := os.Stat(socketPath)
 	if err == nil {

--- a/node/pkg/governor/governor_monitoring.go
+++ b/node/pkg/governor/governor_monitoring.go
@@ -396,7 +396,7 @@ var (
 		})
 )
 
-func (gov *ChainGovernor) CollectMetrics(hb *gossipv1.Heartbeat, sendC chan []byte, gk *ecdsa.PrivateKey, ourAddr ethCommon.Address) {
+func (gov *ChainGovernor) CollectMetrics(hb *gossipv1.Heartbeat, sendC chan<- []byte, gk *ecdsa.PrivateKey, ourAddr ethCommon.Address) {
 	gov.mutex.Lock()
 	defer gov.mutex.Unlock()
 
@@ -464,7 +464,7 @@ func (gov *ChainGovernor) CollectMetrics(hb *gossipv1.Heartbeat, sendC chan []by
 var governorMessagePrefixConfig = []byte("governor_config_000000000000000000|")
 var governorMessagePrefixStatus = []byte("governor_status_000000000000000000|")
 
-func (gov *ChainGovernor) publishConfig(hb *gossipv1.Heartbeat, sendC chan []byte, gk *ecdsa.PrivateKey, ourAddr ethCommon.Address) {
+func (gov *ChainGovernor) publishConfig(hb *gossipv1.Heartbeat, sendC chan<- []byte, gk *ecdsa.PrivateKey, ourAddr ethCommon.Address) {
 	chains := make([]*gossipv1.ChainGovernorConfig_Chain, 0)
 	for _, ce := range gov.chains {
 		chains = append(chains, &gossipv1.ChainGovernorConfig_Chain{
@@ -521,7 +521,7 @@ func (gov *ChainGovernor) publishConfig(hb *gossipv1.Heartbeat, sendC chan []byt
 	sendC <- b
 }
 
-func (gov *ChainGovernor) publishStatus(hb *gossipv1.Heartbeat, sendC chan []byte, startTime time.Time, gk *ecdsa.PrivateKey, ourAddr ethCommon.Address) {
+func (gov *ChainGovernor) publishStatus(hb *gossipv1.Heartbeat, sendC chan<- []byte, startTime time.Time, gk *ecdsa.PrivateKey, ourAddr ethCommon.Address) {
 	chains := make([]*gossipv1.ChainGovernorStatus_Chain, 0)
 	numEnqueued := 0
 	for _, ce := range gov.chains {

--- a/node/pkg/p2p/p2p.go
+++ b/node/pkg/p2p/p2p.go
@@ -69,11 +69,11 @@ func signedObservationRequestDigest(b []byte) common.Hash {
 }
 
 func Run(
-	obsvC chan *gossipv1.SignedObservation,
-	obsvReqC chan *gossipv1.ObservationRequest,
-	obsvReqSendC chan *gossipv1.ObservationRequest,
-	sendC chan []byte,
-	signedInC chan *gossipv1.SignedVAAWithQuorum,
+	obsvC chan<- *gossipv1.SignedObservation,
+	obsvReqC chan<- *gossipv1.ObservationRequest,
+	obsvReqSendC <-chan *gossipv1.ObservationRequest,
+	gossipSendC chan []byte,
+	signedInC chan<- *gossipv1.SignedVAAWithQuorum,
 	priv crypto.PrivKey,
 	gk *ecdsa.PrivateKey,
 	gst *node_common.GuardianSetState,
@@ -252,7 +252,7 @@ func Run(
 					collectNodeMetrics(ourAddr, h.ID(), heartbeat)
 
 					if gov != nil {
-						gov.CollectMetrics(heartbeat, sendC, gk, ourAddr)
+						gov.CollectMetrics(heartbeat, gossipSendC, gk, ourAddr)
 					}
 
 					b, err := proto.Marshal(heartbeat)
@@ -297,7 +297,7 @@ func Run(
 				select {
 				case <-ctx.Done():
 					return
-				case msg := <-sendC:
+				case msg := <-gossipSendC:
 					err := th.Publish(ctx, msg)
 					p2pMessagesSent.Inc()
 					if err != nil {

--- a/node/pkg/processor/broadcast.go
+++ b/node/pkg/processor/broadcast.go
@@ -44,7 +44,7 @@ func (p *Processor) broadcastSignature(
 		panic(err)
 	}
 
-	p.sendC <- msg
+	p.gossipSendC <- msg
 
 	// Store our VAA in case we're going to submit it to Solana
 	hash := hex.EncodeToString(digest.Bytes())
@@ -84,5 +84,5 @@ func (p *Processor) broadcastSignedVAA(v *vaa.VAA) {
 		panic(err)
 	}
 
-	p.sendC <- msg
+	p.gossipSendC <- msg
 }

--- a/node/pkg/processor/cleanup.go
+++ b/node/pkg/processor/cleanup.go
@@ -202,7 +202,7 @@ func (p *Processor) handleCleanup(ctx context.Context) {
 				if err := common.PostObservationRequest(p.obsvReqSendC, req); err != nil {
 					p.logger.Warn("failed to broadcast re-observation request", zap.Error(err))
 				}
-				p.sendC <- s.ourMsg
+				p.gossipSendC <- s.ourMsg
 				s.retryCount += 1
 				s.lastRetry = time.Now()
 				aggregationStateRetries.Inc()

--- a/node/pkg/watchers/algorand/watcher.go
+++ b/node/pkg/watchers/algorand/watcher.go
@@ -33,8 +33,8 @@ type (
 		algodToken   string
 		appid        uint64
 
-		msgChan  chan *common.MessagePublication
-		obsvReqC chan *gossipv1.ObservationRequest
+		msgC     chan<- *common.MessagePublication
+		obsvReqC <-chan *gossipv1.ObservationRequest
 
 		next_round uint64
 	}
@@ -60,8 +60,8 @@ func NewWatcher(
 	algodRPC string,
 	algodToken string,
 	appid uint64,
-	lockEvents chan *common.MessagePublication,
-	obsvReqC chan *gossipv1.ObservationRequest,
+	msgC chan<- *common.MessagePublication,
+	obsvReqC <-chan *gossipv1.ObservationRequest,
 ) *Watcher {
 	return &Watcher{
 		indexerRPC:   indexerRPC,
@@ -69,7 +69,7 @@ func NewWatcher(
 		algodRPC:     algodRPC,
 		algodToken:   algodToken,
 		appid:        appid,
-		msgChan:      lockEvents,
+		msgC:         msgC,
 		obsvReqC:     obsvReqC,
 		next_round:   0,
 	}
@@ -137,7 +137,7 @@ func lookAtTxn(e *Watcher, t types.SignedTxnInBlock, b types.Block, logger *zap.
 			zap.Uint8("consistency_level", observation.ConsistencyLevel),
 		)
 
-		e.msgChan <- observation
+		e.msgC <- observation
 	}
 }
 

--- a/node/pkg/watchers/aptos/watcher.go
+++ b/node/pkg/watchers/aptos/watcher.go
@@ -29,8 +29,8 @@ type (
 		aptosAccount string
 		aptosHandle  string
 
-		msgChan  chan *common.MessagePublication
-		obsvReqC chan *gossipv1.ObservationRequest
+		msgC     chan<- *common.MessagePublication
+		obsvReqC <-chan *gossipv1.ObservationRequest
 	}
 )
 
@@ -52,14 +52,14 @@ func NewWatcher(
 	aptosRPC string,
 	aptosAccount string,
 	aptosHandle string,
-	messageEvents chan *common.MessagePublication,
-	obsvReqC chan *gossipv1.ObservationRequest,
+	msgC chan<- *common.MessagePublication,
+	obsvReqC <-chan *gossipv1.ObservationRequest,
 ) *Watcher {
 	return &Watcher{
 		aptosRPC:     aptosRPC,
 		aptosAccount: aptosAccount,
 		aptosHandle:  aptosHandle,
-		msgChan:      messageEvents,
+		msgC:         msgC,
 		obsvReqC:     obsvReqC,
 	}
 }
@@ -317,5 +317,5 @@ func (e *Watcher) observeData(logger *zap.Logger, data gjson.Result, nativeSeq u
 		zap.Uint8("consistencyLevel", observation.ConsistencyLevel),
 	)
 
-	e.msgChan <- observation
+	e.msgC <- observation
 }

--- a/node/pkg/watchers/cosmwasm/watcher.go
+++ b/node/pkg/watchers/cosmwasm/watcher.go
@@ -36,11 +36,11 @@ type (
 		urlLCD   string
 		contract string
 
-		msgChan chan *common.MessagePublication
+		msgC chan<- *common.MessagePublication
 
 		// Incoming re-observation requests from the network. Pre-filtered to only
 		// include requests for our chainID.
-		obsvReqC chan *gossipv1.ObservationRequest
+		obsvReqC <-chan *gossipv1.ObservationRequest
 
 		// Readiness component
 		readiness readiness.Component
@@ -95,8 +95,8 @@ func NewWatcher(
 	urlWS string,
 	urlLCD string,
 	contract string,
-	lockEvents chan *common.MessagePublication,
-	obsvReqC chan *gossipv1.ObservationRequest,
+	msgC chan<- *common.MessagePublication,
+	obsvReqC <-chan *gossipv1.ObservationRequest,
 	readiness readiness.Component,
 	chainID vaa.ChainID) *Watcher {
 
@@ -121,7 +121,7 @@ func NewWatcher(
 		urlWS:                    urlWS,
 		urlLCD:                   urlLCD,
 		contract:                 contract,
-		msgChan:                  lockEvents,
+		msgC:                     msgC,
 		obsvReqC:                 obsvReqC,
 		readiness:                readiness,
 		chainID:                  chainID,
@@ -273,7 +273,7 @@ func (e *Watcher) Run(ctx context.Context) error {
 
 				msgs := EventsToMessagePublications(e.contract, txHash, events.Array(), logger, e.chainID, e.contractAddressLogKey)
 				for _, msg := range msgs {
-					e.msgChan <- msg
+					e.msgC <- msg
 					messagesConfirmed.WithLabelValues(networkName).Inc()
 				}
 			}
@@ -313,7 +313,7 @@ func (e *Watcher) Run(ctx context.Context) error {
 
 				msgs := EventsToMessagePublications(e.contract, txHash, events.Array(), logger, e.chainID, e.contractAddressLogKey)
 				for _, msg := range msgs {
-					e.msgChan <- msg
+					e.msgC <- msg
 					messagesConfirmed.WithLabelValues(networkName).Inc()
 				}
 

--- a/sdk/vaa/structs.go
+++ b/sdk/vaa/structs.go
@@ -276,6 +276,38 @@ func ChainIDFromString(s string) (ChainID, error) {
 	}
 }
 
+func GetAllNetworkIDs() []ChainID {
+	return []ChainID{
+		ChainIDSolana,
+		ChainIDEthereum,
+		ChainIDTerra,
+		ChainIDBSC,
+		ChainIDPolygon,
+		ChainIDAvalanche,
+		ChainIDOasis,
+		ChainIDAlgorand,
+		ChainIDAurora,
+		ChainIDFantom,
+		ChainIDKarura,
+		ChainIDAcala,
+		ChainIDKlaytn,
+		ChainIDCelo,
+		ChainIDNear,
+		ChainIDMoonbeam,
+		ChainIDNeon,
+		ChainIDTerra2,
+		ChainIDInjective,
+		ChainIDSui,
+		ChainIDAptos,
+		ChainIDArbitrum,
+		ChainIDOptimism,
+		ChainIDPythNet,
+		ChainIDXpla,
+		ChainIDBtc,
+		ChainIDWormchain,
+	}
+}
+
 const (
 	ChainIDUnset ChainID = 0
 	// ChainIDSolana is the ChainID of Solana


### PR DESCRIPTION
there are no functional changes in this PR. 

I am adding read/write type constraints to the main channels defined in cmd/guardiand/node.go. This makes the code easier to audit. 