### PR TITLE
wormchain ibc - update wormchain service name

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -823,7 +823,7 @@ if ibc_relayer:
         port_forwards = [
             port_forward(7597, name = "HTTPDEBUG [:7597]", host = webHost),
         ],
-        resource_deps = ["guardian-validator", "terra2-terrad"],
+        resource_deps = ["wormchain", "terra2-terrad"],
         labels = ["ibc-relayer"],
         trigger_mode = trigger_mode,
     )

--- a/wormchain/ibc-relayer/chains/wormchain.json
+++ b/wormchain/ibc-relayer/chains/wormchain.json
@@ -1,16 +1,16 @@
 {
-    "type": "cosmos",
-    "value": {
-      "key": "default",
-      "chain-id": "wormchain",
-      "rpc-addr": "http://guardian-validator:26657",
-      "account-prefix": "wormhole",
-      "keyring-backend": "test",
-      "gas-adjustment": 1.2,
-      "gas-prices": "0.01utest",
-      "debug": true,
-      "timeout": "20s",
-      "output-format": "json",
-      "sign-mode": "direct"
-    }
+  "type": "cosmos",
+  "value": {
+    "key": "default",
+    "chain-id": "wormchain",
+    "rpc-addr": "http://wormchain:26657",
+    "account-prefix": "wormhole",
+    "keyring-backend": "test",
+    "gas-adjustment": 1.2,
+    "gas-prices": "0.01utest",
+    "debug": true,
+    "timeout": "20s",
+    "output-format": "json",
+    "sign-mode": "direct"
   }
+}


### PR DESCRIPTION
Updates the devnet k8s service name of wormchain for IBC. `guardian-validator` is out of date. cc @nik-suri 