### PR TITLE
sui: byte addressing for Sui CoinTypes

### DIFF
--- a/sui/token_bridge/sources/attest_token.move
+++ b/sui/token_bridge/sources/attest_token.move
@@ -4,7 +4,8 @@ module token_bridge::attest_token {
     use sui::transfer::transfer;
     use sui::tx_context::{Self, TxContext};
 
-    use token_bridge::bridge_state::{BridgeState};
+    use wormhole::state::{State as WormholeState};
+    use token_bridge::bridge_state::{Self as state, BridgeState};
 
     /// Spec: we need this function to accurately get
     /// the name, symbol, decimals of CoinType
@@ -12,24 +13,14 @@ module token_bridge::attest_token {
     /// Calls token_bridge::register_native_asset
     /// Make attest_token permissioned? Typically this function is not permissioned.
     public fun attest_token<CoinType>(
-        _bridge_state: &mut BridgeState,
+        wormhole_state: &mut WormholeState,
+        bridge_state: &mut BridgeState,
         fee_coins: Coin<SUI>,
         ctx: &mut TxContext
     ): u64 {
-        // assert CoinType is not a wrapped asset
-
-        // TODO - generate a 32-byte ExternalAddress for CoinType
-        // TODO - register the native asset in bridge_state.move
-
+        state::register_native_asset<CoinType>(wormhole_state, bridge_state, ctx);
         transfer(fee_coins, tx_context::sender(ctx));
+        // TODO: publish message
         return 0 //sequence number of publish message
     }
 }
-
-// TODO - actual token attestation
-//        currently blocked because there is no token metadata standard yet
-//        we need to know where to get info like symbols, decimals, name, etc.
-//        to do the attestation. The problems are summarized below.
-
-// Problem 1) cannot compute a TokenHash of a CoinType, AKA a unique 32-byte identifier for it
-// Problem 2) cannot find the token metadata for a CoinType, e.g. symbol, name, decimals...

--- a/sui/token_bridge/sources/bridge_state.move
+++ b/sui/token_bridge/sources/bridge_state.move
@@ -312,9 +312,8 @@ module token_bridge::bridge_state {
       set::add(&mut bridge_state.consumed_vaas, vaa);
    }
 
-   public(friend) fun register_wrapped_asset<CoinType>(bridge_state: &mut BridgeState, wrapped_asset_info: WrappedAssetInfo<CoinType>, ctx: &mut TxContext) {
+   public(friend) fun register_wrapped_asset<CoinType>(bridge_state: &mut BridgeState, wrapped_asset_info: WrappedAssetInfo<CoinType>) {
       dynamic_set::add<WrappedAssetInfo<CoinType>>(&mut bridge_state.id, wrapped_asset_info);
-      assign_coin_type_bytes_address<CoinType>(bridge_state, ctx);
    }
 
     public(friend) fun register_native_asset<CoinType>(bridge_state: &mut BridgeState, native_asset_info: NativeAssetInfo<CoinType>, ctx: &mut TxContext) {

--- a/sui/token_bridge/sources/wrapped.move
+++ b/sui/token_bridge/sources/wrapped.move
@@ -113,6 +113,6 @@ module token_bridge::wrapped {
         assert!(!bridge_state::is_registered_native_asset<CoinType>(bridge_state), E_WRAPPING_REGISTERED_NATIVE_COIN);
         assert!(!bridge_state::is_wrapped_asset<CoinType>(bridge_state), E_WRAPPED_COIN_ALREADY_INITIALIZED);
 
-        bridge_state::register_wrapped_asset<CoinType>(bridge_state, wrapped_asset_info, ctx);
+        bridge_state::register_wrapped_asset<CoinType>(bridge_state, wrapped_asset_info);
     }
 }

--- a/sui/token_bridge/sources/wrapped.move
+++ b/sui/token_bridge/sources/wrapped.move
@@ -89,12 +89,6 @@ module token_bridge::wrapped {
 
         let payload = parse_and_get_payload(vaa_bytes);
 
-        // TODO - parse and verify VAA (& replay protect) instead of merely extracting payload
-        //        let vaa = token_bridge_vaa::parse_and_verify_and_replay_protect(state, bridge_state, bytes, ctx);
-        //        let _payload = destroy(vaa);
-
-        // TODO (pending Mysten Labs uniform token standard) -  extract and store token metadata
-
         let metadata = asset_meta::parse(payload);
         let origin_chain = asset_meta::get_token_chain(&metadata);
         let external_address = asset_meta::get_token_address(&metadata);
@@ -110,6 +104,6 @@ module token_bridge::wrapped {
         assert!(!bridge_state::is_registered_native_asset<CoinType>(bridge_state), E_WRAPPING_REGISTERED_NATIVE_COIN);
         assert!(!bridge_state::is_wrapped_asset<CoinType>(bridge_state), E_WRAPPED_COIN_ALREADY_INITIALIZED);
 
-        bridge_state::register_wrapped_asset<CoinType>(bridge_state, wrapped_asset_info);
+        bridge_state::register_wrapped_asset<CoinType>(bridge_state, wrapped_asset_info, ctx);
     }
 }


### PR DESCRIPTION
Introduce byte-addressing for CoinTypes on-chain. The byte addresses are taken from an increasing sequence of numbers starting from 0.

- `assign_coin_type_bytes_address`
- `get_coin_type_bytes_address`

Write tests for these as well.