### PR TITLE
sui: update to devnet version 0.20.0, fix tests

### DIFF
--- a/sui/Docker.md
+++ b/sui/Docker.md
@@ -2,8 +2,8 @@
 #(cd ..; DOCKER_BUILDKIT=1 docker build --no-cache --progress plain -f sui/Dockerfile.base -t sui .)
 (cd ..; DOCKER_BUILDKIT=1 docker build $1 --progress plain -f sui/Dockerfile.base -t sui .)
 # tag the image with the appropriate version
-docker tag sui:latest ghcr.io/wormhole-foundation/sui:0.19.0
+docker tag sui:latest ghcr.io/wormhole-foundation/sui:0.20.0
 # push to ghcr
-docker push ghcr.io/wormhole-foundation/sui:0.19.0
+docker push ghcr.io/wormhole-foundation/sui:0.20.0
 
 echo remember to update both Dockerfile and Dockerfile.export

--- a/sui/Dockerfile
+++ b/sui/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/wormhole-foundation/sui:0.19.0@sha256:8181f3b2cc64fdb51de8f112eede3a829ae687d5fc62d9e37e96e3bb4665494a as sui
+FROM ghcr.io/wormhole-foundation/sui:0.20.0@sha256:793963650dcc76d8937f671213be53f39442cf0f74e5dd9697446fef4d093e9b as sui
 
 RUN dnf -y install make git
 

--- a/sui/wormhole/sources/external_address.move
+++ b/sui/wormhole/sources/external_address.move
@@ -3,7 +3,7 @@
 module wormhole::external_address {
     use std::vector;
 
-    use sui::object;
+    use sui::address;
 
     use wormhole::cursor::Cursor;
     use wormhole::deserialize;
@@ -70,7 +70,7 @@ module wormhole::external_address {
         };
         // reverse back to original order
         vector::reverse(&mut vec);
-        object::address_from_bytes(vec)
+        address::from_bytes(vec)
     }
 
 }


### PR DESCRIPTION
- Build new `sui 0.20.0` docker image and push to ghcr: https://github.com/orgs/wormhole-foundation/packages/container/sui/61872809?tag=0.20.0
- fix serialize function in external_address.move affected by update
