### PR TITLE
tilt: remove wormchain gentx folder to make deployment robust

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,5 @@ target
 bin
 **/target
 **/node_modules
+
+wormchain/build/config/gentx/


### PR DESCRIPTION
Running `make validators` in wormchain will fail if there already exists a `wormchain/build/config/gentx/` folder:
```
Error: failed to write signed gen tx: open build/config/gentx/gentx-<uuid>.json: file exists`
```

This change ensures that starting tilt with wormchain doesn't fail with this error by remove the `gentx/` from the wormchain directory that's copied over to the docker container.