### PR TITLE
sdk/js: Use BN.toArrayLike for compatibility with browserify and similar tools.

### DIFF
--- a/sdk/js/CHANGELOG.md
+++ b/sdk/js/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.9.8
+
+## Changed
+
+Use BN.toArrayLike for compatibility with browserify and similar tools
+
 ## 0.9.7
 
 ## Added

--- a/sdk/js/package-lock.json
+++ b/sdk/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@certusone/wormhole-sdk",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@certusone/wormhole-sdk",
-      "version": "0.9.7",
+      "version": "0.9.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@certusone/wormhole-sdk-proto-web": "0.0.6",

--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@certusone/wormhole-sdk",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "description": "SDK for interacting with Wormhole",
   "homepage": "https://wormhole.com",
   "main": "./lib/cjs/index.js",

--- a/sdk/js/src/solana/nftBridge/accounts/wrapped.ts
+++ b/sdk/js/src/solana/nftBridge/accounts/wrapped.ts
@@ -38,7 +38,7 @@ export function deriveWrappedMintKey(
         return buf;
       })(),
       tokenAddress,
-      new BN(tokenId.toString()).toBuffer("be", 32),
+      new BN(tokenId.toString()).toArrayLike(Buffer, "be", 32),
     ],
     tokenBridgeProgramId
   );


### PR DESCRIPTION
Fixes this error when calling `deriveWrappedMintKey` in the browser:
TypeError: (intermediate value).toBuffer is not a function