### PR TITLE
[SDK] Adds parsing for v2 and v3 vaas

### DIFF
--- a/sdk/js/src/bridge/getClaimAddress.ts
+++ b/sdk/js/src/bridge/getClaimAddress.ts
@@ -1,12 +1,12 @@
 import { PublicKeyInitData } from "@solana/web3.js";
 import { deriveClaimKey } from "../solana/wormhole";
-import { parseVaa, SignedVaa } from "../vaa/wormhole";
+import {parseVaaV1, SignedVaa} from "../vaa/wormhole";
 
 export async function getClaimAddressSolana(
   programAddress: PublicKeyInitData,
   signedVaa: SignedVaa
 ) {
-  const parsed = parseVaa(signedVaa);
+  const parsed = parseVaaV1(signedVaa);
   return deriveClaimKey(
     programAddress,
     parsed.emitterAddress,

--- a/sdk/js/src/bridge/getSignedVAAHash.ts
+++ b/sdk/js/src/bridge/getSignedVAAHash.ts
@@ -1,6 +1,6 @@
 import { keccak256 } from "../utils";
-import { parseVaa, SignedVaa } from "../vaa/wormhole";
+import {parseVaaV1, SignedVaa} from "../vaa/wormhole";
 
 export function getSignedVAAHash(signedVaa: SignedVaa): string {
-  return `0x${keccak256(parseVaa(signedVaa).hash).toString("hex")}`;
+  return `0x${keccak256(parseVaaV1(signedVaa).hash).toString("hex")}`;
 }

--- a/sdk/js/src/nft_bridge/getIsTransferCompleted.ts
+++ b/sdk/js/src/nft_bridge/getIsTransferCompleted.ts
@@ -5,7 +5,7 @@ import { Commitment, Connection, PublicKeyInitData } from "@solana/web3.js";
 import { LCDClient } from "@terra-money/terra.js";
 import axios from "axios";
 import { redeemOnTerra } from ".";
-import { TERRA_REDEEMED_CHECK_WALLET_ADDRESS } from "..";
+import {parseVaaV1, TERRA_REDEEMED_CHECK_WALLET_ADDRESS} from "..";
 import { getClaim } from "../solana/wormhole";
 import { parseVaa, SignedVaa } from "../vaa/wormhole";
 
@@ -63,7 +63,7 @@ export async function getIsTransferCompletedSolana(
   connection: Connection,
   commitment?: Commitment
 ) {
-  const parsed = parseVaa(signedVAA);
+  const parsed = parseVaaV1(signedVAA);
   return getClaim(
     connection,
     nftBridgeAddress,

--- a/sdk/js/src/nft_bridge/redeem.ts
+++ b/sdk/js/src/nft_bridge/redeem.ts
@@ -8,7 +8,7 @@ import {
 import { MsgExecuteContract } from "@terra-money/terra.js";
 import { ethers, Overrides } from "ethers";
 import { fromUint8Array } from "js-base64";
-import { CHAIN_ID_SOLANA } from "..";
+import {CHAIN_ID_SOLANA, parseVaaV1} from "..";
 import { Bridge__factory } from "../ethers-contracts";
 import {
   createCompleteTransferNativeInstruction,
@@ -32,7 +32,7 @@ export async function redeemOnEth(
 export async function isNFTVAASolanaNative(
   signedVAA: Uint8Array
 ): Promise<boolean> {
-  return parseVaa(signedVAA).payload.readUInt16BE(33) === CHAIN_ID_SOLANA;
+  return parseVaaV1(signedVAA).payload.readUInt16BE(33) === CHAIN_ID_SOLANA;
 }
 
 export async function redeemOnSolana(

--- a/sdk/js/src/solana/sendAndConfirmPostVaa.ts
+++ b/sdk/js/src/solana/sendAndConfirmPostVaa.ts
@@ -18,7 +18,7 @@ import {
   createPostVaaInstruction,
   createVerifySignaturesInstructions,
 } from "./wormhole";
-import { isBytes, ParsedVaa, parseVaa, SignedVaa } from "../vaa/wormhole";
+import {isBytes, ParsedVaaV1, parseVaaV1, SignedVaa} from "../vaa/wormhole";
 
 export async function postVaaWithRetry(
   connection: Connection,
@@ -131,10 +131,10 @@ export async function createPostSignedVaaTransactions(
   connection: Connection,
   wormholeProgramId: PublicKeyInitData,
   payer: PublicKeyInitData,
-  vaa: SignedVaa | ParsedVaa,
+  vaa: SignedVaa | ParsedVaaV1,
   commitment?: Commitment
 ): Promise<PreparedTransactions> {
-  const parsed = isBytes(vaa) ? parseVaa(vaa) : vaa;
+  const parsed = isBytes(vaa) ? parseVaaV1(vaa) : vaa;
   const signatureSet = Keypair.generate();
 
   const verifySignaturesInstructions = await createVerifySignaturesInstructions(

--- a/sdk/js/src/solana/wormhole/instructions/postVaa.ts
+++ b/sdk/js/src/solana/wormhole/instructions/postVaa.ts
@@ -12,7 +12,7 @@ import {
   deriveGuardianSetKey,
   derivePostedVaaKey,
 } from "../accounts";
-import { isBytes, ParsedVaa, parseVaa, SignedVaa } from "../../../vaa";
+import {isBytes, ParsedVaaV1, parseVaa, parseVaaV1, SignedVaa} from "../../../vaa";
 
 /**
  * Make {@link TransactionInstruction} for `post_vaa` instruction.
@@ -25,16 +25,16 @@ import { isBytes, ParsedVaa, parseVaa, SignedVaa } from "../../../vaa";
  *
  * @param {PublicKeyInitData} wormholeProgramId - wormhole program address
  * @param {PublicKeyInitData} payer - transaction signer address
- * @param {SignedVaa | ParsedVaa} vaa - either signed VAA bytes or parsed VAA (use {@link parseVaa} on signed VAA)
+ * @param {SignedVaa | ParsedVaaV1} vaa - either signed VAA bytes or parsed VAA (use {@link parseVaa} on signed VAA)
  * @param {PublicKeyInitData} signatureSet - key for signature set account
  */
 export function createPostVaaInstruction(
   wormholeProgramId: PublicKeyInitData,
   payer: PublicKeyInitData,
-  vaa: SignedVaa | ParsedVaa,
+  vaa: SignedVaa | ParsedVaaV1,
   signatureSet: PublicKeyInitData
 ): TransactionInstruction {
-  const parsed = isBytes(vaa) ? parseVaa(vaa) : vaa;
+  const parsed = isBytes(vaa) ? parseVaaV1(vaa) : vaa;
   const methods = createReadOnlyWormholeProgramInterface(
     wormholeProgramId
   ).methods.postVaa(
@@ -79,9 +79,9 @@ export function getPostVaaAccounts(
   wormholeProgramId: PublicKeyInitData,
   payer: PublicKeyInitData,
   signatureSet: PublicKeyInitData,
-  vaa: SignedVaa | ParsedVaa
+  vaa: SignedVaa | ParsedVaaV1
 ): PostVaaAccounts {
-  const parsed = isBytes(vaa) ? parseVaa(vaa) : vaa;
+  const parsed = isBytes(vaa) ? parseVaaV1(vaa) : vaa;
   return {
     guardianSet: deriveGuardianSetKey(
       wormholeProgramId,

--- a/sdk/js/src/solana/wormhole/instructions/verifySignature.ts
+++ b/sdk/js/src/solana/wormhole/instructions/verifySignature.ts
@@ -14,7 +14,7 @@ import {
   deriveGuardianSetKey,
   getWormholeBridgeData,
 } from "../accounts";
-import { isBytes, ParsedVaa, parseVaa, SignedVaa } from "../../../vaa";
+import {isBytes, ParsedVaaV1, parseVaa, parseVaaV1, SignedVaa} from "../../../vaa";
 import { createReadOnlyWormholeProgramInterface } from "../program";
 
 const MAX_LEN_GUARDIAN_KEYS = 19;
@@ -36,7 +36,7 @@ const MAX_LEN_GUARDIAN_KEYS = 19;
  * @param {Connection} connection - Solana web3 connection
  * @param {PublicKeyInitData} wormholeProgramId - wormhole program address
  * @param {PublicKeyInitData} payer - transaction signer address
- * @param {SignedVaa | ParsedVaa} vaa - either signed VAA bytes or parsed VAA (use {@link parseVaa} on signed VAA)
+ * @param {SignedVaa | ParsedVaaV1} vaa - either signed VAA bytes or parsed VAA (use {@link parseVaa} on signed VAA)
  * @param {PublicKeyInitData} signatureSet - address to account of verified signatures
  * @param {web3.ConfirmOptions} [options] - Solana confirmation options
  */
@@ -44,11 +44,11 @@ export async function createVerifySignaturesInstructions(
   connection: Connection,
   wormholeProgramId: PublicKeyInitData,
   payer: PublicKeyInitData,
-  vaa: SignedVaa | ParsedVaa,
+  vaa: SignedVaa | ParsedVaaV1,
   signatureSet: PublicKeyInitData,
   commitment?: Commitment
 ): Promise<TransactionInstruction[]> {
-  const parsed = isBytes(vaa) ? parseVaa(vaa) : vaa;
+  const parsed = isBytes(vaa) ? parseVaaV1(vaa) : vaa;
   const guardianSetIndex = parsed.guardianSetIndex;
   const info = await getWormholeBridgeData(connection, wormholeProgramId);
   if (guardianSetIndex != info.guardianSetIndex) {
@@ -111,7 +111,7 @@ export async function createVerifySignaturesInstructions(
  *
  * @param {PublicKeyInitData} wormholeProgramId - wormhole program address
  * @param {PublicKeyInitData} payer - transaction signer address
- * @param {SignedVaa | ParsedVaa} vaa - either signed VAA (Buffer) or parsed VAA (use {@link parseVaa} on signed VAA)
+ * @param {SignedVaa | ParsedVaaV1} vaa - either signed VAA (Buffer) or parsed VAA (use {@link parseVaa} on signed VAA)
  * @param {PublicKeyInitData} signatureSet - key for signature set account
  * @param {Buffer} signatureStatus - array of guardian indices
  *
@@ -119,7 +119,7 @@ export async function createVerifySignaturesInstructions(
 function createVerifySignaturesInstruction(
   wormholeProgramId: PublicKeyInitData,
   payer: PublicKeyInitData,
-  vaa: SignedVaa | ParsedVaa,
+  vaa: SignedVaa | ParsedVaaV1,
   signatureSet: PublicKeyInitData,
   signatureStatus: Buffer
 ): TransactionInstruction {
@@ -155,9 +155,9 @@ export function getVerifySignatureAccounts(
   wormholeProgramId: PublicKeyInitData,
   payer: PublicKeyInitData,
   signatureSet: PublicKeyInitData,
-  vaa: SignedVaa | ParsedVaa
+  vaa: SignedVaa | ParsedVaaV1
 ): VerifySignatureAccounts {
-  const parsed = isBytes(vaa) ? parseVaa(vaa) : vaa;
+  const parsed = isBytes(vaa) ? parseVaaV1(vaa) : vaa;
   return {
     payer: new PublicKey(payer),
     guardianSet: deriveGuardianSetKey(

--- a/sdk/js/src/token_bridge/getIsTransferCompleted.ts
+++ b/sdk/js/src/token_bridge/getIsTransferCompleted.ts
@@ -9,7 +9,7 @@ import { fromUint8Array } from "js-base64";
 import { redeemOnTerra } from ".";
 import {
   ensureHexPrefix,
-  parseSmartContractStateResponse,
+  parseSmartContractStateResponse, parseVaaV1,
   TERRA_REDEEMED_CHECK_WALLET_ADDRESS,
 } from "..";
 import { getClaim } from "../solana/wormhole";
@@ -155,7 +155,7 @@ export async function getIsTransferCompletedSolana(
   connection: Connection,
   commitment?: Commitment
 ): Promise<boolean> {
-  const parsed = parseVaa(signedVAA);
+  const parsed = parseVaaV1(signedVAA);
   return getClaim(
     connection,
     tokenBridgeAddress,

--- a/sdk/js/src/utils/repairVaa.ts
+++ b/sdk/js/src/utils/repairVaa.ts
@@ -1,7 +1,7 @@
 import { ethers } from "ethers";
 import { CONTRACTS } from "./consts";
 import { Implementation__factory } from "../ethers-contracts";
-import { parseVaa, GuardianSignature } from "../vaa";
+import {GuardianSignature, parseVaaV1} from "../vaa";
 import { hexToUint8Array } from "./array";
 import { keccak256 } from "../utils";
 
@@ -50,7 +50,7 @@ export function repairVaa(
   const minNumSignatures =
     Math.floor((2.0 * currentGuardianSet.length) / 3.0) + 1;
   const version = vaaHex.slice(0, 2);
-  const parsedVaa = parseVaa(hexToUint8Array(vaaHex));
+  const parsedVaa = parseVaaV1(hexToUint8Array(vaaHex));
   const numSignatures = parsedVaa.guardianSignatures.length;
   const digest = keccak256(parsedVaa.hash).toString("hex");
 

--- a/sdk/js/src/vaa/governance.ts
+++ b/sdk/js/src/vaa/governance.ts
@@ -1,4 +1,4 @@
-import { ParsedVaa, parseVaa, SignedVaa } from "./wormhole";
+import {ParsedVaaV1, parseVaa, parseVaaV1, SignedVaa} from "./wormhole";
 
 export interface Governance {
   module: string;
@@ -7,10 +7,10 @@ export interface Governance {
   orderPayload: Buffer;
 }
 
-export interface ParsedGovernanceVaa extends ParsedVaa, Governance {}
+export interface ParsedGovernanceVaa extends ParsedVaaV1, Governance {}
 
 export function parseGovernanceVaa(vaa: SignedVaa): ParsedGovernanceVaa {
-  const parsed = parseVaa(vaa);
+  const parsed = parseVaaV1(vaa);
   return {
     ...parsed,
     ...parseGovernancePayload(parsed.payload),

--- a/sdk/js/src/vaa/nftBridge.ts
+++ b/sdk/js/src/vaa/nftBridge.ts
@@ -6,7 +6,7 @@ import {
   TokenBridgeRegisterChain,
   TokenBridgeUpgradeContract,
 } from "./tokenBridge";
-import { ParsedVaa, parseVaa, SignedVaa } from "./wormhole";
+import {ParsedVaaV1, parseVaaV1, SignedVaa} from "./wormhole";
 
 export enum NftBridgePayload {
   Transfer = 1,
@@ -57,10 +57,10 @@ export function parseNftTransferPayload(payload: Buffer): NftTransfer {
   };
 }
 
-export interface ParsedNftTransferVaa extends ParsedVaa, NftTransfer {}
+export interface ParsedNftTransferVaa extends ParsedVaaV1, NftTransfer {}
 
 export function parseNftTransferVaa(vaa: SignedVaa): ParsedNftTransferVaa {
-  const parsed = parseVaa(vaa);
+  const parsed = parseVaaV1(vaa);
   return {
     ...parsed,
     ...parseNftTransferPayload(parsed.payload),

--- a/sdk/js/src/vaa/tokenBridge.ts
+++ b/sdk/js/src/vaa/tokenBridge.ts
@@ -1,6 +1,6 @@
 import { BN } from "@project-serum/anchor";
 import { ParsedGovernanceVaa, parseGovernanceVaa } from "./governance";
-import { ParsedVaa, parseVaa, SignedVaa } from "./wormhole";
+import {ParsedVaaV1, parseVaa, parseVaaV1, SignedVaa} from "./wormhole";
 
 export enum TokenBridgePayload {
   Transfer = 1,
@@ -59,10 +59,10 @@ export function parseTokenTransferPayload(payload: Buffer): TokenTransfer {
   };
 }
 
-export interface ParsedTokenTransferVaa extends ParsedVaa, TokenTransfer {}
+export interface ParsedTokenTransferVaa extends ParsedVaaV1, TokenTransfer {}
 
 export function parseTokenTransferVaa(vaa: SignedVaa): ParsedTokenTransferVaa {
-  const parsed = parseVaa(vaa);
+  const parsed = parseVaaV1(vaa);
   return {
     ...parsed,
     ...parseTokenTransferPayload(parsed.payload),
@@ -98,11 +98,11 @@ export function parseAttestMetaPayload(payload: Buffer): AssetMeta {
   };
 }
 
-export interface ParsedAssetMetaVaa extends ParsedVaa, AssetMeta {}
+export interface ParsedAssetMetaVaa extends ParsedVaaV1, AssetMeta {}
 export type ParsedAttestMetaVaa = ParsedAssetMetaVaa;
 
 export function parseAttestMetaVaa(vaa: SignedVaa): ParsedAssetMetaVaa {
-  const parsed = parseVaa(vaa);
+  const parsed = parseVaaV1(vaa);
   return {
     ...parsed,
     ...parseAttestMetaPayload(parsed.payload),

--- a/sdk/js/src/vaa/wormhole.ts
+++ b/sdk/js/src/vaa/wormhole.ts
@@ -7,10 +7,26 @@ export interface GuardianSignature {
   signature: Buffer;
 }
 
-export interface ParsedVaa {
+interface ParsedVaaHeader {
   version: number;
   guardianSetIndex: number;
   guardianSignatures: GuardianSignature[];
+}
+
+export type ParsedVaaV1 = ParsedVaaHeader & ParsedVaaV3;
+
+// BatchVAA
+export interface ParsedVaaV2 {
+  version: number;
+  guardianSetIndex: number;
+  guardianSignatures: GuardianSignature[];
+  hashes: Buffer[];
+  observations: ParsedVaaV3[];
+}
+
+// Headless VAA inside Batch
+export interface ParsedVaaV3 {
+  version: number;
   timestamp: number;
   nonce: number;
   emitterChain: number;
@@ -21,28 +37,40 @@ export interface ParsedVaa {
   hash: Buffer;
 }
 
+type ParsedVaa = ParsedVaaV1 | ParsedVaaV2 | ParsedVaaV3;
+
 export type SignedVaa = Uint8Array | Buffer;
 
 export function parseVaa(vaa: SignedVaa): ParsedVaa {
   const signedVaa = Buffer.isBuffer(vaa) ? vaa : Buffer.from(vaa as Uint8Array);
-  const sigStart = 6;
-  const numSigners = signedVaa[5];
-  const sigLength = 66;
+  const version = signedVaa[0];
+  switch (version) {
+    case 1:
+      // Traditional VAA
+      return parseVaaV1(signedVaa);
+    case 2:
+      // Batch VAA
+      return parseVaaV2(signedVaa);
+    default:
+      throw new Error("Unrecognized Vaa Version");
+  }
+}
 
-  const guardianSignatures: GuardianSignature[] = [];
-  for (let i = 0; i < numSigners; ++i) {
-    const start = sigStart + i * sigLength;
-    guardianSignatures.push({
-      index: signedVaa[start],
-      signature: signedVaa.subarray(start + 1, start + 66),
-    });
+export function parseVaaV1(vaa: SignedVaa): ParsedVaaV1 {
+  const signedVaa = Buffer.isBuffer(vaa) ? vaa : Buffer.from(vaa as Uint8Array);
+  const {
+    header: { version, guardianSetIndex, guardianSignatures },
+    headerSize,
+  } = parseHeader(signedVaa);
+  if (version !== 1) {
+    throw new Error("trying to parse a different version vaa");
   }
 
-  const body = signedVaa.subarray(sigStart + sigLength * numSigners);
+  const body = signedVaa.subarray(headerSize);
 
   return {
-    version: signedVaa[0],
-    guardianSetIndex: signedVaa.readUInt32BE(1),
+    version,
+    guardianSetIndex,
     guardianSignatures,
     timestamp: body.readUInt32BE(0),
     nonce: body.readUInt32BE(4),
@@ -52,5 +80,112 @@ export function parseVaa(vaa: SignedVaa): ParsedVaa {
     consistencyLevel: body[50],
     payload: body.subarray(51),
     hash: keccak256(body),
+  };
+}
+
+const minBatchVAALength = 94; // HEADER + BATCH
+
+// Batch VAA Parsing. Whitepaper: https://github.com/wormhole-foundation/wormhole/blob/main/whitepapers/0008_batch_messaging.md#payloads-encoded-messages
+export function parseVaaV2(vaa: SignedVaa): ParsedVaaV2 {
+  const signedVaa = Buffer.isBuffer(vaa) ? vaa : Buffer.from(vaa as Uint8Array);
+  if (signedVaa.length < minBatchVAALength) {
+    throw new Error("BatchVAA.Observation is too short");
+  }
+
+  const {
+    header: { version, guardianSetIndex, guardianSignatures },
+    headerSize,
+  } = parseHeader(signedVaa);
+  if (version !== 2) {
+    throw new Error("trying to parse a different version vaa");
+  }
+
+  // calculate when hashes and observations begin and end
+  const lenHashes = signedVaa[headerSize];
+  const hashLength = 32;
+  const hashesStartAt = headerSize + 1;
+  const observationsStartAt = hashesStartAt + lenHashes * hashLength;
+
+  // parse hashes
+  const hashesBytes = signedVaa.subarray(hashesStartAt, observationsStartAt);
+  const hashes = [];
+  for (let i = 0; i < lenHashes; ++i) {
+    const start = i * hashLength;
+    hashes.push(hashesBytes.subarray(start, start + hashLength));
+  }
+
+  // parse observations
+  const observationsBytes = signedVaa.subarray(observationsStartAt);
+  const lenObservations = observationsBytes[0];
+  if (lenObservations !== lenHashes) {
+    throw new Error(
+      "failed unmarshaling BatchVAA, observations differs from hashes"
+    );
+  }
+  const observations = [];
+  let offset = 1;
+  for (let i = 0; i < lenObservations; i++) {
+    const index = observationsBytes.readUInt8(offset);
+    offset += 1;
+    const size = observationsBytes.readUInt32BE(offset);
+    offset += 4;
+    // TODO checks & validation
+    const vaaBodyBytes = observationsBytes.subarray(offset, offset + size);
+    const observation = parseVaaV3(vaaBodyBytes);
+    observations[index] = observation;
+    offset += size;
+  }
+
+  return {
+    version,
+    guardianSetIndex,
+    guardianSignatures,
+    hashes,
+    observations,
+  };
+}
+
+function parseHeader(signedVaa: Buffer): {
+  header: ParsedVaaHeader;
+  headerSize: number;
+} {
+  const signaturesStartAt = 6;
+  const version = signedVaa[0];
+  if (version !== 2) {
+    throw new Error("trying to parse a different version vaa");
+  }
+  const guardianSetIndex = signedVaa.readUInt32BE(1);
+  // parse signatures
+  const lenSigners = signedVaa[5];
+  const sigLength = 66;
+  const guardianSignatures = [];
+  for (let i = 0; i < lenSigners; ++i) {
+    const start = signaturesStartAt + i * sigLength;
+    guardianSignatures.push({
+      index: signedVaa[start],
+      signature: signedVaa.subarray(start + 1, start + sigLength),
+    });
+  }
+  return {
+    header: {
+      version,
+      guardianSetIndex,
+      guardianSignatures,
+    },
+    headerSize: signaturesStartAt + sigLength * lenSigners,
+  };
+}
+
+function parseVaaV3(vaaBodyBytes: any): ParsedVaaV3 {
+  return {
+    version: 3,
+    timestamp: vaaBodyBytes.readUInt32BE(0),
+    nonce: vaaBodyBytes.readUInt32BE(4),
+    emitterChain: vaaBodyBytes.readUInt16BE(8),
+    emitterAddress: vaaBodyBytes.subarray(10, 42),
+    sequence: vaaBodyBytes.readBigUInt64BE(42),
+    consistencyLevel: vaaBodyBytes[50],
+    payload: vaaBodyBytes.subarray(51),
+    hash: keccak256(vaaBodyBytes),
   };
 }


### PR DESCRIPTION
Missing from the PR:

- [ ] Tests
- [ ] The parseVaa function now returns a union type, is this breaking change ok?

This is a draft, I'm not a contributor so I can't mark it as such but I'm looking for feedback in terms of the coding style and approach taking for parsing batch vaas. 