### PR TITLE
sui: update to 0.19.0, rebuild docker image, fix tests

### DIFF
--- a/sui/Docker.md
+++ b/sui/Docker.md
@@ -2,8 +2,8 @@
 #(cd ..; DOCKER_BUILDKIT=1 docker build --no-cache --progress plain -f sui/Dockerfile.base -t sui .)
 (cd ..; DOCKER_BUILDKIT=1 docker build $1 --progress plain -f sui/Dockerfile.base -t sui .)
 # tag the image with the appropriate version
-docker tag sui:latest ghcr.io/wormhole-foundation/sui:0.17.0
+docker tag sui:latest ghcr.io/wormhole-foundation/sui:0.19.0
 # push to ghcr
-docker push ghcr.io/wormhole-foundation/sui:0.17.0
+docker push ghcr.io/wormhole-foundation/sui:0.19.0
 
 echo remember to update both Dockerfile and Dockerfile.export

--- a/sui/Dockerfile
+++ b/sui/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/wormhole-foundation/sui:0.17.0@sha256:70ce60378c268fad1ca275b79353c71ff149119736cda43ac9a5f435613621da as sui
+FROM ghcr.io/wormhole-foundation/sui:0.19.0@sha256:8181f3b2cc64fdb51de8f112eede3a829ae687d5fc62d9e37e96e3bb4665494a as sui
 
 RUN dnf -y install make git
 

--- a/sui/token_bridge/sources/bridge_state.move
+++ b/sui/token_bridge/sources/bridge_state.move
@@ -380,7 +380,7 @@ module token_bridge::bridge_state_test{
     }
 
     #[test]
-    #[expected_failure(abort_code = 0)]
+    #[expected_failure(abort_code = 0, location=0000000000000000000000000000000000000002::dynamic_field)]
     fun test_coin_type_addressing_failure_case(){
         test_coin_type_addressing_failure_case_(scenario())
     }

--- a/sui/token_bridge/sources/newtypes/string32.move
+++ b/sui/token_bridge/sources/newtypes/string32.move
@@ -126,7 +126,7 @@ module token_bridge::string32_test {
     }
 
     #[test]
-    #[expected_failure(abort_code = 0)]
+    #[expected_failure(abort_code = string32::E_STRING_TOO_LONG)]
     public fun test_right_pad_fail() {
         let too_long = string::utf8(b"this string is very very very very very very very very very very very very very very very long");
         string32::right_pad(&too_long);

--- a/sui/token_bridge/sources/register_chain.move
+++ b/sui/token_bridge/sources/register_chain.move
@@ -111,7 +111,7 @@ module token_bridge::register_chain_test {
     }
 
     #[test]
-    #[expected_failure(abort_code = 0)]
+    #[expected_failure(abort_code = 0, location=token_bridge::register_chain)]
     fun test_parse_fail(){
         test_parse_fail_(scenario())
     }
@@ -122,7 +122,7 @@ module token_bridge::register_chain_test {
     }
 
     #[test]
-    #[expected_failure(abort_code = 0)]
+    #[expected_failure(abort_code = 0, location=0000000000000000000000000000000000000002::dynamic_field)]
     fun test_replay_protect(){
         test_replay_protect_(scenario())
     }

--- a/sui/token_bridge/sources/vaa.move
+++ b/sui/token_bridge/sources/vaa.move
@@ -83,7 +83,7 @@ module token_bridge::token_bridge_vaa_test{
     const VAA: vector<u8> = x"01000000000100102d399190fa61daccb11c2ea4f7a3db3a9365e5936bcda4cded87c1b9eeb095173514f226256d5579af71d4089eb89496befb998075ba94cd1d4460c5c57b84000000000100000001000200000000000000000000000000000000000000000000000000000000deadbeef0000000002634973000200000000000000000000000000000000000000000000000000000000beefface00020c0000000000000000000000000000000000000000000000000000000042454546000000000000000000000000000000000042656566206661636520546f6b656e";
 
     #[test]
-    #[expected_failure(abort_code = 0)] // E_UNKNOWN_CHAIN
+    #[expected_failure(abort_code = vaa::E_UNKNOWN_CHAIN)]
     fun test_unknown_chain() {
         let (admin, _, _) = people();
         let test = scenario();
@@ -101,7 +101,7 @@ module token_bridge::token_bridge_vaa_test{
 
 
     #[test]
-    #[expected_failure(abort_code = 1)] // E_UNKNOWN_EMITTER
+    #[expected_failure(abort_code = vaa::E_UNKNOWN_EMITTER)]
     fun test_unknown_emitter() {
         let (admin, _, _) = people();
         let test = scenario();
@@ -156,7 +156,7 @@ module token_bridge::token_bridge_vaa_test{
     }
 
     #[test]
-    #[expected_failure(abort_code = 0)]
+    #[expected_failure(abort_code = 0, location=0000000000000000000000000000000000000002::dynamic_field)]
     fun test_replay_protection_works() {
         let (admin, _, _) = people();
         let test = scenario();

--- a/sui/wormhole/sources/external_address.move
+++ b/sui/wormhole/sources/external_address.move
@@ -100,7 +100,7 @@ module wormhole::external_address_test {
     }
 
     #[test]
-    #[expected_failure(abort_code = 0)]
+    #[expected_failure(abort_code = 0, location=wormhole::external_address)]
     public fun test_left_pad_vector_too_long() {
         let v = x"123456789123456789123456789123451234567891234567891234567891234500"; //33 bytes
         let res = external_address::left_pad(&v);
@@ -119,7 +119,7 @@ module wormhole::external_address_test {
     }
 
     #[test]
-    #[expected_failure(abort_code = 0)]
+    #[expected_failure(abort_code = 0, location=wormhole::external_address)]
     public fun test_from_bytes_over_32_bytes() {
         let v = x"00000000000000000000000000000000000000000000000000000000000000001234";
         let ea = external_address::from_bytes(v);
@@ -141,14 +141,14 @@ module wormhole::external_address_test {
     }
 
     #[test]
-    #[expected_failure(abort_code = 0)]
+    #[expected_failure(abort_code = 0, location=wormhole::external_address)]
     fun test_pad_left_long() {
         let v = x"665555555555555555555555555555555555555555555555555555555555555555";
         external_address::pad_left_32(&v);
     }
 
     #[test]
-    #[expected_failure(abort_code = 1)]
+    #[expected_failure(abort_code = 1, location=wormhole::external_address)]
     public fun test_to_address_too_long() {
         // non-0 bytes in first 12 bytes
         let v = x"0000010000000000000000000000000000000000000000000000000000001234";

--- a/sui/wormhole/sources/guardian_pubkey.move
+++ b/sui/wormhole/sources/guardian_pubkey.move
@@ -2,7 +2,7 @@
 /// That is, they are computed by taking the last 20 bytes of the keccak256
 /// hash of their 64 byte secp256k1 public key.
 module wormhole::guardian_pubkey {
-    use sui::ecdsa;
+    use sui::ecdsa_k1::{Self as ecdsa};
     use std::vector;
     use wormhole::keccak256::keccak256;
 

--- a/sui/wormhole/sources/keccack256.move
+++ b/sui/wormhole/sources/keccack256.move
@@ -1,5 +1,5 @@
 module wormhole::keccak256 {
-    use sui::ecdsa;
+    use sui::ecdsa_k1::{Self as ecdsa};
 
     spec module {
         pragma verify=false;

--- a/sui/wormhole/sources/myu256.move
+++ b/sui/wormhole/sources/myu256.move
@@ -519,7 +519,7 @@ module wormhole::myu256 {
     }
 
     #[test]
-    #[expected_failure(abort_code = 1)]
+    #[expected_failure(abort_code = 1, location=wormhole::myu256)]
     fun test_get_d_overflow() {
         let a = DU256 {
             v0: 1,
@@ -568,7 +568,7 @@ module wormhole::myu256 {
     }
 
     #[test]
-    #[expected_failure(abort_code = 1)]
+    #[expected_failure(abort_code = 1, location=wormhole::myu256)]
     fun test_put_d_overflow() {
         let a = DU256 {
             v0: 1,
@@ -631,7 +631,7 @@ module wormhole::myu256 {
     }
 
     #[test]
-    #[expected_failure(abort_code = 1)]
+    #[expected_failure(abort_code = 1, location=wormhole::myu256)]
     fun test_get_aborts() {
         let _ = get(&zero(), 4);
     }
@@ -656,7 +656,7 @@ module wormhole::myu256 {
     }
 
     #[test]
-    #[expected_failure(abort_code = 1)]
+    #[expected_failure(abort_code = 1, location=wormhole::myu256)]
     fun test_put_overflow() {
         let a = zero();
         put(&mut a, 6, 255);
@@ -688,7 +688,7 @@ module wormhole::myu256 {
     }
 
     #[test]
-    #[expected_failure(abort_code = 2)]
+    #[expected_failure(abort_code = 2, location=wormhole::myu256)]
     fun test_add_overflow() {
         let max = (U64_MAX as u64);
 
@@ -712,7 +712,7 @@ module wormhole::myu256 {
     }
 
     #[test]
-    #[expected_failure(abort_code = 2)]
+    #[expected_failure(abort_code = 2, location=wormhole::myu256)]
     fun test_sub_overflow() {
         let a = from_u128(0);
         let b = from_u128(1);
@@ -721,7 +721,7 @@ module wormhole::myu256 {
     }
 
     #[test]
-    #[expected_failure(abort_code = 0)]
+    #[expected_failure(abort_code = 0, location=wormhole::myu256)]
     fun test_too_big_to_cast_to_u128() {
         let a = from_u128(U128_MAX);
         let b = from_u128(U128_MAX);
@@ -798,7 +798,7 @@ module wormhole::myu256 {
     }
 
     #[test]
-    #[expected_failure(abort_code = 2)]
+    #[expected_failure(abort_code = 2, location=wormhole::myu256)]
     fun test_mul_overflow() {
         let max = (U64_MAX as u64);
 
@@ -880,7 +880,7 @@ module wormhole::myu256 {
     }
 
     #[test]
-    #[expected_failure(abort_code=0)]
+    #[expected_failure(abort_code=0, location=wormhole::myu256)]
     fun test_as_u64_overflow() {
         let _ = as_u64(from_u128(U128_MAX));
     }

--- a/sui/wormhole/sources/myvaa.move
+++ b/sui/wormhole/sources/myvaa.move
@@ -322,7 +322,7 @@ module wormhole::vaa_test {
     }
 
     #[test]
-    #[expected_failure(abort_code = 3)] // E_GUARDIAN_SET_EXPIRED
+    #[expected_failure(abort_code = vaa::E_GUARDIAN_SET_EXPIRED)]
     /// Ensures that the GOV_VAA can no longer be verified after the guardian set
     /// upgrade after expiry
     public fun test_guardian_set_expired() {
@@ -353,7 +353,7 @@ module wormhole::vaa_test {
     }
 
     #[test]
-    #[expected_failure(abort_code = 8)] // E_OLD_GUARDIAN_SET_GOVERNANCE
+    #[expected_failure(abort_code = vaa::E_OLD_GUARDIAN_SET_GOVERNANCE)]
     /// Ensures that governance GOV_VAAs can only be verified by the latest guardian
     /// set, even if the signer hasn't expired yet
     public fun test_governance_guardian_set_latest() {
@@ -388,7 +388,7 @@ module wormhole::vaa_test {
     }
 
     #[test]
-    #[expected_failure(abort_code = 5)] // E_INVALID_GOVERNANCE_EMITTER
+    #[expected_failure(abort_code = vaa::E_INVALID_GOVERNANCE_EMITTER)]
     /// Ensures that governance GOV_VAAs can only be sent from the correct governance emitter
     public fun test_invalid_governance_emitter() {
         let (admin, _, _) = people();
@@ -412,7 +412,7 @@ module wormhole::vaa_test {
     }
 
     #[test]
-    #[expected_failure(abort_code = 4)] // E_INVALID_GOVERNANCE_CHAIN
+    #[expected_failure(abort_code = vaa::E_INVALID_GOVERNANCE_CHAIN)]
     /// Ensures that governance GOV_VAAs can only be sent from the correct governance chain
     public fun test_invalid_governance_chain() {
         let (admin, _, _) = people();
@@ -462,7 +462,7 @@ module wormhole::vaa_test {
     }
 
     #[test]
-    #[expected_failure(abort_code = 0)] // NO_QUORUM
+    #[expected_failure(abort_code = vaa::E_NO_QUORUM)]
     public fun test_no_quorum() {
         let (admin, _, _) = people();
         let test = init_wormhole_state(scenario(), admin);
@@ -490,7 +490,7 @@ module wormhole::vaa_test {
     }
 
     #[test]
-    #[expected_failure(abort_code = 7)] // E_NON_INCREASING_SIGNERS
+    #[expected_failure(abort_code = vaa::E_NON_INCREASING_SIGNERS)]  
     public fun test_double_signed() {
         let (admin, _, _) = people();
         let test = init_wormhole_state(scenario(), admin);
@@ -518,7 +518,7 @@ module wormhole::vaa_test {
     }
 
     #[test]
-    #[expected_failure(abort_code = 2)] // E_INVALID_SIGNATURE
+    #[expected_failure(abort_code = vaa::E_INVALID_SIGNATURE)]
     public fun test_out_of_order_signers() {
         let (admin, _, _) = people();
         let test = init_wormhole_state(scenario(), admin);


### PR DESCRIPTION
## Update to Sui 0.19.0
- re-build and push Docker image with updated Sui binaries to ghcr 
- update test annotations to use either `location` indicating place of failure or a `const u64` abort code