### PR TITLE
aptos/cache_fix: remove the usage of the cache from the aptos test

### DIFF
--- a/aptos/Dockerfile
+++ b/aptos/Dockerfile
@@ -21,5 +21,4 @@ FROM aptos AS tests
 
 WORKDIR /tmp
 
-RUN --mount=type=cache,target=/root/.move,id=move_cache \
-    make test
+RUN    make test


### PR DESCRIPTION
…at runs in the Dockerfile