### PR TITLE
sdk: enforce single canonical VerifySignatures method

### DIFF
--- a/sdk/vaa/structs.go
+++ b/sdk/vaa/structs.go
@@ -632,6 +632,9 @@ func (v *BatchVAA) ObsvHashArray() []common.Hash {
 }
 
 func VerifySignatures(data []byte, signatures []*Signature, addresses []common.Address) bool {
+	if len(addresses) < len(signatures) {
+		return false
+	}
 
 	last_index := -1
 	signing_addresses := []common.Address{}
@@ -674,20 +677,12 @@ func VerifySignatures(data []byte, signatures []*Signature, addresses []common.A
 // VerifySignatures verifies the signature of the VAA given the signer addresses.
 // Returns true if the signatures were verified successfully.
 func (v *VAA) VerifySignatures(addresses []common.Address) bool {
-	if len(addresses) < len(v.Signatures) {
-		return false
-	}
-
 	return VerifySignatures(v.SigningMsg().Bytes(), v.Signatures, addresses)
 }
 
 // VerifySignatures verifies the signature of the BatchVAA given the signer addresses.
 // Returns true if the signatures were verified successfully.
 func (v *BatchVAA) VerifySignatures(addresses []common.Address) bool {
-	if len(addresses) < len(v.Signatures) {
-		return false
-	}
-
 	return VerifySignatures(v.SigningMsg().Bytes(), v.Signatures, addresses)
 }
 


### PR DESCRIPTION
This PR establishes the precedent that `VAA.VerifySignatures` and `BatchVAA.VerifySignatures` should **only** be wrapper methods.

We should ensure that all logic is added in the main `VerifySignatures` method. This will help us guard against future confusion and cases where individual branches of logic may be accidentally added to one of the struct methods and not the main method.