### PR TITLE
cosmwasm: accounting: Use json encoding for event attributes

### DIFF
--- a/cosmwasm/contracts/wormchain-accounting/src/contract.rs
+++ b/cosmwasm/contracts/wormchain-accounting/src/contract.rs
@@ -239,14 +239,17 @@ fn handle_observation(
 
     Ok(Some(
         Event::new("Transfer")
-            .add_attribute("tx_hash", o.tx_hash.to_base64())
+            .add_attribute("tx_hash", format!("\"{}\"", o.tx_hash))
             .add_attribute("timestamp", o.timestamp.to_string())
             .add_attribute("nonce", o.nonce.to_string())
             .add_attribute("emitter_chain", o.emitter_chain.to_string())
-            .add_attribute("emitter_address", Address(o.emitter_address).to_string())
+            .add_attribute(
+                "emitter_address",
+                format!("\"{}\"", Address(o.emitter_address)),
+            )
             .add_attribute("sequence", o.sequence.to_string())
             .add_attribute("consistency_level", o.consistency_level.to_string())
-            .add_attribute("payload", o.payload.to_base64()),
+            .add_attribute("payload", format!("\"{}\"", o.payload)),
     ))
 }
 

--- a/cosmwasm/contracts/wormchain-accounting/tests/submit_observations.rs
+++ b/cosmwasm/contracts/wormchain-accounting/tests/submit_observations.rs
@@ -777,14 +777,17 @@ fn emit_event_with_quorum() {
     let (o, responses) = transfer_tokens(&wh, &mut contract, key, msg, index, quorum).unwrap();
 
     let expected = Event::new("wasm-Transfer")
-        .add_attribute("tx_hash", o.tx_hash.to_base64())
+        .add_attribute("tx_hash", format!("\"{}\"", o.tx_hash))
         .add_attribute("timestamp", o.timestamp.to_string())
         .add_attribute("nonce", o.nonce.to_string())
         .add_attribute("emitter_chain", o.emitter_chain.to_string())
-        .add_attribute("emitter_address", Address(o.emitter_address).to_string())
+        .add_attribute(
+            "emitter_address",
+            format!("\"{}\"", Address(o.emitter_address)),
+        )
         .add_attribute("sequence", o.sequence.to_string())
         .add_attribute("consistency_level", o.consistency_level.to_string())
-        .add_attribute("payload", o.payload.to_base64());
+        .add_attribute("payload", format!("\"{}\"", o.payload));
 
     assert_eq!(responses.len(), quorum);
     for (i, r) in responses.into_iter().enumerate() {


### PR DESCRIPTION
Ensure that event attribute values use proper json encoding so that they
can be parsed more easily by client code.  In practice this just means
adding wrapping quotation marks ('"') around string values.