### PR TITLE
Fix MockTokenBridge

### DIFF
--- a/sdk/js/src/mock/tokenBridge.ts
+++ b/sdk/js/src/mock/tokenBridge.ts
@@ -74,7 +74,7 @@ export class MockTokenBridge extends MockEmitter {
     fromAddress?: Buffer
   ) {
     const serialized = Buffer.alloc(133);
-    serialized.writeUInt8(1, 0);
+    serialized.writeUInt8(withPayload ? 3 : 1, 0);
     const amountBytes = new BN(amount.toString()).toBuffer();
     serialized.write(
       amountBytes.toString("hex"),

--- a/testing/solana-test-validator/sdk-tests/2_token_bridge.ts
+++ b/testing/solana-test-validator/sdk-tests/2_token_bridge.ts
@@ -731,6 +731,7 @@ describe("Token Bridge", () => {
         nonce,
         timestamp
       );
+      expect(message[51]).to.equal(3);
 
       const signedVaa = guardians.addSignatures(
         message,
@@ -751,7 +752,7 @@ describe("Token Bridge", () => {
         "GnQ6fGttTRnJpAJuy2XEg5TLgEMtbyU4HDJnBWmojsTv"
       );
       expect(accounts.vaa.toString()).to.equal(
-        "4qSDmrTmsUziHvKjjcCpLpfZNaRuxpKcuE95T6875jb1"
+        "9jdun7HMoJp7KL1jRYF7MT9pjRLVM3RPDbDgf6qXNBR4"
       );
       expect(accounts.tokenBridgeClaim.toString()).to.equal(
         "HzjTihvhEx7BbKnB2KHATNBwGFCEm2nnMG6c4Pwx6pPE"
@@ -803,6 +804,7 @@ describe("Token Bridge", () => {
         nonce,
         timestamp
       );
+      expect(message[51]).to.equal(3);
 
       const signedVaa = guardians.addSignatures(
         message,
@@ -823,7 +825,7 @@ describe("Token Bridge", () => {
         "GnQ6fGttTRnJpAJuy2XEg5TLgEMtbyU4HDJnBWmojsTv"
       );
       expect(accounts.vaa.toString()).to.equal(
-        "A51Qrypowzrj4LgSRadTJ8p6ZnXH52oxFG6Su5u2zLPB"
+        "3czQYHVjwCNBAaQAAoMcmtLwXkF16UG1E1wU4RM9tje7"
       );
       expect(accounts.tokenBridgeClaim.toString()).to.equal(
         "7Ae57QxvZMwCrknoDWpeaMTLbMP3LBeCJee6KaLEwxP6"


### PR DESCRIPTION
# Objective

Fix the Javascript SDK's `MockTokenBridge`'s `serializeTransferOnly` method, which did not use the `withPayload` parameter to change the serialized payload ID. Without this fix, mock serialized token transfer messages will end up being deserialized as payload 1 transfers despite there being an additional payload associated with this transfer.

Workaround without this fix is to force the payload ID byte (at 51) of the resulting `Buffer` to `3` if you intend to use `publishTransferTokensWithPayload`.

# How to Review
1. Go to _testing/solana-test-validator_ and run `make test`.
2. Review change in _tokenBridge.ts_.
3. Review change in tests.