### PR TITLE
cosmwasm: Add backfill method for accounting

### DIFF
--- a/cosmwasm/Cargo.lock
+++ b/cosmwasm/Cargo.lock
@@ -1038,6 +1038,7 @@ dependencies = [
  "ecdsa 0.12.4",
  "elliptic-curve 0.10.6",
  "sha2",
+ "sha3 0.9.1",
 ]
 
 [[package]]
@@ -2263,6 +2264,7 @@ dependencies = [
  "k256 0.9.6",
  "schemars",
  "serde",
+ "wormhole-core",
 ]
 
 [[package]]
@@ -2292,6 +2294,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bstr",
+ "schemars",
  "serde",
  "serde_wormhole",
  "sha3 0.10.6",

--- a/cosmwasm/contracts/wormchain-accounting/Cargo.toml
+++ b/cosmwasm/contracts/wormchain-accounting/Cargo.toml
@@ -29,7 +29,7 @@ thiserror = { version = "1.0.31" }
 tinyvec = { version = "1.6", default-features = false, features = ["alloc", "serde"]}
 tokenbridge = { package = "token-bridge-terra-2", version = "0.1.0", features = ["library"] }
 wormhole-bindings = "0.1.0"
-wormhole-core = "0.1.0"
+wormhole-core = { version = "0.1.0", features = ["schemars"] }
 
 [dev-dependencies]
 anyhow = { version = "1", features = ["backtrace"] }

--- a/cosmwasm/contracts/wormchain-accounting/schema/wormchain-accounting.json
+++ b/cosmwasm/contracts/wormchain-accounting/schema/wormchain-accounting.json
@@ -65,6 +65,7 @@
     "title": "ExecuteMsg",
     "oneOf": [
       {
+        "description": "Submit a series of observations.  Once the contract has received a quorum of signatures for a particular observation, the transfer associated with the observation will be committed to the on-chain state.",
         "type": "object",
         "required": [
           "submit_observations"
@@ -96,6 +97,7 @@
         "additionalProperties": false
       },
       {
+        "description": "Modifies the balance of a single account.  Used to manually override the balance.",
         "type": "object",
         "required": [
           "modify_balance"
@@ -156,6 +158,32 @@
               },
               "upgrade": {
                 "$ref": "#/definitions/Binary"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "description": "Submit one or more signed token transfer VAAs to update the on-chain state.  If committing any of the transfers returns an error, the entire transaction is aborted and none of the transfers are committed.",
+        "type": "object",
+        "required": [
+          "submit_v_a_as"
+        ],
+        "properties": {
+          "submit_v_a_as": {
+            "type": "object",
+            "required": [
+              "vaas"
+            ],
+            "properties": {
+              "vaas": {
+                "description": "One or more VAAs to be submitted.  Each VAA should be encoded in the standard wormhole wire format.",
+                "type": "array",
+                "items": {
+                  "$ref": "#/definitions/Binary"
+                }
               }
             },
             "additionalProperties": false

--- a/cosmwasm/contracts/wormchain-accounting/schema/wormchain-accounting.json
+++ b/cosmwasm/contracts/wormchain-accounting/schema/wormchain-accounting.json
@@ -34,6 +34,7 @@
         "type": "string"
       },
       "Signature": {
+        "description": "Signatures are typical ECDSA signatures prefixed with a Guardian position. These have the following byte layout: ```markdown 0  .. 64: Signature   (ECDSA) 64 .. 65: Recovery ID (ECDSA) ```",
         "type": "object",
         "required": [
           "index",
@@ -41,21 +42,21 @@
         ],
         "properties": {
           "index": {
-            "description": "The index of the guardian in the guardian set.",
             "type": "integer",
-            "format": "uint16",
+            "format": "uint8",
             "minimum": 0.0
           },
           "signature": {
-            "description": "The signature, which should be exactly 65 bytes with the following layout:\n\n```markdown 0  .. 64: Signature   (ECDSA) 64 .. 65: Recovery ID (ECDSA) ```",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Binary"
-              }
-            ]
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            },
+            "maxItems": 65,
+            "minItems": 65
           }
-        },
-        "additionalProperties": false
+        }
       }
     }
   },
@@ -169,6 +170,7 @@
         "type": "string"
       },
       "Signature": {
+        "description": "Signatures are typical ECDSA signatures prefixed with a Guardian position. These have the following byte layout: ```markdown 0  .. 64: Signature   (ECDSA) 64 .. 65: Recovery ID (ECDSA) ```",
         "type": "object",
         "required": [
           "index",
@@ -176,21 +178,21 @@
         ],
         "properties": {
           "index": {
-            "description": "The index of the guardian in the guardian set.",
             "type": "integer",
-            "format": "uint16",
+            "format": "uint8",
             "minimum": 0.0
           },
           "signature": {
-            "description": "The signature, which should be exactly 65 bytes with the following layout:\n\n```markdown 0  .. 64: Signature   (ECDSA) 64 .. 65: Recovery ID (ECDSA) ```",
-            "allOf": [
-              {
-                "$ref": "#/definitions/Binary"
-              }
-            ]
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0.0
+            },
+            "maxItems": 65,
+            "minItems": 65
           }
-        },
-        "additionalProperties": false
+        }
       }
     }
   },
@@ -681,6 +683,7 @@
           "additionalProperties": false
         },
         "Signature": {
+          "description": "Signatures are typical ECDSA signatures prefixed with a Guardian position. These have the following byte layout: ```markdown 0  .. 64: Signature   (ECDSA) 64 .. 65: Recovery ID (ECDSA) ```",
           "type": "object",
           "required": [
             "index",
@@ -688,21 +691,21 @@
           ],
           "properties": {
             "index": {
-              "description": "The index of the guardian in the guardian set.",
               "type": "integer",
-              "format": "uint16",
+              "format": "uint8",
               "minimum": 0.0
             },
             "signature": {
-              "description": "The signature, which should be exactly 65 bytes with the following layout:\n\n```markdown 0  .. 64: Signature   (ECDSA) 64 .. 65: Recovery ID (ECDSA) ```",
-              "allOf": [
-                {
-                  "$ref": "#/definitions/Binary"
-                }
-              ]
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "uint8",
+                "minimum": 0.0
+              },
+              "maxItems": 65,
+              "minItems": 65
             }
-          },
-          "additionalProperties": false
+          }
         },
         "TokenAddress": {
           "type": "string"
@@ -960,6 +963,7 @@
           "additionalProperties": false
         },
         "Signature": {
+          "description": "Signatures are typical ECDSA signatures prefixed with a Guardian position. These have the following byte layout: ```markdown 0  .. 64: Signature   (ECDSA) 64 .. 65: Recovery ID (ECDSA) ```",
           "type": "object",
           "required": [
             "index",
@@ -967,21 +971,21 @@
           ],
           "properties": {
             "index": {
-              "description": "The index of the guardian in the guardian set.",
               "type": "integer",
-              "format": "uint16",
+              "format": "uint8",
               "minimum": 0.0
             },
             "signature": {
-              "description": "The signature, which should be exactly 65 bytes with the following layout:\n\n```markdown 0  .. 64: Signature   (ECDSA) 64 .. 65: Recovery ID (ECDSA) ```",
-              "allOf": [
-                {
-                  "$ref": "#/definitions/Binary"
-                }
-              ]
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "uint8",
+                "minimum": 0.0
+              },
+              "maxItems": 65,
+              "minItems": 65
             }
-          },
-          "additionalProperties": false
+          }
         },
         "TokenAddress": {
           "type": "string"

--- a/cosmwasm/contracts/wormchain-accounting/src/contract.rs
+++ b/cosmwasm/contracts/wormchain-accounting/src/contract.rs
@@ -14,7 +14,10 @@ use cosmwasm_std::{
 use cw2::set_contract_version;
 use cw_storage_plus::Bound;
 use tinyvec::{Array, TinyVec};
-use wormhole::{token::Message, vaa::Signature};
+use wormhole::{
+    token::Message,
+    vaa::{Body, Header, Signature},
+};
 use wormhole_bindings::WormholeQuery;
 
 use crate::{
@@ -103,6 +106,7 @@ pub fn execute(
             guardian_set_index,
             signatures,
         } => upgrade_contract(deps, env, info, upgrade, guardian_set_index, signatures),
+        ExecuteMsg::SubmitVAAs { vaas } => submit_vaas(deps, info, vaas),
     }
 }
 
@@ -318,6 +322,82 @@ fn upgrade_contract(
         }))
         .add_attribute("action", "contract_upgrade")
         .add_attribute("owner", info.sender))
+}
+
+fn submit_vaas(
+    mut deps: DepsMut<WormholeQuery>,
+    info: MessageInfo,
+    vaas: Vec<Binary>,
+) -> Result<Response, AnyError> {
+    let evts = vaas
+        .into_iter()
+        .map(|v| handle_vaa(deps.branch(), v))
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    Ok(Response::new()
+        .add_attribute("action", "submit_vaas")
+        .add_attribute("owner", info.sender)
+        .add_events(evts))
+}
+
+fn handle_vaa(mut deps: DepsMut<WormholeQuery>, vaa: Binary) -> anyhow::Result<Event> {
+    let (header, data) = serde_wormhole::from_slice_with_payload::<Header>(&vaa)
+        .context("failed to parse VAA header")?;
+
+    ensure!(header.version == 1, "unsupported VAA version");
+
+    deps.querier
+        .query::<Empty>(
+            &WormholeQuery::VerifyQuorum {
+                data: data.to_vec().into(),
+                guardian_set_index: header.guardian_set_index,
+                signatures: header.signatures,
+            }
+            .into(),
+        )
+        .context(ContractError::VerifyQuorum)?;
+
+    let (body, _) = serde_wormhole::from_slice_with_payload::<Body<Message>>(data)
+        .context("failed to parse VAA body")?;
+
+    let data = match body.payload {
+        Message::Transfer {
+            amount,
+            token_address,
+            token_chain,
+            recipient_chain,
+            ..
+        }
+        | Message::TransferWithPayload {
+            amount,
+            token_address,
+            token_chain,
+            recipient_chain,
+            ..
+        } => transfer::Data {
+            amount: Uint256::from_be_bytes(amount.0),
+            token_address: TokenAddress::new(token_address.0),
+            token_chain: token_chain.into(),
+            recipient_chain: recipient_chain.into(),
+        },
+        _ => bail!("Unknown tokenbridge payload"),
+    };
+
+    let key = transfer::Key::new(
+        body.emitter_chain.into(),
+        TokenAddress::new(body.emitter_address.0),
+        body.sequence,
+    );
+
+    let tx = Transfer {
+        key: key.clone(),
+        data,
+    };
+    let evt = accounting::commit_transfer(deps.branch(), tx)
+        .with_context(|| format!("failed to commit transfer for key {key}"))?;
+
+    PENDING_TRANSFERS.remove(deps.storage, key);
+
+    Ok(evt)
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]

--- a/cosmwasm/contracts/wormchain-accounting/src/contract.rs
+++ b/cosmwasm/contracts/wormchain-accounting/src/contract.rs
@@ -14,8 +14,8 @@ use cosmwasm_std::{
 use cw2::set_contract_version;
 use cw_storage_plus::Bound;
 use tinyvec::{Array, TinyVec};
-use wormhole::token::Message;
-use wormhole_bindings::{Signature, WormholeQuery};
+use wormhole::{token::Message, vaa::Signature};
+use wormhole_bindings::WormholeQuery;
 
 use crate::{
     bail,
@@ -118,7 +118,7 @@ fn submit_observations(
             &WormholeQuery::VerifySignature {
                 data: observations.clone(),
                 guardian_set_index,
-                signature: signature.clone(),
+                signature,
             }
             .into(),
         )
@@ -139,15 +139,7 @@ fn submit_observations(
 
     let events = observations
         .into_iter()
-        .map(|o| {
-            handle_observation(
-                deps.branch(),
-                o,
-                guardian_set_index,
-                quorum,
-                signature.clone(),
-            )
-        })
+        .map(|o| handle_observation(deps.branch(), o, guardian_set_index, quorum, signature))
         .filter_map(Result::transpose)
         .collect::<anyhow::Result<Vec<_>>>()
         .context("failed to handle `Observation`")?;

--- a/cosmwasm/contracts/wormchain-accounting/src/msg.rs
+++ b/cosmwasm/contracts/wormchain-accounting/src/msg.rs
@@ -57,6 +57,9 @@ pub struct Upgrade {
 
 #[cw_serde]
 pub enum ExecuteMsg {
+    /// Submit a series of observations.  Once the contract has received a quorum of signatures
+    /// for a particular observation, the transfer associated with the observation will be
+    /// committed to the on-chain state.
     SubmitObservations {
         // A serialized `Vec<Observation>`. Multiple observations can be submitted together to reduce
         // transaction overhead.
@@ -66,6 +69,8 @@ pub enum ExecuteMsg {
         // A signature for `observations`.
         signature: Signature,
     },
+
+    /// Modifies the balance of a single account.  Used to manually override the balance.
     ModifyBalance {
         // A serialized `Modification` message.
         modification: Binary,
@@ -76,6 +81,7 @@ pub enum ExecuteMsg {
         // A quorum of signatures for `modification`.
         signatures: Vec<Signature>,
     },
+
     UpgradeContract {
         // A serialized `Upgrade` message.
         upgrade: Binary,
@@ -85,6 +91,15 @@ pub enum ExecuteMsg {
 
         // A quorum of signatures for `key`.
         signatures: Vec<Signature>,
+    },
+
+    /// Submit one or more signed token transfer VAAs to update the on-chain state.  If committing
+    /// any of the transfers returns an error, the entire transaction is aborted and none of the
+    /// transfers are committed.
+    SubmitVAAs {
+        /// One or more VAAs to be submitted.  Each VAA should be encoded in the standard wormhole
+        /// wire format.
+        vaas: Vec<Binary>,
     },
 }
 

--- a/cosmwasm/contracts/wormchain-accounting/src/msg.rs
+++ b/cosmwasm/contracts/wormchain-accounting/src/msg.rs
@@ -1,7 +1,7 @@
 use accounting::state::{account, transfer, Account, Modification, Transfer};
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::Binary;
-use wormhole_bindings::Signature;
+use wormhole::vaa::Signature;
 
 use crate::state::{self, PendingTransfer};
 

--- a/cosmwasm/contracts/wormchain-accounting/src/state.rs
+++ b/cosmwasm/contracts/wormchain-accounting/src/state.rs
@@ -4,7 +4,7 @@ use cosmwasm_std::Addr;
 use cw_storage_plus::{Item, Map};
 use thiserror::Error;
 use tinyvec::TinyVec;
-use wormhole_bindings::Signature;
+use wormhole::vaa::Signature;
 
 use crate::msg::Observation;
 

--- a/cosmwasm/contracts/wormchain-accounting/tests/helpers/mod.rs
+++ b/cosmwasm/contracts/wormchain-accounting/tests/helpers/mod.rs
@@ -92,6 +92,15 @@ impl Contract {
         )
     }
 
+    pub fn submit_vaas(&mut self, vaas: Vec<Binary>) -> anyhow::Result<AppResponse> {
+        self.app.execute_contract(
+            Addr::unchecked(ADMIN),
+            self.addr(),
+            &ExecuteMsg::SubmitVAAs { vaas },
+            &[],
+        )
+    }
+
     pub fn query_balance(&self, key: account::Key) -> StdResult<account::Balance> {
         self.app
             .wrap()

--- a/cosmwasm/contracts/wormchain-accounting/tests/helpers/mod.rs
+++ b/cosmwasm/contracts/wormchain-accounting/tests/helpers/mod.rs
@@ -15,6 +15,7 @@ use wormchain_accounting::{
     },
     state,
 };
+use wormhole::vaa::Signature;
 use wormhole_bindings::{fake, WormholeQuery};
 
 mod fake_tokenbridge;
@@ -41,7 +42,7 @@ impl Contract {
         &mut self,
         observations: Binary,
         guardian_set_index: u32,
-        signature: wormhole_bindings::Signature,
+        signature: Signature,
     ) -> anyhow::Result<AppResponse> {
         self.app.execute_contract(
             Addr::unchecked(USER),
@@ -59,7 +60,7 @@ impl Contract {
         &mut self,
         modification: Binary,
         guardian_set_index: u32,
-        signatures: Vec<wormhole_bindings::Signature>,
+        signatures: Vec<Signature>,
     ) -> anyhow::Result<AppResponse> {
         self.app.execute_contract(
             Addr::unchecked(USER),
@@ -77,7 +78,7 @@ impl Contract {
         &mut self,
         upgrade: Binary,
         guardian_set_index: u32,
-        signatures: Vec<wormhole_bindings::Signature>,
+        signatures: Vec<Signature>,
     ) -> anyhow::Result<AppResponse> {
         self.app.execute_contract(
             Addr::unchecked(ADMIN),

--- a/cosmwasm/contracts/wormchain-accounting/tests/submit_observations.rs
+++ b/cosmwasm/contracts/wormchain-accounting/tests/submit_observations.rs
@@ -141,9 +141,7 @@ fn duplicates() {
         .unwrap() as usize;
 
     for (i, s) in signatures.iter().take(quorum).cloned().enumerate() {
-        contract
-            .submit_observations(obs.clone(), index, s.clone())
-            .unwrap();
+        contract.submit_observations(obs.clone(), index, s).unwrap();
         let err = contract
             .submit_observations(obs.clone(), index, s)
             .expect_err("successfully submitted duplicate observations");

--- a/cosmwasm/contracts/wormchain-accounting/tests/submit_vaas.rs
+++ b/cosmwasm/contracts/wormchain-accounting/tests/submit_vaas.rs
@@ -1,0 +1,281 @@
+mod helpers;
+
+use accounting::state::{transfer, TokenAddress};
+use cosmwasm_std::{to_binary, Binary, Event, Uint256};
+use helpers::*;
+use wormhole::{
+    token::Message,
+    vaa::{Body, Header, Vaa},
+    Address, Amount, Chain,
+};
+use wormhole_bindings::fake::WormholeKeeper;
+
+fn create_transfer_vaas(wh: &WormholeKeeper, count: usize) -> (Vec<Vaa<Message>>, Vec<Binary>) {
+    let mut vaas = Vec::with_capacity(count);
+    let mut payloads = Vec::with_capacity(count);
+
+    for i in 0..count {
+        let (v, data) = sign_vaa_body(wh, create_vaa_body(i));
+        vaas.push(v);
+        payloads.push(data);
+    }
+
+    (vaas, payloads)
+}
+
+fn create_vaa_body(i: usize) -> Body<Message> {
+    Body {
+        timestamp: i as u32,
+        nonce: i as u32,
+        emitter_chain: (i as u16).into(),
+        emitter_address: Address([(i as u8); 32]),
+        sequence: i as u64,
+        consistency_level: 32,
+        payload: Message::Transfer {
+            amount: Amount(Uint256::from(i as u128).to_be_bytes()),
+            token_address: Address([(i + 1) as u8; 32]),
+            token_chain: (i as u16).into(),
+            recipient: Address([i as u8; 32]),
+            recipient_chain: ((i + 2) as u16).into(),
+            fee: Amount([0u8; 32]),
+        },
+    }
+}
+
+fn sign_vaa_body(wh: &WormholeKeeper, body: Body<Message>) -> (Vaa<Message>, Binary) {
+    let data = serde_wormhole::to_vec(&body).unwrap();
+    let signatures = wh.sign(&data);
+
+    let header = Header {
+        version: 1,
+        guardian_set_index: wh.guardian_set_index(),
+        signatures,
+    };
+
+    let v = (header, body).into();
+    let data = serde_wormhole::to_vec(&v).map(From::from).unwrap();
+
+    (v, data)
+}
+
+fn transfer_data_from_token_message(msg: Message) -> transfer::Data {
+    match msg {
+        Message::Transfer {
+            amount,
+            token_address,
+            token_chain,
+            recipient_chain,
+            ..
+        }
+        | Message::TransferWithPayload {
+            amount,
+            token_address,
+            token_chain,
+            recipient_chain,
+            ..
+        } => transfer::Data {
+            amount: Uint256::from_be_bytes(amount.0),
+            token_address: TokenAddress::new(token_address.0),
+            token_chain: token_chain.into(),
+            recipient_chain: recipient_chain.into(),
+        },
+        _ => panic!("not a transfer payload"),
+    }
+}
+
+#[test]
+fn basic() {
+    const COUNT: usize = 7;
+
+    let (wh, mut contract) = proper_instantiate(Vec::new(), Vec::new(), Vec::new());
+
+    let (vaas, payloads) = create_transfer_vaas(&wh, COUNT);
+
+    let resp = contract.submit_vaas(payloads).unwrap();
+
+    for v in vaas {
+        let key = transfer::Key::new(
+            v.emitter_chain.into(),
+            TokenAddress::new(v.emitter_address.0),
+            v.sequence,
+        );
+        let data = transfer_data_from_token_message(v.payload);
+        assert_eq!(data, contract.query_transfer(key.clone()).unwrap());
+        resp.assert_event(
+            &Event::new("wasm-CommitTransfer")
+                .add_attribute("key", key.to_string())
+                .add_attribute("amount", data.amount.to_string())
+                .add_attribute("token_chain", data.token_chain.to_string())
+                .add_attribute("token_address", data.token_address.to_string())
+                .add_attribute("recipient_chain", data.recipient_chain.to_string()),
+        );
+    }
+}
+
+#[test]
+fn invalid_transfer() {
+    let (wh, mut contract) = proper_instantiate(Vec::new(), Vec::new(), Vec::new());
+
+    let mut body = create_vaa_body(1);
+    match body.payload {
+        Message::Transfer {
+            ref mut token_chain,
+            recipient_chain,
+            ..
+        }
+        | Message::TransferWithPayload {
+            ref mut token_chain,
+            recipient_chain,
+            ..
+        } => *token_chain = recipient_chain,
+        _ => panic!("not a transfer payload"),
+    }
+
+    let (_, data) = sign_vaa_body(&wh, body);
+    contract
+        .submit_vaas(vec![data])
+        .expect_err("successfully submitted VAA containing invalid transfer");
+}
+
+#[test]
+fn no_quorum() {
+    let (wh, mut contract) = proper_instantiate(Vec::new(), Vec::new(), Vec::new());
+    let index = wh.guardian_set_index();
+    let quorum = wh
+        .calculate_quorum(index, contract.app().block_info().height)
+        .unwrap() as usize;
+
+    let (mut v, _) = sign_vaa_body(&wh, create_vaa_body(3));
+    v.signatures.truncate(quorum - 1);
+
+    let data = serde_wormhole::to_vec(&v).map(From::from).unwrap();
+
+    contract
+        .submit_vaas(vec![data])
+        .expect_err("successfully submitted VAA without a quorum of signatures");
+}
+
+#[test]
+fn bad_serialization() {
+    let (wh, mut contract) = proper_instantiate(Vec::new(), Vec::new(), Vec::new());
+
+    let (v, _) = sign_vaa_body(&wh, create_vaa_body(3));
+
+    // Rather than using the wormhole wire format use cosmwasm json.
+    let data = to_binary(&v).unwrap();
+
+    contract
+        .submit_vaas(vec![data])
+        .expect_err("successfully submitted VAA with bad serialization");
+}
+
+#[test]
+fn bad_signature() {
+    let (wh, mut contract) = proper_instantiate(Vec::new(), Vec::new(), Vec::new());
+    let (mut v, _) = sign_vaa_body(&wh, create_vaa_body(3));
+
+    // Flip a bit in the first signature so it becomes invalid.
+    v.signatures[0].signature[0] ^= 1;
+
+    let data = serde_wormhole::to_vec(&v).map(From::from).unwrap();
+    contract
+        .submit_vaas(vec![data])
+        .expect_err("successfully submitted VAA with bad signature");
+}
+
+#[test]
+fn non_transfer_message() {
+    let (wh, mut contract) = proper_instantiate(Vec::new(), Vec::new(), Vec::new());
+    let body = Body {
+        timestamp: 2,
+        nonce: 2,
+        emitter_chain: Chain::Ethereum,
+        emitter_address: Address([2u8; 32]),
+        sequence: 2,
+        consistency_level: 32,
+        payload: Message::AssetMeta {
+            token_address: Address([
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0xbe, 0xef, 0xfa, 0xce,
+            ]),
+            token_chain: Chain::Ethereum,
+            decimals: 12,
+            symbol: "BEEF".into(),
+            name: "Beef face Token".into(),
+        },
+    };
+
+    let (_, data) = sign_vaa_body(&wh, body);
+    contract
+        .submit_vaas(vec![data])
+        .expect_err("successfully submitted VAA with non-transfer message");
+}
+
+#[test]
+fn transfer_with_payload() {
+    let (wh, mut contract) = proper_instantiate(Vec::new(), Vec::new(), Vec::new());
+    let body = Body {
+        timestamp: 2,
+        nonce: 2,
+        emitter_chain: Chain::Ethereum,
+        emitter_address: Address([2u8; 32]),
+        sequence: 2,
+        consistency_level: 32,
+        payload: Message::TransferWithPayload {
+            amount: Amount(Uint256::from(2u128).to_be_bytes()),
+            token_address: Address([3u8; 32]),
+            token_chain: Chain::Ethereum,
+            recipient: Address([2u8; 32]),
+            recipient_chain: Chain::Bsc,
+            sender_address: Address([0u8; 32]),
+        },
+    };
+
+    let payload = [0x88; 17];
+    let mut data = serde_wormhole::to_vec(&body).unwrap();
+    data.extend_from_slice(&payload);
+
+    let signatures = wh.sign(&data);
+    let header = Header {
+        version: 1,
+        guardian_set_index: wh.guardian_set_index(),
+        signatures,
+    };
+
+    let v = Vaa::from((header, body));
+
+    let mut data = serde_wormhole::to_vec(&v).unwrap();
+    data.extend_from_slice(&payload);
+    let resp = contract.submit_vaas(vec![data.into()]).unwrap();
+
+    let key = transfer::Key::new(
+        v.emitter_chain.into(),
+        TokenAddress::new(v.emitter_address.0),
+        v.sequence,
+    );
+    let data = transfer_data_from_token_message(v.payload);
+    assert_eq!(data, contract.query_transfer(key.clone()).unwrap());
+    resp.assert_event(
+        &Event::new("wasm-CommitTransfer")
+            .add_attribute("key", key.to_string())
+            .add_attribute("amount", data.amount.to_string())
+            .add_attribute("token_chain", data.token_chain.to_string())
+            .add_attribute("token_address", data.token_address.to_string())
+            .add_attribute("recipient_chain", data.recipient_chain.to_string()),
+    );
+}
+
+#[test]
+fn unsupported_version() {
+    let (wh, mut contract) = proper_instantiate(Vec::new(), Vec::new(), Vec::new());
+
+    let (mut v, _) = sign_vaa_body(&wh, create_vaa_body(6));
+    v.version = 0;
+
+    let data = serde_wormhole::to_vec(&v).map(From::from).unwrap();
+
+    contract
+        .submit_vaas(vec![data])
+        .expect_err("successfully submitted VAA with unsupported version");
+}

--- a/cosmwasm/packages/wormhole-bindings/Cargo.toml
+++ b/cosmwasm/packages/wormhole-bindings/Cargo.toml
@@ -14,4 +14,5 @@ cosmwasm-std = "1"
 schemars = "0.8.8"
 serde = { version = "1.0.137", default-features = false, features = ["derive"] }
 cw-multi-test = { version = "0.13.2", optional = true }
-k256 = { version = "0.9.4", optional = true }
+k256 = { version = "0.9.4", optional = true, features = ["ecdsa", "keccak256"] }
+wormhole-core = "0.1.0"

--- a/cosmwasm/packages/wormhole-bindings/src/query.rs
+++ b/cosmwasm/packages/wormhole-bindings/src/query.rs
@@ -1,19 +1,6 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Binary, CustomQuery, Empty};
-
-#[cw_serde]
-pub struct Signature {
-    /// The index of the guardian in the guardian set.
-    pub index: u8,
-
-    /// The signature, which should be exactly 65 bytes with the following layout:
-    ///
-    /// ```markdown
-    /// 0  .. 64: Signature   (ECDSA)
-    /// 64 .. 65: Recovery ID (ECDSA)
-    /// ```
-    pub signature: Binary,
-}
+use wormhole::vaa::Signature;
 
 #[cw_serde]
 #[derive(QueryResponses)]

--- a/sdk/rust/Cargo.lock
+++ b/sdk/rust/Cargo.lock
@@ -50,6 +50,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f94fa09c2aeea5b8839e414b7b841bf429fd25b9c522116ac97ee87856d88b2"
+
+[[package]]
 name = "generic-array"
 version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,6 +120,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
+name = "schemars"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a5fb6c61f29e723026dc8e923d94c694313212abbecbbe5f55a7748eec5b307"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f188d036977451159430f3b8dc82ec76364a42b7e289c2b18a9a18f4470058e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -136,6 +166,17 @@ name = "serde_derive"
 version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -240,6 +281,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bstr",
+ "schemars",
  "serde",
  "serde_json",
  "serde_wormhole",

--- a/sdk/rust/core/Cargo.toml
+++ b/sdk/rust/core/Cargo.toml
@@ -6,9 +6,14 @@ edition = "2021"
 [lib]
 name = "wormhole"
 
+[features]
+schemars = ["dep:schemars"]
+default = ["schemars"]
+
 [dependencies]
 anyhow = "1"
 bstr = { version = "1", features = ["serde"] }
+schemars = { version = "0.8.8", optional = true }
 serde = { version = "1", default-features = false, features = ["alloc", "derive"] }
 serde_wormhole = "0.1.0"
 sha3 = "0.10.4"


### PR DESCRIPTION
Add a mechanism to backfill missing transfer messages.  This will also
be used to initialize the on-chain state as there is too much data to
initialize the contract via the normal `instantiate` mechanism.

Fixes #1883, fixes #1884.
