### PR TITLE
cosmwasm: Makefile: Separate unit and integration tests

### DIFF
--- a/cosmwasm/Makefile
+++ b/cosmwasm/Makefile
@@ -63,7 +63,7 @@ unit-test:
 
 .PHONY: test
 ## Run unit and integration tests
-test: artifacts test/node_modules LocalTerra unit-test
+test: artifacts test/node_modules LocalTerra
 	@if pgrep terrad; then echo "Error: terrad already running. Stop it before running tests"; exit 1; fi
 	cd LocalTerra && docker-compose up --detach
 	sleep 5


### PR DESCRIPTION
We already run the unit tests as part of the rust-lint-and-tests CI job
so don't run them again before running the integration tests.