### PR TITLE
wormchain - contracts deploy CI test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -260,11 +260,14 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: "1.19.3"
-      - run: |
+      - name: make proto -B && make test
+        run: |
           cd wormchain
           make proto -B
           git diff --name-only --exit-code && echo "✅ Generated proto matches committed proto" || (echo "❌ Generated proto differs from committed proto, run \`make proto -B\` and commit the result" >&2 && exit 1)
           make test
+      - name: deploy-test
+        run: cd wormchain && make contracts-deploy-test
 
   # Verify go sdk unit tests
   sdk_vaa:

--- a/wormchain/Makefile
+++ b/wormchain/Makefile
@@ -44,7 +44,7 @@ run: build/wormchaind
 	./$< start --home build  --log_level="debug"
 
 # get npm packages for contracts/tools
-contracts-tools-deps: contracts/tools/package-lock.json
+contracts-tools-deps: ts-sdk contracts/tools/package-lock.json
 	npm ci --prefix=contracts/tools
 
 # get .env and devnet-consts.json for contracts/tools
@@ -63,6 +63,10 @@ contracts-deploy-setup: contracts-tools-deps contracts-devnet-env contracts-arti
 # runs the contract deployment script
 contracts-deploy-local: contracts-deploy-setup
 	npm run deploy-wormchain --prefix=contracts/tools
+
+# starts wormchaind in a container, deploys contracts, tests contract interaction
+contracts-deploy-test: client contracts-deploy-setup
+	./contracts/run_deploy_test.sh
 
 .PHONY: test
 test:

--- a/wormchain/contracts/run_deploy_test.sh
+++ b/wormchain/contracts/run_deploy_test.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -exu pipefail
+
+echo "Starting wormchaind"
+./build/wormchaind start --home build --rpc.laddr="tcp://0.0.0.0:26659" > wormchaind.out 2>&1 &
+# give wormchain 2 seconds to startup
+sleep 2
+
+cleanup() {
+    echo "cleaning up test container"
+    # kill wormchain, any dependents of the process (just in case)
+    pkill -f "./build/wormchaind start --home build --rpc.laddr=tcp://0.0.0.0:26659"
+    pkill -P $$
+    # remove wormchaind log file
+    rm wormchaind.out
+}
+
+cleanup_and_exit_failure() {
+    cleanup
+    echo "exiting with failure code"
+    exit 1
+}
+
+# run the deploy, and catch if it returns an error code
+npm run deploy-and-test --prefix contracts/tools  || cleanup_and_exit_failure
+
+# cleanup and return success
+cleanup


### PR DESCRIPTION
Adds a shell script that starts up a local wormchain node and then deploys contracts and runs tests, so that it can be run in CI.
Adds the new job to CI.
