### PR TITLE
sui: wormhole test guardian set expiry

### DIFF
--- a/sui/wormhole/sources/state.move
+++ b/sui/wormhole/sources/state.move
@@ -86,7 +86,7 @@ module wormhole::state {
             governance_contract: external_address::from_bytes(governance_contract),
             guardian_set_index: u32::from_u64(0),
             guardian_sets: vec_map::empty<U32, GuardianSet>(),
-            guardian_set_expiry: u32::from_u64(0),
+            guardian_set_expiry: u32::from_u64(2), // TODO - what is the right #epochs to set this to?
             consumed_governance_actions: set::new(ctx),
             emitter_registry: emitter::init_emitter_registry(),
             message_fee: 0,
@@ -214,7 +214,7 @@ module wormhole::state {
 
 #[test_only]
 module wormhole::test_state{
-    use sui::test_scenario::{Self, Scenario, next_tx, ctx, take_from_address, take_shared, return_shared};//, take_shared};
+    use sui::test_scenario::{Self, Scenario, next_tx, ctx, take_from_address, take_shared, return_shared};
 
     use wormhole::state::{Self, test_init, State, DeployerCapability};
     use wormhole::myu16::{Self as u16};


### PR DESCRIPTION
test that:
- old guardian set does not expire immediately after a guardian set upgrade
- but does so after 3 epochs have passed

In general, what should we set delta epochs to be? Right now it is set to 2 epochs. 

Note: the token bridge tests do not pass right now, because of the update to the CoinMetadata, which is fixed on a different branch