### PR TITLE
sdk/rust: Properly support tokenbridge payload3 messages

### DIFF
--- a/cosmwasm/contracts/wormchain-accounting/src/contract.rs
+++ b/cosmwasm/contracts/wormchain-accounting/src/contract.rs
@@ -184,7 +184,7 @@ fn handle_observation(
         return Ok(None);
     }
 
-    let (msg, _) = serde_wormhole::from_slice::<(Message, &RawMessage)>(&o.payload)
+    let msg = serde_wormhole::from_slice::<Message<&RawMessage>>(&o.payload)
         .context("failed to parse observation payload")?;
     let tx_data = match msg {
         Message::Transfer {
@@ -370,7 +370,7 @@ fn handle_vaa(mut deps: DepsMut<WormholeQuery>, vaa: Binary) -> anyhow::Result<E
             .context("failed to parse governance packet")?;
         handle_governance_vaa(deps.branch(), body.with_payload(govpacket))?
     } else {
-        let (msg, _) = serde_wormhole::from_slice::<(_, &RawMessage)>(body.payload)
+        let msg = serde_wormhole::from_slice(body.payload)
             .context("failed to parse tokenbridge message")?;
         handle_tokenbridge_vaa(deps.branch(), body.with_payload(msg))?
     };
@@ -413,7 +413,7 @@ fn handle_governance_vaa(
 
 fn handle_tokenbridge_vaa(
     mut deps: DepsMut<WormholeQuery>,
-    body: Body<Message>,
+    body: Body<Message<&RawMessage>>,
 ) -> anyhow::Result<Event> {
     let data = match body.payload {
         Message::Transfer {

--- a/cosmwasm/contracts/wormchain-accounting/tests/missing_observations.rs
+++ b/cosmwasm/contracts/wormchain-accounting/tests/missing_observations.rs
@@ -7,7 +7,7 @@ use wormchain_accounting::msg::Observation;
 use wormhole::{token::Message, Address, Amount, Chain};
 
 fn create_observation() -> Observation {
-    let msg = Message::Transfer {
+    let msg: Message = Message::Transfer {
         amount: Amount(Uint256::from(500u128).to_be_bytes()),
         token_address: Address([0x02; 32]),
         token_chain: Chain::Ethereum,
@@ -106,7 +106,7 @@ fn different_observations() {
     }
 
     // Create a new observation with a different tx hash and payload.
-    let msg = Message::Transfer {
+    let msg: Message = Message::Transfer {
         amount: Amount(Uint256::from(900u128).to_be_bytes()),
         token_address: Address([0x02; 32]),
         token_chain: Chain::Ethereum,

--- a/cosmwasm/contracts/wormchain-accounting/tests/query.rs
+++ b/cosmwasm/contracts/wormchain-accounting/tests/query.rs
@@ -53,7 +53,7 @@ fn create_transfers(
         let recipient_chain = emitter_chain + 1;
         let amount = Uint256::from(i as u128);
 
-        let body = Body {
+        let body: Body<Message> = Body {
             timestamp: i as u32,
             nonce: i as u32,
             emitter_chain: emitter_chain.into(),

--- a/sdk/rust/core/src/vaa.rs
+++ b/sdk/rust/core/src/vaa.rs
@@ -246,17 +246,10 @@ impl<P: Serialize> Body<P> {
     /// and hashing the result using on-chain primitives.
     #[inline]
     pub fn digest(&self) -> anyhow::Result<Digest> {
-        self.digest_with_payload(&[])
-    }
-
-    /// Like `digest` but allows specifying an additional payload to include in the body hash.
-    pub fn digest_with_payload(&self, payload: &[u8]) -> anyhow::Result<Digest> {
         // The `body` of the VAA is hashed to produce a `digest` of the VAA.
         let hash: [u8; 32] = {
             let mut h = sha3::Keccak256::default();
             serde_wormhole::to_writer(&mut h, self).context("failed to serialize body")?;
-            h.write_all(payload)
-                .context("failed to hash extra payload")?;
             h.finalize().into()
         };
 


### PR DESCRIPTION
Add the payload as an explicit field to the `TransferWithPayload` enum
variant.  This is a generic parameter that defaults to `Box<RawMessage>`
for maximum flexibility (and to avoid leaking lifetimes higher up the
stack) but users are encouraged to replace this default type parameter
with an explicit `&RawMessage` in places where the serde_wormhole data
format is used.

The main benefit of this change is that the payload is now included as
part of the actual message and no longer requires callers to awkwardly
append it after serialization.  This is especially useful in human-
readable formats like JSON (see the `transfer_with_payload` test in
token.rs for an example of this simplification).

The main downside is that this now requires explicit type annotations
when using the non-payload3 variants so that the compiler will pick up
the default generic parameter.  This is a relatively minor inconvenience
and the benefit appears to be worth the cost.

There should be no functional change.

