### PR TITLE
node: enforce minimum heartbeat message length

### DIFF
--- a/node/pkg/p2p/p2p.go
+++ b/node/pkg/p2p/p2p.go
@@ -443,6 +443,11 @@ func processSignedHeartbeat(from peer.ID, s *gossipv1.SignedHeartbeat, gs *node_
 
 	digest := heartbeatDigest(s.Heartbeat)
 
+	// SECURITY: see whitepapers/0009_guardian_key.md
+	if len(heartbeatMessagePrefix)+len(s.Heartbeat) < 34 {
+		return nil, fmt.Errorf("invalid message: too short")
+	}
+
 	pubKey, err := ethcrypto.Ecrecover(digest.Bytes(), s.Signature)
 	if err != nil {
 		return nil, errors.New("failed to recover public key")


### PR DESCRIPTION
Enforce a minimum heartbeat message length such that signed observations, which have the format `signature(hash(hash(observation))` cannot be replayed as heartbeat messages, which have the format `signature(hash("heartbeat|..."))` in case where `hash(observation) = "heartbeat|...". 

I can't think of any concrete security risk with the current implementation, but it's better to tidy things up. 