### PR TITLE
evm gas profile setup

### DIFF
--- a/ethereum/.gitignore
+++ b/ethereum/.gitignore
@@ -2,3 +2,4 @@ ganache.log
 lib/*
 !lib/README.md
 flattened
+.gas-snapshot

--- a/ethereum/Makefile
+++ b/ethereum/Makefile
@@ -78,5 +78,9 @@ test-forge: dependencies
 	./compare-method-identifiers.sh contracts/nft/NFTBridgeImplementation.sol:NFTBridgeImplementation contracts/nft/interfaces/INFTBridge.sol:INFTBridge
 	forge test
 
+.PHONY:
+test-forge-gas: dependencies
+	forge snapshot --match-contract MessagesGasBenchmark
+
 clean:
 	rm -rf ganache.log .env node_modules build flattened

--- a/ethereum/forge-test/MessagesGasBenchmark.t.sol
+++ b/ethereum/forge-test/MessagesGasBenchmark.t.sol
@@ -1,0 +1,90 @@
+/// SPDX-License-Identifier: Apache 2
+
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+import "./utils/WormholeTestUtils.t.sol";
+import "../contracts/interfaces/IWormhole.sol";
+
+contract MessagesGasBenchmark is Test, WormholeTestUtils {
+    // 19, current mainnet number of guardians, is used to have gas estimates
+    // close to our mainnet transactions.
+    uint8 constant NUM_GUARDIANS = 19;
+    // 2/3 of the guardians should sign a message for a VAA which is 13 out of 19 guardians.
+    // It is possible to have more signers but the median seems to be 13.
+    uint8 constant NUM_GUARDIAN_SIGNERS = 13;
+
+    uint constant PYTH_PAYLOAD_SIZE = 24; //approximately assuming there are 5 attestations in a batch
+
+    uint constant TOKEN_BRIDGE_PAYLOAD_SIZE = 4; //approximately
+    
+    IWormhole public wormhole;
+    
+    bytes VAA;
+    bytes pythPayload;
+    bytes tokenBridgePayload;
+
+    uint64 sequence;
+    uint randSeed;
+
+    function setUp() public {
+        wormhole = IWormhole(setUpWormhole(NUM_GUARDIANS));
+
+        for(uint i=0; i< PYTH_PAYLOAD_SIZE; i++){
+            pythPayload = abi.encodePacked(pythPayload, bytes32(getRand()));
+        }
+
+        for(uint i=0; i< TOKEN_BRIDGE_PAYLOAD_SIZE; i++){
+            tokenBridgePayload = abi.encodePacked(tokenBridgePayload, bytes32(getRand()));
+        }
+    }
+
+    function getRand() internal returns (uint val) {
+        ++randSeed;
+        val = uint(keccak256(abi.encode(randSeed)));
+    }
+
+    function testBenchmarkParseAndVerifyVMPythPayload(uint32 timestamp, uint16 emitterChainId, bytes32 emitterAddress, uint64 sequence) public {
+        bytes memory vaa = generateVaa(
+                timestamp,
+                emitterChainId,
+                emitterAddress,
+                sequence,
+                pythPayload,
+                NUM_GUARDIAN_SIGNERS
+            );
+        wormhole.parseAndVerifyVM(vaa);
+    }
+
+    function testBenchmarkParseAndVerifyVMTokenBridgePayload(uint32 timestamp, uint16 emitterChainId, bytes32 emitterAddress, uint64 sequence) public {
+        bytes memory vaa = generateVaa(
+                timestamp,
+                emitterChainId,
+                emitterAddress,
+                sequence,
+                tokenBridgePayload,
+                NUM_GUARDIAN_SIGNERS
+            );
+        wormhole.parseAndVerifyVM(vaa);
+    }
+
+    function testBenchmarkParseAndVerifyVMRandomPayload(uint32 timestamp, uint16 emitterChainId, bytes32 emitterAddress, uint64 sequence, bytes memory payloadRandom) public {
+        bytes memory vaa = generateVaa(
+                timestamp,
+                emitterChainId,
+                emitterAddress,
+                sequence,
+                payloadRandom,
+                NUM_GUARDIAN_SIGNERS
+            );
+        wormhole.parseAndVerifyVM(vaa);
+    }
+
+    function testBenchmarkMessageFee() public view {
+        wormhole.messageFee();
+    }
+
+    function testPublishMessage(bytes memory payload) public {
+        wormhole.publishMessage(0, payload, 0);
+    }
+}

--- a/ethereum/forge-test/utils/WormholeTestUtils.t.sol
+++ b/ethereum/forge-test/utils/WormholeTestUtils.t.sol
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache 2
+
+pragma solidity ^0.8.0;
+
+import "../../contracts/Implementation.sol";
+import "../../contracts/Setup.sol";
+import "../../contracts/Wormhole.sol";
+import "../../contracts/interfaces/IWormhole.sol";
+
+import "forge-std/Test.sol";
+
+abstract contract WormholeTestUtils is Test {
+    function setUpWormhole(uint8 numGuardians) public returns (address) {
+        Implementation wormholeImpl = new Implementation();
+        Setup wormholeSetup = new Setup();
+
+        Wormhole wormhole = new Wormhole(address(wormholeSetup), new bytes(0));
+
+        address[] memory initSigners = new address[](numGuardians);
+
+        for (uint256 i = 0; i < numGuardians; ++i) {
+            initSigners[i] = vm.addr(i + 1); // i+1 is the private key for the i-th signer.
+        }
+
+        // These values are the default values used in our tilt test environment
+        // and are not important.
+        Setup(address(wormhole)).setup(
+            address(wormholeImpl),
+            initSigners,
+            2, // Ethereum chain ID
+            1, // Governance source chain ID (1 = solana)
+            0x0000000000000000000000000000000000000000000000000000000000000004, // Governance source address
+            block.chainid // EVM chain Id must be same as block.chainid
+        );
+
+        return address(wormhole);
+    }
+
+    function generateVaa(
+        uint32 timestamp,
+        uint16 emitterChainId,
+        bytes32 emitterAddress,
+        uint64 sequence,
+        bytes memory payload,
+        uint8 numSigners
+    ) public returns (bytes memory vaa) {
+        bytes memory body = abi.encodePacked(
+            timestamp,
+            uint32(0), // Nonce. It is zero for single VAAs.
+            emitterChainId,
+            emitterAddress,
+            sequence,
+            uint8(0), // Consistency level (sometimes no. confirmation block). Not important here.
+            payload
+        );
+
+        bytes32 hash = keccak256(abi.encodePacked(keccak256(body)));
+
+        bytes memory signatures = new bytes(0);
+
+        for (uint256 i = 0; i < numSigners; ++i) {
+            (uint8 v, bytes32 r, bytes32 s) = vm.sign(i + 1, hash);
+            // encodePacked uses padding for arrays and we don't want it, so we manually concat them.
+            signatures = abi.encodePacked(
+                signatures,
+                uint8(i), // Guardian index of the signature
+                r,
+                s,
+                v - 27 // v is either 27 or 28. 27 is added to v in Eth (following BTC) but Wormhole doesn't use it.
+            );
+        }
+
+        vaa = abi.encodePacked(
+            uint8(1), // Version
+            uint32(0), // Guardian set index. it is initialized by 0
+            numSigners,
+            signatures,
+            body
+        );
+    }
+}
+
+contract WormholeTestUtilsTest is Test, WormholeTestUtils {
+    function testGenerateVaaWorks() public {
+        IWormhole wormhole = IWormhole(setUpWormhole(5));
+
+        bytes memory vaa = generateVaa(
+            112,
+            7,
+            0x0000000000000000000000000000000000000000000000000000000000000bad,
+            10,
+            hex"deadbeaf",
+            4
+        );
+
+        (IWormhole.VM memory vm, bool valid, ) = wormhole.parseAndVerifyVM(vaa);
+        assertTrue(valid);
+
+        assertEq(vm.timestamp, 112);
+        assertEq(vm.emitterChainId, 7);
+        assertEq(
+            vm.emitterAddress,
+            0x0000000000000000000000000000000000000000000000000000000000000bad
+        );
+        assertEq(vm.payload, hex"deadbeaf");
+        assertEq(vm.signatures.length, 4);
+    }
+}

--- a/ethereum/foundry.toml
+++ b/ethereum/foundry.toml
@@ -1,4 +1,4 @@
-[default]
+[profile.default]
 solc_version = "0.8.4"
 optimizer = true
 optimizer_runs = 200


### PR DESCRIPTION
Using foundry to help profile gas costs for parseAndVerifyVM() across arbitary length VAAs, VAAs of length as expected by the Token bridge and Pyth contracts. A first step towards #1870 