### PR TITLE
devnet: add memory limits

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -179,7 +179,7 @@ def build_node_yaml():
                 container["command"] += [
                     "--suiRPC",
                     "http://sui:9002",
-# In testnet and mainnet, you will need to also specify the suiPackage argument.  In Devnet, we subscribe to 
+# In testnet and mainnet, you will need to also specify the suiPackage argument.  In Devnet, we subscribe to
 # event traffic purely based on the account since that is the only thing that is deterministic.
 #                    "--suiPackage",
 #                    "0x.....",
@@ -265,13 +265,13 @@ def build_node_yaml():
 
 k8s_yaml_with_ns(build_node_yaml())
 
-guardian_resource_deps = ["eth-devnet"]
+guardian_resource_deps = ["eth-deploy"]
 if evm2:
-    guardian_resource_deps = guardian_resource_deps + ["eth-devnet2"]
+    guardian_resource_deps = guardian_resource_deps + ["eth-deploy2"]
 if solana:
     guardian_resource_deps = guardian_resource_deps + ["solana-devnet"]
 if near:
-    guardian_resource_deps = guardian_resource_deps + ["near"]
+    guardian_resource_deps = guardian_resource_deps + ["near-deploy"]
 if terra_classic:
     guardian_resource_deps = guardian_resource_deps + ["terra-terrad"]
 if terra2:
@@ -498,6 +498,13 @@ k8s_resource(
     trigger_mode = trigger_mode,
 )
 
+k8s_resource(
+    "eth-deploy",
+    resource_deps = ["eth-devnet"],
+    labels = ["evm"],
+    trigger_mode = trigger_mode,
+)
+
 if evm2:
     k8s_yaml_with_ns("devnet/eth-devnet2.yaml")
 
@@ -507,6 +514,13 @@ if evm2:
             port_forward(8546, name = "Ganache RPC [:8546]", host = webHost),
         ],
         resource_deps = ["const-gen"],
+        labels = ["evm"],
+        trigger_mode = trigger_mode,
+    )
+
+    k8s_resource(
+        "eth-deploy2",
+        resource_deps = ["eth-devnet2"],
         labels = ["evm"],
         trigger_mode = trigger_mode,
     )
@@ -712,6 +726,13 @@ if near:
             port_forward(3031, name = "webserver [:3031]", host = webHost),
         ],
         resource_deps = ["const-gen"],
+        labels = ["near"],
+        trigger_mode = trigger_mode,
+    )
+
+    k8s_resource(
+        "near-deploy",
+        resource_deps = ["near"],
         labels = ["near"],
         trigger_mode = trigger_mode,
     )

--- a/devnet/README.md
+++ b/devnet/README.md
@@ -1,0 +1,43 @@
+# Memory allocation
+| container          | measured VmHWM | set limit | service/job           |
+|--------------------|----------------|-----------|-----------------------|
+| guardiand          | 2777Mi         | 3300Mi    | service               |
+| ganache            | 471Mi          | 500Mi     | service               |
+| eth-deploy         | ?              | 1Gi       | job                   |
+| mine               | 271Mi          | 300Mi     | service               |
+| spy                | 116Mi          | 150Mi     | service               |
+| algorand-postgres  | ?              | 80Mi      | service               |
+| algorand-algod     | 644Mi          | 1000Mi    | service               |
+| algorand-indexer   | ?              | 100Mi     | service               |
+| algorand-contracts | ?              | 200Mi     | service, could be job |
+| aptos-node         | 143Mi          | 500Mi     | service               |
+| aptos-contracts    | ?              | 300Mi     | service, could be job |
+| btc-node           | 310Mi          | 350Mi     | service               |
+| near-node          | 639Mi          | 700Mi     | service               |
+| near-deploy        | 462Mi          | 500Mi     | job                   |
+| solana-devnet      | 1769Mi         | 2000Mi    | service               |
+| solana-setup       | ?              | 750Mi     | service, could be job |
+| spy-listener       | ?              | 150Mi     | service               |
+| spy-relayer        | 76Mi           | 200Mi     | service               |
+| spy-wallet-monitor | 81Mi           | 100Mi     | service               |
+| spy                | 102Mi          | 120Mi     | service               |
+| terra-terrad       | 343Mi          | 400Mi     | service               |
+| terra-contracts    | ?              | 200Mi     | could be job          |
+| fcd-postgres       | ?              | 50Mi      | service               |
+| fcd-collector      | ?              | 500Mi     | service               |
+| fcd-api            | ?              | 200Mi     | service               |
+| wormchaind         | 559Mi          | 1000Mi    | service               |
+| sdk-ci-tests       | ?              | 2500Mi    | job                   |
+| spydk-ci-tests     | ?              | 1000Mi    | job                   |
+
+## Debugging
+* Detecting oomkill:
+    * The symptom of an oomkill is the container being killed.
+    * oomkill messages should show up in `/var/log/messages`. E.g.: `Nov 27 01:26:57 hostname kernel: oom-kill:constraint=CONSTRAINT_MEMCG,nodemask=(null),cpuset=2d90ae0dc04950f146d262fd80f1da3b4bbc69cf059b2bb7c66616d35e4d3ffd,mems_allowed=0,oom_memcg=/docker/8b5e1b8686b3a5082ea70faa5809e3053bb1f75077ce19236582b6d67190a48a/kubepods/burstable/podda04e81e-3992-4dd3-aea5-112148b37b9e/2d90ae0dc04950f146d262fd80f1da3b4bbc69cf059b2bb7c66616d35e4d3ffd,task_memcg=/docker/8b5e1b8686b3a5082ea70faa5809e3053bb1f75077ce19236582b6d67190a48a/kubepods/burstable/podda04e81e-3992-4dd3-aea5-112148b37b9e/2d90ae0dc04950f146d262fd80f1da3b4bbc69cf059b2bb7c66616d35e4d3ffd,task=near-sandbox,pid=3723608,uid=0`
+    * To get the exit status of a container, you can do `kubectl get pod -o jsonpath='{.items[*].status.containerStatuses[*].lastState.terminated}' | jq` and look at `exitCode`, which would be `137` and `reason`, which would be `OOMKilled`.
+* kubectl top:
+    * Enable metrics server: `minikube addons enable metrics-server`
+    * Wait for ~60s (metrics are usually collected every minute)
+    * `kubectl top pod --containers=true`
+* Get the max memory consumption of a process over its lifetime:
+    * e.g. for `algod`: `name=[a]lgod;P=$(ps aux | grep $name | awk '{print $2}'); grep ^VmHWM /proc/$P/status | awk '{print $2}'`

--- a/devnet/algorand-devnet.yaml
+++ b/devnet/algorand-devnet.yaml
@@ -43,7 +43,6 @@ spec:
           name: algorand-postgres
           ports:
             - containerPort: 5432
-          resources: {}
           env:
             - name: POSTGRES_USER
               value: algorand
@@ -51,6 +50,15 @@ spec:
               value: algorand
             - name: POSTGRES_DB
               value: indexer_db
+          resources:
+            limits:
+              memory: "80Mi"
+          readinessProbe:
+            exec:
+              command:
+                - /usr/local/bin/pg_isready
+            failureThreshold: 2
+            periodSeconds: 5
         - name: algorand-algod
           image: algorand-algod
           command:
@@ -64,9 +72,20 @@ spec:
             - containerPort: 4002
               name: kmd
               protocol: TCP
+          startupProbe:
+            tcpSocket:
+              port: 4001
+            failureThreshold: 300
+            initialDelaySeconds: 20
+            periodSeconds: 1
           readinessProbe:
             tcpSocket:
               port: 4001
+            failureThreshold: 2
+            periodSeconds: 1
+          resources:
+            limits:
+              memory: "1000Mi"
         - name: algorand-indexer
           image: algorand-indexer
           command:
@@ -80,18 +99,25 @@ spec:
           readinessProbe:
             tcpSocket:
               port: 8980
+          resources:
+            limits:
+              memory: "100Mi"
         - name: algorand-contracts
           image: algorand-contracts
           command:
             - /bin/sh
             - -c
             - "sh deploy.sh && touch success && sleep infinity"
-          readinessProbe:
+          startupProbe:
             exec:
               command:
                 - test
                 - -e
                 - "success"
-            initialDelaySeconds: 5
-            periodSeconds: 5
+            failureThreshold: 300
+            initialDelaySeconds: 30
+            periodSeconds: 1
+          resources:
+            limits:
+              memory: "200Mi"
       restartPolicy: Always

--- a/devnet/aptos-localnet.yaml
+++ b/devnet/aptos-localnet.yaml
@@ -52,20 +52,34 @@ spec:
             - containerPort: 8081
               name: faucet
               protocol: TCP
-          readinessProbe:
+          startupProbe:
             tcpSocket:
-              port: 8081
+              port: 8080
+            failureThreshold: 60
+            periodSeconds: 10
+          readinessProbe:
+            periodSeconds: 1
+            tcpSocket:
+              port: 8080
+          resources:
+            limits:
+              memory: "500Mi"
         - name: aptos-contracts
           image: aptos-node
           command: ["/bin/bash", "-c"]
           args:
             [
-              "cd /tmp/scripts && ./wait_for_devnet && ./deploy devnet && ./register_devnet && touch success && sleep infinity",
+              "cd /tmp/scripts && ./wait_for_devnet && ./deploy devnet && ./register_devnet && touch /tmp/scripts/success && sleep infinity",
             ]
-          readinessProbe:
-            periodSeconds: 1
+          startupProbe:
             failureThreshold: 300
+            initialDelaySeconds: 20
+            periodSeconds: 1
             exec:
               command:
-                - cat
-                - /tmp/scripts/success
+                - test
+                - -e
+                - "/tmp/scripts/success"
+          resources:
+            limits:
+              memory: "300Mi"

--- a/devnet/btc-localnet.yaml
+++ b/devnet/btc-localnet.yaml
@@ -40,6 +40,17 @@ spec:
             - containerPort: 18556
               name: node
               protocol: TCP
-          readinessProbe:
+          startupProbe:
+            failureThreshold: 300
+            initialDelaySeconds: 20
+            periodSeconds: 1
             tcpSocket:
               port: 18557
+          readinessProbe:
+            failureThreshold: 2
+            periodSeconds: 1
+            tcpSocket:
+              port: 18557
+          resources:
+            limits:
+              memory: "350Mi"

--- a/devnet/eth-devnet.yaml
+++ b/devnet/eth-devnet.yaml
@@ -45,26 +45,47 @@ spec:
             - containerPort: 8545
               name: rpc
               protocol: TCP
-          readinessProbe:
+          startupProbe:
+            failureThreshold: 300
+            initialDelaySeconds: 20
+            periodSeconds: 1
             tcpSocket:
               port: rpc
-        - name: tests
-          image: eth-node
-          stdin: true
-          command:
-            - /bin/sh
-            - -c
-            - "npm run migrate && npx truffle exec scripts/deploy_test_token.js && npm run deploy-batched-vaa-sender && npx truffle exec scripts/register_solana_chain.js && npx truffle exec scripts/register_terra_chain.js && npx truffle exec scripts/register_terra2_chain.js && npx truffle exec scripts/register_bsc_chain.js && npx truffle exec scripts/register_algo_chain.js && npx truffle exec scripts/register_near_chain.js && npx truffle exec scripts/register_worm_chain.js && npx truffle exec scripts/register_aptos_chain.js && nc -lkp 2000 0.0.0.0"
           readinessProbe:
+            failureThreshold: 2
             periodSeconds: 1
-            failureThreshold: 300
             tcpSocket:
-              port: 2000
+              port: rpc
+          resources:
+            limits:
+              memory: "500Mi"
         - name: mine
           image: eth-node
           command:
             - /bin/sh
             - -c
             - "npx truffle exec mine.js"
+          resources:
+            limits:
+              memory: "300Mi"
 ---
-
+kind: Job
+apiVersion: batch/v1
+metadata:
+  name: eth-deploy
+spec:
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: tests
+          image: eth-node
+          stdin: true
+          command:
+            - /bin/sh
+            - -c
+            - "sed -i 's/host: \"127.0.0.1\"/host: \"eth-devnet\"/g' truffle-config.js && npm run migrate && npx truffle exec scripts/deploy_test_token.js && npm run deploy-batched-vaa-sender && npx truffle exec scripts/register_solana_chain.js && npx truffle exec scripts/register_terra_chain.js && npx truffle exec scripts/register_terra2_chain.js && npx truffle exec scripts/register_bsc_chain.js && npx truffle exec scripts/register_algo_chain.js && npx truffle exec scripts/register_near_chain.js && npx truffle exec scripts/register_worm_chain.js && npx truffle exec scripts/register_aptos_chain.js"
+          resources:
+            limits:
+              memory: "1Gi"

--- a/devnet/eth-devnet2.yaml
+++ b/devnet/eth-devnet2.yaml
@@ -47,24 +47,47 @@ spec:
             - containerPort: 8545
               name: rpc
               protocol: TCP
-          readinessProbe:
+          startupProbe:
+            failureThreshold: 300
+            initialDelaySeconds: 20
+            periodSeconds: 1
             tcpSocket:
               port: rpc
-        - name: tests
-          image: eth-node
-          stdin: true
-          command:
-            - /bin/sh
-            - -c
-            - "sed -i 's/CHAIN_ID=0x2/CHAIN_ID=0x4/g;s/EVM_CHAIN_ID=1/EVM_CHAIN_ID=1397/g' .env && npm run migrate && npx truffle exec scripts/deploy_test_token.js && npx truffle exec scripts/register_solana_chain.js && npx truffle exec scripts/register_terra_chain.js && npx truffle exec scripts/register_terra2_chain.js && npx truffle exec scripts/register_eth_chain.js && npx truffle exec scripts/register_algo_chain.js && npx truffle exec scripts/register_near_chain.js && npx truffle exec scripts/register_worm_chain.js && npx truffle exec scripts/register_aptos_chain.js && nc -lkp 2000 0.0.0.0"
           readinessProbe:
+            failureThreshold: 2
             periodSeconds: 1
-            failureThreshold: 300
             tcpSocket:
-              port: 2000
+              port: rpc
+          resources:
+            limits:
+              memory: "500Mi"
         - name: mine
           image: eth-node
           command:
             - /bin/sh
             - -c
             - "npx truffle exec mine.js"
+          resources:
+            limits:
+              memory: "300Mi"
+---
+kind: Job
+apiVersion: batch/v1
+metadata:
+  name: eth-deploy2
+spec:
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: tests
+          image: eth-node
+          stdin: true
+          command:
+            - /bin/sh
+            - -c
+            - "sed -i 's/host: \"127.0.0.1\"/host: \"eth-devnet2\"/g' truffle-config.js && sed -i 's/CHAIN_ID=0x2/CHAIN_ID=0x4/g;s/EVM_CHAIN_ID=1/EVM_CHAIN_ID=1397/g' .env && npm run migrate && npx truffle exec scripts/deploy_test_token.js && npx truffle exec scripts/register_solana_chain.js && npx truffle exec scripts/register_terra_chain.js && npx truffle exec scripts/register_terra2_chain.js && npx truffle exec scripts/register_eth_chain.js && npx truffle exec scripts/register_algo_chain.js && npx truffle exec scripts/register_near_chain.js && npx truffle exec scripts/register_worm_chain.js && npx truffle exec scripts/register_aptos_chain.js"
+          resources:
+            limits:
+              memory: "1Gi"

--- a/devnet/near-devnet.yaml
+++ b/devnet/near-devnet.yaml
@@ -9,6 +9,9 @@ spec:
     - name: node
       port: 3030
       targetPort: node
+    - name: webserver
+      port: 3031
+      targetPort: webserver
   selector:
     app: near
 ---
@@ -49,18 +52,37 @@ spec:
               name: webserver
               protocol: TCP
           readinessProbe:
+          startupProbe:
             tcpSocket:
               port: 3030
-        - name: near-deploy
-          image: near-deploy
-          command:
-            - /bin/sh
-            - -c
-            - "sh /app/devnet_deploy.sh && touch success && sleep infinity"
+            failureThreshold: 300
+            initialDelaySeconds: 20
+            periodSeconds: 1
           readinessProbe:
             tcpSocket:
               port: 3030
+            failureThreshold: 2
             periodSeconds: 1
-            initialDelaySeconds: 15
-
-      restartPolicy: Always
+          resources:
+            limits:
+              memory: "1000Mi"
+---
+kind: Job
+apiVersion: batch/v1
+metadata:
+  name: near-deploy
+spec:
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: near-deploy
+          image: near-deploy
+          stdin: true
+          command:
+            - /bin/sh
+            - /app/devnet_deploy.sh
+          resources:
+            limits:
+              memory: "500Mi"

--- a/devnet/node.yaml
+++ b/devnet/node.yaml
@@ -39,7 +39,7 @@ spec:
       labels:
         app: guardian
     spec:
-      terminationGracePeriodSeconds: 0
+      terminationGracePeriodSeconds: 2
       volumes:
         # mount shared between containers for runtime state
         - name: node-rundir
@@ -150,10 +150,20 @@ spec:
               add:
                 # required for syscall.Mlockall
                 - IPC_LOCK
+          startupProbe:
+            httpGet:
+              port: 6060
+              path: /readyz
+            failureThreshold: 300
+            initialDelaySeconds: 20
+            periodSeconds: 1
           readinessProbe:
             httpGet:
               port: 6060
               path: /readyz
+            failureThreshold: 2
+            periodSeconds: 1
+
           ports:
             - containerPort: 8999
               name: p2p
@@ -170,3 +180,16 @@ spec:
             - containerPort: 2345
               name: debugger
               protocol: TCP
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - sh
+                  - -c
+                  - kill guardiand
+          resources:
+            limits:
+              memory: "3300Mi" # don't forget to change GOMEMLIMIT below
+          env:
+          - name: GOMEMLIMIT
+            value: 3300MiB # don't forget to change memory resource limit above accordingly

--- a/devnet/redis.yaml
+++ b/devnet/redis.yaml
@@ -33,12 +33,22 @@ spec:
       containers:
         - name: redis
           image: redis
+          startupProbe:
+            tcpSocket:
+              port: 6379
+            failureThreshold: 300
+            initialDelaySeconds: 20
+            periodSeconds: 1
           readinessProbe:
             tcpSocket:
               port: 6379
+            failureThreshold: 2
             periodSeconds: 1
-            failureThreshold: 300
+
           ports:
             - containerPort: 6379
               name: redis
               protocol: TCP
+          resources:
+            limits:
+              memory: "100Mi"

--- a/devnet/solana-devnet.yaml
+++ b/devnet/solana-devnet.yaml
@@ -34,7 +34,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 1
       containers:
-        - name: devnet
+        - name: solana-devnet
           image: solana-contract
           command:
             - /root/.local/share/solana/install/active_release/bin/solana-test-validator
@@ -89,17 +89,37 @@ spec:
             - containerPort: 9900
               name: faucet
               protocol: TCP
+          startupProbe:
+            httpGet:
+              port: rpc
+              path: /health
+            failureThreshold: 300
+            initialDelaySeconds: 20
+            periodSeconds: 1
           readinessProbe:
             httpGet:
               port: rpc
               path: /health
+            failureThreshold: 2
             periodSeconds: 1
-        - name: setup
+          resources:
+            limits:
+              memory: "2000Mi"
+        - name: solana-setup
           image: bridge-client
           command:
             - /usr/src/solana/devnet_setup.sh
+          startupProbe:
+            tcpSocket:
+              port: 2000
+            failureThreshold: 300
+            initialDelaySeconds: 20
+            periodSeconds: 1
           readinessProbe:
             tcpSocket:
               port: 2000
+            failureThreshold: 2
             periodSeconds: 1
-            failureThreshold: 300
+          resources:
+            limits:
+              memory: "750Mi"

--- a/devnet/spy-listener.yaml
+++ b/devnet/spy-listener.yaml
@@ -44,11 +44,17 @@ spec:
             - /app
             - tilt_listener
           tty: true
+          startupProbe:
+            tcpSocket:
+              port: 2000
+            failureThreshold: 300
+            initialDelaySeconds: 20
+            periodSeconds: 1
           readinessProbe:
             tcpSocket:
               port: 2000
+            failureThreshold: 2
             periodSeconds: 1
-            failureThreshold: 300
           ports:
             - containerPort: 4201
               name: rest
@@ -56,3 +62,6 @@ spec:
             - containerPort: 8082
               name: prometheus
               protocol: TCP
+          resources:
+            limits:
+              memory: "150Mi"

--- a/devnet/spy-relayer.yaml
+++ b/devnet/spy-relayer.yaml
@@ -48,8 +48,17 @@ spec:
               name: prometheus
               protocol: TCP
           tty: true
+          startupProbe:
+            tcpSocket:
+              port: 2000
+            failureThreshold: 300
+            initialDelaySeconds: 20
+            periodSeconds: 1
           readinessProbe:
             tcpSocket:
               port: 2000
+            failureThreshold: 2
             periodSeconds: 1
-            failureThreshold: 300
+          resources:
+            limits:
+              memory: "200Mi"

--- a/devnet/spy-wallet-monitor.yaml
+++ b/devnet/spy-wallet-monitor.yaml
@@ -48,8 +48,17 @@ spec:
               name: prometheus
               protocol: TCP
           tty: true
+          startupProbe:
+            tcpSocket:
+              port: 2000
+            failureThreshold: 300
+            initialDelaySeconds: 20
+            periodSeconds: 1
           readinessProbe:
             tcpSocket:
               port: 2000
+            failureThreshold: 2
             periodSeconds: 1
-            failureThreshold: 300
+          resources:
+            limits:
+              memory: "100Mi"

--- a/devnet/spy.yaml
+++ b/devnet/spy.yaml
@@ -54,7 +54,22 @@ spec:
             - containerPort: 6060
               name: status
               protocol: TCP
+          startupProbe:
+            httpGet:
+              port: 6060
+              path: /metrics
+            failureThreshold: 300
+            initialDelaySeconds: 20
+            periodSeconds: 1
           readinessProbe:
             httpGet:
               port: 6060
               path: /metrics
+            failureThreshold: 2
+            periodSeconds: 1
+          resources:
+            limits:
+              memory: "120Mi" # don't forget to change memory resource limit below accordingly
+          env:
+          - name: GOMEMLIMIT
+            value: 120MiB # don't forget to change memory resource limit above accordingly

--- a/devnet/sui-devnet.yaml
+++ b/devnet/sui-devnet.yaml
@@ -42,8 +42,8 @@ spec:
         - name: sui-node
           image: sui-node
           command:
-            - /bin/sh 
-            - -c 
+            - /bin/sh
+            - -c
             - /tmp/start_node.sh
           ports:
             - containerPort: 9002
@@ -58,8 +58,18 @@ spec:
             - containerPort: 5003
               name: faucet
               protocol: TCP
+          startupProbe:
+            tcpSocket:
+              port: 9002
+            failureThreshold: 300
+            initialDelaySeconds: 20
+            periodSeconds: 1
           readinessProbe:
             tcpSocket:
               port: 9002
-
+            failureThreshold: 2
+            periodSeconds: 1
+          resources:
+            limits:
+              memory: "200Mi"
       restartPolicy: Always

--- a/devnet/terra-devnet.yaml
+++ b/devnet/terra-devnet.yaml
@@ -68,10 +68,21 @@ spec:
           ports:
             - containerPort: 26657
             - containerPort: 1317
+          startupProbe:
+            httpGet:
+              port: 26657
+            failureThreshold: 300
+            initialDelaySeconds: 20
+            periodSeconds: 1
           readinessProbe:
             httpGet:
               port: 26657
+            failureThreshold: 2
+            periodSeconds: 1
           resources: {}
+          resources:
+            limits:
+              memory: "2Gi"
         - name: terra-contracts
           image: terra-contracts
           command:
@@ -84,8 +95,12 @@ spec:
                 - test
                 - -e
                 - "/app/tools/success"
-            initialDelaySeconds: 5
-            periodSeconds: 5
+            initialDelaySeconds: 30
+            periodSeconds: 1
+            failureThreshold: 300
+          resources:
+            limits:
+              memory: "200Mi"
       restartPolicy: Always
   serviceName: terra-terrad
 ---
@@ -118,6 +133,9 @@ spec:
               value: dev
             - name: POSTGRES_DB
               value: fcd
+          resources:
+            limits:
+              memory: "50Mi"
       restartPolicy: Always
   serviceName: terra-fcd
 ---
@@ -170,13 +188,15 @@ spec:
               value: "false"
             - name: TYPEORM_ENTITIES
               value: "src/orm/*Entity.ts"
+          resources:
+            limits:
+              memory: "500Mi"
         - image: terramoney/fcd:bombay
           name: fcd-api
           command:
             - sh
             - -c
             - "sed -i \"s/level: \\'info\\'/level: \\'warn\\'/g\" src/lib/logger.ts && ./entrypoint.sh start"
-          resources: {}
           ports:
             - containerPort: 3060
           env:
@@ -204,5 +224,8 @@ spec:
               value: "false"
             - name: TYPEORM_ENTITIES
               value: "src/orm/*Entity.ts"
+          resources:
+            limits:
+              memory: "200Mi"
       restartPolicy: Always
   serviceName: terra-fcd

--- a/devnet/terra2-devnet.yaml
+++ b/devnet/terra2-devnet.yaml
@@ -68,10 +68,21 @@ spec:
           ports:
             - containerPort: 26657
             - containerPort: 1317
+          startupProbe:
+            httpGet:
+              port: 26657
+            failureThreshold: 300
+            initialDelaySeconds: 20
+            periodSeconds: 1
           readinessProbe:
             httpGet:
               port: 26657
+            failureThreshold: 2
+            periodSeconds: 1
           resources: {}
+          resources:
+            limits:
+              memory: "2Gi"
         - name: terra2-contracts
           image: terra2-contracts
           command:
@@ -86,6 +97,9 @@ spec:
                 - "/app/tools/success"
             initialDelaySeconds: 5
             periodSeconds: 5
+          resources:
+            limits:
+              memory: "200Mi"
       restartPolicy: Always
   serviceName: terra2-terrad
 ---
@@ -118,6 +132,9 @@ spec:
               value: dev
             - name: POSTGRES_DB
               value: fcd
+          resources:
+            limits:
+              memory: "50Mi"
       restartPolicy: Always
   serviceName: terra2-fcd
 ---
@@ -170,6 +187,9 @@ spec:
               value: "false"
             - name: TYPEORM_ENTITIES
               value: "src/orm/*Entity.ts"
+          resources:
+            limits:
+              memory: "500Mi"
         - image: terramoney/fcd:2.0.5
           name: fcd-api
           command:
@@ -204,5 +224,8 @@ spec:
               value: "false"
             - name: TYPEORM_ENTITIES
               value: "src/orm/*Entity.ts"
+          resources:
+            limits:
+              memory: "200Mi"
       restartPolicy: Always
   serviceName: terra2-fcd

--- a/devnet/tests.yaml
+++ b/devnet/tests.yaml
@@ -12,16 +12,10 @@ spec:
           image: sdk-test-image
           command:
             - /bin/sh
-            - -c
-            - "sh /app/testing/sdk.sh && touch /app/testing/success"
-          readinessProbe:
-            exec:
-              command:
-                - test
-                - -e
-                - "/app/testing/success"
-            initialDelaySeconds: 5
-            periodSeconds: 5
+            - /app/testing/sdk.sh
+          resources:
+            limits:
+              memory: "2500Mi"
 ---
 kind: Job
 apiVersion: batch/v1
@@ -37,13 +31,7 @@ spec:
           image: spydk-test-image
           command:
             - /bin/sh
-            - -c
-            - "sh /app/testing/spydk.sh && touch /app/testing/success"
-          readinessProbe:
-            exec:
-              command:
-                - test
-                - -e
-                - "/app/testing/success"
-            initialDelaySeconds: 5
-            periodSeconds: 5
+            - /app/testing/spydk.sh
+          resources:
+            limits:
+              memory: "1000Mi"

--- a/near/devnet_deploy.ts
+++ b/near/devnet_deploy.ts
@@ -13,7 +13,7 @@ function getConfig(env: any) {
     case "local":
       return {
         networkId: "sandbox",
-        nodeUrl: "http://localhost:3030",
+        nodeUrl: "http://near:3030",
         masterAccount: "test.near",
         wormholeAccount: "wormhole.test.near",
         tokenAccount: "token.test.near",
@@ -43,7 +43,7 @@ async function initNear() {
 
   if (e === "sandbox") {
     // Retrieve the validator key directly in the Tilt environment
-    const response = await fetch("http://localhost:3031/validator_key.json");
+    const response = await fetch("http://near:3031/validator_key.json");
 
     const keyFile = await response.json();
 

--- a/near/test/devnet_upgrade.ts
+++ b/near/test/devnet_upgrade.ts
@@ -19,7 +19,7 @@ function getConfig(env: any) {
     case "local":
       return {
         networkId: "sandbox",
-        nodeUrl: "http://localhost:3030",
+        nodeUrl: "http://near:3030",
         masterAccount: "test.near",
         wormholeAccount: "wormhole.test.near",
         tokenAccount: "token.test.near",
@@ -38,7 +38,7 @@ async function testDeploy() {
   let config = getConfig(process.env.NEAR_ENV || "sandbox");
 
   // Retrieve the validator key directly in the Tilt environment
-  const response = await fetch("http://localhost:3031/validator_key.json");
+  const response = await fetch("http://near:3031/validator_key.json");
 
   const keyFile = await response.json();
 

--- a/near/test/foo.ts
+++ b/near/test/foo.ts
@@ -18,7 +18,7 @@ function getConfig(env: any) {
     case "local":
       return {
         networkId: "sandbox",
-        nodeUrl: "http://localhost:3030",
+        nodeUrl: "http://near:3030",
         masterAccount: "test.near",
         wormholeAccount: "wormhole.test.near",
         tokenAccount: "token.test.near",

--- a/near/test/msg.ts
+++ b/near/test/msg.ts
@@ -27,7 +27,7 @@ function getConfig(env: any) {
     case "local":
       return {
         networkId: "sandbox",
-        nodeUrl: "http://localhost:3030",
+        nodeUrl: "http://near:3030",
         masterAccount: "test.near",
         wormholeAccount: "wormhole.test.near",
         tokenAccount: "token.test.near",
@@ -45,7 +45,7 @@ async function testNearMsg() {
   let config = getConfig(process.env.NEAR_ENV || "sandbox");
 
   // Retrieve the validator key directly in the Tilt environment
-  const response = await fetch("http://localhost:3031/validator_key.json");
+  const response = await fetch("http://near:3031/validator_key.json");
 
   const keyFile = await response.json();
 

--- a/near/test/nft.ts
+++ b/near/test/nft.ts
@@ -41,7 +41,7 @@ const fetch = require("node-fetch");
 const ERC721 = require("@openzeppelin/contracts/build/contracts/ERC721PresetMinterPauserAutoId.json");
 const nearAPI = require("near-api-js");
 
-export const ETH_NODE_URL = "ws://localhost:8545";
+export const ETH_NODE_URL = "ws://eth-devnet:8545";
 export const ETH_PRIVATE_KEY =
   "0x6cbed15c793ce57650b9877cf6fa156fbef513c4e6134f022a85b1ffdd59b2a1"; // account 1
 export const ETH_CORE_BRIDGE_ADDRESS =
@@ -137,7 +137,7 @@ function getConfig(env: any) {
     case "local":
       return {
         networkId: "sandbox",
-        nodeUrl: "http://localhost:3030",
+        nodeUrl: "http://near:3030",
         masterAccount: "test.near",
         wormholeAccount: "wormhole.test.near",
         tokenAccount: "token.test.near",
@@ -157,7 +157,7 @@ async function testNearSDK() {
   let config = getConfig(process.env.NEAR_ENV || "sandbox");
 
   // Retrieve the validator key directly in the Tilt environment
-  const response = await fetch("http://localhost:3031/validator_key.json");
+  const response = await fetch("http://near:3031/validator_key.json");
 
   const keyFile = await response.json();
 

--- a/near/test/p3.ts
+++ b/near/test/p3.ts
@@ -58,7 +58,7 @@ function getConfig(env: any) {
     case "local":
       return {
         networkId: "sandbox",
-        nodeUrl: "http://localhost:3030",
+        nodeUrl: "http://near:3030",
         masterAccount: "test.near",
         wormholeAccount: "wormhole.test.near",
         tokenAccount: "token.test.near",
@@ -100,7 +100,7 @@ async function testNearSDK() {
   let config = getConfig(process.env.NEAR_ENV || "sandbox");
 
   // Retrieve the validator key directly in the Tilt environment
-  const response = await fetch("http://localhost:3031/validator_key.json");
+  const response = await fetch("http://near:3031/validator_key.json");
 
   const keyFile = await response.json();
 
@@ -282,7 +282,7 @@ async function testNearSDK() {
     }
 
     const { vaaBytes: signedVAA } = await getSignedVAAWithRetry(
-      ["http://localhost:7071"],
+      ["http://near:7071"],
       CHAIN_ID_NEAR,
       getEmitterAddressNear(token_bridge),
       sequence,
@@ -360,7 +360,7 @@ async function testNearSDK() {
     const txSid = parseSequenceFromLogAlgorand(transferResult);
     transferAlgoToNearP3 = (
       await getSignedVAAWithRetry(
-        ["http://localhost:7071"],
+        ["http://near:7071"],
         CHAIN_ID_ALGORAND,
         emitterAddr,
         txSid,
@@ -404,7 +404,7 @@ async function testNearSDK() {
     const txSid = parseSequenceFromLogAlgorand(transferResult);
     transferAlgoToNearRandoP3 = (
       await getSignedVAAWithRetry(
-        ["http://localhost:7071"],
+        ["http://near:7071"],
         CHAIN_ID_ALGORAND,
         emitterAddr,
         txSid,

--- a/near/test/recoverTest.ts
+++ b/near/test/recoverTest.ts
@@ -12,7 +12,7 @@ function getConfig(env: any) {
     case "local":
       return {
         networkId: "sandbox",
-        nodeUrl: "http://localhost:3030",
+        nodeUrl: "http://near:3030",
         masterAccount: "test.near",
         contractAccount: Math.floor(Math.random() * 10000).toString() + "wormhole2.test.near",
       };
@@ -34,7 +34,7 @@ async function initNear() {
   config = getConfig(process.env.NEAR_ENV || "sandbox");
 
   // Retrieve the validator key directly in the Tilt environment
-  const response = await fetch('http://localhost:3031/validator_key.json');
+  const response = await fetch('http://near:3031/validator_key.json');
   const keyFile = await response.json();
 
   masterKey = nearAPI.utils.KeyPair.fromString(
@@ -69,7 +69,7 @@ async function createContractUser(
     new BN(10).pow(new BN(25))
   );
   console.log("accountId: " + JSON.stringify(resp))
-    
+
   keyStore.setKey(config.networkId, accountId, masterKey);
   const account = new nearAPI.Account(near.connection, accountId);
   const accountUseContract = new nearAPI.Contract(
@@ -110,7 +110,7 @@ async function test() {
     // The actual hash function here doesn't matter that much but this happens to be the hash function used by wormhole
     const hash = web3Utils.keccak256(web3Utils.keccak256("0x" + message)).substr(2);
 
-    
+
     const ec = new elliptic.ec("secp256k1");
     const key = ec.keyFromPrivate(guardianPrivKeys);
     const signature = key.sign(hash, { canonical: true });

--- a/near/test/sdk.ts
+++ b/near/test/sdk.ts
@@ -70,7 +70,7 @@ function getConfig(env: any) {
     case "local":
       return {
         networkId: "sandbox",
-        nodeUrl: "http://localhost:3030",
+        nodeUrl: "http://near:3030",
         masterAccount: "test.near",
         wormholeAccount: "wormhole.test.near",
         tokenAccount: "token.test.near",
@@ -179,7 +179,7 @@ async function testNearSDK() {
   let config = getConfig(process.env.NEAR_ENV || "sandbox");
 
   // Retrieve the validator key directly in the Tilt environment
-  const response = await fetch("http://localhost:3031/validator_key.json");
+  const response = await fetch("http://near:3031/validator_key.json");
 
   const keyFile = await response.json();
 

--- a/near/test/test.ts
+++ b/near/test/test.ts
@@ -29,7 +29,7 @@ function getConfig(env: any) {
     case "local":
       return {
         networkId: "sandbox",
-        nodeUrl: "http://localhost:3030",
+        nodeUrl: "http://near:3030",
         masterAccount: "test.near",
         wormholeAccount:
           Math.floor(Math.random() * 10000).toString() + "wormhole.test.near",
@@ -90,7 +90,7 @@ async function initNear() {
   config = getConfig(process.env.NEAR_ENV || "sandbox");
 
   // Retrieve the validator key directly in the Tilt environment
-  const response = await fetch("http://localhost:3031/validator_key.json");
+  const response = await fetch("http://near:3031/validator_key.json");
 
   const keyFile = await response.json();
 
@@ -559,7 +559,7 @@ async function test() {
 
   console.log("npm i -g near-cli");
   console.log(
-    "near --nodeUrl http://localhost:3030 view " +
+    "near --nodeUrl http://near:3030 view " +
       tname +
       ' ft_balance_of \'{"account_id": "' +
       tokenUseContract.account.accountId +
@@ -653,7 +653,7 @@ async function test() {
   });
 
   console.log(
-    "near --nodeUrl http://localhost:3030 view " +
+    "near --nodeUrl http://near:3030 view " +
       randoToken +
       ' ft_balance_of \'{"account_id": "' +
       tokenUseContract.account.accountId +
@@ -802,7 +802,7 @@ async function test() {
                 receiver_id: config.tokenAccount,
                 amount: "3210000000",
                 msg: JSON.stringify(
-                    { 
+                    {
                         receiver: "33445566",
                         chain: 1,
                         fee: 0,
@@ -884,7 +884,7 @@ async function test() {
 //        let out = []
 //        for (const idx in result.receipts_outcome) {
 //            let r = result.receipts_outcome[idx];
-//            out.push({ 
+//            out.push({
 //                executor: r.outcome.executor_id,
 //                gas: r.outcome.gas_burnt,
 //                token: r.outcome.tokens_burnt,

--- a/near/test/test2.ts
+++ b/near/test/test2.ts
@@ -29,7 +29,7 @@ function getConfig(env: any) {
     case "local":
       return {
         networkId: "sandbox",
-        nodeUrl: "http://localhost:3030",
+        nodeUrl: "http://near:3030",
         masterAccount: "test.near",
         wormholeAccount:
           Math.floor(Math.random() * 10000).toString() + "wormhole.test.near",
@@ -90,7 +90,7 @@ async function initNear() {
   config = getConfig(process.env.NEAR_ENV || "sandbox");
 
   // Retrieve the validator key directly in the Tilt environment
-  const response = await fetch("http://localhost:3031/validator_key.json");
+  const response = await fetch("http://near:3031/validator_key.json");
 
   const keyFile = await response.json();
 

--- a/near/test/upgrade_test.ts
+++ b/near/test/upgrade_test.ts
@@ -20,7 +20,7 @@ function getConfig(env: any) {
     case "local":
       return {
         networkId: "sandbox",
-        nodeUrl: "http://localhost:3030",
+        nodeUrl: "http://near:3030",
         masterAccount: "test.near",
         wormholeAccount:
           Math.floor(Math.random() * 10000).toString() + "wormhole.test.near",
@@ -59,7 +59,7 @@ async function initNear() {
 
   if (e === "sandbox") {
     // Retrieve the validator key directly in the Tilt environment
-    const response = await fetch("http://localhost:3031/validator_key.json");
+    const response = await fetch("http://near:3031/validator_key.json");
 
     const keyFile = await response.json();
 

--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -17,7 +17,7 @@
     "build-lib": "tsc -p tsconfig.json && tsc -p tsconfig-cjs.json && node scripts/copyEthersTypes.js",
     "build-all": "npm run build-deps && npm run build-lib",
     "test": "jest --config jestconfig.json --verbose",
-    "test-ci": "NEAR_NO_LOGS=true jest --config jestconfig.json --verbose --setupFiles ./ci-config.js --forceExit",
+    "test-ci": "NEAR_NO_LOGS=true jest --config jestconfig.json --verbose --setupFiles ./ci-config.js --forceExit --runInBand",
     "build": "npm run build-all",
     "format": "echo \"disabled: prettier --write \"src/**/*.ts\"\"",
     "lint": "tslint -p tsconfig.json",

--- a/wormchain/validators/kubernetes/wormchain-guardian-devnet.yaml
+++ b/wormchain/validators/kubernetes/wormchain-guardian-devnet.yaml
@@ -59,5 +59,8 @@ spec:
               port: 26657
               path: /
             periodSeconds: 1
+          resources:
+            limits:
+              memory: "1000Mi"
       restartPolicy: Always
   serviceName: guardian-validator


### PR DESCRIPTION
fixes #1984 (see the issue for the rationale here)

I picked the memory limits based on running everything locally for 1h and picking the max memory consumption plus some buffer in some cases, see devnet/README.md. Everything together added up to more than 16GiB, which is the limit in `start-recommended-minikube`, so I move some services to be jobs such that the peak memory consumption stays under 16GiB. 

I'm no expert here, so would appreciate feedback on this approach. 