### PR TITLE
cosmwasm: accounting: Add ValidateTransfer query

### DIFF
--- a/cosmwasm/contracts/wormchain-accounting/schema/wormchain-accounting.json
+++ b/cosmwasm/contracts/wormchain-accounting/schema/wormchain-accounting.json
@@ -386,9 +386,58 @@
           }
         },
         "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": [
+          "validate_transfer"
+        ],
+        "properties": {
+          "validate_transfer": {
+            "type": "object",
+            "required": [
+              "transfer"
+            ],
+            "properties": {
+              "transfer": {
+                "$ref": "#/definitions/Transfer"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
       }
     ],
     "definitions": {
+      "Data": {
+        "type": "object",
+        "required": [
+          "amount",
+          "recipient_chain",
+          "token_address",
+          "token_chain"
+        ],
+        "properties": {
+          "amount": {
+            "$ref": "#/definitions/Uint256"
+          },
+          "recipient_chain": {
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0.0
+          },
+          "token_address": {
+            "$ref": "#/definitions/TokenAddress"
+          },
+          "token_chain": {
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0.0
+          }
+        },
+        "additionalProperties": false
+      },
       "Key": {
         "type": "object",
         "required": [
@@ -414,6 +463,26 @@
         "additionalProperties": false
       },
       "TokenAddress": {
+        "type": "string"
+      },
+      "Transfer": {
+        "type": "object",
+        "required": [
+          "data",
+          "key"
+        ],
+        "properties": {
+          "data": {
+            "$ref": "#/definitions/Data"
+          },
+          "key": {
+            "$ref": "#/definitions/Key"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Uint256": {
+        "description": "An implementation of u256 that is using strings for JSON encoding/decoding, such that the full u256 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances out of primitive uint types or `new` to provide big endian bytes:\n\n``` # use cosmwasm_std::Uint256; let a = Uint256::from(258u128); let b = Uint256::new([ 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 1u8, 2u8, ]); assert_eq!(a, b); ```",
         "type": "string"
       }
     }
@@ -1026,6 +1095,12 @@
           "type": "string"
         }
       }
+    },
+    "validate_transfer": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Empty",
+      "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressable in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
+      "type": "object"
     }
   }
 }

--- a/cosmwasm/contracts/wormchain-accounting/src/contract.rs
+++ b/cosmwasm/contracts/wormchain-accounting/src/contract.rs
@@ -3,6 +3,7 @@ use std::marker::PhantomData;
 use accounting::{
     query_balance, query_modification, query_transfer,
     state::{account, transfer, Modification, TokenAddress, Transfer},
+    validate_transfer,
 };
 use anyhow::{ensure, Context};
 #[cfg(not(feature = "library"))]
@@ -351,6 +352,13 @@ pub fn query(deps: Deps<WormholeQuery>, _env: Env, msg: QueryMsg) -> StdResult<B
         QueryMsg::AllModifications { start_after, limit } => {
             query_all_modifications(deps, start_after, limit).and_then(|resp| to_binary(&resp))
         }
+        QueryMsg::ValidateTransfer { transfer } => validate_transfer(deps, &transfer)
+            .map_err(|e| {
+                e.downcast().unwrap_or_else(|e| StdError::GenericErr {
+                    msg: format!("{e:#}"),
+                })
+            })
+            .and_then(|()| to_binary(&Empty {})),
     }
 }
 

--- a/cosmwasm/contracts/wormchain-accounting/src/msg.rs
+++ b/cosmwasm/contracts/wormchain-accounting/src/msg.rs
@@ -122,6 +122,8 @@ pub enum QueryMsg {
         start_after: Option<u64>,
         limit: Option<u32>,
     },
+    #[returns(cosmwasm_std::Empty)]
+    ValidateTransfer { transfer: Transfer },
 }
 
 #[cw_serde]


### PR DESCRIPTION
Add a query to validate transfers.  This can be useful for guardians to
sanity check a transfer before submitting a signed observation for it

Part of #1933.