### PR TITLE
Fix Clippy Errors

### DIFF
--- a/cosmwasm/contracts/cw20-wrapped/src/contract.rs
+++ b/cosmwasm/contracts/cw20-wrapped/src/contract.rs
@@ -63,7 +63,7 @@ pub fn instantiate(
 
     if let Some(mint_info) = msg.mint {
         execute_mint(deps, env, info, mint_info.recipient, mint_info.amount)
-            .map_err(|e| StdError::generic_err(format!("{}", e)))?;
+            .map_err(|e| StdError::generic_err(format!("{e}")))?;
     }
 
     if let Some(hook) = msg.init_hook {

--- a/cosmwasm/contracts/token-bridge/src/contract.rs
+++ b/cosmwasm/contracts/token-bridge/src/contract.rs
@@ -395,8 +395,8 @@ fn handle_register_asset(
 
     Ok(Response::new()
         .add_attribute("action", "register_asset")
-        .add_attribute("token_chain", format!("{:?}", chain))
-        .add_attribute("token_address", format!("{:?}", token_address))
+        .add_attribute("token_chain", format!("{chain:?}"))
+        .add_attribute("token_address", format!("{token_address:?}"))
         .add_attribute("contract_addr", info.sender))
 }
 
@@ -424,13 +424,11 @@ fn handle_attest_meta(
 
     let token_address: [u8; 32] = match token_id {
         TokenId::Bank { denom } => Err(StdError::generic_err(format!(
-            "{} is native to this chain and should not be attested",
-            denom
+            "{denom} is native to this chain and should not be attested"
         ))),
         TokenId::Contract(ContractId::NativeCW20 { contract_address }) => {
             Err(StdError::generic_err(format!(
-                "Contract {} is native to this chain and should not be attested",
-                contract_address
+                "Contract {contract_address} is native to this chain and should not be attested"
             )))
         }
         TokenId::Contract(ContractId::ForeignToken {
@@ -1518,7 +1516,7 @@ fn query_transfer_info(deps: Deps, env: Env, vaa: &Binary) -> StdResult<Transfer
                 payload: info.payload,
             })
         }
-        other => Err(StdError::generic_err(format!("Invalid action: {}", other))),
+        other => Err(StdError::generic_err(format!("Invalid action: {other}"))),
     }
 }
 

--- a/cosmwasm/contracts/token-bridge/src/token_address.rs
+++ b/cosmwasm/contracts/token-bridge/src/token_address.rs
@@ -92,7 +92,7 @@ impl ExternalTokenId {
                         contract_address: human_address,
                     }))
                 }
-                b => Err(StdError::generic_err(format!("Unknown marker byte: {}", b))),
+                b => Err(StdError::generic_err(format!("Unknown marker byte: {b}"))),
             }
         } else {
             Ok(TokenId::Contract(ContractId::ForeignToken {

--- a/cosmwasm/contracts/wormhole/src/error.rs
+++ b/cosmwasm/contracts/wormhole/src/error.rs
@@ -103,7 +103,7 @@ pub enum ContractError {
 impl ContractError {
     pub fn std(&self) -> StdError {
         StdError::GenericErr {
-            msg: format!("{}", self),
+            msg: format!("{self}"),
         }
     }
 

--- a/sdk/rust/core/src/serde_array.rs
+++ b/sdk/rust/core/src/serde_array.rs
@@ -23,7 +23,7 @@ impl<'de, const N: usize> Visitor<'de> for ArrayVisitor<N> {
     type Value = [u8; N];
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        write!(formatter, "an array of length {}", N)
+        write!(formatter, "an array of length {N}")
     }
 
     fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>

--- a/sdk/rust/serde_wormhole/src/lib.rs
+++ b/sdk/rust/serde_wormhole/src/lib.rs
@@ -209,7 +209,7 @@ mod tests {
             type Value = [u8; N];
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                write!(formatter, "an array of length {}", N)
+                write!(formatter, "an array of length {N}")
             }
 
             fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>

--- a/terra/contracts/cw20-wrapped/src/contract.rs
+++ b/terra/contracts/cw20-wrapped/src/contract.rs
@@ -63,7 +63,7 @@ pub fn instantiate(
 
     if let Some(mint_info) = msg.mint {
         execute_mint(deps, env, info, mint_info.recipient, mint_info.amount)
-            .map_err(|e| StdError::generic_err(format!("{}", e)))?;
+            .map_err(|e| StdError::generic_err(format!("{e}")))?;
     }
 
     if let Some(hook) = msg.init_hook {

--- a/terra/contracts/nft-bridge/src/contract.rs
+++ b/terra/contracts/nft-bridge/src/contract.rs
@@ -502,7 +502,7 @@ fn handle_register_asset(
 
     Ok(Response::new()
         .add_attribute("action", "register_asset")
-        .add_attribute("asset_id", format!("{:?}", asset_id))
+        .add_attribute("asset_id", format!("{asset_id:?}"))
         .add_attribute("contract_addr", info.sender))
 }
 

--- a/terra/contracts/nft-bridge/src/state.rs
+++ b/terra/contracts/nft-bridge/src/state.rs
@@ -134,7 +134,7 @@ impl<T, const N: usize> BoundedVec<T, N> {
     pub fn new(vec: Vec<T>) -> StdResult<Self> {
         if vec.len() > N {
             return Result::Err(StdError::GenericErr {
-                msg: format!("vector length exceeds {}", N),
+                msg: format!("vector length exceeds {N}"),
             });
         };
         Ok(Self { vec })

--- a/terra/contracts/nft-bridge/src/token_id.rs
+++ b/terra/contracts/nft-bridge/src/token_id.rs
@@ -80,8 +80,7 @@ pub fn to_external_token_id(
         U256::from_dec_str(&token_id_internal)
             .map_err(|_| {
                 StdError::generic_err(format!(
-                    "{} could not be parsed as a decimal number",
-                    token_id_internal
+                    "{token_id_internal} could not be parsed as a decimal number"
                 ))
             })?
             .to_big_endian(&mut bytes);

--- a/terra/contracts/token-bridge/src/contract.rs
+++ b/terra/contracts/token-bridge/src/contract.rs
@@ -405,7 +405,7 @@ fn handle_register_asset(
 
     Ok(Response::new()
         .add_attribute("action", "register_asset")
-        .add_attribute("asset_id", format!("{:?}", asset_id))
+        .add_attribute("asset_id", format!("{asset_id:?}"))
         .add_attribute("contract_addr", info.sender))
 }
 
@@ -754,7 +754,7 @@ fn handle_complete_transfer(
                 data,
                 relayer_address,
             ),
-            b => Err(StdError::generic_err(format!("Unknown marker byte: {}", b))),
+            b => Err(StdError::generic_err(format!("Unknown marker byte: {b}"))),
         }
     } else {
         handle_complete_transfer_token(
@@ -1449,7 +1449,7 @@ fn query_transfer_info(deps: Deps, env: Env, vaa: &Binary) -> StdResult<Transfer
                 payload: info.payload,
             })
         }
-        other => Err(StdError::generic_err(format!("Invalid action: {}", other))),
+        other => Err(StdError::generic_err(format!("Invalid action: {other}"))),
     }
 }
 

--- a/terra/contracts/wormhole/src/error.rs
+++ b/terra/contracts/wormhole/src/error.rs
@@ -103,7 +103,7 @@ pub enum ContractError {
 impl ContractError {
     pub fn std(&self) -> StdError {
         StdError::GenericErr {
-            msg: format!("{}", self),
+            msg: format!("{self}"),
         }
     }
 


### PR DESCRIPTION
# Objective

Latest clippy triggers errors resemble:
```
error: variables can be used directly in the `format!` string
  --> core/src/serde_array.rs:26:9
   |
26 |         write!(formatter, "an array of length {}", N)
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
```

This PR fixes these errors in _sdk/rust_, _cosmwasm_ and _terra_ directories.

# How to Review this PR

1. Verify that Github CI works.
2. Review code change.