### PR TITLE
node: p2p: change message type string for signed observation

### DIFF
--- a/node/pkg/p2p/p2p.go
+++ b/node/pkg/p2p/p2p.go
@@ -443,6 +443,11 @@ func processSignedHeartbeat(from peer.ID, s *gossipv1.SignedHeartbeat, gs *node_
 
 	digest := heartbeatDigest(s.Heartbeat)
 
+	// SECURITY: see whitepapers/0009_guardian_key.md
+	if len(heartbeatMessagePrefix)+len(s.Heartbeat) < 34 {
+		return nil, fmt.Errorf("invalid message: too short")
+	}
+
 	pubKey, err := ethcrypto.Ecrecover(digest.Bytes(), s.Signature)
 	if err != nil {
 		return nil, errors.New("failed to recover public key")


### PR DESCRIPTION
same vain as https://github.com/wormhole-foundation/wormhole/pull/1958 but in this case I think it's better to just update the message type since I'd assume nobody external is parsing these kinds of messages from the p2p network. 

fixes https://github.com/wormhole-foundation/wormhole/issues/1991