### PR TITLE
sui: Import and fund default account

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ bigtable-writer.json
 /solana/artifacts-mainnet/
 /ethereum/out/
 /ethereum/cache/
+sui.log.*

--- a/Tiltfile
+++ b/Tiltfile
@@ -678,8 +678,8 @@ if sui:
     k8s_resource(
         "sui",
         port_forwards = [
-            port_forward(9001, name = "WS [:9001]", host = webHost),
             port_forward(9000, 9002, name = "RPC [:9000]", host = webHost),
+            port_forward(9001, name = "WS [:9001]", host = webHost),
             port_forward(5003, name = "Faucet [:5003]", host = webHost),
             port_forward(9184, name = "Prometheus [:9184]", host = webHost),
         ],

--- a/sui/NOTES.md
+++ b/sui/NOTES.md
@@ -16,7 +16,7 @@ brew install cmake
 
    % sui client addresses
    Showing 1 results.
-   0x2acab6bb0e4722e528291bc6ca4f097e18ce9331
+   0x13b3cb89cf3226d3b860294fc75dc6c91f0c5ecf
 
 # Give yourself some money
 
@@ -24,7 +24,7 @@ brew install cmake
 
 # Looking at the prefunded address
 
-   % sui client objects --address 0x2acab6bb0e4722e528291bc6ca4f097e18ce9331
+   % sui client objects --address 0x13b3cb89cf3226d3b860294fc75dc6c91f0c5ecf
 
 === Boot tilt
 
@@ -46,15 +46,15 @@ brew install cmake
 
 ``` sh
   % rm -rf $HOME/.sui
-  % sui keytool import "daughter exclude wheat pudding police weapon giggle taste space whip satoshi occur" secp256k1
+  % sui keytool import "daughter exclude wheat pudding police weapon giggle taste space whip satoshi occur" ed25519
   % sui client
 ```
-     point it at http://localhost:9002.  The key you create doesn't matter.
+     point it at http://localhost:9000.  The key you create doesn't matter.
 
 # edit $HOME/.sui/sui_config/client.yaml
 
 ``` sh
-   sed -i -e 's/active_address.*/active_address: "0x2acab6bb0e4722e528291bc6ca4f097e18ce9331"/' ~/.sui/sui_config/client.yaml 
+   sed -i -e 's/active_address.*/active_address: "0x13b3cb89cf3226d3b860294fc75dc6c91f0c5ecf"/' ~/.sui/sui_config/client.yaml 
 ```
 
 

--- a/sui/scripts/funder.sh
+++ b/sui/scripts/funder.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -f
 
-sui client transfer-sui --to 0x2acab6bb0e4722e528291bc6ca4f097e18ce9331 --sui-coin-object-id `sui client objects | grep sui::SUI | tail -1 | sed -e 's/|.*//'` --gas-budget 10000
+sui client transfer-sui --to 0x13b3cb89cf3226d3b860294fc75dc6c91f0c5ecf --sui-coin-object-id `sui client objects | grep sui::SUI | tail -1 | sed -e 's/|.*//'` --gas-budget 10000

--- a/sui/scripts/import_account_and_deploy.sh
+++ b/sui/scripts/import_account_and_deploy.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# This dev script imports and funds an account, following the steps in 
+# `sui/NOTES.md`. It also deploys the core/token bridge contracts.
+
+# Remove directory for idempotency
+rm -rf $HOME/.sui
+
+# Import key so we have a deterministic address and make it the default account
+sui keytool import "daughter exclude wheat pudding police weapon giggle taste space whip satoshi occur" ed25519
+sui client << EOF
+y
+http://localhost:9000
+dev
+0
+EOF
+sed -i -e 's/active_address.*/active_address: "0x13b3cb89cf3226d3b860294fc75dc6c91f0c5ecf"/' ~/.sui/sui_config/client.yaml
+
+# Fund account
+kubectl exec -it sui-0 -c sui-node -- /tmp/funder.sh
+
+# Deploy contracts
+DIR_PATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+$DIR_PATH/deploy.sh

--- a/sui/scripts/start_node.sh
+++ b/sui/scripts/start_node.sh
@@ -5,7 +5,6 @@ set -x
 sui start &
 sleep 10
 #sleep infinity
-sui client object --id 0x5
 #sui-faucet --host-ip 0.0.0.0&
 #sleep 2
 #curl -X POST -d '{"FixedAmountRequest":{"recipient": "'"0x2acab6bb0e4722e528291bc6ca4f097e18ce9331"'"}}' -H 'Content-Type: application/json' http://127.0.0.1:5003/gas


### PR DESCRIPTION
Previously, deploying Sui contracts locally required following several steps in [sui/NOTES.md](https://github.com/wormhole-foundation/wormhole/blob/sui/integration/sui/NOTES.md). This PR automates that process via a simple bash script.

The default account is generated with the same seed as before, but now uses ed25519 instead of secp256k1 for the keygen scheme because Sui wallet, which is used for testing in the ui repo, derives imported accounts using ed25519.