### PR TITLE
cosmwasm: accounting: Change error message for duplicate observation

### DIFF
--- a/cosmwasm/contracts/wormchain-accounting/src/contract.rs
+++ b/cosmwasm/contracts/wormchain-accounting/src/contract.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 use accounting::{
     query_balance, query_modification,
     state::{account, transfer, Modification, TokenAddress, Transfer},
-    validate_transfer,
+    validate_transfer, TransferError,
 };
 use anyhow::{ensure, Context};
 #[cfg(not(feature = "library"))]
@@ -146,7 +146,7 @@ fn handle_observation(
             bail!(ContractError::DigestMismatch);
         }
 
-        bail!(ContractError::DuplicateMessage);
+        bail!(TransferError::DuplicateTransfer);
     }
 
     let tx_key = transfer::Key::new(o.emitter_chain, o.emitter_address.into(), o.sequence);

--- a/cosmwasm/contracts/wormchain-accounting/tests/submit_vaas.rs
+++ b/cosmwasm/contracts/wormchain-accounting/tests/submit_vaas.rs
@@ -302,7 +302,7 @@ fn reobservation() {
         let err = contract
             .submit_observations(obs.clone(), index, s)
             .expect_err("successfully submitted observation for processed VAA");
-        assert!(format!("{err:#}").contains("message already processed"));
+        assert!(format!("{err:#}").contains("transfer already committed"));
     }
 }
 


### PR DESCRIPTION
Change the error message when handling duplicate observations from
"message already processed" -> "transfer already committed".