### PR TITLE
terra/tools: restore broadcast waiting fix

### DIFF
--- a/sdk/js/src/token_bridge/__tests__/consts.ts
+++ b/sdk/js/src/token_bridge/__tests__/consts.ts
@@ -46,8 +46,11 @@ export const TERRA_GAS_PRICES_URL = ci
 export const TERRA2_GAS_PRICES_URL = ci
   ? "http://terra2-fcd:3060/v1/txs/gas_prices"
   : "http://localhost:3061/v1/txs/gas_prices";
+// NOTE: test1 is used by getIsTransferCompletedTerra, so avoid using it in the integration tests
+// Accounts from https://github.com/terra-money/LocalTerra/blob/main/README.md#accounts
+export const TERRA_PUBLIC_KEY = "terra17tv2hvwpg0ukqgd2y5ct2w54fyan7z0zxrm2f9"; // test7
 export const TERRA_PRIVATE_KEY =
-  "notice oak worry limit wrap speak medal online prefer cluster roof addict wrist behave treat actual wasp year salad speed social layer crew genius"; // test1
+  "noble width taxi input there patrol clown public spell aunt wish punch moment will misery eight excess arena pen turtle minimum grain vague inmate"; // test7
 export const TERRA_PRIVATE_KEY2 =
   "quality vacuum heart guard buzz spike sight swarm shove special gym robust assume sudden deposit grid alcohol choice devote leader tilt noodle tide penalty"; // test2
 export const TERRA2_PRIVATE_KEY =

--- a/sdk/js/src/token_bridge/__tests__/terra-integration.ts
+++ b/sdk/js/src/token_bridge/__tests__/terra-integration.ts
@@ -42,6 +42,7 @@ import {
   TERRA_GAS_PRICES_URL,
   TERRA_NODE_URL,
   TERRA_PRIVATE_KEY,
+  TERRA_PUBLIC_KEY,
   TEST_ERC20,
   WORMHOLE_RPC_HOSTS,
 } from "./consts";
@@ -301,8 +302,7 @@ describe("Terra Integration Tests", () => {
           const signer = new ethers.Wallet(ETH_PRIVATE_KEY4, provider);
           const amount = parseUnits("1", 18);
           const ERC20 = "0x2D8BE6BF0baA74e0A907016679CaE9190e80dD0A";
-          const TerraWalletAddress: string =
-            "terra1x46rqay4d3cssq8gxxvqz8xt6nwlz4td20k38v";
+          const TerraWalletAddress: string = TERRA_PUBLIC_KEY;
           interface Erc20Balance {
             balance: string;
           }
@@ -482,8 +482,7 @@ describe("Terra Integration Tests", () => {
           });
           const wallet = lcd.wallet(mk);
           const Asset: string = "uluna";
-          const TerraWalletAddress: string =
-            "terra1x46rqay4d3cssq8gxxvqz8xt6nwlz4td20k38v";
+          const TerraWalletAddress: string = TERRA_PUBLIC_KEY;
           const msg = await attestFromTerra(
             CONTRACTS.DEVNET.terra.token_bridge,
             TerraWalletAddress,
@@ -843,8 +842,7 @@ describe("Terra Integration Tests", () => {
           const Asset: string = "uluna";
           const FeeAsset: string = "uusd";
           const Amount: string = "1000000";
-          const TerraWalletAddress: string =
-            "terra1x46rqay4d3cssq8gxxvqz8xt6nwlz4td20k38v";
+          const TerraWalletAddress: string = TERRA_PUBLIC_KEY;
 
           interface Cw20Balance {
             balance: string;

--- a/terra/devnet/config/config.toml
+++ b/terra/devnet/config/config.toml
@@ -140,7 +140,7 @@ max_subscriptions_per_client = 5
 # WARNING: Using a value larger than 10s will result in increasing the
 # global HTTP write timeout, which applies to all connections and endpoints.
 # See https://github.com/tendermint/tendermint/issues/3435
-timeout_broadcast_tx_commit = "10s"
+timeout_broadcast_tx_commit = "30s"
 
 # Maximum size of request body, in bytes
 max_body_bytes = 4194304

--- a/terra/tools/deploy.js
+++ b/terra/tools/deploy.js
@@ -200,6 +200,10 @@ addresses["mock.wasm"] = await instantiate("cw20_base.wasm", {
       address: wallet.key.accAddress,
       amount: "100000000",
     },
+    {
+      address: "terra17tv2hvwpg0ukqgd2y5ct2w54fyan7z0zxrm2f9",
+      amount: "100000000",
+    },
   ],
   mint: null,
 });

--- a/terra/tools/deploy.js
+++ b/terra/tools/deploy.js
@@ -15,7 +15,13 @@ function sleep(ms) {
 }
 
 async function broadcastAndWait(terra, tx) {
-  return await terra.tx.broadcast(tx);
+  const response = await terra.tx.broadcast(tx);
+  let currentHeight = (await terra.tendermint.blockInfo()).block.header.height;
+  while (currentHeight <= response.height) {
+    await sleep(100);
+    currentHeight = (await terra.tendermint.blockInfo()).block.header.height;
+  }
+  return response;
 }
 
 /*


### PR DESCRIPTION
This PR patches the issues observed in #2064.

1. Updates the `timeout_broadcast_tx_commit` to `30s` (which matches the current LocalTerra config), resolving the timeout issue.

2. Forces the functions broadcasting transactions to wait for the next block.

3. Avoids using the test1 key in the Terra Classic tests to prevent a sequence mismatch on simulation within `getIsTransferCompletedTerra`.