### PR TITLE
cosmwasm: wormhole: remove unnecessary cast to usize

### DIFF
--- a/cosmwasm/contracts/wormhole/src/state.rs
+++ b/cosmwasm/contracts/wormhole/src/state.rs
@@ -137,7 +137,7 @@ impl ParsedVAA {
         // Load 4 bytes starting from index 1
         let guardian_set_index: u32 = data.get_u32(Self::GUARDIAN_SET_INDEX_POS);
         let len_signers = data.get_u8(Self::LEN_SIGNER_POS) as usize;
-        let body_offset: usize = Self::HEADER_LEN + Self::SIGNATURE_LEN * len_signers as usize;
+        let body_offset: usize = Self::HEADER_LEN + Self::SIGNATURE_LEN * len_signers;
 
         // Hash the body
         if body_offset >= data.len() {

--- a/terra/contracts/wormhole/src/state.rs
+++ b/terra/contracts/wormhole/src/state.rs
@@ -102,7 +102,7 @@ impl ParsedVAA {
         // Load 4 bytes starting from index 1
         let guardian_set_index: u32 = data.get_u32(Self::GUARDIAN_SET_INDEX_POS);
         let len_signers = data.get_u8(Self::LEN_SIGNER_POS) as usize;
-        let body_offset: usize = Self::HEADER_LEN + Self::SIGNATURE_LEN * len_signers as usize;
+        let body_offset: usize = Self::HEADER_LEN + Self::SIGNATURE_LEN * len_signers;
 
         // Hash the body
         if body_offset >= data.len() {


### PR DESCRIPTION
Remove unnecessary casting to `usize`. This fixes the clippy errors in ci.