### PR TITLE
sui: finish complete transfer impl + tests, decimal denormalization

### DIFF
--- a/sui/token_bridge/sources/attest_token.move
+++ b/sui/token_bridge/sources/attest_token.move
@@ -98,7 +98,7 @@ module token_bridge::attest_token_test{
                 ctx(&mut test)
             );
 
-            assert!(asset_meta::get_decimals(&asset_meta)==5, 0);
+            assert!(asset_meta::get_decimals(&asset_meta)==10, 0);
             assert!(asset_meta::get_symbol(&asset_meta)==string32::from_bytes(x"00"), 0);
             assert!(asset_meta::get_name(&asset_meta)==string32::from_bytes(x"11"), 0);
 

--- a/sui/token_bridge/sources/complete_transfer.move
+++ b/sui/token_bridge/sources/complete_transfer.move
@@ -297,7 +297,7 @@ module token_bridge::complete_transfer_test {
             let to = admin;
             let amount = 1000000000;
             let fee_amount = 100000000;
-            let decimals = 8;
+            let decimals = 10;
             let token_address = external_address::from_bytes(x"01");
             let token_chain = wormhole_state::get_chain_id(&worm_state);
             let to_chain = wormhole_state::get_chain_id(&worm_state);
@@ -380,7 +380,8 @@ module token_bridge::complete_transfer_test {
             let coin_meta = take_shared<CoinMetadata<NATIVE_COIN_WITNESS>>(&test);
 
             let to = admin;
-            let amount = 1000000000; // dust at the end gets rounded to nothing
+            // dust at the end gets rounded to nothing, since 10-8=2 digits are lopped off
+            let amount = 1000000079;
             let fee_amount = 100000000;
             let decimals = 10;
             let token_address = external_address::from_bytes(x"01");

--- a/sui/token_bridge/sources/testing/native_coin.move
+++ b/sui/token_bridge/sources/testing/native_coin.move
@@ -14,7 +14,7 @@ module token_bridge::native_coin_witness {
     fun init(coin_witness: NATIVE_COIN_WITNESS, ctx: &mut TxContext) {
         let (treasury_cap, coin_metadata) = coin::create_currency<NATIVE_COIN_WITNESS>(
             coin_witness,
-            5,
+            10,
             x"00",
             x"11",
             x"22",

--- a/sui/token_bridge/sources/testing/native_coin_v2.move
+++ b/sui/token_bridge/sources/testing/native_coin_v2.move
@@ -14,7 +14,7 @@ module token_bridge::native_coin_witness_v2 {
     fun init(coin_witness: NATIVE_COIN_WITNESS_V2, ctx: &mut TxContext) {
         let (treasury_cap, coin_metadata) = coin::create_currency<NATIVE_COIN_WITNESS_V2>(
             coin_witness,
-            9,
+            4,
             x"33",
             x"44",
             x"55",

--- a/sui/token_bridge/sources/wrapped.move
+++ b/sui/token_bridge/sources/wrapped.move
@@ -100,7 +100,6 @@ module token_bridge::wrapped {
         state: &mut WormholeState,
         bridge_state: &mut BridgeState,
         new_wrapped_coin: NewWrappedCoin<CoinType>,
-        //coin_metadata: CoinMetadata<CoinType>,
         ctx: &mut TxContext,
     ) {
         let NewWrappedCoin { id, vaa_bytes, treasury_cap, coin_metadata } = new_wrapped_coin;
@@ -113,8 +112,6 @@ module token_bridge::wrapped {
             ctx
         );
         let payload = core_vaa::destroy(vaa);
-
-        // TODO (pending Mysten Labs uniform token standard) -  extract and store token metadata
 
         let metadata = asset_meta::parse(payload);
         let origin_chain = asset_meta::get_token_chain(&metadata);


### PR DESCRIPTION
### Updates
- Finish `complete_transfer.move` using `coin_metadata`
-  Write `complete_transfer_native`, `complete_transfer_wrapped`, `submit_vaa_native`, `submit_vaa_wrapped`.
- Note: we distinguish between the native and wrapped cases because for native tokens, we have to pass in the `coin_metadata` explicitly. For the wrapped case, we instead look up the metadata from the `bridge_state`
- Implement normalization / denormalization properly by looking up decimals in `coin_metadata`
- `complete_transfer` tests are up-to-date with [Aptos counterparts](https://github.com/wormhole-foundation/wormhole/blob/main/aptos/token_bridge/sources/complete_transfer.move)
