### PR TITLE
ci: make solana integration tests single-threaded

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -184,7 +184,7 @@ jobs:
             cargo build-bpf --manifest-path "${p}"
           done
 
-          cargo test --workspace --features "nft-bridge/instructions token-bridge/instructions wormhole-bridge-solana/instructions"
+          cargo test --workspace --features "nft-bridge/instructions token-bridge/instructions wormhole-bridge-solana/instructions" -- --test-threads=1
 
   aptos:
     name: Aptos


### PR DESCRIPTION
Solana tests are extremely flaky. This changes makes the tests run sequentially instead of in parallel. The testing code is not built to work well in parallel (sequences may race and cause issues etc).

With this change, tests run 11s on my local machine compared to 4s before. Given most time in CI is spent in the compilation step anyway this change should be negligible. 

Rel #2105 