### PR TITLE
Node/Acct: audit stuck pending

### DIFF
--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -1019,6 +1019,7 @@ func runNode(cmd *cobra.Command, args []string) {
 			rootCtx,
 			logger,
 			db,
+			obsvReqWriteC,
 			*accountantContract,
 			*accountantWS,
 			wormchainConn,

--- a/node/pkg/accountant/accountant.go
+++ b/node/pkg/accountant/accountant.go
@@ -367,6 +367,13 @@ func (pe *pendingEntry) setSubmitPending(val bool) {
 	pe.state.updTime = time.Now()
 }
 
+// submitPending returns the "submit pending" flag from the pending transfer object. It grabs the state lock.
+func (pe *pendingEntry) submitPending() bool {
+	pe.stateLock.Lock()
+	defer pe.stateLock.Unlock()
+	return pe.state.submitPending
+}
+
 // updTime returns the last update time from the pending transfer object. It grabs the state lock.
 func (pe *pendingEntry) updTime() time.Time {
 	pe.stateLock.Lock()

--- a/node/pkg/accountant/audit.go
+++ b/node/pkg/accountant/audit.go
@@ -1,0 +1,292 @@
+// This code audits the set of pending transfers against the state reported by the smart contract. It is called from the processor every minute,
+// but the audit is performed less frequently. The audit occurs in two phases that operate off of a temporary map of all pending transfers known to this guardian.
+//
+// The first phase involves querying the smart contract for any observations that it thinks are missing for this guardian. The audit processes everything in the
+// returned results and does one of the following:
+// - If the observation is in our temporary map, we resubmit an observation to the contract and delete it from our temporary map.
+// - If the observation is not in the temporary map, we request a reobservation from the local watcher.
+//
+// The second phase consists of requesting the status from the contract for everything that is still in the temporary map. For each returned item, we do the following:
+// - If the contract indicates that the transfer has been committed, we validate the digest, then publish it and delete it from the map.
+// - If the contract indicates that the transfer is pending, we continue to wait for it.
+// - If the contract indicates any other status (most likely meaning it does not know about it), we resubmit an observation to the contract
+//
+// Note that any time we are considering resubmitting an observation to the contract, we first check the "submit pending" flag. If that is set, we do not
+// submit the observation to the contract, but continue to wait for it to work its way through the queue.
+
+package accountant
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
+	"github.com/wormhole-foundation/wormhole/sdk/vaa"
+
+	cosmossdk "github.com/cosmos/cosmos-sdk/types"
+
+	ethCommon "github.com/ethereum/go-ethereum/common"
+
+	"go.uber.org/zap"
+)
+
+const (
+	// auditInterval indicates how often the audit runs (given that it is invoked by the processor once per minute)
+	auditInterval = 30 * time.Second // TODO: Make this something like five minutes?
+
+	// maxSubmitPendingTime indicates how long a transfer can be in the pending state before the audit starts complaining about it.
+	maxSubmitPendingTime = 10 * time.Minute
+)
+
+type (
+	// MissingObservationsResponse is the result returned from the "missing_observations" query.
+	MissingObservationsResponse struct {
+		Missing []MissingObservation
+	}
+
+	MissingObservation struct {
+		ChainId uint16 `json:"chain_id"`
+		TxHash  []byte `json:"tx_hash"`
+	}
+
+	// BatchTransferStatusResponse is the result returned by the "batch_transfer_status" query.
+	BatchTransferStatusResponse struct {
+		Details []TransferDetails `json:"details"`
+	}
+
+	TransferDetails struct {
+		Key    TransferKey
+		Status TransferStatus
+	}
+
+	TransferStatus struct {
+		Committed *TransferStatusCommitted `json:"committed"`
+		Pending   *TransferStatusPending   `json:"pending"`
+	}
+
+	TransferStatusCommitted struct {
+		Data   TransferData `json:"data"`
+		Digest []byte       `json:"digest"`
+	}
+
+	TransferData struct {
+		Amount         *cosmossdk.Int `json:"amount"`
+		TokenChain     uint16         `json:"token_chain"`
+		TokenAddress   vaa.Address    `json:"token_address"`
+		RecipientChain uint16         `json:"recipient_chain"`
+	}
+
+	TransferStatusPending struct {
+	}
+)
+
+// makeAuditKey creates an audit map key from a missing observation.
+func (mo *MissingObservation) makeAuditKey() string {
+	return fmt.Sprintf("%d-%s", mo.ChainId, hex.EncodeToString(mo.TxHash[:]))
+}
+
+// makeAuditKey creates an audit map key from a pending observation entry.
+func (pe *pendingEntry) makeAuditKey() string {
+	return fmt.Sprintf("%d-%s", pe.msg.EmitterChain, pe.msg.TxHash.String())
+}
+
+// AuditPendingTransfers is the entry point for the audit of the pending transfer map. It determines if it has been long enough since the last audit.
+// If so, it creates a temporary map of all pending transfers and invokes the main audit function as a go routine.
+func (acct *Accountant) AuditPendingTransfers() {
+	acct.pendingTransfersLock.Lock()
+	defer acct.pendingTransfersLock.Unlock()
+
+	if time.Since(acct.lastAuditTime) < auditInterval {
+		acct.logger.Debug("acctaudit: in AuditPendingTransfers, not time to run yet", zap.Stringer("lastAuditTime", acct.lastAuditTime))
+		return
+	}
+
+	tmpMap := make(map[string]*pendingEntry)
+	for _, pe := range acct.pendingTransfers {
+		if (pe.submitPending) && (time.Since(pe.updTime) > maxSubmitPendingTime) {
+			auditErrors.Inc()
+			acct.logger.Error("acctaudit: transfer has been in the submit pending state for too long", zap.Stringer("lastUpdateTime", pe.updTime))
+		}
+		acct.logger.Debug("acctaudit: will audit pending transfer", zap.String("msgId", pe.msgId), zap.Stringer("lastUpdateTime", pe.updTime))
+		tmpMap[pe.makeAuditKey()] = pe
+	}
+
+	acct.logger.Debug("acctaudit: in AuditPendingTransfers: starting audit", zap.Int("numPending", len(tmpMap)))
+	acct.lastAuditTime = time.Now()
+	go acct.performAudit(tmpMap)
+	acct.logger.Debug("acctaudit: leaving AuditPendingTransfers")
+}
+
+// performAudit audits the temporary map against the smart contract. It is meant to be run in a go routine. It takes a temporary map of all pending transfers
+// and validates that against what is reported by the smart contract. For more details, please see the prologue of this file.
+func (acct *Accountant) performAudit(tmpMap map[string]*pendingEntry) {
+	acct.logger.Debug("acctaudit: entering performAudit")
+	missingObservations, err := acct.queryMissingObservations()
+	if err != nil {
+		acct.logger.Error("acctaudit: unable to perform audit, failed to query missing observations", zap.Error(err))
+		for _, pe := range tmpMap {
+			acct.logger.Error("acctaudit: unsure of status of pending transfer due to query error", zap.String("msgId", pe.msgId))
+		}
+		return
+	}
+
+	if len(missingObservations) != 0 {
+		for _, mo := range missingObservations {
+			key := mo.makeAuditKey()
+			pe, exists := tmpMap[key]
+			if exists {
+				if !pe.submitPending {
+					auditErrors.Inc()
+					acct.logger.Error("acctaudit: contract reported pending observation as missing, resubmitting it", zap.String("msgID", pe.msgId))
+					acct.submitObservation(pe)
+				} else {
+					acct.logger.Info("acctaudit: contract reported pending observation as missing but it is queued up to be submitted, skipping it", zap.String("msgID", pe.msgId))
+				}
+
+				delete(tmpMap, key)
+			} else {
+				acct.handleMissingObservation(mo)
+			}
+		}
+	}
+
+	if len(tmpMap) != 0 {
+		var keys []TransferKey
+		var pendingTransfers []*pendingEntry
+		for _, pe := range tmpMap {
+			keys = append(keys, TransferKey{EmitterChain: uint16(pe.msg.EmitterChain), EmitterAddress: pe.msg.EmitterAddress, Sequence: pe.msg.Sequence})
+			pendingTransfers = append(pendingTransfers, pe)
+		}
+
+		transferDetails, err := acct.queryBatchTransferStatus(keys)
+		if err != nil {
+			acct.logger.Error("acctaudit: unable to finish audit, failed to query for transfer statuses", zap.Error(err))
+			for _, pe := range tmpMap {
+				acct.logger.Error("acctaudit: unsure of status of pending transfer due to query error", zap.String("msgId", pe.msgId))
+			}
+			return
+		}
+
+		for _, pe := range pendingTransfers {
+			item, exists := transferDetails[pe.msgId]
+			if !exists {
+				if !pe.submitPending {
+					auditErrors.Inc()
+					acct.logger.Error("acctaudit: query did not return status for transfer, this should not happen, resubmitting it", zap.String("msgId", pe.msgId))
+					acct.submitObservation(pe)
+				} else {
+					acct.logger.Debug("acctaudit: query did not return status for transfer we have not submitted yet, ignoring it", zap.String("msgId", pe.msgId))
+				}
+
+				continue
+			}
+
+			if item.Status.Committed != nil {
+				digest := hex.EncodeToString(item.Status.Committed.Digest)
+				if pe.digest == digest {
+					acct.logger.Info("acctaudit: audit determined that transfer has been committed, publishing it", zap.String("msgId", pe.msgId))
+					acct.handleCommittedTransfer(pe.msgId)
+				} else {
+					digestMismatches.Inc()
+					acct.logger.Error("acctaudit: audit detected a digest mismatch, dropping transfer", zap.String("msgId", pe.msgId), zap.String("ourDigest", pe.digest), zap.String("reportedDigest", digest))
+					acct.deletePendingTransfer(pe.msgId)
+				}
+			} else if item.Status.Pending != nil {
+				acct.logger.Debug("acctaudit: contract says transfer is still pending", zap.String("msgId", pe.msgId))
+			} else if !pe.submitPending {
+				auditErrors.Inc()
+				acct.logger.Error("acctaudit: contract does not know about pending transfer, resubmitting it", zap.String("msgId", pe.msgId))
+				acct.submitObservation(pe)
+			}
+		}
+	}
+
+	acct.logger.Debug("acctaudit: exiting performAudit")
+}
+
+// handleMissingObservation submits a reobservation request if appropriate.
+func (acct *Accountant) handleMissingObservation(mo MissingObservation) {
+	// It's possible we received this transfer after we built the temporary map. If so, we don't want to do a reobservation.
+	if acct.transferNowExists(mo) {
+		acct.logger.Debug("acctaudit: contract reported unknown observation as missing but it is now in our pending map, ignoring it", zap.Uint16("chainId", mo.ChainId), zap.String("txHash", hex.EncodeToString(mo.TxHash)))
+		return
+	}
+
+	acct.logger.Debug("acctaudit: contract reported unknown observation as missing, requesting reobservation", zap.Uint16("chainId", mo.ChainId), zap.String("txHash", hex.EncodeToString(mo.TxHash)))
+	msg := &gossipv1.ObservationRequest{ChainId: uint32(mo.ChainId), TxHash: mo.TxHash}
+	acct.obsvReqWriteC <- msg
+}
+
+// transferNowExists checks to see if a missed observation exists in the pending transfer map. It grabs the lock.
+func (acct *Accountant) transferNowExists(mo MissingObservation) bool {
+	acct.pendingTransfersLock.Lock()
+	defer acct.pendingTransfersLock.Unlock()
+
+	chanId := vaa.ChainID(mo.ChainId)
+	txHash := ethCommon.BytesToHash(mo.TxHash)
+	for _, pe := range acct.pendingTransfers {
+		if (pe.msg.EmitterChain == chanId) && (pe.msg.TxHash == txHash) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// queryMissingObservations queries the contract for the set of observations it thinks are missing for this guardian.
+func (acct *Accountant) queryMissingObservations() ([]MissingObservation, error) {
+	gs := acct.gst.Get()
+	if gs == nil {
+		return nil, fmt.Errorf("failed to get guardian set")
+	}
+
+	guardianIndex, found := gs.KeyIndex(acct.guardianAddr)
+	if !found {
+		return nil, fmt.Errorf("failed to get guardian index")
+	}
+
+	query := fmt.Sprintf(`{"missing_observations":{"guardian_set": %d, "index": %d}}`, gs.Index, guardianIndex)
+	acct.logger.Debug("acctaudit: submitting missing_observations query", zap.String("query", query))
+	resp, err := acct.wormchainConn.SubmitQuery(acct.ctx, acct.contract, []byte(query))
+	if err != nil {
+		return nil, fmt.Errorf("missing_observations query failed: %w", err)
+	}
+
+	var ret MissingObservationsResponse
+	if err := json.Unmarshal(resp.Data, &ret); err != nil {
+		return nil, fmt.Errorf("failed to parse missing_observations response: %w", err)
+	}
+
+	acct.logger.Debug("acctaudit: missing_observations query response", zap.Int("numEntries", len(ret.Missing)), zap.String("result", string(resp.Data)))
+	return ret.Missing, nil
+}
+
+// queryBatchTransferStatus queries the status of the specified transfers and returns a map keyed by transfer key (as a string) to the status.
+func (acct *Accountant) queryBatchTransferStatus(keys []TransferKey) (map[string]TransferDetails, error) {
+	bytes, err := json.Marshal(keys)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal keys: %w", err)
+	}
+
+	query := fmt.Sprintf(`{"batch_transfer_status":%s}`, string(bytes))
+	acct.logger.Debug("acctaudit: submitting batch_transfer_status query", zap.String("query", query))
+	resp, err := acct.wormchainConn.SubmitQuery(acct.ctx, acct.contract, []byte(query))
+	if err != nil {
+		return nil, fmt.Errorf("batch_transfer_status query failed: %w", err)
+	}
+
+	var response BatchTransferStatusResponse
+	if err := json.Unmarshal(resp.Data, &response); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+
+	ret := make(map[string]TransferDetails)
+	for _, item := range response.Details {
+		ret[item.Key.String()] = item
+	}
+
+	acct.logger.Debug("acctaudit: batch_transfer_status query response", zap.Int("numEntries", len(ret)), zap.String("result", string(resp.Data)))
+	return ret, nil
+}

--- a/node/pkg/accountant/audit.go
+++ b/node/pkg/accountant/audit.go
@@ -33,7 +33,7 @@ import (
 
 const (
 	// auditInterval indicates how often the audit runs.
-	auditInterval = 1 * time.Minute // TODO: Dont commit this!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+	auditInterval = 5 * time.Minute
 
 	// maxSubmitPendingTime indicates how long a transfer can be in the submit pending state before the audit starts complaining about it.
 	maxSubmitPendingTime = 30 * time.Minute

--- a/node/pkg/accountant/audit.go
+++ b/node/pkg/accountant/audit.go
@@ -1,5 +1,5 @@
-// This code audits the set of pending transfers against the state reported by the smart contract. It is called from the processor every minute,
-// but the audit is performed less frequently. The audit occurs in two phases that operate off of a temporary map of all pending transfers known to this guardian.
+// This code audits the set of pending transfers against the state reported by the smart contract. It has a runnable that is started when the accountant initializes.
+// It uses a ticker to periodically run the audit. The audit occurs in two phases that operate off of a temporary map of all pending transfers known to this guardian.
 //
 // The first phase involves querying the smart contract for any observations that it thinks are missing for this guardian. The audit processes everything in the
 // returned results and does one of the following:
@@ -7,9 +7,9 @@
 // - If the observation is not in the temporary map, we request a reobservation from the local watcher.
 //
 // The second phase consists of requesting the status from the contract for everything that is still in the temporary map. For each returned item, we do the following:
-// - If the contract indicates that the transfer has been committed, we validate the digest, then publish it and delete it from the map.
+// - If the contract indicates that the transfer has been committed, we validate the digest, then publish the transfer and delete it from the map.
 // - If the contract indicates that the transfer is pending, we continue to wait for it to be committed.
-// - If the contract indicates any other status (most likely meaning it does not know about it), we resubmit an observation to the contract
+// - If the contract indicates any other status (most likely meaning it does not know about it), we resubmit an observation to the contract.
 //
 // Note that any time we are considering resubmitting an observation to the contract, we first check the "submit pending" flag. If that is set, we do not
 // submit the observation to the contract, but continue to wait for it to work its way through the queue.
@@ -17,6 +17,7 @@
 package accountant
 
 import (
+	"context"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -27,14 +28,12 @@ import (
 
 	cosmossdk "github.com/cosmos/cosmos-sdk/types"
 
-	ethCommon "github.com/ethereum/go-ethereum/common"
-
 	"go.uber.org/zap"
 )
 
 const (
-	// auditInterval indicates how often the audit runs (given that it is invoked by the processor once per minute)
-	auditInterval = 5 * time.Minute
+	// auditInterval indicates how often the audit runs.
+	auditInterval = 1 * time.Minute // TODO: Dont commit this!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 	// maxSubmitPendingTime indicates how long a transfer can be in the submit pending state before the audit starts complaining about it.
 	maxSubmitPendingTime = 30 * time.Minute
@@ -43,34 +42,39 @@ const (
 type (
 	// MissingObservationsResponse is the result returned from the "missing_observations" query.
 	MissingObservationsResponse struct {
-		Missing []MissingObservation
+		Missing []MissingObservation `json:"missing"`
 	}
 
+	// MissingObservation is what is returned for a single missing observation.
 	MissingObservation struct {
 		ChainId uint16 `json:"chain_id"`
 		TxHash  []byte `json:"tx_hash"`
 	}
 
-	// BatchTransferStatusResponse is the result returned by the "batch_transfer_status" query.
+	// BatchTransferStatusResponse contains the details returned by the "batch_transfer_status" query.
 	BatchTransferStatusResponse struct {
 		Details []TransferDetails `json:"details"`
 	}
 
+	// TransferDetails contains the details returned for a single transfer.
 	TransferDetails struct {
-		Key    TransferKey
-		Status TransferStatus
+		Key    TransferKey     `json:"key"`
+		Status *TransferStatus `json:"status"`
 	}
 
+	// TransferStatus contains the status returned for a transfer.
 	TransferStatus struct {
 		Committed *TransferStatusCommitted `json:"committed"`
 		Pending   *TransferStatusPending   `json:"pending"`
 	}
 
+	// TransferStatusCommitted contains the data returned for a committed transfer.
 	TransferStatusCommitted struct {
 		Data   TransferData `json:"data"`
 		Digest []byte       `json:"digest"`
 	}
 
+	// TransferData contains the detailed data returned for a committed transfer.
 	TransferData struct {
 		Amount         *cosmossdk.Int `json:"amount"`
 		TokenChain     uint16         `json:"token_chain"`
@@ -78,9 +82,15 @@ type (
 		RecipientChain uint16         `json:"recipient_chain"`
 	}
 
+	// TransferStatusPending contains the data returned for a committed transfer.
 	TransferStatusPending struct {
+		// TODO: Fill this in once we get a sample.
 	}
 )
+
+func (mo MissingObservation) String() string {
+	return fmt.Sprintf("%d-%s", mo.ChainId, hex.EncodeToString(mo.TxHash))
+}
 
 // makeAuditKey creates an audit map key from a missing observation.
 func (mo *MissingObservation) makeAuditKey() string {
@@ -92,31 +102,52 @@ func (pe *pendingEntry) makeAuditKey() string {
 	return fmt.Sprintf("%d-%s", pe.msg.EmitterChain, pe.msg.TxHash.String())
 }
 
-// AuditPendingTransfers is the entry point for the audit of the pending transfer map. It determines if it has been long enough since the last audit.
-// If so, it creates a temporary map of all pending transfers and invokes the main audit function as a go routine.
-func (acct *Accountant) AuditPendingTransfers() {
+// audit is the runnable that executes the audit each interval.
+func (acct *Accountant) audit(ctx context.Context) error {
+	ticker := time.NewTicker(auditInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			acct.runAudit()
+		}
+	}
+}
+
+// runAudit is the entry point for the audit of the pending transfer map. It creates a temporary map of all pending transfers and invokes the main audit function.
+func (acct *Accountant) runAudit() {
+	tmpMap := acct.createAuditMap()
+	acct.logger.Debug("acctaudit: in AuditPendingTransfers: starting audit", zap.Int("numPending", len(tmpMap)))
+	acct.performAudit(tmpMap)
+	acct.logger.Debug("acctaudit: leaving AuditPendingTransfers")
+}
+
+// createAuditMap creates a temporary map of all pending transfers. It grabs the pending transfer lock.
+func (acct *Accountant) createAuditMap() map[string]*pendingEntry {
 	acct.pendingTransfersLock.Lock()
 	defer acct.pendingTransfersLock.Unlock()
 
-	if time.Since(acct.lastAuditTime) < auditInterval {
-		acct.logger.Debug("acctaudit: in AuditPendingTransfers, not time to run yet", zap.Stringer("lastAuditTime", acct.lastAuditTime))
-		return
-	}
-
 	tmpMap := make(map[string]*pendingEntry)
 	for _, pe := range acct.pendingTransfers {
-		if (pe.submitPending) && (time.Since(pe.updTime) > maxSubmitPendingTime) {
+		if pe.hasBeenPendingForTooLong() {
 			auditErrors.Inc()
-			acct.logger.Error("acctaudit: transfer has been in the submit pending state for too long", zap.Stringer("lastUpdateTime", pe.updTime))
+			acct.logger.Error("acctaudit: transfer has been in the submit pending state for too long", zap.Stringer("lastUpdateTime", pe.updTime()))
 		}
-		acct.logger.Debug("acctaudit: will audit pending transfer", zap.String("msgId", pe.msgId), zap.Stringer("lastUpdateTime", pe.updTime))
+		acct.logger.Debug("acctaudit: will audit pending transfer", zap.String("msgId", pe.msgId), zap.Stringer("lastUpdateTime", pe.updTime()))
 		tmpMap[pe.makeAuditKey()] = pe
 	}
 
-	acct.logger.Debug("acctaudit: in AuditPendingTransfers: starting audit", zap.Int("numPending", len(tmpMap)))
-	acct.lastAuditTime = time.Now()
-	go acct.performAudit(tmpMap)
-	acct.logger.Debug("acctaudit: leaving AuditPendingTransfers")
+	return tmpMap
+}
+
+// hasBeenPendingForTooLong determines if a transfer has been in the "submit pending" state for too long.
+func (pe *pendingEntry) hasBeenPendingForTooLong() bool {
+	pe.stateLock.Lock()
+	defer pe.stateLock.Unlock()
+	return pe.state.submitPending && time.Since(pe.state.updTime) > maxSubmitPendingTime
 }
 
 // performAudit audits the temporary map against the smart contract. It is meant to be run in a go routine. It takes a temporary map of all pending transfers
@@ -132,23 +163,20 @@ func (acct *Accountant) performAudit(tmpMap map[string]*pendingEntry) {
 		return
 	}
 
-	if len(missingObservations) != 0 {
-		for _, mo := range missingObservations {
-			key := mo.makeAuditKey()
-			pe, exists := tmpMap[key]
-			if exists {
-				if !pe.submitPending {
-					auditErrors.Inc()
-					acct.logger.Error("acctaudit: contract reported pending observation as missing, resubmitting it", zap.String("msgID", pe.msgId))
-					acct.submitObservation(pe)
-				} else {
-					acct.logger.Info("acctaudit: contract reported pending observation as missing but it is queued up to be submitted, skipping it", zap.String("msgID", pe.msgId))
-				}
-
-				delete(tmpMap, key)
+	for _, mo := range missingObservations {
+		key := mo.makeAuditKey()
+		pe, exists := tmpMap[key]
+		if exists {
+			if acct.submitObservation(pe) {
+				auditErrors.Inc()
+				acct.logger.Error("acctaudit: contract reported pending observation as missing, resubmitting it", zap.String("msgID", pe.msgId))
 			} else {
-				acct.handleMissingObservation(mo)
+				acct.logger.Info("acctaudit: contract reported pending observation as missing but it is queued up to be submitted, skipping it", zap.String("msgID", pe.msgId))
 			}
+
+			delete(tmpMap, key)
+		} else {
+			acct.handleMissingObservation(mo)
 		}
 	}
 
@@ -170,21 +198,20 @@ func (acct *Accountant) performAudit(tmpMap map[string]*pendingEntry) {
 		}
 
 		for _, pe := range pendingTransfers {
-			item, exists := transferDetails[pe.msgId]
+			status, exists := transferDetails[pe.msgId]
 			if !exists {
-				if !pe.submitPending {
+				if acct.submitObservation(pe) {
 					auditErrors.Inc()
 					acct.logger.Error("acctaudit: query did not return status for transfer, this should not happen, resubmitting it", zap.String("msgId", pe.msgId))
-					acct.submitObservation(pe)
 				} else {
-					acct.logger.Debug("acctaudit: query did not return status for transfer we have not submitted yet, ignoring it", zap.String("msgId", pe.msgId))
+					acct.logger.Info("acctaudit: query did not return status for transfer we have not submitted yet, ignoring it", zap.String("msgId", pe.msgId))
 				}
 
 				continue
 			}
 
-			if item.Status.Committed != nil {
-				digest := hex.EncodeToString(item.Status.Committed.Digest)
+			if status.Committed != nil {
+				digest := hex.EncodeToString(status.Committed.Digest)
 				if pe.digest == digest {
 					acct.logger.Info("acctaudit: audit determined that transfer has been committed, publishing it", zap.String("msgId", pe.msgId))
 					acct.handleCommittedTransfer(pe.msgId)
@@ -193,12 +220,14 @@ func (acct *Accountant) performAudit(tmpMap map[string]*pendingEntry) {
 					acct.logger.Error("acctaudit: audit detected a digest mismatch, dropping transfer", zap.String("msgId", pe.msgId), zap.String("ourDigest", pe.digest), zap.String("reportedDigest", digest))
 					acct.deletePendingTransfer(pe.msgId)
 				}
-			} else if item.Status.Pending != nil {
+			} else if status.Pending != nil {
 				acct.logger.Debug("acctaudit: contract says transfer is still pending", zap.String("msgId", pe.msgId))
-			} else if !pe.submitPending {
-				auditErrors.Inc()
-				acct.logger.Error("acctaudit: contract does not know about pending transfer, resubmitting it", zap.String("msgId", pe.msgId))
-				acct.submitObservation(pe)
+			} else {
+				// This is the case when the contract does not know about a transfer. Resubmit it.
+				if acct.submitObservation(pe) {
+					auditErrors.Inc()
+					acct.logger.Error("acctaudit: contract does not know about pending transfer, resubmitting it", zap.String("msgId", pe.msgId))
+				}
 			}
 		}
 	}
@@ -206,33 +235,17 @@ func (acct *Accountant) performAudit(tmpMap map[string]*pendingEntry) {
 	acct.logger.Debug("acctaudit: exiting performAudit")
 }
 
-// handleMissingObservation submits a reobservation request if appropriate.
+// handleMissingObservation submits a local reobservation request. It relies on the reobservation code to throttle requests.
 func (acct *Accountant) handleMissingObservation(mo MissingObservation) {
-	// It's possible we received this transfer after we built the temporary map. If so, we don't want to do a reobservation.
-	if acct.transferNowExists(mo) {
-		acct.logger.Debug("acctaudit: contract reported unknown observation as missing but it is now in our pending map, ignoring it", zap.Uint16("chainId", mo.ChainId), zap.String("txHash", hex.EncodeToString(mo.TxHash)))
-		return
-	}
-
-	acct.logger.Debug("acctaudit: contract reported unknown observation as missing, requesting reobservation", zap.Uint16("chainId", mo.ChainId), zap.String("txHash", hex.EncodeToString(mo.TxHash)))
+	acct.logger.Info("acctaudit: contract reported unknown observation as missing, requesting local reobservation", zap.Stringer("moKey", mo))
 	msg := &gossipv1.ObservationRequest{ChainId: uint32(mo.ChainId), TxHash: mo.TxHash}
-	acct.obsvReqWriteC <- msg
-}
 
-// transferNowExists checks to see if a missed observation exists in the pending transfer map. It grabs the lock.
-func (acct *Accountant) transferNowExists(mo MissingObservation) bool {
-	acct.pendingTransfersLock.Lock()
-	defer acct.pendingTransfersLock.Unlock()
-
-	chanId := vaa.ChainID(mo.ChainId)
-	txHash := ethCommon.BytesToHash(mo.TxHash)
-	for _, pe := range acct.pendingTransfers {
-		if (pe.msg.EmitterChain == chanId) && (pe.msg.TxHash == txHash) {
-			return true
-		}
+	select {
+	case acct.obsvReqWriteC <- msg:
+		acct.logger.Debug("acct: submitted local reobservation", zap.Stringer("moKey", mo))
+	default:
+		acct.logger.Error("acct: unable to submit local reobservation because the channel is full, will try next interval", zap.Stringer("moKey", mo))
 	}
-
-	return false
 }
 
 // queryMissingObservations queries the contract for the set of observations it thinks are missing for this guardian.
@@ -249,22 +262,22 @@ func (acct *Accountant) queryMissingObservations() ([]MissingObservation, error)
 
 	query := fmt.Sprintf(`{"missing_observations":{"guardian_set": %d, "index": %d}}`, gs.Index, guardianIndex)
 	acct.logger.Debug("acctaudit: submitting missing_observations query", zap.String("query", query))
-	resp, err := acct.wormchainConn.SubmitQuery(acct.ctx, acct.contract, []byte(query))
+	respBytes, err := acct.wormchainConn.SubmitQuery(acct.ctx, acct.contract, []byte(query))
 	if err != nil {
 		return nil, fmt.Errorf("missing_observations query failed: %w", err)
 	}
 
 	var ret MissingObservationsResponse
-	if err := json.Unmarshal(resp.Data, &ret); err != nil {
+	if err := json.Unmarshal(respBytes, &ret); err != nil {
 		return nil, fmt.Errorf("failed to parse missing_observations response: %w", err)
 	}
 
-	acct.logger.Debug("acctaudit: missing_observations query response", zap.Int("numEntries", len(ret.Missing)), zap.String("result", string(resp.Data)))
+	acct.logger.Debug("acctaudit: missing_observations query response", zap.Int("numEntries", len(ret.Missing)), zap.String("result", string(respBytes)))
 	return ret.Missing, nil
 }
 
 // queryBatchTransferStatus queries the status of the specified transfers and returns a map keyed by transfer key (as a string) to the status.
-func (acct *Accountant) queryBatchTransferStatus(keys []TransferKey) (map[string]TransferDetails, error) {
+func (acct *Accountant) queryBatchTransferStatus(keys []TransferKey) (map[string]TransferStatus, error) {
 	bytes, err := json.Marshal(keys)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal keys: %w", err)
@@ -272,21 +285,21 @@ func (acct *Accountant) queryBatchTransferStatus(keys []TransferKey) (map[string
 
 	query := fmt.Sprintf(`{"batch_transfer_status":%s}`, string(bytes))
 	acct.logger.Debug("acctaudit: submitting batch_transfer_status query", zap.String("query", query))
-	resp, err := acct.wormchainConn.SubmitQuery(acct.ctx, acct.contract, []byte(query))
+	respBytes, err := acct.wormchainConn.SubmitQuery(acct.ctx, acct.contract, []byte(query))
 	if err != nil {
 		return nil, fmt.Errorf("batch_transfer_status query failed: %w", err)
 	}
 
 	var response BatchTransferStatusResponse
-	if err := json.Unmarshal(resp.Data, &response); err != nil {
+	if err := json.Unmarshal(respBytes, &response); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
-	ret := make(map[string]TransferDetails)
+	ret := make(map[string]TransferStatus)
 	for _, item := range response.Details {
-		ret[item.Key.String()] = item
+		ret[item.Key.String()] = *item.Status
 	}
 
-	acct.logger.Debug("acctaudit: batch_transfer_status query response", zap.Int("numEntries", len(ret)), zap.String("result", string(resp.Data)))
+	acct.logger.Debug("acctaudit: batch_transfer_status query response", zap.Int("numEntries", len(ret)), zap.String("result", string(respBytes)))
 	return ret, nil
 }

--- a/node/pkg/accountant/audit.go
+++ b/node/pkg/accountant/audit.go
@@ -8,7 +8,7 @@
 //
 // The second phase consists of requesting the status from the contract for everything that is still in the temporary map. For each returned item, we do the following:
 // - If the contract indicates that the transfer has been committed, we validate the digest, then publish it and delete it from the map.
-// - If the contract indicates that the transfer is pending, we continue to wait for it.
+// - If the contract indicates that the transfer is pending, we continue to wait for it to be committed.
 // - If the contract indicates any other status (most likely meaning it does not know about it), we resubmit an observation to the contract
 //
 // Note that any time we are considering resubmitting an observation to the contract, we first check the "submit pending" flag. If that is set, we do not
@@ -34,10 +34,10 @@ import (
 
 const (
 	// auditInterval indicates how often the audit runs (given that it is invoked by the processor once per minute)
-	auditInterval = 30 * time.Second // TODO: Make this something like five minutes?
+	auditInterval = 5 * time.Minute
 
-	// maxSubmitPendingTime indicates how long a transfer can be in the pending state before the audit starts complaining about it.
-	maxSubmitPendingTime = 10 * time.Minute
+	// maxSubmitPendingTime indicates how long a transfer can be in the submit pending state before the audit starts complaining about it.
+	maxSubmitPendingTime = 30 * time.Minute
 )
 
 type (

--- a/node/pkg/accountant/metrics.go
+++ b/node/pkg/accountant/metrics.go
@@ -52,4 +52,9 @@ var (
 			Name: "global_accountant_connection_errors_total",
 			Help: "Total number of connection errors on accountant",
 		})
+	auditErrors = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "global_accountant_audit_errors_total",
+			Help: "Total number of audit errors detected by accountant",
+		})
 )

--- a/node/pkg/accountant/query_test.go
+++ b/node/pkg/accountant/query_test.go
@@ -15,7 +15,32 @@ import (
 )
 
 func TestParseMissingObservationsResponse(t *testing.T) {
-	//TODO: Write this test once we get a sample response.
+	responsesJson := []byte("{\"missing\":[{\"chain_id\":2,\"tx_hash\":\"y1E+jwgozWKEVbHt9dIeErgNXlHnntQwdzymYSCmBEA=\"},{\"chain_id\":4,\"tx_hash\":\"FZyF7xR5bIwtvdBIlIrDEZc+mrCkN/ixjGazgJdJdQQ=\"}]}")
+	var response MissingObservationsResponse
+	err := json.Unmarshal(responsesJson, &response)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(response.Missing))
+
+	expectedTxHash0, err := hex.DecodeString("cb513e8f0828cd628455b1edf5d21e12b80d5e51e79ed430773ca66120a60440")
+	require.NoError(t, err)
+
+	expectedTxHash1, err := hex.DecodeString("159c85ef14796c8c2dbdd048948ac311973e9ab0a437f8b18c66b38097497504")
+	require.NoError(t, err)
+
+	expectedResult := MissingObservationsResponse{
+		Missing: []MissingObservation{
+			MissingObservation{
+				ChainId: uint16(vaa.ChainIDEthereum),
+				TxHash:  expectedTxHash0,
+			},
+			MissingObservation{
+				ChainId: uint16(vaa.ChainIDBSC),
+				TxHash:  expectedTxHash1,
+			},
+		},
+	}
+
+	assert.Equal(t, expectedResult, response)
 }
 
 func TestParseBatchTransferStatusCommittedResponse(t *testing.T) {

--- a/node/pkg/accountant/query_test.go
+++ b/node/pkg/accountant/query_test.go
@@ -18,12 +18,12 @@ func TestParseMissingObservationsResponse(t *testing.T) {
 	//TODO: Write this test once we get a sample response.
 }
 
-func TestParseBatchTransferStatusResponse(t *testing.T) {
-	responsesJson := []byte("{\"details\":[{\"key\":{\"emitter_chain\":2,\"emitter_address\":\"0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16\",\"sequence\":1674568234},\"status\":{\"committed\":{\"data\":{\"amount\":\"1000000000000000000\",\"token_chain\":2,\"token_address\":\"0000000000000000000000002d8be6bf0baa74e0a907016679cae9190e80dd0a\",\"recipient_chain\":4},\"digest\":\"1nbbff/7/ai9GJUs4h2JymFuO4+XcasC6t05glXc99M=\"}}},{\"key\":{\"emitter_chain\":2,\"emitter_address\":\"0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16\",\"sequence\":1674484597},\"status\":null}]}")
+func TestParseBatchTransferStatusCommittedResponse(t *testing.T) {
+	responsesJson := []byte("{\"details\":[{\"key\":{\"emitter_chain\":2,\"emitter_address\":\"0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16\",\"sequence\":1674568234},\"status\":{\"committed\":{\"data\":{\"amount\":\"1000000000000000000\",\"token_chain\":2,\"token_address\":\"0000000000000000000000002d8be6bf0baa74e0a907016679cae9190e80dd0a\",\"recipient_chain\":4},\"digest\":\"1nbbff/7/ai9GJUs4h2JymFuO4+XcasC6t05glXc99M=\"}}}]}")
 	var response BatchTransferStatusResponse
 	err := json.Unmarshal(responsesJson, &response)
 	require.NoError(t, err)
-	require.Equal(t, 2, len(response.Details))
+	require.Equal(t, 1, len(response.Details))
 
 	expectedEmitterAddress, err := vaa.StringToAddress("0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16")
 	require.NoError(t, err)
@@ -31,44 +31,57 @@ func TestParseBatchTransferStatusResponse(t *testing.T) {
 	expectedTokenAddress, err := vaa.StringToAddress("0000000000000000000000002d8be6bf0baa74e0a907016679cae9190e80dd0a")
 	require.NoError(t, err)
 
-	expectedAmount0 := cosmossdk.NewInt(1000000000000000000)
+	expectedAmount := cosmossdk.NewInt(1000000000000000000)
 
-	expectedDigest0, err := hex.DecodeString("d676db7dfffbfda8bd18952ce21d89ca616e3b8f9771ab02eadd398255dcf7d3")
+	expectedDigest, err := hex.DecodeString("d676db7dfffbfda8bd18952ce21d89ca616e3b8f9771ab02eadd398255dcf7d3")
 	require.NoError(t, err)
 
-	expectedResult0 := TransferDetails{
+	expectedResult := TransferDetails{
 		Key: TransferKey{
 			EmitterChain:   uint16(vaa.ChainIDEthereum),
 			EmitterAddress: expectedEmitterAddress,
 			Sequence:       1674568234,
 		},
-		Status: TransferStatus{
+		Status: &TransferStatus{
 			Committed: &TransferStatusCommitted{
 				Data: TransferData{
-					Amount:         &expectedAmount0,
+					Amount:         &expectedAmount,
 					TokenChain:     uint16(vaa.ChainIDEthereum),
 					TokenAddress:   expectedTokenAddress,
 					RecipientChain: uint16(vaa.ChainIDBSC),
 				},
-				Digest: expectedDigest0,
+				Digest: expectedDigest,
 			},
 		},
 	}
 
-	expectedResult1 := TransferDetails{
+	// Use DeepEqual() because the response contains pointers.
+	assert.True(t, reflect.DeepEqual(expectedResult, response.Details[0]))
+}
+
+func TestParseBatchTransferStatusNotFoundResponse(t *testing.T) {
+	responsesJson := []byte("{\"details\":[{\"key\":{\"emitter_chain\":2,\"emitter_address\":\"0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16\",\"sequence\":1674484597},\"status\":null}]}")
+	var response BatchTransferStatusResponse
+	err := json.Unmarshal(responsesJson, &response)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(response.Details))
+
+	expectedEmitterAddress, err := vaa.StringToAddress("0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16")
+	require.NoError(t, err)
+
+	expectedResult := TransferDetails{
 		Key: TransferKey{
 			EmitterChain:   uint16(vaa.ChainIDEthereum),
 			EmitterAddress: expectedEmitterAddress,
 			Sequence:       1674484597,
 		},
-		Status: TransferStatus{},
+		Status: nil,
 	}
 
-	require.NotNil(t, response.Details[0].Status.Committed)
-	require.Nil(t, response.Details[0].Status.Pending)
-	assert.True(t, reflect.DeepEqual(expectedResult0, response.Details[0]))
-
 	// Use DeepEqual() because the response contains pointers.
-	assert.True(t, reflect.DeepEqual(expectedResult0, response.Details[0]))
-	assert.True(t, reflect.DeepEqual(expectedResult1, response.Details[1]))
+	assert.True(t, reflect.DeepEqual(expectedResult, response.Details[0]))
+}
+
+func TestParseBatchTransferStatusPendingResponse(t *testing.T) {
+	//TODO: Write this test once we get a sample response.
 }

--- a/node/pkg/accountant/query_test.go
+++ b/node/pkg/accountant/query_test.go
@@ -1,0 +1,74 @@
+package accountant
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/wormhole-foundation/wormhole/sdk/vaa"
+
+	cosmossdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseMissingObservationsResponse(t *testing.T) {
+	//TODO: Write this test once we get a sample response.
+}
+
+func TestParseBatchTransferStatusResponse(t *testing.T) {
+	responsesJson := []byte("{\"details\":[{\"key\":{\"emitter_chain\":2,\"emitter_address\":\"0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16\",\"sequence\":1674568234},\"status\":{\"committed\":{\"data\":{\"amount\":\"1000000000000000000\",\"token_chain\":2,\"token_address\":\"0000000000000000000000002d8be6bf0baa74e0a907016679cae9190e80dd0a\",\"recipient_chain\":4},\"digest\":\"1nbbff/7/ai9GJUs4h2JymFuO4+XcasC6t05glXc99M=\"}}},{\"key\":{\"emitter_chain\":2,\"emitter_address\":\"0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16\",\"sequence\":1674484597},\"status\":null}]}")
+	var response BatchTransferStatusResponse
+	err := json.Unmarshal(responsesJson, &response)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(response.Details))
+
+	expectedEmitterAddress, err := vaa.StringToAddress("0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16")
+	require.NoError(t, err)
+
+	expectedTokenAddress, err := vaa.StringToAddress("0000000000000000000000002d8be6bf0baa74e0a907016679cae9190e80dd0a")
+	require.NoError(t, err)
+
+	expectedAmount0 := cosmossdk.NewInt(1000000000000000000)
+
+	expectedDigest0, err := hex.DecodeString("d676db7dfffbfda8bd18952ce21d89ca616e3b8f9771ab02eadd398255dcf7d3")
+	require.NoError(t, err)
+
+	expectedResult0 := TransferDetails{
+		Key: TransferKey{
+			EmitterChain:   uint16(vaa.ChainIDEthereum),
+			EmitterAddress: expectedEmitterAddress,
+			Sequence:       1674568234,
+		},
+		Status: TransferStatus{
+			Committed: &TransferStatusCommitted{
+				Data: TransferData{
+					Amount:         &expectedAmount0,
+					TokenChain:     uint16(vaa.ChainIDEthereum),
+					TokenAddress:   expectedTokenAddress,
+					RecipientChain: uint16(vaa.ChainIDBSC),
+				},
+				Digest: expectedDigest0,
+			},
+		},
+	}
+
+	expectedResult1 := TransferDetails{
+		Key: TransferKey{
+			EmitterChain:   uint16(vaa.ChainIDEthereum),
+			EmitterAddress: expectedEmitterAddress,
+			Sequence:       1674484597,
+		},
+		Status: TransferStatus{},
+	}
+
+	require.NotNil(t, response.Details[0].Status.Committed)
+	require.Nil(t, response.Details[0].Status.Pending)
+	assert.True(t, reflect.DeepEqual(expectedResult0, response.Details[0]))
+
+	// Use DeepEqual() because the response contains pointers.
+	assert.True(t, reflect.DeepEqual(expectedResult0, response.Details[0]))
+	assert.True(t, reflect.DeepEqual(expectedResult1, response.Details[1]))
+}

--- a/node/pkg/accountant/submit_obs_test.go
+++ b/node/pkg/accountant/submit_obs_test.go
@@ -14,14 +14,14 @@ import (
 func TestParseObservationResponseDataKey(t *testing.T) {
 	dataJson := []byte("{\"emitter_chain\":2,\"emitter_address\":\"0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16\",\"sequence\":1673978163}")
 
-	var key ObservationKey
+	var key TransferKey
 	err := json.Unmarshal(dataJson, &key)
 	require.NoError(t, err)
 
 	expectedEmitterAddress, err := vaa.StringToAddress("0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16")
 	require.NoError(t, err)
 
-	expectedResult := ObservationKey{
+	expectedResult := TransferKey{
 		EmitterChain:   uint16(vaa.ChainIDEthereum),
 		EmitterAddress: expectedEmitterAddress,
 		Sequence:       1673978163,
@@ -40,7 +40,7 @@ func TestParseObservationResponseData(t *testing.T) {
 	require.NoError(t, err)
 
 	expectedResult0 := ObservationResponse{
-		Key: ObservationKey{
+		Key: TransferKey{
 			EmitterChain:   uint16(vaa.ChainIDEthereum),
 			EmitterAddress: expectedEmitterAddress,
 			Sequence:       1674061268,
@@ -51,7 +51,7 @@ func TestParseObservationResponseData(t *testing.T) {
 	}
 
 	expectedResult1 := ObservationResponse{
-		Key: ObservationKey{
+		Key: TransferKey{
 			EmitterChain:   uint16(vaa.ChainIDEthereum),
 			EmitterAddress: expectedEmitterAddress,
 			Sequence:       1674061267,

--- a/node/pkg/accountant/watcher.go
+++ b/node/pkg/accountant/watcher.go
@@ -117,8 +117,8 @@ type (
 
 	// WasmObservationError represents an error event from the smart contract.
 	WasmObservationError struct {
-		Key   ObservationKey `json:"key"`
-		Error string         `json:"error"`
+		Key   TransferKey `json:"key"`
+		Error string      `json:"error"`
 	}
 )
 
@@ -127,7 +127,7 @@ func parseEvent[T any](logger *zap.Logger, event tmAbci.Event, name string, cont
 	for _, attr := range event.Attributes {
 		if string(attr.Key) == "_contract_address" {
 			if string(attr.Value) != contractAddress {
-				return nil, fmt.Errorf("wasm-Observation event from unexpected contract: %s", string(attr.Value))
+				return nil, fmt.Errorf("%s event from unexpected contract: %s", name, string(attr.Value))
 			}
 		} else {
 			logger.Debug("acctwatcher: event attribute", zap.String("event", name), zap.String("key", string(attr.Key)), zap.String("value", string(attr.Value)))
@@ -137,12 +137,12 @@ func parseEvent[T any](logger *zap.Logger, event tmAbci.Event, name string, cont
 
 	attrBytes, err := json.Marshal(attrs)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal wasm-Observation event attributes: %w", err)
+		return nil, fmt.Errorf("failed to marshal %s event attributes: %w", name, err)
 	}
 
 	evt := new(T)
 	if err := json.Unmarshal(attrBytes, evt); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal wasm-Observation event: %w", err)
+		return nil, fmt.Errorf("failed to unmarshal %s event: %w", name, err)
 	}
 
 	return evt, nil

--- a/node/pkg/accountant/watcher_test.go
+++ b/node/pkg/accountant/watcher_test.go
@@ -100,7 +100,7 @@ func TestParseWasmObservationError(t *testing.T) {
 	require.NoError(t, err)
 
 	expectedResult := WasmObservationError{
-		Key: ObservationKey{
+		Key: TransferKey{
 			EmitterChain:   uint16(vaa.ChainIDEthereum),
 			EmitterAddress: expectedEmitterAddress,
 			Sequence:       1674144545,

--- a/node/pkg/processor/processor.go
+++ b/node/pkg/processor/processor.go
@@ -260,9 +260,6 @@ func (p *Processor) Run(ctx context.Context) error {
 					}
 				}
 			}
-			if p.acct != nil {
-				p.acct.AuditPendingTransfers()
-			}
 			if (p.governor != nil) || (p.acct != nil) {
 				govTimer = time.NewTimer(time.Minute)
 			}

--- a/node/pkg/wormconn/query.go
+++ b/node/pkg/wormconn/query.go
@@ -1,0 +1,19 @@
+package wormconn
+
+import (
+	"context"
+	"fmt"
+
+	wasmdtypes "github.com/CosmWasm/wasmd/x/wasm/types"
+)
+
+// SubmitQuery submits a query to a smart contract and returns the result.
+func (c *ClientConn) SubmitQuery(ctx context.Context, contractAddress string, query []byte) (*wasmdtypes.QuerySmartContractStateResponse, error) {
+	req := wasmdtypes.QuerySmartContractStateRequest{Address: contractAddress, QueryData: query}
+	qc := wasmdtypes.NewQueryClient(c.c)
+	if qc == nil {
+		return nil, fmt.Errorf("failed to create query client")
+	}
+
+	return qc.SmartContractState(ctx, &req)
+}

--- a/node/pkg/wormconn/query.go
+++ b/node/pkg/wormconn/query.go
@@ -8,12 +8,17 @@ import (
 )
 
 // SubmitQuery submits a query to a smart contract and returns the result.
-func (c *ClientConn) SubmitQuery(ctx context.Context, contractAddress string, query []byte) (*wasmdtypes.QuerySmartContractStateResponse, error) {
+func (c *ClientConn) SubmitQuery(ctx context.Context, contractAddress string, query []byte) ([]byte, error) {
 	req := wasmdtypes.QuerySmartContractStateRequest{Address: contractAddress, QueryData: query}
 	qc := wasmdtypes.NewQueryClient(c.c)
 	if qc == nil {
-		return nil, fmt.Errorf("failed to create query client")
+		return []byte{}, fmt.Errorf("failed to create query client")
 	}
 
-	return qc.SmartContractState(ctx, &req)
+	resp, err := qc.SmartContractState(ctx, &req)
+	if err != nil {
+		return []byte{}, err
+	}
+
+	return resp.Data, nil
 }


### PR DESCRIPTION
This PR implements the global account audit in the guardian. It verifies that the set of pending transfers the guardian knows about matches what the smart contract thinks. If mismatches are detected, it will either resubmit the observation to the contract or request a reobservation from the local watcher.

Additionally, this PR cleans up a couple of minor issues left over from the previous code review.

Fixes #2002 


Change-Id: I643ce699b5d5e21129d957dae8677e8f2fccdbfd