### PR TITLE
Fix Transfer and Redeem Native SOL

### DIFF
--- a/sdk/js/src/mock/tokenBridge.ts
+++ b/sdk/js/src/mock/tokenBridge.ts
@@ -6,8 +6,13 @@ import { MockEmitter } from "./wormhole";
 export class MockTokenBridge extends MockEmitter {
   consistencyLevel: number;
 
-  constructor(emitterAddress: string, chain: number, consistencyLevel: number) {
-    super(emitterAddress, chain);
+  constructor(
+    emitterAddress: string,
+    chain: number,
+    consistencyLevel: number,
+    startSequence?: number
+  ) {
+    super(emitterAddress, chain, startSequence);
     this.consistencyLevel = consistencyLevel;
   }
 
@@ -156,9 +161,14 @@ export class MockTokenBridge extends MockEmitter {
 }
 
 export class MockEthereumTokenBridge extends MockTokenBridge {
-  constructor(emitterAddress: string) {
+  constructor(emitterAddress: string, startSequence?: number) {
     const chain = 2;
-    super(tryNativeToHexString(emitterAddress, chain as ChainId), chain, 15);
+    super(
+      tryNativeToHexString(emitterAddress, chain as ChainId),
+      chain,
+      15,
+      startSequence
+    );
   }
 
   publishAttestMeta(

--- a/sdk/js/src/token_bridge/redeem.ts
+++ b/sdk/js/src/token_bridge/redeem.ts
@@ -1,9 +1,9 @@
 import {
-  AccountLayout,
+  ACCOUNT_SIZE,
   createCloseAccountInstruction,
   createInitializeAccountInstruction,
   createTransferInstruction,
-  getMinimumBalanceForRentExemptMint,
+  getMinimumBalanceForRentExemptAccount,
   getMint,
   NATIVE_MINT,
   TOKEN_PROGRAM_ID,
@@ -135,7 +135,10 @@ export async function redeemAndUnwrapOnSolana(
     (info) =>
       parsed.amount * BigInt(Math.pow(10, info.decimals - MAX_VAA_DECIMALS))
   );
-  const rentBalance = await getMinimumBalanceForRentExemptMint(connection);
+  const rentBalance = await getMinimumBalanceForRentExemptAccount(
+    connection,
+    commitment
+  );
   if (Buffer.compare(parsed.tokenAddress, NATIVE_MINT.toBuffer()) != 0) {
     return Promise.reject("tokenAddress != NATIVE_MINT");
   }
@@ -154,12 +157,12 @@ export async function redeemAndUnwrapOnSolana(
     fromPubkey: payerPublicKey,
     newAccountPubkey: ancillaryKeypair.publicKey,
     lamports: rentBalance, //spl token accounts need rent exemption
-    space: AccountLayout.span,
+    space: ACCOUNT_SIZE,
     programId: TOKEN_PROGRAM_ID,
   });
 
   //Initialize the account as a WSOL account, with the original payerAddress as owner
-  const initAccountIx = await createInitializeAccountInstruction(
+  const initAccountIx = createInitializeAccountInstruction(
     ancillaryKeypair.publicKey,
     NATIVE_MINT,
     payerPublicKey


### PR DESCRIPTION
# Objective

Closes #1965. 

This also removes redundant core bridge fee transfer instructions for transferring tokens from Solana; this instruction already exists within the transfer instruction (see [this](https://github.com/wormhole-foundation/wormhole/blob/cddfe74b678747885e6165af8cc6169db49ae3e2/solana/modules/token_bridge/program/src/api/transfer.rs#L237) for example).

# How to Review this PR

1. Run `make test` in _testing/solana-local-validator_.
2. Review code changes in _transfer.ts_ and _redeem.ts_.