### PR TITLE
sui: simplify storage model

### DIFF
--- a/sui/token_bridge/sources/bridge_state.move
+++ b/sui/token_bridge/sources/bridge_state.move
@@ -65,34 +65,31 @@ module token_bridge::bridge_state {
 
    /// OriginInfo is a non-Sui object that stores info about a tokens native token
    /// chain and address
-   // TODO(csongor): should this take a phantom CoinType argument too? If it
-   // does, then create_origin_info needs to be private
-   struct OriginInfo has store, copy, drop {
+   struct OriginInfo<phantom CoinType> has store, copy, drop {
       token_chain: U16,
       token_address: ExternalAddress,
    }
 
-   // TODO(csongor): why is this not (friend)? it is on aptos...
-   public fun create_origin_info(token_chain: U16, token_address: ExternalAddress): OriginInfo {
+   public(friend) fun create_origin_info<CoinType>(token_chain: U16, token_address: ExternalAddress): OriginInfo<CoinType> {
       return OriginInfo {
          token_chain,
          token_address
       }
    }
 
-   public fun get_token_chain_from_origin_info(origin_info: &OriginInfo): U16 {
+   public fun get_token_chain_from_origin_info<CoinType>(origin_info: &OriginInfo<CoinType>): U16 {
       return origin_info.token_chain
    }
 
-   public fun get_token_address_from_origin_info(origin_info: &OriginInfo): ExternalAddress {
+   public fun get_token_address_from_origin_info<CoinType>(origin_info: &OriginInfo<CoinType>): ExternalAddress {
       return origin_info.token_address
    }
 
-   public fun get_origin_info_from_wrapped_asset_info<CoinType>(wrapped_asset_info: &WrappedAssetInfo<CoinType>): OriginInfo {
+   public fun get_origin_info_from_wrapped_asset_info<CoinType>(wrapped_asset_info: &WrappedAssetInfo<CoinType>): OriginInfo<CoinType> {
       create_origin_info(wrapped_asset_info.token_chain, wrapped_asset_info.token_address)
    }
 
-   public fun get_origin_info_from_native_asset_info<CoinType>(native_asset_info: &NativeAssetInfo<CoinType>): OriginInfo {
+   public fun get_origin_info_from_native_asset_info<CoinType>(native_asset_info: &NativeAssetInfo<CoinType>): OriginInfo<CoinType> {
       create_origin_info(native_asset_info.token_chain, native_asset_info.token_address)
    }
 
@@ -236,13 +233,13 @@ module token_bridge::bridge_state {
       dynamic_set::exists_<NativeAssetInfo<CoinType>>(&bridge_state.id)
    }
 
-   public fun get_wrapped_asset_origin_info<CoinType>(bridge_state: &BridgeState): OriginInfo {
+   public fun get_wrapped_asset_origin_info<CoinType>(bridge_state: &BridgeState): OriginInfo<CoinType> {
       assert!(is_wrapped_asset<CoinType>(bridge_state), E_IS_NOT_WRAPPED_ASSET);
       let wrapped_asset_info = dynamic_set::borrow<WrappedAssetInfo<CoinType>>(&bridge_state.id);
       get_origin_info_from_wrapped_asset_info(wrapped_asset_info)
    }
 
-   public fun get_registered_native_asset_origin_info<CoinType>(bridge_state: &BridgeState): OriginInfo {
+   public fun get_registered_native_asset_origin_info<CoinType>(bridge_state: &BridgeState): OriginInfo<CoinType> {
       assert!(is_wrapped_asset<CoinType>(bridge_state), E_IS_NOT_REGISTERED_NATIVE_ASSET);
       let native_asset_info = dynamic_set::borrow<NativeAssetInfo<CoinType>>(&bridge_state.id);
       get_origin_info_from_native_asset_info(native_asset_info)

--- a/sui/token_bridge/sources/dynamic_set.move
+++ b/sui/token_bridge/sources/dynamic_set.move
@@ -1,0 +1,45 @@
+/// This module recovers a Diem-style storage model where objects are collected
+/// into a heterogeneous global storage, identified by their type.
+///
+/// Under the hood, it uses dynamic object fields, but set up in a way that the
+/// key is derived from the value's type.
+module token_bridge::dynamic_set {
+    use sui::dynamic_object_field as ofield;
+    use sui::object::{UID};
+
+    /// Wrap the value type. Avoids key collisions with other uses of dynamic
+    /// fields.
+    struct Wrapper<phantom Value> has copy, drop, store {
+    }
+
+    public fun add<Value: key + store>(
+        object: &mut UID,
+        value: Value,
+    ) {
+        ofield::add(object, Wrapper<Value>{}, value)
+    }
+
+    public fun borrow<Value: key + store>(
+        object: &UID,
+    ): &Value {
+        ofield::borrow(object, Wrapper<Value>{})
+    }
+
+    public fun borrow_mut<Value: key + store>(
+        object: &mut UID,
+    ): &mut Value {
+        ofield::borrow_mut(object, Wrapper<Value>{})
+    }
+
+    public fun remove<Value: key + store>(
+        object: &mut UID,
+    ): Value {
+        ofield::remove(object, Wrapper<Value>{})
+    }
+
+    public fun exists_<Value: key + store>(
+        object: &UID,
+    ): bool {
+        ofield::exists_<Wrapper<Value>>(object, Wrapper<Value>{})
+    }
+}


### PR DESCRIPTION
This PR introduces a new module, `dynamic_set`, which acts like the storage model of traditional move. That is, objects are identified by their type, and there's at most a single one of them. Implemented as dynamic object fields, so rather than belonging to an account, the elements belong to another object (the bridge state in this case). This module allows cleaning up the dummy fields, and overall a little more concise.