### PR TITLE
Slightly less verbose guardian logging at info level

### DIFF
--- a/node/pkg/watchers/aptos/watcher.go
+++ b/node/pkg/watchers/aptos/watcher.go
@@ -208,7 +208,8 @@ func (e *Watcher) Run(ctx context.Context) error {
 
 			}
 
-			logger.Info(string(health) + string(eventsJson))
+			// TODO: Make this log more useful for humans
+			logger.Debug(string(health) + string(eventsJson))
 
 			pHealth := gjson.ParseBytes(health)
 

--- a/node/pkg/watchers/cosmwasm/watcher.go
+++ b/node/pkg/watchers/cosmwasm/watcher.go
@@ -214,7 +214,7 @@ func (e *Watcher) Run(ctx context.Context) error {
 
 				blockJSON := string(blocksBody)
 				latestBlock := gjson.Get(blockJSON, "block.header.height")
-				logger.Info("current height", zap.String("network", networkName), zap.Int64("block", latestBlock.Int()))
+				logger.Debug("current height", zap.String("network", networkName), zap.Int64("block", latestBlock.Int()))
 				currentSlotHeight.WithLabelValues(networkName).Set(float64(latestBlock.Int()))
 				p2p.DefaultRegistry.SetNetworkStats(e.chainID, &gossipv1.Heartbeat_Network{
 					Height:          latestBlock.Int(),

--- a/node/pkg/watchers/evm/watcher.go
+++ b/node/pkg/watchers/evm/watcher.go
@@ -606,7 +606,7 @@ func (w *Watcher) Run(ctx context.Context) error {
 
 				start := time.Now()
 				currentHash := ev.Hash
-				logger.Info("processing new header",
+				logger.Debug("processing new header",
 					zap.Stringer("current_block", ev.Number),
 					zap.Stringer("current_blockhash", currentHash),
 					zap.Bool("is_safe_block", ev.Safe),
@@ -759,7 +759,7 @@ func (w *Watcher) Run(ctx context.Context) error {
 				}
 
 				w.pendingMu.Unlock()
-				logger.Info("processed new header",
+				logger.Debug("processed new header",
 					zap.Stringer("current_block", ev.Number),
 					zap.Bool("is_safe_block", ev.Safe),
 					zap.Stringer("current_blockhash", currentHash),
@@ -787,7 +787,7 @@ func (w *Watcher) fetchAndUpdateGuardianSet(
 	ethConn connectors.Connector,
 ) error {
 	msm := time.Now()
-	logger.Info("fetching guardian set")
+	logger.Debug("fetching guardian set")
 	timeout, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 	idx, gs, err := fetchCurrentGuardianSet(timeout, ethConn)

--- a/node/pkg/watchers/near/metrics.go
+++ b/node/pkg/watchers/near/metrics.go
@@ -77,7 +77,7 @@ func (e *Watcher) runMetrics(ctx context.Context) error {
 			l2 := len(e.chunkProcessingQueue)
 			txqueueLen.Set(float64(l1))
 			chunkqueueLen.Set(float64(l2))
-			logger.Info("metrics", zap.Int64("txqueueLen", l1), zap.Int("chunkqueueLen", l2))
+			logger.Debug("metrics", zap.Int64("txqueueLen", l1), zap.Int("chunkqueueLen", l2))
 
 		case event := <-e.eventChan:
 			switch event {

--- a/node/pkg/watchers/near/poll.go
+++ b/node/pkg/watchers/near/poll.go
@@ -60,7 +60,7 @@ func (e *Watcher) recursivelyReadFinalizedBlocks(logger *zap.Logger, ctx context
 			return err
 		}
 
-		logger.Info(
+		logger.Debug(
 			"block_polled",
 			zap.String("log_msg_type", "block_poll"),
 			zap.Uint64("height", startBlock.Header.Height),
@@ -90,7 +90,7 @@ func (e *Watcher) ReadFinalChunksSince(logger *zap.Logger, ctx context.Context, 
 
 	if newestFinalHeight > startHeight {
 
-		logger.Info(
+		logger.Debug(
 			"polling_attempt",
 			zap.String("log_msg_type", "polling_attempt"),
 			zap.Uint64("previous_height", startHeight),

--- a/node/pkg/watchers/solana/client.go
+++ b/node/pkg/watchers/solana/client.go
@@ -431,7 +431,7 @@ func (s *SolanaWatcher) fetchBlock(ctx context.Context, logger *zap.Logger, slot
 	if err != nil {
 		var rpcErr *jsonrpc.RPCError
 		if errors.As(err, &rpcErr) && (rpcErr.Code == -32007 /* SLOT_SKIPPED */ || rpcErr.Code == -32004 /* BLOCK_NOT_AVAILABLE */) {
-			logger.Info("empty slot", zap.Uint64("slot", slot),
+			logger.Debug("empty slot", zap.Uint64("slot", slot),
 				zap.Int("code", rpcErr.Code),
 				zap.String("commitment", string(s.commitment)))
 

--- a/node/pkg/watchers/sui/watcher.go
+++ b/node/pkg/watchers/sui/watcher.go
@@ -162,13 +162,13 @@ func (e *Watcher) inspectBody(logger *zap.Logger, body SuiResult) error {
 	}
 
 	if e.suiAccount != *moveEvent.Sender {
-		logger.Info("account missmatch", zap.String("e.suiAccount", e.suiAccount), zap.String("account", *moveEvent.Sender))
-		return errors.New("account missmatch")
+		logger.Info("account mismatch", zap.String("e.suiAccount", e.suiAccount), zap.String("account", *moveEvent.Sender))
+		return errors.New("account mismatch")
 	}
 
 	if !e.unsafeDevMode && e.suiPackage != *moveEvent.PackageID {
-		logger.Info("package missmatch", zap.String("e.suiPackage", e.suiPackage), zap.String("package", *moveEvent.PackageID))
-		return errors.New("package missmatch")
+		logger.Info("package mismatch", zap.String("e.suiPackage", e.suiPackage), zap.String("package", *moveEvent.PackageID))
+		return errors.New("package mismatch")
 	}
 
 	emitter := make([]byte, 8)
@@ -360,7 +360,7 @@ func (e *Watcher) Run(ctx context.Context) error {
 			}
 			if res.ID != nil {
 				if *res.ID == e.subId {
-					logger.Info("Subscribed set to true")
+					logger.Debug("Subscribed set to true")
 					e.subscribed = true
 				}
 				continue

--- a/node/pkg/watchers/wormchain/watcher.go
+++ b/node/pkg/watchers/wormchain/watcher.go
@@ -149,7 +149,7 @@ func (e *Watcher) Run(ctx context.Context) error {
 
 			blockJSON := string(blocksBody)
 			latestBlock := gjson.Get(blockJSON, "block.header.height")
-			logger.Info("current Wormchain height", zap.Int64("block", latestBlock.Int()))
+			logger.Debug("current Wormchain height", zap.Int64("block", latestBlock.Int()))
 			currentWormchainHeight.Set(float64(latestBlock.Int()))
 			p2p.DefaultRegistry.SetNetworkStats(vaa.ChainIDWormchain, &gossipv1.Heartbeat_Network{
 				Height: latestBlock.Int(),


### PR DESCRIPTION
This change is the first in what will likely be a series of changes to log less debugging information by default. Useful non-debug data should be returned from the guardian at the info log level.

I looked through each guardian by searching for `logger\.Info` and updating where it made sense.