### PR TITLE
sdk/js: decouple nft/token bridge eth tx creation from sending to network

### DIFF
--- a/sdk/js/CHANGELOG.md
+++ b/sdk/js/CHANGELOG.md
@@ -1,14 +1,16 @@
 # Changelog
 
+## 0.9.11
+
+### Changed
+
+Add functions to build the nft/token bridge transactions for each Eth action through the `populateTransaction` method, adding an alternative workflow to the default sign & method behavior
+
 ## 0.9.10
 
 ### Added
 
 Aptos NFT bridge support
-
-### Changed
-
-Add functions to build the nft/token bridge transactions for each Eth action through the `populateTransaction` method, adding an alternative workflow to the default sign & method behavior
 
 ## 0.9.9
 

--- a/sdk/js/CHANGELOG.md
+++ b/sdk/js/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## 0.9.10
 
-## Added
+### Added
 
 Aptos NFT bridge support
+
+### Changed
+
+Add functions to build the nft/token bridge transactions for each Eth action through the `populateTransaction` method, adding an alternative workflow to the default sign & method behavior
 
 ## 0.9.9
 

--- a/sdk/js/package-lock.json
+++ b/sdk/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@certusone/wormhole-sdk",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@certusone/wormhole-sdk",
-      "version": "0.9.10",
+      "version": "0.9.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@certusone/wormhole-sdk-proto-web": "0.0.6",
@@ -9269,7 +9269,6 @@
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.5.tgz",
       "integrity": "sha512-HTm14iMQKK2FjFLRTM5lAVcyaUzOnqbPtesFIvREgXpJHdQm8bWS+GkQgIkfaBYRHuCnea7w8UVNfwiAQhlr9A==",
       "dev": true,
-      "hasInstallScript": true,
       "optional": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
@@ -9632,7 +9631,6 @@
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.7.tgz",
       "integrity": "sha512-vLt1O5Pp+flcArHGIyKEQq883nBt8nN8tVBcoL0qUXj2XT1n7p70yGIq2VK98I5FdZ1YHc0wk/koOnHjnXWk1Q==",
       "dev": true,
-      "hasInstallScript": true,
       "optional": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"

--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@certusone/wormhole-sdk",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "description": "SDK for interacting with Wormhole",
   "homepage": "https://wormhole.com",
   "main": "./lib/cjs/index.js",

--- a/sdk/js/src/token_bridge/attest.ts
+++ b/sdk/js/src/token_bridge/attest.ts
@@ -49,10 +49,20 @@ export async function attestFromEth(
   tokenAddress: string,
   overrides: PayableOverrides & { from?: string | Promise<string> } = {}
 ): Promise<ethers.ContractReceipt> {
-  const bridge = Bridge__factory.connect(tokenBridgeAddress, signer);
-  const v = await bridge.attestToken(tokenAddress, createNonce(), overrides);
+  const tx = await attestFromEthTx(tokenBridgeAddress, signer, tokenAddress, overrides);
+  const v = await signer.sendTransaction(tx);
   const receipt = await v.wait();
   return receipt;
+}
+
+export async function attestFromEthTx(
+  tokenBridgeAddress: string,
+  signer: ethers.Signer,
+  tokenAddress: string,
+  overrides: PayableOverrides & { from?: string | Promise<string> } = {}
+): Promise<ethers.PopulatedTransaction> {
+  const bridge = Bridge__factory.connect(tokenBridgeAddress, signer);
+  return bridge.populateTransaction.attestToken(tokenAddress, createNonce(), overrides);
 }
 
 export async function attestFromTerra(

--- a/sdk/js/src/token_bridge/createWrapped.ts
+++ b/sdk/js/src/token_bridge/createWrapped.ts
@@ -35,10 +35,20 @@ export async function createWrappedOnEth(
   signedVAA: Uint8Array,
   overrides: Overrides & { from?: string | Promise<string> } = {}
 ): Promise<ethers.ContractReceipt> {
-  const bridge = Bridge__factory.connect(tokenBridgeAddress, signer);
-  const v = await bridge.createWrapped(signedVAA, overrides);
+  const tx = await createWrappedOnEthTx(tokenBridgeAddress, signer, signedVAA, overrides)
+  const v = await signer.sendTransaction(tx);
   const receipt = await v.wait();
   return receipt;
+}
+
+export async function createWrappedOnEthTx(
+  tokenBridgeAddress: string,
+  signer: ethers.Signer,
+  signedVAA: Uint8Array,
+  overrides: Overrides & { from?: string | Promise<string> } = {}
+): Promise<ethers.PopulatedTransaction> {
+  const bridge = Bridge__factory.connect(tokenBridgeAddress, signer);
+  return bridge.populateTransaction.createWrapped(signedVAA, overrides);
 }
 
 export async function createWrappedOnTerra(

--- a/sdk/js/src/token_bridge/redeem.ts
+++ b/sdk/js/src/token_bridge/redeem.ts
@@ -55,11 +55,21 @@ export async function redeemOnEth(
   signer: ethers.Signer,
   signedVAA: Uint8Array,
   overrides: Overrides & { from?: string | Promise<string> } = {}
-) {
-  const bridge = Bridge__factory.connect(tokenBridgeAddress, signer);
-  const v = await bridge.completeTransfer(signedVAA, overrides);
+): Promise<ethers.ContractReceipt> {
+  const tx = await redeeomOnEthTx(tokenBridgeAddress, signer, signedVAA, overrides);
+  const v = await signer.sendTransaction(tx);
   const receipt = await v.wait();
   return receipt;
+}
+
+export async function redeeomOnEthTx(
+  tokenBridgeAddress: string,
+  signer: ethers.Signer,
+  signedVAA: Uint8Array,
+  overrides: Overrides & { from?: string | Promise<string> } = {}
+): Promise<ethers.PopulatedTransaction> {
+  const bridge = Bridge__factory.connect(tokenBridgeAddress, signer);
+  return bridge.populateTransaction.completeTransfer(signedVAA, overrides);
 }
 
 export async function redeemOnEthNative(
@@ -67,11 +77,21 @@ export async function redeemOnEthNative(
   signer: ethers.Signer,
   signedVAA: Uint8Array,
   overrides: Overrides & { from?: string | Promise<string> } = {}
-) {
-  const bridge = Bridge__factory.connect(tokenBridgeAddress, signer);
-  const v = await bridge.completeTransferAndUnwrapETH(signedVAA, overrides);
+): Promise<ethers.ContractReceipt> {
+  const tx = await redeemOnEthNativeTx(tokenBridgeAddress, signer, signedVAA, overrides);
+  const v = await signer.sendTransaction(tx);
   const receipt = await v.wait();
   return receipt;
+}
+
+export async function redeemOnEthNativeTx(
+  tokenBridgeAddress: string,
+  signer: ethers.Signer,
+  signedVAA: Uint8Array,
+  overrides: Overrides & { from?: string | Promise<string> } = {}
+): Promise<ethers.PopulatedTransaction> {
+  const bridge = Bridge__factory.connect(tokenBridgeAddress, signer);
+  return bridge.populateTransaction.completeTransferAndUnwrapETH(signedVAA, overrides);
 }
 
 export async function redeemOnTerra(

--- a/sdk/js/src/token_bridge/transfer.ts
+++ b/sdk/js/src/token_bridge/transfer.ts
@@ -110,11 +110,11 @@ export async function approveEthTx(
 
 export async function transferFromEth(
   tokenBridgeAddress: string,
+  signer: ethers.Signer,
   tokenAddress: string,
   amount: ethers.BigNumberish,
   recipientChain: ChainId | ChainName,
   recipientAddress: Uint8Array,
-  signer: ethers.Signer,
   relayerFee: ethers.BigNumberish = 0,
   overrides: PayableOverrides & { from?: string | Promise<string> } = {},
   payload: Uint8Array | null = null

--- a/sdk/js/src/token_bridge/updateWrapped.ts
+++ b/sdk/js/src/token_bridge/updateWrapped.ts
@@ -15,11 +15,21 @@ export async function updateWrappedOnEth(
   signer: ethers.Signer,
   signedVAA: Uint8Array,
   overrides: Overrides & { from?: string | Promise<string> } = {}
-) {
-  const bridge = Bridge__factory.connect(tokenBridgeAddress, signer);
-  const v = await bridge.updateWrapped(signedVAA, overrides);
+): Promise<ethers.ContractReceipt> {
+  const tx = await updateWrappedOnEthTx(tokenBridgeAddress, signer, signedVAA, overrides);
+  const v = await signer.sendTransaction(tx);
   const receipt = await v.wait();
   return receipt;
+}
+
+export async function updateWrappedOnEthTx(
+  tokenBridgeAddress: string,
+  signer: ethers.Signer,
+  signedVAA: Uint8Array,
+  overrides: Overrides & { from?: string | Promise<string> } = {}
+): Promise<ethers.PopulatedTransaction> {
+  const bridge = Bridge__factory.connect(tokenBridgeAddress, signer);
+  return bridge.populateTransaction.updateWrapped(signedVAA, overrides);
 }
 
 export const updateWrappedOnTerra = createWrappedOnTerra;


### PR DESCRIPTION
Add functions to build the transactions for each Eth action through the `populateTransaction` method, instead of outright signing and sending it.

This will provide a different behavior than the default sign & send of the existing methods, which would keep it consistent with the workflow provided by other chains' routines (i.e. return some data that the client will somehow sign). This way xDapps can stablish some level of abstraction on a common workflow across multiple chains (e.g: build tx -> sign -> send).

This change only adds functions which are internally called by the original ones. The existing functionalities should not be affected by this PR.