### PR TITLE
sdk/go: Add unmarshal for vaa.Address

### DIFF
--- a/sdk/vaa/structs.go
+++ b/sdk/vaa/structs.go
@@ -126,7 +126,7 @@ func (a Address) MarshalJSON() ([]byte, error) {
 // Standard marshal stores the Address like this: "[0,0,0,0,0,0,0,0,0,0,0,0,2,144,251,22,114,8,175,69,91,177,55,120,1,99,183,183,169,161,12,22]"
 // The above MarshalJSON stores it like this (66 bytes): ""0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16""
 func (a *Address) UnmarshalJSON(data []byte) error {
-	addr, err := StringToAddress("0x" + string(data[1:65]))
+	addr, err := StringToAddress(strings.Trim(string(data), `"`))
 	if err != nil {
 		return err
 	}

--- a/sdk/vaa/structs.go
+++ b/sdk/vaa/structs.go
@@ -123,6 +123,17 @@ func (a Address) MarshalJSON() ([]byte, error) {
 	return []byte(fmt.Sprintf(`"%s"`, a)), nil
 }
 
+// Standard marshal stores the Address like this: "[0,0,0,0,0,0,0,0,0,0,0,0,2,144,251,22,114,8,175,69,91,177,55,120,1,99,183,183,169,161,12,22]"
+// The above MarshalJSON stores it like this (66 bytes): ""0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16""
+func (a *Address) UnmarshalJSON(data []byte) error {
+	addr, err := StringToAddress("0x" + string(data[1:65]))
+	if err != nil {
+		return err
+	}
+	*a = addr
+	return nil
+}
+
 func (a Address) String() string {
 	return hex.EncodeToString(a[:])
 }

--- a/sdk/vaa/structs_test.go
+++ b/sdk/vaa/structs_test.go
@@ -135,6 +135,33 @@ func TestAddress_Unmarshal(t *testing.T) {
 	assert.Equal(t, addr, unmarshalAddr)
 }
 
+func TestAddress_UnmarshalEmptyBuffer(t *testing.T) {
+	b := []byte{}
+
+	var unmarshalAddr Address
+	err := json.Unmarshal(b, &unmarshalAddr)
+	require.Error(t, err)
+}
+
+func TestAddress_UnmarshalBufferTooShort(t *testing.T) {
+	addr, _ := StringToAddress("0x0290fb167208af455bb137780163b7b7a9a10c16")
+
+	b, err := json.Marshal(addr)
+	require.NoError(t, err)
+
+	var unmarshalAddr Address
+
+	// Lop off the first byte, and it should fail.
+	b1 := b[1:]
+	err = json.Unmarshal(b1, &unmarshalAddr)
+	assert.Error(t, err)
+
+	// Lop off the last byte, and it should fail.
+	b2 := b[0 : len(b)-1]
+	err = json.Unmarshal(b2, &unmarshalAddr)
+	assert.Error(t, err)
+}
+
 func TestAddress_String(t *testing.T) {
 	addr := Address{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4}
 	expected := "0000000000000000000000000000000000000000000000000000000000000004"

--- a/sdk/vaa/structs_test.go
+++ b/sdk/vaa/structs_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"math/big"
 	"reflect"
 	"testing"
@@ -106,6 +107,32 @@ func TestAddress_MarshalJSON(t *testing.T) {
 	marshalJsonAddress, err := addr.MarshalJSON()
 	assert.Equal(t, hex.EncodeToString(marshalJsonAddress), expected)
 	assert.NoError(t, err)
+}
+
+func TestAddress_UnmarshalJSON(t *testing.T) {
+	addr, _ := StringToAddress("0x0290fb167208af455bb137780163b7b7a9a10c16")
+
+	b, err := addr.MarshalJSON()
+	require.NoError(t, err)
+
+	var unmarshalAddr Address
+	err = unmarshalAddr.UnmarshalJSON(b)
+	require.NoError(t, err)
+
+	assert.Equal(t, addr, unmarshalAddr)
+}
+
+func TestAddress_Unmarshal(t *testing.T) {
+	addr, _ := StringToAddress("0x0290fb167208af455bb137780163b7b7a9a10c16")
+
+	b, err := json.Marshal(addr)
+	require.NoError(t, err)
+
+	var unmarshalAddr Address
+	err = json.Unmarshal(b, &unmarshalAddr)
+	require.NoError(t, err)
+
+	assert.Equal(t, addr, unmarshalAddr)
 }
 
 func TestAddress_String(t *testing.T) {


### PR DESCRIPTION
As part of the guardian changes for accounting, we need to start persisting common.MessagePublication objects in the badger db. It would be nice to be able to use JSON for that. To make that work, we need a custom unmarshal method for vaa.Address, since it has a custom marshal. (I don't want to change the existing marshal because that may cause unexpected breakage.)

Change-Id: I1beb99f82673d1fc3225a8c6628a0019648d7e01