### PR TITLE
node/p2p: enforce ObservationRequest signature payload >= 34 bytes

### DIFF
--- a/node/pkg/p2p/p2p.go
+++ b/node/pkg/p2p/p2p.go
@@ -479,6 +479,11 @@ func processSignedObservationRequest(s *gossipv1.SignedObservationRequest, gs *n
 		pk = gs.Keys[idx]
 	}
 
+	// SECURITY: see whitepapers/0009_guardian_key.md
+	if len(signedObservationRequestPrefix)+len(s.ObservationRequest) < 34 {
+		return nil, fmt.Errorf("invalid observation request: too short")
+	}
+
 	digest := signedObservationRequestDigest(s.ObservationRequest)
 
 	pubKey, err := ethcrypto.Ecrecover(digest.Bytes(), s.Signature)


### PR DESCRIPTION
a possible solution to fixes https://github.com/wormhole-foundation/wormhole/issues/1991