### PR TITLE
wormchain: fix wormhole keeper wasmd field

### DIFF
--- a/wormchain/app/app.go
+++ b/wormchain/app/app.go
@@ -319,8 +319,6 @@ func New(
 		app.BankKeeper,
 	)
 
-	wormholeModule := wormholemodule.NewAppModule(appCodec, app.WormholeKeeper)
-
 	stakingKeeper := stakingkeeper.NewKeeper(
 		appCodec, keys[stakingtypes.StoreKey], app.AccountKeeper, app.BankKeeper, app.WormholeKeeper, app.GetSubspace(stakingtypes.ModuleName),
 	)
@@ -414,6 +412,8 @@ func New(
 	)
 	permissionedWasmKeeper := wasmkeeper.NewDefaultPermissionKeeper(app.wasmKeeper)
 	app.WormholeKeeper.SetWasmdKeeper(permissionedWasmKeeper)
+	// the wormhole module must be instantiated after the wasmd module
+	wormholeModule := wormholemodule.NewAppModule(appCodec, app.WormholeKeeper)
 
 	// this line is used by starport scaffolding # stargate/app/keeperDefinition
 


### PR DESCRIPTION
Fixes the following issue:
```
failed to execute message; message index: 0: x/wasmd not set: feature not supported
```
when trying to `msgStoreCode` when calling via the wormhole module.
