### PR TITLE
sdk/js: solana cpi and serialization fixes

### DIFF
--- a/sdk/js/src/solana/tokenBridge/cpi.ts
+++ b/sdk/js/src/solana/tokenBridge/cpi.ts
@@ -340,23 +340,24 @@ export interface CompleteTransferNativeWithPayloadCpiAccounts
  * you only need to pass your `toTokenAccount` into the complete transfer
  * instruction for the `toFeesTokenAccount`.
  *
- * @param cpiProgramId
  * @param tokenBridgeProgramId
  * @param wormholeProgramId
  * @param payer
  * @param vaa
+ * @param toTokenAccount
  * @returns
  */
 export function getCompleteTransferNativeWithPayloadCpiAccounts(
-  cpiProgramId: PublicKeyInitData,
   tokenBridgeProgramId: PublicKeyInitData,
   wormholeProgramId: PublicKeyInitData,
   payer: PublicKeyInitData,
-  vaa: SignedVaa | ParsedTokenTransferVaa
+  vaa: SignedVaa | ParsedTokenTransferVaa,
+  toTokenAccount: PublicKeyInitData
 ): CompleteTransferNativeWithPayloadCpiAccounts {
   const parsed = isBytes(vaa) ? parseTokenTransferVaa(vaa) : vaa;
   const mint = new PublicKey(parsed.tokenAddress);
-  const toTokenAccount = new PublicKey(parsed.to);
+  const cpiProgramId = new PublicKey(parsed.to);
+
   return {
     payer: new PublicKey(payer),
     tokenBridgeConfig: deriveTokenBridgeConfigKey(tokenBridgeProgramId),
@@ -372,9 +373,9 @@ export function getCompleteTransferNativeWithPayloadCpiAccounts(
       parsed.emitterChain,
       parsed.emitterAddress
     ),
-    toTokenAccount,
+    toTokenAccount: new PublicKey(toTokenAccount),
     tokenBridgeRedeemer: deriveRedeemerAccountKey(cpiProgramId),
-    toFeesTokenAccount: toTokenAccount,
+    toFeesTokenAccount: new PublicKey(toTokenAccount),
     tokenBridgeCustody: deriveCustodyKey(tokenBridgeProgramId, mint),
     mint,
     tokenBridgeCustodySigner: deriveCustodySignerKey(tokenBridgeProgramId),
@@ -435,11 +436,11 @@ export interface CompleteTransferWrappedWithPayloadCpiAccounts
  * @returns
  */
 export function getCompleteTransferWrappedWithPayloadCpiAccounts(
-  cpiProgramId: PublicKeyInitData,
   tokenBridgeProgramId: PublicKeyInitData,
   wormholeProgramId: PublicKeyInitData,
   payer: PublicKeyInitData,
-  vaa: SignedVaa | ParsedTokenTransferVaa
+  vaa: SignedVaa | ParsedTokenTransferVaa,
+  toTokenAccount: PublicKeyInitData
 ): CompleteTransferWrappedWithPayloadCpiAccounts {
   const parsed = isBytes(vaa) ? parseTokenTransferVaa(vaa) : vaa;
   const mint = deriveWrappedMintKey(
@@ -447,7 +448,7 @@ export function getCompleteTransferWrappedWithPayloadCpiAccounts(
     parsed.tokenChain,
     parsed.tokenAddress
   );
-  const toTokenAccount = new PublicKey(parsed.to);
+  const cpiProgramId = new PublicKey(parsed.to);
   return {
     payer: new PublicKey(payer),
     tokenBridgeConfig: deriveTokenBridgeConfigKey(tokenBridgeProgramId),
@@ -463,9 +464,9 @@ export function getCompleteTransferWrappedWithPayloadCpiAccounts(
       parsed.emitterChain,
       parsed.emitterAddress
     ),
-    toTokenAccount,
+    toTokenAccount: new PublicKey(toTokenAccount),
     tokenBridgeRedeemer: deriveRedeemerAccountKey(cpiProgramId),
-    toFeesTokenAccount: toTokenAccount,
+    toFeesTokenAccount: new PublicKey(toTokenAccount),
     tokenBridgeWrappedMint: mint,
     tokenBridgeWrappedMeta: deriveWrappedMetaKey(tokenBridgeProgramId, mint),
     tokenBridgeMintAuthority: deriveMintAuthorityKey(tokenBridgeProgramId),

--- a/sdk/js/src/solana/wormhole/accounts/claim.ts
+++ b/sdk/js/src/solana/wormhole/accounts/claim.ts
@@ -20,7 +20,7 @@ export function deriveClaimKey(
     throw Error("address.length != 32");
   }
   const sequenceSerialized = Buffer.alloc(8);
-  sequenceSerialized.writeBigInt64BE(
+  sequenceSerialized.writeBigUInt64BE(
     typeof sequence == "number" ? BigInt(sequence) : sequence
   );
   return deriveAddress(

--- a/sdk/js/src/solana/wormhole/coder/accounts.ts
+++ b/sdk/js/src/solana/wormhole/coder/accounts.ts
@@ -65,7 +65,7 @@ function encodePostVaaData(account: PostVAAData): Buffer {
   serialized.writeUInt32LE(account.nonce, 9);
   serialized.writeUInt16LE(account.emitterChain, 13);
   serialized.write(account.emitterAddress.toString("hex"), 15, "hex");
-  serialized.writeBigInt64LE(account.sequence, 47);
+  serialized.writeBigUInt64LE(account.sequence, 47);
   serialized.writeUInt8(account.consistencyLevel, 55);
   serialized.writeUInt32LE(payload.length, 56);
   serialized.write(payload.toString("hex"), 60, "hex");

--- a/sdk/js/src/solana/wormhole/coder/instruction.ts
+++ b/sdk/js/src/solana/wormhole/coder/instruction.ts
@@ -123,7 +123,7 @@ function encodePostVaa({
   serialized.writeUInt32LE(nonce, 9);
   serialized.writeUInt16LE(emitterChain, 13);
   serialized.write(emitterAddress.toString("hex"), 15, "hex");
-  serialized.writeBigInt64LE(sequence, 47);
+  serialized.writeBigUInt64LE(sequence, 47);
   serialized.writeUInt8(consistencyLevel, 55);
   serialized.writeUInt32LE(payload.length, 56);
   serialized.write(payload.toString("hex"), 60, "hex");

--- a/testing/solana-test-validator/sdk-tests/2_token_bridge.ts
+++ b/testing/solana-test-validator/sdk-tests/2_token_bridge.ts
@@ -29,6 +29,7 @@ import {
   deriveCustodyKey,
   deriveEndpointKey,
   deriveMintAuthorityKey,
+  deriveRedeemerAccountKey,
   deriveWrappedMintKey,
   getAttestTokenAccounts,
   getCompleteTransferNativeAccounts,
@@ -714,7 +715,8 @@ describe("Token Bridge", () => {
 
     it("getCompleteTransferNativeWithPayloadCpiAccounts", () => {
       const mint = NATIVE_MINT;
-      const mintAta = getAssociatedTokenAddressSync(mint, cpiProgramId, true);
+      const redeemer = deriveRedeemerAccountKey(cpiProgramId);
+      const mintAta = getAssociatedTokenAddressSync(mint, redeemer, true);
 
       const amountEncoded = 42069n;
 
@@ -725,7 +727,7 @@ describe("Token Bridge", () => {
         1,
         amountEncoded,
         1,
-        mintAta.toBuffer().toString("hex"),
+        cpiProgramId.toBuffer().toString("hex"),
         Buffer.alloc(32, 0),
         Buffer.from("All your base are belong to us"),
         nonce,
@@ -739,11 +741,11 @@ describe("Token Bridge", () => {
       );
 
       const accounts = getCompleteTransferNativeWithPayloadCpiAccounts(
-        cpiProgramId,
         TOKEN_BRIDGE_ADDRESS,
         CORE_BRIDGE_ADDRESS,
         payer,
-        signedVaa
+        signedVaa,
+        mintAta
       );
 
       // verify accounts
@@ -752,7 +754,7 @@ describe("Token Bridge", () => {
         "GnQ6fGttTRnJpAJuy2XEg5TLgEMtbyU4HDJnBWmojsTv"
       );
       expect(accounts.vaa.toString()).to.equal(
-        "9jdun7HMoJp7KL1jRYF7MT9pjRLVM3RPDbDgf6qXNBR4"
+        "GtiCPc4mxBVsrPQVgYnuVUzhuvh24A54KaDZhcP4mhDa"
       );
       expect(accounts.tokenBridgeClaim.toString()).to.equal(
         "HzjTihvhEx7BbKnB2KHATNBwGFCEm2nnMG6c4Pwx6pPE"
@@ -787,7 +789,8 @@ describe("Token Bridge", () => {
         tokenChain,
         tokenAddress
       );
-      const mintAta = getAssociatedTokenAddressSync(mint, cpiProgramId, true);
+      const redeemer = deriveRedeemerAccountKey(cpiProgramId);
+      const mintAta = getAssociatedTokenAddressSync(mint, redeemer, true);
 
       const amount = 4206942069n;
       const recipientChain = 1;
@@ -798,7 +801,7 @@ describe("Token Bridge", () => {
         tokenChain,
         amount,
         recipientChain,
-        mintAta.toBuffer().toString("hex"),
+        cpiProgramId.toBuffer().toString("hex"),
         Buffer.alloc(32, 0),
         Buffer.from("All your base are belong to us"),
         nonce,
@@ -812,11 +815,11 @@ describe("Token Bridge", () => {
       );
 
       const accounts = getCompleteTransferWrappedWithPayloadCpiAccounts(
-        cpiProgramId,
         TOKEN_BRIDGE_ADDRESS,
         CORE_BRIDGE_ADDRESS,
         payer,
-        signedVaa
+        signedVaa,
+        mintAta
       );
 
       // verify accounts
@@ -825,7 +828,7 @@ describe("Token Bridge", () => {
         "GnQ6fGttTRnJpAJuy2XEg5TLgEMtbyU4HDJnBWmojsTv"
       );
       expect(accounts.vaa.toString()).to.equal(
-        "3czQYHVjwCNBAaQAAoMcmtLwXkF16UG1E1wU4RM9tje7"
+        "9nFMaAfuXmE4FdJe8koZ4ScvYcJ5znoJPDgT29aVZM1x"
       );
       expect(accounts.tokenBridgeClaim.toString()).to.equal(
         "7Ae57QxvZMwCrknoDWpeaMTLbMP3LBeCJee6KaLEwxP6"


### PR DESCRIPTION
# Objective

Minor fixes for Solana-related interactions using the Javascript SDK.
- generating CPI accounts for completing transfer (native and wrapped)
- serialization of account and instruction data 

# How to Review this PR
1. Go to _testing/solana_test_validator_ and run `make test` to verify that the tests work.
2. Review code changes.
3. Review changes in the test.