### PR TITLE
sui: change RPC to port 9000

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -178,7 +178,7 @@ def build_node_yaml():
             if sui:
                 container["command"] += [
                     "--suiRPC",
-                    "http://sui:9002",
+                    "http://sui:9000",
 # In testnet and mainnet, you will need to also specify the suiPackage argument.  In Devnet, we subscribe to
 # event traffic purely based on the account since that is the only thing that is deterministic.
 #                    "--suiPackage",
@@ -395,7 +395,6 @@ if solana:
         port_forwards = [
             port_forward(8899, name = "Solana RPC [:8899]", host = webHost),
             port_forward(8900, name = "Solana WS [:8900]", host = webHost),
-            port_forward(9000, name = "Solana PubSub [:9000]", host = webHost),
         ],
         resource_deps = ["const-gen"],
         labels = ["solana"],
@@ -679,8 +678,8 @@ if sui:
     k8s_resource(
         "sui",
         port_forwards = [
+            port_forward(9000, name = "RPC [:9000]", host = webHost),
             port_forward(9001, name = "WS [:9001]", host = webHost),
-            port_forward(9002, name = "RPC [:9002]", host = webHost),
             port_forward(5003, name = "Faucet [:5003]", host = webHost),
             port_forward(9184, name = "Prometheus [:9184]", host = webHost),
         ],

--- a/devnet/sui-devnet.yaml
+++ b/devnet/sui-devnet.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   ports:
     - name: node
-      port: 9002
+      port: 9000
       targetPort: node
     - name: ws
       port: 9001
@@ -46,7 +46,7 @@ spec:
             - -c 
             - /tmp/start_node.sh
           ports:
-            - containerPort: 9002
+            - containerPort: 9000
               name: node
               protocol: TCP
             - containerPort: 9001
@@ -60,6 +60,6 @@ spec:
               protocol: TCP
           readinessProbe:
             tcpSocket:
-              port: 9002
+              port: 9000
 
       restartPolicy: Always

--- a/sui/scripts/start_node.sh
+++ b/sui/scripts/start_node.sh
@@ -9,7 +9,6 @@ sui client object --id 0x5
 #sui-faucet --host-ip 0.0.0.0&
 #sleep 2
 #curl -X POST -d '{"FixedAmountRequest":{"recipient": "'"0x2acab6bb0e4722e528291bc6ca4f097e18ce9331"'"}}' -H 'Content-Type: application/json' http://127.0.0.1:5003/gas
-sed -i -e 's/:9000/:9002/' ~/.sui/sui_config/fullnode.yaml
 sui-node --config-path ~/.sui/sui_config/fullnode.yaml
 
 #sleep infinity


### PR DESCRIPTION
This PR changes the Sui RPC port to 9000 as apps such as Sui wallet and Sui explorer expect. Previously, `Tiltfile` was incorrectly attempting to forward Solana gossip onto 9000, which has been fixed as well.

Resolves #2019 