### PR TITLE
cosmwasm: accounting: Return transfer status for observations

### DIFF
--- a/cosmwasm/Cargo.lock
+++ b/cosmwasm/Cargo.lock
@@ -7,7 +7,6 @@ name = "accounting"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "base64",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus",

--- a/cosmwasm/contracts/wormchain-accounting/schema/wormchain-accounting.json
+++ b/cosmwasm/contracts/wormchain-accounting/schema/wormchain-accounting.json
@@ -756,14 +756,7 @@
               "minimum": 0.0
             },
             "emitter_address": {
-              "type": "array",
-              "items": {
-                "type": "integer",
-                "format": "uint8",
-                "minimum": 0.0
-              },
-              "maxItems": 32,
-              "minItems": 32
+              "type": "string"
             },
             "emitter_chain": {
               "type": "integer",
@@ -1055,14 +1048,7 @@
               "minimum": 0.0
             },
             "emitter_address": {
-              "type": "array",
-              "items": {
-                "type": "integer",
-                "format": "uint8",
-                "minimum": 0.0
-              },
-              "maxItems": 32,
-              "minItems": 32
+              "type": "string"
             },
             "emitter_chain": {
               "type": "integer",
@@ -1404,14 +1390,7 @@
               "minimum": 0.0
             },
             "emitter_address": {
-              "type": "array",
-              "items": {
-                "type": "integer",
-                "format": "uint8",
-                "minimum": 0.0
-              },
-              "maxItems": 32,
-              "minItems": 32
+              "type": "string"
             },
             "emitter_chain": {
               "type": "integer",

--- a/cosmwasm/contracts/wormchain-accounting/schema/wormchain-accounting.json
+++ b/cosmwasm/contracts/wormchain-accounting/schema/wormchain-accounting.json
@@ -705,10 +705,9 @@
               "$ref": "#/definitions/Observation"
             },
             "signatures": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Signature"
-              }
+              "type": "integer",
+              "format": "uint128",
+              "minimum": 0.0
             }
           },
           "additionalProperties": false
@@ -805,31 +804,6 @@
             }
           },
           "additionalProperties": false
-        },
-        "Signature": {
-          "description": "Signatures are typical ECDSA signatures prefixed with a Guardian position. These have the following byte layout: ```markdown 0  .. 64: Signature   (ECDSA) 64 .. 65: Recovery ID (ECDSA) ```",
-          "type": "object",
-          "required": [
-            "index",
-            "signature"
-          ],
-          "properties": {
-            "index": {
-              "type": "integer",
-              "format": "uint8",
-              "minimum": 0.0
-            },
-            "signature": {
-              "type": "array",
-              "items": {
-                "type": "integer",
-                "format": "uint8",
-                "minimum": 0.0
-              },
-              "maxItems": 65,
-              "minItems": 65
-            }
-          }
         },
         "TokenAddress": {
           "type": "string"
@@ -997,10 +971,9 @@
               "$ref": "#/definitions/Observation"
             },
             "signatures": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Signature"
-              }
+              "type": "integer",
+              "format": "uint128",
+              "minimum": 0.0
             }
           },
           "additionalProperties": false
@@ -1078,31 +1051,6 @@
             }
           },
           "additionalProperties": false
-        },
-        "Signature": {
-          "description": "Signatures are typical ECDSA signatures prefixed with a Guardian position. These have the following byte layout: ```markdown 0  .. 64: Signature   (ECDSA) 64 .. 65: Recovery ID (ECDSA) ```",
-          "type": "object",
-          "required": [
-            "index",
-            "signature"
-          ],
-          "properties": {
-            "index": {
-              "type": "integer",
-              "format": "uint8",
-              "minimum": 0.0
-            },
-            "signature": {
-              "type": "array",
-              "items": {
-                "type": "integer",
-                "format": "uint8",
-                "minimum": 0.0
-              },
-              "maxItems": 65,
-              "minItems": 65
-            }
-          }
         },
         "TokenAddress": {
           "type": "string"
@@ -1363,10 +1311,9 @@
               "$ref": "#/definitions/Observation"
             },
             "signatures": {
-              "type": "array",
-              "items": {
-                "$ref": "#/definitions/Signature"
-              }
+              "type": "integer",
+              "format": "uint128",
+              "minimum": 0.0
             }
           },
           "additionalProperties": false
@@ -1420,31 +1367,6 @@
             }
           },
           "additionalProperties": false
-        },
-        "Signature": {
-          "description": "Signatures are typical ECDSA signatures prefixed with a Guardian position. These have the following byte layout: ```markdown 0  .. 64: Signature   (ECDSA) 64 .. 65: Recovery ID (ECDSA) ```",
-          "type": "object",
-          "required": [
-            "index",
-            "signature"
-          ],
-          "properties": {
-            "index": {
-              "type": "integer",
-              "format": "uint8",
-              "minimum": 0.0
-            },
-            "signature": {
-              "type": "array",
-              "items": {
-                "type": "integer",
-                "format": "uint8",
-                "minimum": 0.0
-              },
-              "maxItems": 65,
-              "minItems": 65
-            }
-          }
         }
       }
     },

--- a/cosmwasm/contracts/wormchain-accounting/schema/wormchain-accounting.json
+++ b/cosmwasm/contracts/wormchain-accounting/schema/wormchain-accounting.json
@@ -691,23 +691,33 @@
         "Data": {
           "type": "object",
           "required": [
+            "digest",
+            "emitter_chain",
             "guardian_set_index",
-            "observation",
-            "signatures"
+            "signatures",
+            "tx_hash"
           ],
           "properties": {
+            "digest": {
+              "$ref": "#/definitions/Binary"
+            },
+            "emitter_chain": {
+              "type": "integer",
+              "format": "uint16",
+              "minimum": 0.0
+            },
             "guardian_set_index": {
               "type": "integer",
               "format": "uint32",
               "minimum": 0.0
             },
-            "observation": {
-              "$ref": "#/definitions/Observation"
-            },
             "signatures": {
               "type": "integer",
               "format": "uint128",
               "minimum": 0.0
+            },
+            "tx_hash": {
+              "$ref": "#/definitions/Binary"
             }
           },
           "additionalProperties": false
@@ -732,56 +742,6 @@
               "type": "integer",
               "format": "uint64",
               "minimum": 0.0
-            }
-          },
-          "additionalProperties": false
-        },
-        "Observation": {
-          "type": "object",
-          "required": [
-            "consistency_level",
-            "emitter_address",
-            "emitter_chain",
-            "nonce",
-            "payload",
-            "sequence",
-            "timestamp",
-            "tx_hash"
-          ],
-          "properties": {
-            "consistency_level": {
-              "type": "integer",
-              "format": "uint8",
-              "minimum": 0.0
-            },
-            "emitter_address": {
-              "type": "string"
-            },
-            "emitter_chain": {
-              "type": "integer",
-              "format": "uint16",
-              "minimum": 0.0
-            },
-            "nonce": {
-              "type": "integer",
-              "format": "uint32",
-              "minimum": 0.0
-            },
-            "payload": {
-              "$ref": "#/definitions/Binary"
-            },
-            "sequence": {
-              "type": "integer",
-              "format": "uint64",
-              "minimum": 0.0
-            },
-            "timestamp": {
-              "type": "integer",
-              "format": "uint32",
-              "minimum": 0.0
-            },
-            "tx_hash": {
-              "$ref": "#/definitions/Binary"
             }
           },
           "additionalProperties": false
@@ -957,23 +917,33 @@
         "Data": {
           "type": "object",
           "required": [
+            "digest",
+            "emitter_chain",
             "guardian_set_index",
-            "observation",
-            "signatures"
+            "signatures",
+            "tx_hash"
           ],
           "properties": {
+            "digest": {
+              "$ref": "#/definitions/Binary"
+            },
+            "emitter_chain": {
+              "type": "integer",
+              "format": "uint16",
+              "minimum": 0.0
+            },
             "guardian_set_index": {
               "type": "integer",
               "format": "uint32",
               "minimum": 0.0
             },
-            "observation": {
-              "$ref": "#/definitions/Observation"
-            },
             "signatures": {
               "type": "integer",
               "format": "uint128",
               "minimum": 0.0
+            },
+            "tx_hash": {
+              "$ref": "#/definitions/Binary"
             }
           },
           "additionalProperties": false
@@ -998,56 +968,6 @@
               "type": "integer",
               "format": "uint64",
               "minimum": 0.0
-            }
-          },
-          "additionalProperties": false
-        },
-        "Observation": {
-          "type": "object",
-          "required": [
-            "consistency_level",
-            "emitter_address",
-            "emitter_chain",
-            "nonce",
-            "payload",
-            "sequence",
-            "timestamp",
-            "tx_hash"
-          ],
-          "properties": {
-            "consistency_level": {
-              "type": "integer",
-              "format": "uint8",
-              "minimum": 0.0
-            },
-            "emitter_address": {
-              "type": "string"
-            },
-            "emitter_chain": {
-              "type": "integer",
-              "format": "uint16",
-              "minimum": 0.0
-            },
-            "nonce": {
-              "type": "integer",
-              "format": "uint32",
-              "minimum": 0.0
-            },
-            "payload": {
-              "$ref": "#/definitions/Binary"
-            },
-            "sequence": {
-              "type": "integer",
-              "format": "uint64",
-              "minimum": 0.0
-            },
-            "timestamp": {
-              "type": "integer",
-              "format": "uint32",
-              "minimum": 0.0
-            },
-            "tx_hash": {
-              "$ref": "#/definitions/Binary"
             }
           },
           "additionalProperties": false
@@ -1297,69 +1217,29 @@
         "Data": {
           "type": "object",
           "required": [
-            "guardian_set_index",
-            "observation",
-            "signatures"
-          ],
-          "properties": {
-            "guardian_set_index": {
-              "type": "integer",
-              "format": "uint32",
-              "minimum": 0.0
-            },
-            "observation": {
-              "$ref": "#/definitions/Observation"
-            },
-            "signatures": {
-              "type": "integer",
-              "format": "uint128",
-              "minimum": 0.0
-            }
-          },
-          "additionalProperties": false
-        },
-        "Observation": {
-          "type": "object",
-          "required": [
-            "consistency_level",
-            "emitter_address",
+            "digest",
             "emitter_chain",
-            "nonce",
-            "payload",
-            "sequence",
-            "timestamp",
+            "guardian_set_index",
+            "signatures",
             "tx_hash"
           ],
           "properties": {
-            "consistency_level": {
-              "type": "integer",
-              "format": "uint8",
-              "minimum": 0.0
-            },
-            "emitter_address": {
-              "type": "string"
+            "digest": {
+              "$ref": "#/definitions/Binary"
             },
             "emitter_chain": {
               "type": "integer",
               "format": "uint16",
               "minimum": 0.0
             },
-            "nonce": {
+            "guardian_set_index": {
               "type": "integer",
               "format": "uint32",
               "minimum": 0.0
             },
-            "payload": {
-              "$ref": "#/definitions/Binary"
-            },
-            "sequence": {
+            "signatures": {
               "type": "integer",
-              "format": "uint64",
-              "minimum": 0.0
-            },
-            "timestamp": {
-              "type": "integer",
-              "format": "uint32",
+              "format": "uint128",
               "minimum": 0.0
             },
             "tx_hash": {

--- a/cosmwasm/contracts/wormchain-accounting/src/msg.rs
+++ b/cosmwasm/contracts/wormchain-accounting/src/msg.rs
@@ -58,6 +58,32 @@ impl Observation {
     }
 }
 
+// The default externally-tagged serde representation of enums is awkward in JSON when the
+// enum contains unit variants mixed with newtype variants.  We can't use the internally-tagged
+// representation because it only supports newtype variants that contain structs or maps.  So use
+// the adjacently tagged variant representation here: the enum is always encoded as an object with
+// a "type" field that indicates the variant and an optional "data" field that contains the data for
+// the variant, if any.
+#[cw_serde]
+#[serde(tag = "type", content = "data")]
+pub enum ObservationStatus {
+    Pending,
+    Committed,
+    Error(String),
+}
+
+#[cw_serde]
+pub struct SubmitObservationResponse {
+    pub key: transfer::Key,
+    pub status: ObservationStatus,
+}
+
+#[cw_serde]
+pub struct ObservationError {
+    pub key: transfer::Key,
+    pub error: String,
+}
+
 #[cw_serde]
 pub struct Upgrade {
     pub new_addr: [u8; 32],

--- a/cosmwasm/contracts/wormchain-accounting/src/state.rs
+++ b/cosmwasm/contracts/wormchain-accounting/src/state.rs
@@ -4,8 +4,6 @@ use cosmwasm_std::Binary;
 use cw_storage_plus::Map;
 use tinyvec::TinyVec;
 
-use crate::msg::Observation;
-
 pub const PENDING_TRANSFERS: Map<transfer::Key, TinyVec<[Data; 2]>> = Map::new("pending_transfers");
 pub const CHAIN_REGISTRATIONS: Map<u16, Binary> = Map::new("chain_registrations");
 pub const DIGESTS: Map<(u16, Vec<u8>, u64), Binary> = Map::new("digests");
@@ -19,22 +17,39 @@ pub struct PendingTransfer {
 #[cw_serde]
 #[derive(Default)]
 pub struct Data {
-    observation: Observation,
-    guardian_set_index: u32,
+    digest: Binary,
+    tx_hash: Binary,
     signatures: u128,
+    guardian_set_index: u32,
+    emitter_chain: u16,
 }
 
 impl Data {
-    pub const fn new(observation: Observation, guardian_set_index: u32) -> Self {
+    pub const fn new(
+        digest: Binary,
+        tx_hash: Binary,
+        emitter_chain: u16,
+        guardian_set_index: u32,
+    ) -> Self {
         Self {
-            observation,
-            guardian_set_index,
+            digest,
+            tx_hash,
             signatures: 0,
+            guardian_set_index,
+            emitter_chain,
         }
     }
 
-    pub fn observation(&self) -> &Observation {
-        &self.observation
+    pub fn digest(&self) -> &Binary {
+        &self.digest
+    }
+
+    pub fn tx_hash(&self) -> &Binary {
+        &self.tx_hash
+    }
+
+    pub fn emitter_chain(&self) -> u16 {
+        self.emitter_chain
     }
 
     pub fn guardian_set_index(&self) -> u32 {

--- a/cosmwasm/contracts/wormchain-accounting/tests/missing_observations.rs
+++ b/cosmwasm/contracts/wormchain-accounting/tests/missing_observations.rs
@@ -43,6 +43,7 @@ fn missing_observations() {
         .unwrap() as usize;
 
     let o = create_observation();
+    let digest = o.digest().unwrap();
     let data = to_binary(&[o.clone()]).unwrap();
     let signatures = wh.sign(&data);
 
@@ -56,7 +57,7 @@ fn missing_observations() {
     // The transfer should still be pending.
     let key = transfer::Key::new(o.emitter_chain, o.emitter_address.into(), o.sequence);
     let pending = contract.query_pending_transfer(key).unwrap();
-    assert_eq!(&o, pending[0].observation());
+    assert_eq!(&digest, pending[0].digest());
 
     for (i, s) in signatures.iter().enumerate() {
         let resp = contract.query_missing_observations(index, s.index).unwrap();

--- a/cosmwasm/packages/accounting/Cargo.toml
+++ b/cosmwasm/packages/accounting/Cargo.toml
@@ -15,12 +15,11 @@ library = []
 
 [dependencies]
 anyhow = "1"
-base64 = "0.13"
 cosmwasm-schema = "1"
 cosmwasm-std = "1"
 cw-storage-plus = "0.13.2"
 cw_transcode = "0.1.0"
-hex = "0.4.3"
+hex = { version = "0.4.3", features = ["serde"] }
 schemars = "0.8.8"
 serde = { version = "1.0.137", default-features = false }
 thiserror = "1"

--- a/cosmwasm/packages/wormhole-bindings/src/fake.rs
+++ b/cosmwasm/packages/wormhole-bindings/src/fake.rs
@@ -183,6 +183,10 @@ impl WormholeKeeper {
     pub fn set_index(&self, index: u32) {
         self.0.borrow_mut().index = index;
     }
+
+    pub fn num_guardians(&self) -> usize {
+        self.0.borrow().guardians.len()
+    }
 }
 
 impl Default for WormholeKeeper {


### PR DESCRIPTION
When submitting a batch of observations, we don't want an observation
for an already committed transfer to fail the entire batch.  This leads
to more complexity in the guardian and also delays all the legitimate
observations by at least one more block (~5 seconds).

Fix this by returning the transfer status of each observation as part
of the response data.  Observations for committed transfers will get
a `TransferStatus::Committed` response without failing the tx as long
as the digest of the observation matches the digest of the committed
transfer.  Digest mismatches are still an error and will fail the entire
batch.

Part of #2188 