### PR TITLE
node: remove race condition detector

### DIFF
--- a/Dockerfile.node
+++ b/Dockerfile.node
@@ -19,7 +19,7 @@ RUN --mount=type=cache,target=/root/.cache --mount=type=cache,target=/go \
 COPY node node
 COPY sdk sdk
 
-ARG GO_BUILD_ARGS=-race
+ARG GO_BUILD_ARGS=
 
 RUN --mount=type=cache,target=/root/.cache --mount=type=cache,target=/go \
   cd node && \


### PR DESCRIPTION
race condition detector should not be enabled on a dev build because it can lead to ballooning memory consumption. We can think about adding it back in into a separate test build 