### PR TITLE
wormchain - peer-exchange reactor off by default

### DIFF
--- a/wormchain/devnet/base/config/config.toml
+++ b/wormchain/devnet/base/config/config.toml
@@ -249,7 +249,7 @@ send_rate = 5120000
 recv_rate = 5120000
 
 # Set true to enable the peer-exchange reactor
-pex = true
+pex = false
 
 # Seed mode, in which node constantly crawls the network and looks for
 # peers. If another node asks it for addresses, it responds and disconnects.

--- a/wormchain/devnet/client/config/config.toml
+++ b/wormchain/devnet/client/config/config.toml
@@ -249,7 +249,7 @@ send_rate = 5120000
 recv_rate = 5120000
 
 # Set true to enable the peer-exchange reactor
-pex = true
+pex = false
 
 # Seed mode, in which node constantly crawls the network and looks for
 # peers. If another node asks it for addresses, it responds and disconnects.

--- a/wormchain/devnet/create-config.sh
+++ b/wormchain/devnet/create-config.sh
@@ -43,6 +43,7 @@ sed -i "s/external_address = \"\"/external_address = \"${hostname}:26656\"/g" ${
 
 if [ $instance -eq 0 ] && [ $NUM_GUARDIANS -ge 2 ]; then
   echo "$hostname: enabling seed mode in config.toml."
+  sed -i "s/pex = false/pex = true/g" ${home_path}/config/config.toml
   sed -i "s/seed_mode = false/seed_mode = true/g" ${home_path}/config/config.toml
 elif [ $instance -ge 1 ]; then
   echo "$hostname: adding seed address to config.toml."


### PR DESCRIPTION
this fixes the incessant `wormchain │ {"level":"error","module":"p2p","err":"EOF","peer":{"Logger":{},"Data":{}},"time":"2023-01-19T01:56:18Z","message":"Stopping peer for error"}` log in CI