### PR TITLE
wormchain: move governance consts to sdk

### DIFF
--- a/wormchain/x/wormhole/client/cli/genesis.go
+++ b/wormchain/x/wormhole/client/cli/genesis.go
@@ -20,7 +20,6 @@ import (
 	// "github.com/cosmos/cosmos-sdk/client/flags"
 
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/wormhole-foundation/wormchain/x/wormhole/keeper"
 	"github.com/wormhole-foundation/wormchain/x/wormhole/types"
 	wormholesdk "github.com/wormhole-foundation/wormhole/sdk"
 	"github.com/wormhole-foundation/wormhole/sdk/vaa"
@@ -378,7 +377,7 @@ func CmdGenerateGuardianSetUpdatea() *cobra.Command {
 				set_update = append(set_update, pubkey...)
 			}
 
-			action := keeper.ActionGuardianSetUpdate
+			action := vaa.ActionGuardianSetUpdate
 			chain := 3104
 			module := [32]byte{}
 			copy(module[:], vaa.CoreModule)

--- a/wormchain/x/wormhole/keeper/msg_server_execute_governance_vaa.go
+++ b/wormchain/x/wormhole/keeper/msg_server_execute_governance_vaa.go
@@ -9,13 +9,6 @@ import (
 	"github.com/wormhole-foundation/wormhole/sdk/vaa"
 )
 
-type GovernanceAction uint8
-
-var (
-	ActionContractUpgrade   GovernanceAction = 1
-	ActionGuardianSetUpdate GovernanceAction = 2
-)
-
 func (k msgServer) ExecuteGovernanceVAA(goCtx context.Context, msg *types.MsgExecuteGovernanceVAA) (*types.MsgExecuteGovernanceVAAResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
@@ -34,8 +27,8 @@ func (k msgServer) ExecuteGovernanceVAA(goCtx context.Context, msg *types.MsgExe
 	}
 
 	// Execute action
-	switch GovernanceAction(action) {
-	case ActionGuardianSetUpdate:
+	switch vaa.GovernanceAction(action) {
+	case vaa.ActionGuardianSetUpdate:
 		if len(payload) < 5 {
 			return nil, types.ErrInvalidGovernancePayloadLength
 		}

--- a/wormchain/x/wormhole/keeper/msg_server_execute_governance_vaa_test.go
+++ b/wormchain/x/wormhole/keeper/msg_server_execute_governance_vaa_test.go
@@ -26,7 +26,7 @@ func createExecuteGovernanceVaaPayload(k *keeper.Keeper, ctx sdk.Context, num_gu
 	// governance message with sha3 of wasmBytes as the payload
 	module := [32]byte{}
 	copy(module[:], vaa.CoreModule)
-	gov_msg := types.NewGovernanceMessage(module, byte(keeper.ActionGuardianSetUpdate), uint16(vaa.ChainIDWormchain), set_update)
+	gov_msg := types.NewGovernanceMessage(module, byte(vaa.ActionGuardianSetUpdate), uint16(vaa.ChainIDWormchain), set_update)
 
 	return gov_msg.MarshalBinary(), privateKeys
 }

--- a/wormchain/x/wormhole/keeper/msg_server_wasmd.go
+++ b/wormchain/x/wormhole/keeper/msg_server_wasmd.go
@@ -12,14 +12,6 @@ import (
 	"golang.org/x/crypto/sha3"
 )
 
-// WasmdModule is the identifier of the Wasmd module (which is used for governance messages)
-var WasmdModule = [32]byte{00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 0x57, 0x61, 0x73, 0x6D, 0x64, 0x4D, 0x6F, 0x64, 0x75, 0x6C, 0x65}
-
-var (
-	ActionStoreCode           GovernanceAction = 1
-	ActionInstantiateContract GovernanceAction = 2
-)
-
 // Simple wrapper of x/wasmd StoreCode that requires a VAA
 func (k msgServer) StoreCode(goCtx context.Context, msg *types.MsgStoreCode) (*types.MsgStoreCodeResponse, error) {
 	if !k.setWasmd {
@@ -33,12 +25,12 @@ func (k msgServer) StoreCode(goCtx context.Context, msg *types.MsgStoreCode) (*t
 		return nil, err
 	}
 	// Verify VAA
-	action, payload, err := k.VerifyGovernanceVAA(ctx, v, WasmdModule)
+	action, payload, err := k.VerifyGovernanceVAA(ctx, v, vaa.WasmdModule)
 	if err != nil {
 		return nil, err
 	}
 
-	if GovernanceAction(action) != ActionStoreCode {
+	if vaa.GovernanceAction(action) != vaa.ActionStoreCode {
 		return nil, types.ErrUnknownGovernanceAction
 	}
 
@@ -83,12 +75,12 @@ func (k msgServer) InstantiateContract(goCtx context.Context, msg *types.MsgInst
 	}
 
 	// Verify VAA
-	action, payload, err := k.VerifyGovernanceVAA(ctx, v, WasmdModule)
+	action, payload, err := k.VerifyGovernanceVAA(ctx, v, vaa.WasmdModule)
 	if err != nil {
 		return nil, err
 	}
 
-	if GovernanceAction(action) != ActionInstantiateContract {
+	if vaa.GovernanceAction(action) != vaa.ActionInstantiateContract {
 		return nil, types.ErrUnknownGovernanceAction
 	}
 

--- a/wormchain/x/wormhole/keeper/msg_server_wasmd_test.go
+++ b/wormchain/x/wormhole/keeper/msg_server_wasmd_test.go
@@ -22,7 +22,7 @@ func createWasmStoreCodePayload(wasmBytes []byte) []byte {
 	keccak.Write(wasmBytes)
 	keccak.Sum(hashWasm[:0])
 
-	gov_msg := types.NewGovernanceMessage(keeper.WasmdModule, byte(keeper.ActionStoreCode), uint16(vaa.ChainIDWormchain), hashWasm[:])
+	gov_msg := types.NewGovernanceMessage(vaa.WasmdModule, byte(vaa.ActionStoreCode), uint16(vaa.ChainIDWormchain), hashWasm[:])
 	return gov_msg.MarshalBinary()
 }
 
@@ -34,8 +34,8 @@ func createWasmInstantiatePayload(code_id uint64, label string, json_msg string)
 	expected_hash := vaa.CreateInstatiateCosmwasmContractHash(code_id, label, []byte(json_msg))
 
 	var payload bytes.Buffer
-	payload.Write(keeper.WasmdModule[:])
-	payload.Write([]byte{byte(keeper.ActionInstantiateContract)})
+	payload.Write(vaa.WasmdModule[:])
+	payload.Write([]byte{byte(vaa.ActionInstantiateContract)})
 	binary.Write(&payload, binary.BigEndian, uint16(vaa.ChainIDWormchain))
 	// custom payload
 	payload.Write(expected_hash[:])

--- a/wormchain/x/wormhole/types/tx.pb.go
+++ b/wormchain/x/wormhole/types/tx.pb.go
@@ -528,7 +528,7 @@ type MsgClient interface {
 	RegisterAccountAsGuardian(ctx context.Context, in *MsgRegisterAccountAsGuardian, opts ...grpc.CallOption) (*MsgRegisterAccountAsGuardianResponse, error)
 	// StoreCode to submit Wasm code to the system
 	StoreCode(ctx context.Context, in *MsgStoreCode, opts ...grpc.CallOption) (*MsgStoreCodeResponse, error)
-	//  Instantiate creates a new smart contract instance for the given code id.
+	// Instantiate creates a new smart contract instance for the given code id.
 	InstantiateContract(ctx context.Context, in *MsgInstantiateContract, opts ...grpc.CallOption) (*MsgInstantiateContractResponse, error)
 }
 
@@ -582,7 +582,7 @@ type MsgServer interface {
 	RegisterAccountAsGuardian(context.Context, *MsgRegisterAccountAsGuardian) (*MsgRegisterAccountAsGuardianResponse, error)
 	// StoreCode to submit Wasm code to the system
 	StoreCode(context.Context, *MsgStoreCode) (*MsgStoreCodeResponse, error)
-	//  Instantiate creates a new smart contract instance for the given code id.
+	// Instantiate creates a new smart contract instance for the given code id.
 	InstantiateContract(context.Context, *MsgInstantiateContract) (*MsgInstantiateContractResponse, error)
 }
 


### PR DESCRIPTION
https://github.com/wormhole-foundation/wormhole/pull/2057 added wormchain-specific governance messages to the sdk by hardcoding the "WasmdModule" string and uint8 action IDs. This PR cleans up the hardcoded values by using shared consts, following up on the discussion here - https://github.com/wormhole-foundation/wormhole/pull/2057#discussion_r1039804829.

Bringing the governance action consts into the sdk also allows us to eliminate other hardcoded values in the sdk serialization functions.