### PR TITLE
Node/Acct: batch requests

### DIFF
--- a/node/hack/accountant/send_obs.go
+++ b/node/hack/accountant/send_obs.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/certusone/wormhole/node/pkg/accountant"
@@ -17,6 +19,9 @@ import (
 	nodev1 "github.com/certusone/wormhole/node/pkg/proto/node/v1"
 	"github.com/certusone/wormhole/node/pkg/wormconn"
 	"github.com/wormhole-foundation/wormhole/sdk/vaa"
+
+	sdktypes "github.com/cosmos/cosmos-sdk/types"
+	sdktx "github.com/cosmos/cosmos-sdk/types/tx"
 
 	ethCrypto "github.com/ethereum/go-ethereum/crypto"
 
@@ -29,23 +34,6 @@ import (
 func main() {
 	ctx := context.Background()
 	logger, _ := zap.NewDevelopment()
-
-	// data, err := hex.DecodeString("C3AE4256EAA0BA6D01041585F63AE7CAA69D6D33")
-	// if err != nil {
-	// 	logger.Fatal("failed to hex decode string", zap.Error(err))
-	// }
-
-	// conv, err := bech32.ConvertBits(data, 8, 5, true)
-	// if err != nil {
-	// 	logger.Fatal("failed to convert bits", zap.Error(err))
-	// }
-
-	// encoded, err := bech32.Encode("wormhole", conv)
-	// if err != nil {
-	// 	logger.Fatal("bech32 encode failed", zap.Error(err))
-	// }
-	// logger.Info("encoded", zap.String("str", encoded))
-	// return
 
 	wormchainURL := string("localhost:9090")
 	wormchainKeyPath := string("./dev.wormchain.key")
@@ -77,7 +65,7 @@ func main() {
 	sequence := uint64(time.Now().Unix())
 	timestamp := time.Now()
 
-	if !testSubmit(ctx, logger, gk, wormchainConn, contract, "0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16", timestamp, sequence, false, false, "Submit should succeed") {
+	if !testSubmit(ctx, logger, gk, wormchainConn, contract, "0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16", timestamp, sequence, true, false, "Submit should succeed") {
 		return
 	}
 
@@ -85,10 +73,27 @@ func main() {
 		return
 	}
 
-	sequence += 1
+	sequence += 10
 	if !testSubmit(ctx, logger, gk, wormchainConn, contract, "0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c17", timestamp, sequence, false, true, "Bad emitter address should fail") {
 		return
 	}
+
+	sequence += 10
+	if !testBatch(ctx, logger, gk, wormchainConn, contract, timestamp, sequence) {
+		return
+	}
+
+	sequence += 10
+	if !testBatchWithcommitted(ctx, logger, gk, wormchainConn, contract, timestamp, sequence) {
+		return
+	}
+
+	sequence += 10
+	if !testBatchWithDigestError(ctx, logger, gk, wormchainConn, contract, timestamp, sequence) {
+		return
+	}
+
+	logger.Info("Success! All tests passed!")
 }
 
 func testSubmit(
@@ -107,8 +112,6 @@ func testSubmit(
 	EmitterAddress, _ := vaa.StringToAddress(emitterAddressStr)
 	TxHash, _ := vaa.StringToHash("82ea2536c5d1671830cb49120f94479e34b54596a8dd369fbc2666667a765f4b")
 	Payload, _ := hex.DecodeString("010000000000000000000000000000000000000000000000000de0b6b3a76400000000000000000000000000002d8be6bf0baa74e0a907016679cae9190e80dd0a0002000000000000000000000000c10820983f33456ce7beb3a046f5a83fa34f027d0c200000000000000000000000000000000000000000000000000000000000000000")
-	gsIndex := uint32(0)
-	guardianIndex := uint32(0)
 
 	msg := common.MessagePublication{
 		TxHash:           TxHash,
@@ -121,41 +124,308 @@ func testSubmit(
 		Payload:          Payload,
 	}
 
-	txResp, err := accountant.SubmitObservationToContract(ctx, logger, gk, gsIndex, guardianIndex, wormchainConn, contract, &msg)
+	msgs := []*common.MessagePublication{&msg}
+	txResp, err := submit(ctx, logger, gk, wormchainConn, contract, msgs)
 	if err != nil {
 		logger.Error("acct: failed to broadcast Observation request", zap.String("test", tag), zap.Error(err))
 		return false
 	}
+	logStuff(logger, txResp)
 
-	// out, err := wormchainConn.BroadcastTxResponseToString(txResp)
-	// if err != nil {
-	// 	logger.Error("acct: failed to parse broadcast response", zap.Error(err))
-	// 	return false
-	// }
-
-	alreadyCommitted, err := accountant.CheckSubmitObservationResult(txResp)
+	responses, err := accountant.GetObservationResponses(logger, txResp, 1)
 	if err != nil {
-		if !errorExpected {
-			logger.Error("acct: unexpected error", zap.String("test", tag), zap.Error(err))
-			return false
-		}
-
-		logger.Info("test succeeded, expected error returned", zap.String("test", tag), zap.Error(err))
-		return true
+		logger.Error("acct: failed to get responses", zap.Error(err))
+		return false
 	}
-	if alreadyCommitted != expectedResult {
-		out, err := wormchainConn.BroadcastTxResponseToString(txResp)
-		if err != nil {
-			logger.Error("acct: failed to parse broadcast response", zap.String("test", tag), zap.Error(err))
-			return false
-		}
 
-		logger.Info("test failed", zap.String("test", tag), zap.Uint64("seqNo", sequence), zap.Bool("alreadyCommitted", alreadyCommitted), zap.String("response", out))
+	if responses[0].Key.String() != msgs[0].MessageIDString() {
+		logger.Info("test failed: unexpected msgId in observation response", zap.String("test", tag), zap.String("expected", msgs[0].MessageIDString()), zap.String("actual", responses[0].Key.String()))
+		return false
+	}
+
+	committed := responses[0].Status.Type == "committed"
+
+	if committed != expectedResult {
+		logger.Info("test failed", zap.String("test", tag), zap.Uint64("seqNo", sequence), zap.Bool("committed", committed),
+			zap.String("response", wormchainConn.BroadcastTxResponseToString(txResp)))
 		return false
 	}
 
 	logger.Info("test succeeded", zap.String("test", tag))
 	return true
+}
+
+func testBatch(
+	ctx context.Context,
+	logger *zap.Logger,
+	gk *ecdsa.PrivateKey,
+	wormchainConn *wormconn.ClientConn,
+	contract string,
+	timestamp time.Time,
+	sequence uint64,
+) bool {
+	EmitterAddress, _ := vaa.StringToAddress("0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16")
+	TxHash, _ := vaa.StringToHash("82ea2536c5d1671830cb49120f94479e34b54596a8dd369fbc2666667a765f4b")
+	Payload, _ := hex.DecodeString("010000000000000000000000000000000000000000000000000de0b6b3a76400000000000000000000000000002d8be6bf0baa74e0a907016679cae9190e80dd0a0002000000000000000000000000c10820983f33456ce7beb3a046f5a83fa34f027d0c200000000000000000000000000000000000000000000000000000000000000000")
+
+	nonce := uint32(123456)
+
+	msgs := []*common.MessagePublication{}
+
+	msg1 := common.MessagePublication{
+		TxHash:           TxHash,
+		Timestamp:        timestamp,
+		Nonce:            nonce,
+		Sequence:         sequence,
+		EmitterChain:     vaa.ChainIDEthereum,
+		EmitterAddress:   EmitterAddress,
+		ConsistencyLevel: uint8(15),
+		Payload:          Payload,
+	}
+	msgs = append(msgs, &msg1)
+
+	nonce = nonce + 1
+	sequence = sequence + 1
+	msg2 := common.MessagePublication{
+		TxHash:           TxHash,
+		Timestamp:        time.Now(),
+		Nonce:            nonce,
+		Sequence:         sequence,
+		EmitterChain:     vaa.ChainIDEthereum,
+		EmitterAddress:   EmitterAddress,
+		ConsistencyLevel: uint8(15),
+		Payload:          Payload,
+	}
+	msgs = append(msgs, &msg2)
+
+	txResp, err := submit(ctx, logger, gk, wormchainConn, contract, msgs)
+	if err != nil {
+		logger.Error("acct: failed to broadcast Observation request", zap.Error(err))
+		return false
+	}
+
+	logStuff(logger, txResp)
+
+	responses, err := accountant.GetObservationResponses(logger, txResp, 2)
+	if err != nil {
+		logger.Error("acct: failed to get responses", zap.Error(err))
+		return false
+	}
+
+	for idx, resp := range responses {
+		if responses[idx].Key.String() != msgs[idx].MessageIDString() {
+			logger.Error("acct: unexpected msgId in observation response", zap.Int("idx", idx), zap.String("expected", msgs[idx].MessageIDString()), zap.String("actual", responses[idx].Key.String()))
+			return false
+		}
+
+		if resp.Status.Type != "committed" {
+			logger.Error("acct: unexpected response on observation", zap.Int("idx", idx), zap.String("status", resp.Status.Type), zap.String("text", responses[idx].Status.Data))
+			return false
+		}
+	}
+
+	logger.Info("test of batch passed.")
+	return true
+}
+
+func testBatchWithcommitted(
+	ctx context.Context,
+	logger *zap.Logger,
+	gk *ecdsa.PrivateKey,
+	wormchainConn *wormconn.ClientConn,
+	contract string,
+	timestamp time.Time,
+	sequence uint64,
+) bool {
+	EmitterAddress, _ := vaa.StringToAddress("0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16")
+	TxHash, _ := vaa.StringToHash("82ea2536c5d1671830cb49120f94479e34b54596a8dd369fbc2666667a765f4b")
+	Payload, _ := hex.DecodeString("010000000000000000000000000000000000000000000000000de0b6b3a76400000000000000000000000000002d8be6bf0baa74e0a907016679cae9190e80dd0a0002000000000000000000000000c10820983f33456ce7beb3a046f5a83fa34f027d0c200000000000000000000000000000000000000000000000000000000000000000")
+
+	nonce := uint32(123456)
+
+	msgs := []*common.MessagePublication{}
+
+	logger.Info("submitting a single transfer that should work")
+	msg1 := common.MessagePublication{
+		TxHash:           TxHash,
+		Timestamp:        timestamp,
+		Nonce:            nonce,
+		Sequence:         sequence,
+		EmitterChain:     vaa.ChainIDEthereum,
+		EmitterAddress:   EmitterAddress,
+		ConsistencyLevel: uint8(15),
+		Payload:          Payload,
+	}
+	msgs = append(msgs, &msg1)
+
+	_, err := submit(ctx, logger, gk, wormchainConn, contract, msgs)
+	if err != nil {
+		logger.Error("acct: failed to submit initial observation that should work", zap.Error(err))
+		return false
+	}
+
+	logger.Info("submitting a second batch where the second one has already been committed")
+	msgs = msgs[:0]
+
+	nonce = nonce + 1
+	sequence = sequence + 1
+	msg2 := common.MessagePublication{
+		TxHash:           TxHash,
+		Timestamp:        time.Now(),
+		Nonce:            nonce,
+		Sequence:         sequence,
+		EmitterChain:     vaa.ChainIDEthereum,
+		EmitterAddress:   EmitterAddress,
+		ConsistencyLevel: uint8(15),
+		Payload:          Payload,
+	}
+	msgs = append(msgs, &msg2)
+
+	// Same one we just committed.
+	msg3 := msg1
+	msgs = append(msgs, &msg3)
+
+	txResp, err := submit(ctx, logger, gk, wormchainConn, contract, msgs)
+	if err != nil {
+		logger.Error("acct: failed to broadcast Observation request", zap.Error(err))
+		return false
+	}
+
+	logStuff(logger, txResp)
+
+	responses, err := accountant.GetObservationResponses(logger, txResp, 2)
+	if err != nil {
+		logger.Error("acct: failed to get responses", zap.Error(err))
+		return false
+	}
+
+	for idx, resp := range responses {
+		if responses[idx].Key.String() != msgs[idx].MessageIDString() {
+			logger.Error("acct: unexpected msgId in observation response", zap.Int("idx", idx), zap.String("expected", msgs[idx].MessageIDString()), zap.String("actual", responses[idx].Key.String()))
+			return false
+		}
+
+		if resp.Status.Type != "committed" {
+			logger.Error("acct: unexpected response on observation", zap.Int("idx", idx), zap.String("status", resp.Status.Type), zap.String("text", responses[idx].Status.Data))
+			return false
+		}
+	}
+
+	logger.Info("test of batch with already committed passed.")
+	return true
+}
+
+func testBatchWithDigestError(
+	ctx context.Context,
+	logger *zap.Logger,
+	gk *ecdsa.PrivateKey,
+	wormchainConn *wormconn.ClientConn,
+	contract string,
+	timestamp time.Time,
+	sequence uint64,
+) bool {
+	EmitterAddress, _ := vaa.StringToAddress("0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16")
+	TxHash, _ := vaa.StringToHash("82ea2536c5d1671830cb49120f94479e34b54596a8dd369fbc2666667a765f4b")
+	Payload, _ := hex.DecodeString("010000000000000000000000000000000000000000000000000de0b6b3a76400000000000000000000000000002d8be6bf0baa74e0a907016679cae9190e80dd0a0002000000000000000000000000c10820983f33456ce7beb3a046f5a83fa34f027d0c200000000000000000000000000000000000000000000000000000000000000000")
+
+	nonce := uint32(123456)
+
+	msgs := []*common.MessagePublication{}
+
+	logger.Info("submitting a single transfer that should work")
+	msg1 := common.MessagePublication{
+		TxHash:           TxHash,
+		Timestamp:        timestamp,
+		Nonce:            nonce,
+		Sequence:         sequence,
+		EmitterChain:     vaa.ChainIDEthereum,
+		EmitterAddress:   EmitterAddress,
+		ConsistencyLevel: uint8(15),
+		Payload:          Payload,
+	}
+	msgs = append(msgs, &msg1)
+
+	_, err := submit(ctx, logger, gk, wormchainConn, contract, msgs)
+	if err != nil {
+		logger.Error("acct: failed to submit initial observation that should work", zap.Error(err))
+		return false
+	}
+
+	logger.Info("submitting a second batch where the second one has a digest error")
+	msgs = msgs[:0]
+
+	nonce = nonce + 1
+	sequence = sequence + 1
+	msg2 := common.MessagePublication{
+		TxHash:           TxHash,
+		Timestamp:        time.Now(),
+		Nonce:            nonce,
+		Sequence:         sequence,
+		EmitterChain:     vaa.ChainIDEthereum,
+		EmitterAddress:   EmitterAddress,
+		ConsistencyLevel: uint8(15),
+		Payload:          Payload,
+	}
+	msgs = append(msgs, &msg2)
+
+	// Same key as the message we committed but change the digest.
+	msg3 := msg1
+	msg3.Nonce = msg3.Nonce + 1
+	msgs = append(msgs, &msg3)
+
+	txResp, err := submit(ctx, logger, gk, wormchainConn, contract, msgs)
+	if err != nil {
+		logger.Error("acct: failed to submit second observation that should work", zap.Error(err))
+		return false
+	}
+
+	responses, err := accountant.GetObservationResponses(logger, txResp, 2)
+	if err != nil {
+		logger.Error("acct: failed to get responses", zap.Error(err))
+		return false
+	}
+
+	if responses[0].Key.String() != msgs[0].MessageIDString() {
+		logger.Error("acct: unexpected msgId in observation response", zap.Int("idx", 0), zap.String("expected", msgs[0].MessageIDString()), zap.String("actual", responses[0].Key.String()))
+		return false
+	}
+
+	if responses[0].Status.Type != "committed" {
+		logger.Error("acct: unexpected response on observation 0", zap.String("status", responses[0].Status.Type), zap.String("text", responses[0].Status.Data))
+		return false
+	}
+
+	if responses[1].Key.String() != msgs[1].MessageIDString() {
+		logger.Error("acct: unexpected msgId in observation response", zap.Int("idx", 1), zap.String("expected", msgs[1].MessageIDString()), zap.String("actual", responses[1].Key.String()))
+		return false
+	}
+
+	if responses[1].Status.Type != "error" {
+		logger.Error("acct: unexpected response on observation 1", zap.String("status", responses[1].Status.Type), zap.String("text", responses[1].Status.Data))
+		return false
+	}
+
+	if responses[1].Status.Data != "digest mismatch for processed message" {
+		logger.Error("acct: unexpected error text on observation 1", zap.String("text", responses[1].Status.Data))
+		return false
+	}
+
+	logger.Info("test of batch with digest error passed.")
+	return true
+}
+
+func submit(
+	ctx context.Context,
+	logger *zap.Logger,
+	gk *ecdsa.PrivateKey,
+	wormchainConn *wormconn.ClientConn,
+	contract string,
+	msgs []*common.MessagePublication,
+) (*sdktx.BroadcastTxResponse, error) {
+	gsIndex := uint32(0)
+	guardianIndex := uint32(0)
+
+	return accountant.SubmitObservationsToContract(ctx, logger, gk, gsIndex, guardianIndex, wormchainConn, contract, msgs)
 }
 
 const (
@@ -197,15 +467,41 @@ func loadGuardianKey(filename string) (*ecdsa.PrivateKey, error) {
 	return gk, nil
 }
 
-/*
-DEBUG: obs: {
-  key: {
-    emitter_chain: 2,
-    emitter_address: 'AAAAAAAAAAAAAAAAApD7FnIIr0VbsTd4AWO3t6mhDBY=',
-    sequence: 0
-  },
-  nonce: 0,
-  payload: 'AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA3gtrOnZAAAAAAAAAAAAAAAAAAALYvmvwuqdOCpBwFmecrpGQ6A3QoAAgAAAAAAAAAAAAAAAMEIIJg/M0Vs576zoEb1qD+jTwJ9DCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==',
-  tx_hash: '82ea2536c5d1671830cb49120f94479e34b54596a8dd369fbc2666667a765f4b'
+func logStuff(logger *zap.Logger, txResp *sdktx.BroadcastTxResponse) {
+	data, err := hex.DecodeString(txResp.TxResponse.Data)
+	if err != nil {
+		panic(err)
+	}
+
+	var msg sdktypes.TxMsgData
+	if err := msg.Unmarshal([]byte(data)); err != nil {
+		panic(err)
+	}
+
+	str := string(msg.Data[0].Data)
+	idx := strings.Index(str, "[")
+	if idx >= 0 {
+		logger.Info("Why does the data start with this?", zap.String("junk", str[:idx]))
+		str = str[idx:]
+	}
+
+	var responses accountant.ObservationResponses
+	err = json.Unmarshal([]byte(str), &responses)
+	if err != nil {
+		panic(err)
+	}
+
+	logger.Info("responses", zap.Int("numResponses", len(responses)))
+	for idx, resp := range responses {
+		switch resp.Status.Type {
+		case "committed":
+			logger.Info("   response is committed", zap.Int("idx", idx))
+		case "pending":
+			logger.Info("   response is pending", zap.Int("idx", idx))
+		case "error":
+			logger.Info("   response contains an error", zap.Int("idx", idx), zap.String("data", string(msg.Data[0].Data)))
+		default:
+			logger.Error("Unexpected status on response", zap.Int("idx", idx), zap.String("data", string(msg.Data[0].Data)))
+		}
+	}
 }
-*/

--- a/node/pkg/accountant/accountant_test.go
+++ b/node/pkg/accountant/accountant_test.go
@@ -187,7 +187,7 @@ func TestInterestingTransferShouldNotBeBlockedWhenNotEnforcingAccountant(t *test
 	require.NotNil(t, pe)
 
 	// PublishTransfer should not publish to the channel but it should remove it from the map.
-	acct.publishTransfer(pe)
+	acct.publishTransferAlreadyLocked(pe)
 	assert.Equal(t, 0, len(acct.msgChan))
 	assert.Equal(t, 0, len(acct.pendingTransfers))
 }
@@ -236,7 +236,7 @@ func TestInterestingTransferShouldBeBlockedWhenEnforcingAccountant(t *testing.T)
 	require.NotNil(t, pe)
 
 	// PublishTransfer should publish to the channel and remove it from the map.
-	acct.publishTransfer(pe)
+	acct.publishTransferAlreadyLocked(pe)
 	assert.Equal(t, 1, len(acct.msgChan))
 	assert.Equal(t, 0, len(acct.pendingTransfers))
 }

--- a/node/pkg/accountant/metrics.go
+++ b/node/pkg/accountant/metrics.go
@@ -27,6 +27,11 @@ var (
 			Name: "global_accountant_events_received",
 			Help: "Total number of accountant events received from the smart contract",
 		})
+	errorEventsReceived = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "global_accountant_error_events_received",
+			Help: "Total number of accountant error events received from the smart contract",
+		})
 	submitFailures = promauto.NewCounter(
 		prometheus.CounterOpts{
 			Name: "global_accountant_submit_failures",

--- a/node/pkg/accountant/submit_obs.go
+++ b/node/pkg/accountant/submit_obs.go
@@ -253,8 +253,6 @@ func (acct *Accountant) handleTransferError(msgId string, errText string, logTex
 	if strings.Contains(errText, "insufficient balance") {
 		balanceErrors.Inc()
 		acct.logger.Error("acct: insufficient balance error detected, dropping transfer", zap.String("msgId", msgId), zap.String("text", errText))
-		acct.pendingTransfersLock.Lock()
-		defer acct.pendingTransfersLock.Unlock()
 		acct.deletePendingTransfer(msgId)
 	} else {
 		// This will get retried next audit interval.

--- a/node/pkg/accountant/submit_obs_test.go
+++ b/node/pkg/accountant/submit_obs_test.go
@@ -7,14 +7,12 @@ import (
 
 	"github.com/wormhole-foundation/wormhole/sdk/vaa"
 
-	// wasmdtypes "github.com/CosmWasm/wasmd/x/wasm/types"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestParseObservationResponseDataKey(t *testing.T) {
-	dataJson := []byte("{\"emitter_chain\":2,\"emitter_address\":\"AAAAAAAAAAAAAAAAApD7FnIIr0VbsTd4AWO3t6mhDBY=\",\"sequence\":1673978163}")
+	dataJson := []byte("{\"emitter_chain\":2,\"emitter_address\":\"0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16\",\"sequence\":1673978163}")
 
 	var key ObservationKey
 	err := json.Unmarshal(dataJson, &key)
@@ -25,23 +23,14 @@ func TestParseObservationResponseDataKey(t *testing.T) {
 
 	expectedResult := ObservationKey{
 		EmitterChain:   uint16(vaa.ChainIDEthereum),
-		EmitterAddress: expectedEmitterAddress.Bytes(),
+		EmitterAddress: expectedEmitterAddress,
 		Sequence:       1673978163,
 	}
 	assert.Equal(t, expectedResult, key)
 }
 
 func TestParseObservationResponseData(t *testing.T) {
-
-	/*
-		executeContractJson := []byte("\n\ufffd\u0002[{\"key\":{\"emitter_chain\":2,\"emitter_address\":\"AAAAAAAAAAAAAAAAApD7FnIIr0VbsTd4AWO3t6mhDBY=\",\"sequence\":1674061268},\"status\":{\"type\":\"committed\"}},{\"key\":{\"emitter_chain\":2,\"emitter_address\":\"AAAAAAAAAAAAAAAAApD7FnIIr0VbsTd4AWO3t6mhDBY=\",\"sequence\":1674061267},\"status\":{\"type\":\"error\",\"data\":\"digest mismatch for processed message\"}}]")
-		// executeContractHex := []byte("0AFA020A242F636F736D7761736D2E7761736D2E76312E4D736745786563757465436F6E747261637412D1020ACE025B7B226B6579223A7B22656D69747465725F636861696E223A322C22656D69747465725F61646472657373223A224141414141414141414141414141414141704437466E4949723056627354643441574F3374366D684442593D222C2273657175656E6365223A313637343036313236387D2C22737461747573223A7B2274797065223A22636F6D6D6974746564227D7D2C7B226B6579223A7B22656D69747465725F636861696E223A322C22656D69747465725F61646472657373223A224141414141414141414141414141414141704437466E4949723056627354643441574F3374366D684442593D222C2273657175656E6365223A313637343036313236377D2C22737461747573223A7B2274797065223A226572726F72222C2264617461223A22646967657374206D69736D6174636820666F722070726F636573736564206D657373616765227D7D5D")
-		var ec wasmdtypes.MsgExecuteContractResponse
-		err := json.Unmarshal(executeContractJson, &ec)
-		require.NoError(t, err)
-	*/
-
-	responsesJson := []byte("[{\"key\":{\"emitter_chain\":2,\"emitter_address\":\"AAAAAAAAAAAAAAAAApD7FnIIr0VbsTd4AWO3t6mhDBY=\",\"sequence\":1674061268},\"status\":{\"type\":\"committed\"}},{\"key\":{\"emitter_chain\":2,\"emitter_address\":\"AAAAAAAAAAAAAAAAApD7FnIIr0VbsTd4AWO3t6mhDBY=\",\"sequence\":1674061267},\"status\":{\"type\":\"error\",\"data\":\"digest mismatch for processed message\"}}]")
+	responsesJson := []byte("[{\"key\":{\"emitter_chain\":2,\"emitter_address\":\"0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16\",\"sequence\":1674061268},\"status\":{\"type\":\"committed\"}},{\"key\":{\"emitter_chain\":2,\"emitter_address\":\"0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16\",\"sequence\":1674061267},\"status\":{\"type\":\"error\",\"data\":\"digest mismatch for processed message\"}}]")
 	var responses ObservationResponses
 	err := json.Unmarshal(responsesJson, &responses)
 	require.NoError(t, err)
@@ -53,7 +42,7 @@ func TestParseObservationResponseData(t *testing.T) {
 	expectedResult0 := ObservationResponse{
 		Key: ObservationKey{
 			EmitterChain:   uint16(vaa.ChainIDEthereum),
-			EmitterAddress: expectedEmitterAddress.Bytes(),
+			EmitterAddress: expectedEmitterAddress,
 			Sequence:       1674061268,
 		},
 		Status: ObservationResponseStatus{
@@ -64,7 +53,7 @@ func TestParseObservationResponseData(t *testing.T) {
 	expectedResult1 := ObservationResponse{
 		Key: ObservationKey{
 			EmitterChain:   uint16(vaa.ChainIDEthereum),
-			EmitterAddress: expectedEmitterAddress.Bytes(),
+			EmitterAddress: expectedEmitterAddress,
 			Sequence:       1674061267,
 		},
 		Status: ObservationResponseStatus{

--- a/node/pkg/accountant/submit_obs_test.go
+++ b/node/pkg/accountant/submit_obs_test.go
@@ -1,0 +1,78 @@
+package accountant
+
+import (
+	// "encoding/hex"
+	"encoding/json"
+	"testing"
+
+	"github.com/wormhole-foundation/wormhole/sdk/vaa"
+
+	// wasmdtypes "github.com/CosmWasm/wasmd/x/wasm/types"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseObservationResponseDataKey(t *testing.T) {
+	dataJson := []byte("{\"emitter_chain\":2,\"emitter_address\":\"AAAAAAAAAAAAAAAAApD7FnIIr0VbsTd4AWO3t6mhDBY=\",\"sequence\":1673978163}")
+
+	var key ObservationKey
+	err := json.Unmarshal(dataJson, &key)
+	require.NoError(t, err)
+
+	expectedEmitterAddress, err := vaa.StringToAddress("0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16")
+	require.NoError(t, err)
+
+	expectedResult := ObservationKey{
+		EmitterChain:   uint16(vaa.ChainIDEthereum),
+		EmitterAddress: expectedEmitterAddress.Bytes(),
+		Sequence:       1673978163,
+	}
+	assert.Equal(t, expectedResult, key)
+}
+
+func TestParseObservationResponseData(t *testing.T) {
+
+	/*
+		executeContractJson := []byte("\n\ufffd\u0002[{\"key\":{\"emitter_chain\":2,\"emitter_address\":\"AAAAAAAAAAAAAAAAApD7FnIIr0VbsTd4AWO3t6mhDBY=\",\"sequence\":1674061268},\"status\":{\"type\":\"committed\"}},{\"key\":{\"emitter_chain\":2,\"emitter_address\":\"AAAAAAAAAAAAAAAAApD7FnIIr0VbsTd4AWO3t6mhDBY=\",\"sequence\":1674061267},\"status\":{\"type\":\"error\",\"data\":\"digest mismatch for processed message\"}}]")
+		// executeContractHex := []byte("0AFA020A242F636F736D7761736D2E7761736D2E76312E4D736745786563757465436F6E747261637412D1020ACE025B7B226B6579223A7B22656D69747465725F636861696E223A322C22656D69747465725F61646472657373223A224141414141414141414141414141414141704437466E4949723056627354643441574F3374366D684442593D222C2273657175656E6365223A313637343036313236387D2C22737461747573223A7B2274797065223A22636F6D6D6974746564227D7D2C7B226B6579223A7B22656D69747465725F636861696E223A322C22656D69747465725F61646472657373223A224141414141414141414141414141414141704437466E4949723056627354643441574F3374366D684442593D222C2273657175656E6365223A313637343036313236377D2C22737461747573223A7B2274797065223A226572726F72222C2264617461223A22646967657374206D69736D6174636820666F722070726F636573736564206D657373616765227D7D5D")
+		var ec wasmdtypes.MsgExecuteContractResponse
+		err := json.Unmarshal(executeContractJson, &ec)
+		require.NoError(t, err)
+	*/
+
+	responsesJson := []byte("[{\"key\":{\"emitter_chain\":2,\"emitter_address\":\"AAAAAAAAAAAAAAAAApD7FnIIr0VbsTd4AWO3t6mhDBY=\",\"sequence\":1674061268},\"status\":{\"type\":\"committed\"}},{\"key\":{\"emitter_chain\":2,\"emitter_address\":\"AAAAAAAAAAAAAAAAApD7FnIIr0VbsTd4AWO3t6mhDBY=\",\"sequence\":1674061267},\"status\":{\"type\":\"error\",\"data\":\"digest mismatch for processed message\"}}]")
+	var responses ObservationResponses
+	err := json.Unmarshal(responsesJson, &responses)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(responses))
+
+	expectedEmitterAddress, err := vaa.StringToAddress("0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16")
+	require.NoError(t, err)
+
+	expectedResult0 := ObservationResponse{
+		Key: ObservationKey{
+			EmitterChain:   uint16(vaa.ChainIDEthereum),
+			EmitterAddress: expectedEmitterAddress.Bytes(),
+			Sequence:       1674061268,
+		},
+		Status: ObservationResponseStatus{
+			Type: "committed",
+		},
+	}
+
+	expectedResult1 := ObservationResponse{
+		Key: ObservationKey{
+			EmitterChain:   uint16(vaa.ChainIDEthereum),
+			EmitterAddress: expectedEmitterAddress.Bytes(),
+			Sequence:       1674061267,
+		},
+		Status: ObservationResponseStatus{
+			Type: "error",
+			Data: "digest mismatch for processed message",
+		},
+	}
+
+	assert.Equal(t, expectedResult0, responses[0])
+	assert.Equal(t, expectedResult1, responses[1])
+}

--- a/node/pkg/accountant/watcher.go
+++ b/node/pkg/accountant/watcher.go
@@ -230,13 +230,6 @@ func parseWasmObservationError(logger *zap.Logger, event tmAbci.Event, contractA
 		return nil, fmt.Errorf("not a wasm-ObservationError event: %s", event.Type)
 	}
 
-	bytes, err := json.Marshal(event)
-	if err != nil {
-		logger.Info("failed to marshal wasm-ObservationError event", zap.Error(err))
-	} else {
-		logger.Info("wasm-ObservationError", zap.String("bytes", string(bytes)))
-	}
-
 	attrs := make(map[string]json.RawMessage)
 	for _, attr := range event.Attributes {
 		if string(attr.Key) == "_contract_address" {

--- a/node/pkg/accountant/watcher.go
+++ b/node/pkg/accountant/watcher.go
@@ -113,16 +113,7 @@ func (acct *Accountant) handleEvents(ctx context.Context, evts <-chan tmCoreType
 
 type (
 	// WasmObservation represents a transfer event from the smart contract.
-	WasmObservation struct {
-		TxHashBytes      []byte      `json:"tx_hash"`
-		Timestamp        uint32      `json:"timestamp"`
-		Nonce            uint32      `json:"nonce"`
-		EmitterChain     uint16      `json:"emitter_chain"`
-		EmitterAddress   vaa.Address `json:"emitter_address"`
-		Sequence         uint64      `json:"sequence"`
-		ConsistencyLevel uint8       `json:"consistency_level"`
-		Payload          []byte      `json:"payload"`
-	}
+	WasmObservation Observation
 
 	// WasmObservationError represents an error event from the smart contract.
 	WasmObservationError struct {
@@ -163,7 +154,7 @@ func (acct *Accountant) processPendingTransfer(xfer *WasmObservation) {
 	defer acct.pendingTransfersLock.Unlock()
 
 	acct.logger.Info("acctwatch: transfer event detected",
-		zap.String("tx_hash", hex.EncodeToString(xfer.TxHashBytes)),
+		zap.String("tx_hash", hex.EncodeToString(xfer.TxHash)),
 		zap.Uint32("timestamp", xfer.Timestamp),
 		zap.Uint32("nonce", xfer.Nonce),
 		zap.Stringer("emitter_chain", vaa.ChainID(xfer.EmitterChain)),
@@ -174,7 +165,7 @@ func (acct *Accountant) processPendingTransfer(xfer *WasmObservation) {
 	)
 
 	msg := &common.MessagePublication{
-		TxHash:           ethCommon.BytesToHash(xfer.TxHashBytes),
+		TxHash:           ethCommon.BytesToHash(xfer.TxHash),
 		Timestamp:        time.Unix(int64(xfer.Timestamp), 0),
 		Nonce:            xfer.Nonce,
 		Sequence:         xfer.Sequence,

--- a/node/pkg/accountant/watcher_test.go
+++ b/node/pkg/accountant/watcher_test.go
@@ -87,7 +87,7 @@ func TestParseWasmObservationFromPortalBridge(t *testing.T) {
 func TestParseWasmObservationError(t *testing.T) {
 	logger := zap.NewNop()
 
-	eventJson := []byte("{\"type\":\"wasm-ObservationError\",\"attributes\":[{\"key\":\"X2NvbnRyYWN0X2FkZHJlc3M=\",\"value\":\"d29ybWhvbGUxNDY2bmYzenV4cHlhOHE5ZW14dWtkN3ZmdGFmNmg0cHNyMGEwN3NybDV6dzc0emg4NHlqcTRseWptaA==\",\"index\":true},{\"key\":\"a2V5\",\"value\":\"eyJlbWl0dGVyX2NoYWluIjoyLCJlbWl0dGVyX2FkZHJlc3MiOiJBQUFBQUFBQUFBQUFBQUFBQXBEN0ZuSUlyMFZic1RkNEFXTzN0Nm1oREJZPSIsInNlcXVlbmNlIjoxNjc0MDcxOTQwfQ==\",\"index\":true},{\"key\":\"ZXJyb3I=\",\"value\":\"ImRpZ2VzdCBtaXNtYXRjaCBmb3IgcHJvY2Vzc2VkIG1lc3NhZ2Ui\",\"index\":true}]}")
+	eventJson := []byte("{\"type\":\"wasm-ObservationError\",\"attributes\":[{\"key\":\"X2NvbnRyYWN0X2FkZHJlc3M=\",\"value\":\"d29ybWhvbGUxNDY2bmYzenV4cHlhOHE5ZW14dWtkN3ZmdGFmNmg0cHNyMGEwN3NybDV6dzc0emg4NHlqcTRseWptaA==\",\"index\":true},{\"key\":\"a2V5\",\"value\":\"eyJlbWl0dGVyX2NoYWluIjoyLCJlbWl0dGVyX2FkZHJlc3MiOiIwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMjkwZmIxNjcyMDhhZjQ1NWJiMTM3NzgwMTYzYjdiN2E5YTEwYzE2Iiwic2VxdWVuY2UiOjE2NzQxNDQ1NDV9\",\"index\":true},{\"key\":\"ZXJyb3I=\",\"value\":\"ImRpZ2VzdCBtaXNtYXRjaCBmb3IgcHJvY2Vzc2VkIG1lc3NhZ2Ui\",\"index\":true}]}")
 	event := tmAbci.Event{}
 	err := json.Unmarshal(eventJson, &event)
 	require.NoError(t, err)
@@ -102,8 +102,8 @@ func TestParseWasmObservationError(t *testing.T) {
 	expectedResult := WasmObservationError{
 		Key: ObservationKey{
 			EmitterChain:   uint16(vaa.ChainIDEthereum),
-			EmitterAddress: expectedEmitterAddress.Bytes(),
-			Sequence:       1674071940,
+			EmitterAddress: expectedEmitterAddress,
+			Sequence:       1674144545,
 		},
 		Error: "digest mismatch for processed message",
 	}

--- a/node/pkg/accountant/watcher_test.go
+++ b/node/pkg/accountant/watcher_test.go
@@ -23,7 +23,7 @@ func TestParseWasmObservationFromTestTool(t *testing.T) {
 	err := json.Unmarshal(eventJson, &event)
 	require.NoError(t, err)
 
-	xfer, err := parseWasmObservation(logger, event, "wormhole1466nf3zuxpya8q9emxukd7vftaf6h4psr0a07srl5zw74zh84yjq4lyjmh")
+	xfer, err := parseEvent[WasmObservation](logger, event, "wasm-Observation", "wormhole1466nf3zuxpya8q9emxukd7vftaf6h4psr0a07srl5zw74zh84yjq4lyjmh")
 	require.NoError(t, err)
 	require.NotNil(t, xfer)
 
@@ -57,7 +57,7 @@ func TestParseWasmObservationFromPortalBridge(t *testing.T) {
 	err := json.Unmarshal(eventJson, &event)
 	require.NoError(t, err)
 
-	xfer, err := parseWasmObservation(logger, event, "wormhole1466nf3zuxpya8q9emxukd7vftaf6h4psr0a07srl5zw74zh84yjq4lyjmh")
+	xfer, err := parseEvent[WasmObservation](logger, event, "wasm-Observation", "wormhole1466nf3zuxpya8q9emxukd7vftaf6h4psr0a07srl5zw74zh84yjq4lyjmh")
 	require.NoError(t, err)
 	require.NotNil(t, xfer)
 
@@ -92,7 +92,7 @@ func TestParseWasmObservationError(t *testing.T) {
 	err := json.Unmarshal(eventJson, &event)
 	require.NoError(t, err)
 
-	evt, err := parseWasmObservationError(logger, event, "wormhole1466nf3zuxpya8q9emxukd7vftaf6h4psr0a07srl5zw74zh84yjq4lyjmh")
+	evt, err := parseEvent[WasmObservationError](logger, event, "wasm-ObservationError", "wormhole1466nf3zuxpya8q9emxukd7vftaf6h4psr0a07srl5zw74zh84yjq4lyjmh")
 	require.NoError(t, err)
 	require.NotNil(t, evt)
 

--- a/node/pkg/accountant/watcher_test.go
+++ b/node/pkg/accountant/watcher_test.go
@@ -15,15 +15,15 @@ import (
 	"go.uber.org/zap"
 )
 
-func TestParseWasmTransferFromTestTool(t *testing.T) {
+func TestParseWasmObservationFromTestTool(t *testing.T) {
 	logger := zap.NewNop()
 
-	eventJson := []byte("{\"type\":\"wasm-Transfer\",\"attributes\":[{\"key\":\"X2NvbnRyYWN0X2FkZHJlc3M=\",\"value\":\"d29ybWhvbGUxNDY2bmYzenV4cHlhOHE5ZW14dWtkN3ZmdGFmNmg0cHNyMGEwN3NybDV6dzc0emg4NHlqcTRseWptaA==\",\"index\":true},{\"key\":\"dHhfaGFzaA==\",\"value\":\"Imd1b2xOc1hSWnhnd3kwa1NENVJIbmpTMVJaYW8zVGFmdkNabVpucDJYMHM9Ig==\",\"index\":true},{\"key\":\"dGltZXN0YW1w\",\"value\":\"MTY3MjkzMjk5OA==\",\"index\":true},{\"key\":\"bm9uY2U=\",\"value\":\"MA==\",\"index\":true},{\"key\":\"ZW1pdHRlcl9jaGFpbg==\",\"value\":\"Mg==\",\"index\":true},{\"key\":\"ZW1pdHRlcl9hZGRyZXNz\",\"value\":\"IjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAyOTBmYjE2NzIwOGFmNDU1YmIxMzc3ODAxNjNiN2I3YTlhMTBjMTYi\",\"index\":true},{\"key\":\"c2VxdWVuY2U=\",\"value\":\"MTY3MjkzMjk5OA==\",\"index\":true},{\"key\":\"Y29uc2lzdGVuY3lfbGV2ZWw=\",\"value\":\"MTU=\",\"index\":true},{\"key\":\"dGVzdF9maWVsZA==\",\"value\":\"MTU=\",\"index\":true},{\"key\":\"cGF5bG9hZA==\",\"value\":\"IkFRQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUEzZ3RyT25aQUFBQUFBQUFBQUFBQUFBQUFBQUxZdm12d3VxZE9DcEJ3Rm1lY3JwR1E2QTNRb0FBZ0FBQUFBQUFBQUFBQUFBQU1FSUlKZy9NMFZzNTc2em9FYjFxRCtqVHdKOURDQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUE9PSI=\",\"index\":true}]}")
+	eventJson := []byte("{\"type\":\"wasm-Observation\",\"attributes\":[{\"key\":\"X2NvbnRyYWN0X2FkZHJlc3M=\",\"value\":\"d29ybWhvbGUxNDY2bmYzenV4cHlhOHE5ZW14dWtkN3ZmdGFmNmg0cHNyMGEwN3NybDV6dzc0emg4NHlqcTRseWptaA==\",\"index\":true},{\"key\":\"dHhfaGFzaA==\",\"value\":\"Imd1b2xOc1hSWnhnd3kwa1NENVJIbmpTMVJaYW8zVGFmdkNabVpucDJYMHM9Ig==\",\"index\":true},{\"key\":\"dGltZXN0YW1w\",\"value\":\"MTY3MjkzMjk5OA==\",\"index\":true},{\"key\":\"bm9uY2U=\",\"value\":\"MA==\",\"index\":true},{\"key\":\"ZW1pdHRlcl9jaGFpbg==\",\"value\":\"Mg==\",\"index\":true},{\"key\":\"ZW1pdHRlcl9hZGRyZXNz\",\"value\":\"IjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAyOTBmYjE2NzIwOGFmNDU1YmIxMzc3ODAxNjNiN2I3YTlhMTBjMTYi\",\"index\":true},{\"key\":\"c2VxdWVuY2U=\",\"value\":\"MTY3MjkzMjk5OA==\",\"index\":true},{\"key\":\"Y29uc2lzdGVuY3lfbGV2ZWw=\",\"value\":\"MTU=\",\"index\":true},{\"key\":\"dGVzdF9maWVsZA==\",\"value\":\"MTU=\",\"index\":true},{\"key\":\"cGF5bG9hZA==\",\"value\":\"IkFRQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUEzZ3RyT25aQUFBQUFBQUFBQUFBQUFBQUFBQUxZdm12d3VxZE9DcEJ3Rm1lY3JwR1E2QTNRb0FBZ0FBQUFBQUFBQUFBQUFBQU1FSUlKZy9NMFZzNTc2em9FYjFxRCtqVHdKOURDQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUE9PSI=\",\"index\":true}]}")
 	event := tmAbci.Event{}
 	err := json.Unmarshal(eventJson, &event)
 	require.NoError(t, err)
 
-	xfer, err := parseWasmTransfer(logger, event, "wormhole1466nf3zuxpya8q9emxukd7vftaf6h4psr0a07srl5zw74zh84yjq4lyjmh")
+	xfer, err := parseWasmObservation(logger, event, "wormhole1466nf3zuxpya8q9emxukd7vftaf6h4psr0a07srl5zw74zh84yjq4lyjmh")
 	require.NoError(t, err)
 	require.NotNil(t, xfer)
 
@@ -36,7 +36,7 @@ func TestParseWasmTransferFromTestTool(t *testing.T) {
 	expectedPayload, err := hex.DecodeString("010000000000000000000000000000000000000000000000000de0b6b3a76400000000000000000000000000002d8be6bf0baa74e0a907016679cae9190e80dd0a0002000000000000000000000000c10820983f33456ce7beb3a046f5a83fa34f027d0c200000000000000000000000000000000000000000000000000000000000000000")
 	require.NoError(t, err)
 
-	expectedResult := WasmTransfer{
+	expectedResult := WasmObservation{
 		TxHashBytes:      expectedTxHash.Bytes(),
 		Timestamp:        1672932998,
 		Nonce:            0,
@@ -49,15 +49,15 @@ func TestParseWasmTransferFromTestTool(t *testing.T) {
 	assert.Equal(t, expectedResult, *xfer)
 }
 
-func TestParseWasmTransferFromPortalBridge(t *testing.T) {
+func TestParseWasmObservationFromPortalBridge(t *testing.T) {
 	logger := zap.NewNop()
 
-	eventJson := []byte("{\"type\":\"wasm-Transfer\",\"attributes\":[{\"key\":\"X2NvbnRyYWN0X2FkZHJlc3M=\",\"value\":\"d29ybWhvbGUxNDY2bmYzenV4cHlhOHE5ZW14dWtkN3ZmdGFmNmg0cHNyMGEwN3NybDV6dzc0emg4NHlqcTRseWptaA==\",\"index\":true},{\"key\":\"dHhfaGFzaA==\",\"value\":\"IlovM0x1bklSK0FaWjdRdllqS0dHSDBNZU94M1pIZlR1SHZ6TDAxdm9TcjQ9Ig==\",\"index\":true},{\"key\":\"dGltZXN0YW1w\",\"value\":\"OTUwNw==\",\"index\":true},{\"key\":\"bm9uY2U=\",\"value\":\"NTU0MzAzNzQ0\",\"index\":true},{\"key\":\"ZW1pdHRlcl9jaGFpbg==\",\"value\":\"Mg==\",\"index\":true},{\"key\":\"ZW1pdHRlcl9hZGRyZXNz\",\"value\":\"IjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAyOTBmYjE2NzIwOGFmNDU1YmIxMzc3ODAxNjNiN2I3YTlhMTBjMTYi\",\"index\":true},{\"key\":\"c2VxdWVuY2U=\",\"value\":\"MQ==\",\"index\":true},{\"key\":\"Y29uc2lzdGVuY3lfbGV2ZWw=\",\"value\":\"MQ==\",\"index\":true},{\"key\":\"cGF5bG9hZA==\",\"value\":\"IkFRQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBSlVDK1FBQUFBQUFBQUFBQUFBQUFBQTNiWlA1R3FSMUc3aWxDQlRuOEpmMEh4ZjZqNEFBZ0FBQUFBQUFBQUFBQUFBQUpENHYycEhueklPclFkRUVhU3c1NVJPcU1uQkFBUUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUE9PSI=\",\"index\":true}]}")
+	eventJson := []byte("{\"type\":\"wasm-Observation\",\"attributes\":[{\"key\":\"X2NvbnRyYWN0X2FkZHJlc3M=\",\"value\":\"d29ybWhvbGUxNDY2bmYzenV4cHlhOHE5ZW14dWtkN3ZmdGFmNmg0cHNyMGEwN3NybDV6dzc0emg4NHlqcTRseWptaA==\",\"index\":true},{\"key\":\"dHhfaGFzaA==\",\"value\":\"IlovM0x1bklSK0FaWjdRdllqS0dHSDBNZU94M1pIZlR1SHZ6TDAxdm9TcjQ9Ig==\",\"index\":true},{\"key\":\"dGltZXN0YW1w\",\"value\":\"OTUwNw==\",\"index\":true},{\"key\":\"bm9uY2U=\",\"value\":\"NTU0MzAzNzQ0\",\"index\":true},{\"key\":\"ZW1pdHRlcl9jaGFpbg==\",\"value\":\"Mg==\",\"index\":true},{\"key\":\"ZW1pdHRlcl9hZGRyZXNz\",\"value\":\"IjAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAyOTBmYjE2NzIwOGFmNDU1YmIxMzc3ODAxNjNiN2I3YTlhMTBjMTYi\",\"index\":true},{\"key\":\"c2VxdWVuY2U=\",\"value\":\"MQ==\",\"index\":true},{\"key\":\"Y29uc2lzdGVuY3lfbGV2ZWw=\",\"value\":\"MQ==\",\"index\":true},{\"key\":\"cGF5bG9hZA==\",\"value\":\"IkFRQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBSlVDK1FBQUFBQUFBQUFBQUFBQUFBQTNiWlA1R3FSMUc3aWxDQlRuOEpmMEh4ZjZqNEFBZ0FBQUFBQUFBQUFBQUFBQUpENHYycEhueklPclFkRUVhU3c1NVJPcU1uQkFBUUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUE9PSI=\",\"index\":true}]}")
 	event := tmAbci.Event{}
 	err := json.Unmarshal(eventJson, &event)
 	require.NoError(t, err)
 
-	xfer, err := parseWasmTransfer(logger, event, "wormhole1466nf3zuxpya8q9emxukd7vftaf6h4psr0a07srl5zw74zh84yjq4lyjmh")
+	xfer, err := parseWasmObservation(logger, event, "wormhole1466nf3zuxpya8q9emxukd7vftaf6h4psr0a07srl5zw74zh84yjq4lyjmh")
 	require.NoError(t, err)
 	require.NotNil(t, xfer)
 
@@ -70,7 +70,7 @@ func TestParseWasmTransferFromPortalBridge(t *testing.T) {
 	expectedPayload, err := hex.DecodeString("0100000000000000000000000000000000000000000000000000000002540be400000000000000000000000000ddb64fe46a91d46ee29420539fc25fd07c5fea3e000200000000000000000000000090f8bf6a479f320ead074411a4b0e7944ea8c9c100040000000000000000000000000000000000000000000000000000000000000000")
 	require.NoError(t, err)
 
-	expectedResult := WasmTransfer{
+	expectedResult := WasmObservation{
 		TxHashBytes:      expectedTxHash.Bytes(),
 		Timestamp:        9507,
 		Nonce:            554303744,
@@ -82,4 +82,31 @@ func TestParseWasmTransferFromPortalBridge(t *testing.T) {
 	}
 
 	assert.Equal(t, expectedResult, *xfer)
+}
+
+func TestParseWasmObservationError(t *testing.T) {
+	logger := zap.NewNop()
+
+	eventJson := []byte("{\"type\":\"wasm-ObservationError\",\"attributes\":[{\"key\":\"X2NvbnRyYWN0X2FkZHJlc3M=\",\"value\":\"d29ybWhvbGUxNDY2bmYzenV4cHlhOHE5ZW14dWtkN3ZmdGFmNmg0cHNyMGEwN3NybDV6dzc0emg4NHlqcTRseWptaA==\",\"index\":true},{\"key\":\"a2V5\",\"value\":\"eyJlbWl0dGVyX2NoYWluIjoyLCJlbWl0dGVyX2FkZHJlc3MiOiJBQUFBQUFBQUFBQUFBQUFBQXBEN0ZuSUlyMFZic1RkNEFXTzN0Nm1oREJZPSIsInNlcXVlbmNlIjoxNjc0MDcxOTQwfQ==\",\"index\":true},{\"key\":\"ZXJyb3I=\",\"value\":\"ImRpZ2VzdCBtaXNtYXRjaCBmb3IgcHJvY2Vzc2VkIG1lc3NhZ2Ui\",\"index\":true}]}")
+	event := tmAbci.Event{}
+	err := json.Unmarshal(eventJson, &event)
+	require.NoError(t, err)
+
+	evt, err := parseWasmObservationError(logger, event, "wormhole1466nf3zuxpya8q9emxukd7vftaf6h4psr0a07srl5zw74zh84yjq4lyjmh")
+	require.NoError(t, err)
+	require.NotNil(t, evt)
+
+	expectedEmitterAddress, err := vaa.StringToAddress("0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16")
+	require.NoError(t, err)
+
+	expectedResult := WasmObservationError{
+		Key: ObservationKey{
+			EmitterChain:   uint16(vaa.ChainIDEthereum),
+			EmitterAddress: expectedEmitterAddress.Bytes(),
+			Sequence:       1674071940,
+		},
+		Error: "digest mismatch for processed message",
+	}
+
+	assert.Equal(t, expectedResult, *evt)
 }

--- a/node/pkg/accountant/watcher_test.go
+++ b/node/pkg/accountant/watcher_test.go
@@ -37,7 +37,7 @@ func TestParseWasmObservationFromTestTool(t *testing.T) {
 	require.NoError(t, err)
 
 	expectedResult := WasmObservation{
-		TxHashBytes:      expectedTxHash.Bytes(),
+		TxHash:           expectedTxHash.Bytes(),
 		Timestamp:        1672932998,
 		Nonce:            0,
 		EmitterChain:     uint16(vaa.ChainIDEthereum),
@@ -71,7 +71,7 @@ func TestParseWasmObservationFromPortalBridge(t *testing.T) {
 	require.NoError(t, err)
 
 	expectedResult := WasmObservation{
-		TxHashBytes:      expectedTxHash.Bytes(),
+		TxHash:           expectedTxHash.Bytes(),
 		Timestamp:        9507,
 		Nonce:            554303744,
 		EmitterChain:     uint16(vaa.ChainIDEthereum),

--- a/node/pkg/wormconn/clientconn.go
+++ b/node/pkg/wormconn/clientconn.go
@@ -64,13 +64,17 @@ func (c *ClientConn) Close() {
 	c.c.Close()
 }
 
-func (c *ClientConn) BroadcastTxResponseToString(txResp *sdktx.BroadcastTxResponse) (string, error) {
-	out, err := c.encCfg.Marshaler.MarshalJSON(txResp)
-	if err != nil {
-		return "", err
+func (c *ClientConn) BroadcastTxResponseToString(txResp *sdktx.BroadcastTxResponse) string {
+	if txResp == nil {
+		return "txResp is nil"
 	}
 
-	return string(out), nil
+	out, err := c.encCfg.Marshaler.MarshalJSON(txResp)
+	if err != nil {
+		return fmt.Sprintf("failed to format txResp: %s", err)
+	}
+
+	return string(out)
 }
 
 // generateSenderAddress creates the sender address from the private key. It is based on https://pkg.go.dev/github.com/btcsuite/btcutil/bech32#Encode

--- a/node/pkg/wormconn/clientconn.go
+++ b/node/pkg/wormconn/clientconn.go
@@ -71,7 +71,7 @@ func (c *ClientConn) BroadcastTxResponseToString(txResp *sdktx.BroadcastTxRespon
 
 	out, err := c.encCfg.Marshaler.MarshalJSON(txResp)
 	if err != nil {
-		return fmt.Sprintf("failed to format txResp: %s", err)
+		panic(fmt.Sprintf("failed to format txResp: %s", err))
 	}
 
 	return string(out)


### PR DESCRIPTION
This PR enhances the accountant module in the guardian to submit requests in batches.
It also supports the latest interface changes with the smart contract.

Fixes #2188

Change-Id: I3f950c73265f40b2542a9b1222b2df67cb1964b0