### PR TITLE
cosmwasm: accounting: Fix chain registration query return type

### DIFF
--- a/cosmwasm/contracts/wormchain-accounting/src/contract.rs
+++ b/cosmwasm/contracts/wormchain-accounting/src/contract.rs
@@ -15,6 +15,7 @@ use cosmwasm_std::{
 use cw2::set_contract_version;
 use cw_storage_plus::Bound;
 use tinyvec::{Array, TinyVec};
+use tokenbridge::msg::ChainRegistrationResponse;
 use wormhole::{
     token::Message,
     vaa::{Body, Header, Signature},
@@ -224,7 +225,9 @@ fn handle_observation(
         .load(deps.storage)
         .context("failed to load tokenbridge addr")?;
 
-    let registered_emitter: Vec<u8> = deps
+    let ChainRegistrationResponse {
+        address: registered_emitter,
+    } = deps
         .querier
         .query_wasm_smart(
             tokenbridge_addr,

--- a/cosmwasm/contracts/wormchain-accounting/tests/helpers/fake_tokenbridge.rs
+++ b/cosmwasm/contracts/wormchain-accounting/tests/helpers/fake_tokenbridge.rs
@@ -1,7 +1,7 @@
 use cosmwasm_std::{
     to_binary, Binary, Deps, DepsMut, Empty, Env, MessageInfo, Response, StdError, StdResult,
 };
-use tokenbridge::msg::QueryMsg;
+use tokenbridge::msg::{ChainRegistrationResponse, QueryMsg};
 
 pub fn instantiate(_: DepsMut, _: Env, _: MessageInfo, _: Empty) -> StdResult<Response> {
     Ok(Response::new())
@@ -15,7 +15,9 @@ pub fn execute(_: DepsMut, _: Env, _: MessageInfo, _: Empty) -> StdResult<Respon
 
 pub fn query(_: Deps, _: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
-        QueryMsg::ChainRegistration { chain } => to_binary(&vec![chain as u8; 32]),
+        QueryMsg::ChainRegistration { chain } => to_binary(&ChainRegistrationResponse {
+            address: vec![chain as u8; 32].into(),
+        }),
         _ => Err(StdError::GenericErr {
             msg: "unimplemented query message".into(),
         }),


### PR DESCRIPTION
The tokenbridge chain registration query returns a
`ChainRegistrationResponse` struct and not a `Vec<u8>`.  Use the proper
return type when sending the query.