### PR TITLE
node: strip leading 0x for send-observation-request

### DIFF
--- a/node/cmd/guardiand/adminclient.go
+++ b/node/cmd/guardiand/adminclient.go
@@ -345,7 +345,9 @@ func runSendObservationRequest(cmd *cobra.Command, args []string) {
 		log.Fatalf("invalid chain ID: %v", err)
 	}
 
-	txHash, err := hex.DecodeString(args[1])
+	// Support tx with or without leading 0x so copy / pasta
+	// from monitoring tools is easier.
+	txHash, err := hex.DecodeString(strings.TrimPrefix(args[1], "0x"))
 	if err != nil {
 		txHash, err = base58.Decode(args[1])
 		if err != nil {


### PR DESCRIPTION
This allows copying and pasting transactions from montioring tools or an explorer to be reobserved.

Fixes #2273