### PR TITLE
node - wormchain config

### DIFF
--- a/devnet/node.yaml
+++ b/devnet/node.yaml
@@ -59,7 +59,7 @@ spec:
               - key: wormchainKey0
                 path: wormchainKey0
               - key: wormchainKey1
-                path: wormchainKey1               
+                path: wormchainKey1
       containers:
         - name: guardiand
           image: guardiand-image
@@ -104,19 +104,19 @@ spec:
             - --neonRPC
             - ws://eth-devnet:8545
             # - --wormchainWS
-            # - ws://guardian-validator:26657/websocket
+            # - ws://wormchain:26657/websocket
             # - --wormchainLCD
-            # - http://guardian-validator:1317
+            # - http://wormchain:1317
             # - --wormchainURL
-            # - guardian-validator:9090
+            # - wormchain:9090
             # - --wormchainKeyPath
             # - /tmp/mounted-keys/wormchain/wormchainKey
             # - --wormchainKeyPassPhrase
             # - test0000
             # - --accountantWS
-            # - http://guardian-validator:26657
+            # - http://wormchain:26657
             # - --accountantContract
-            # - wormhole1466nf3zuxpya8q9emxukd7vftaf6h4psr0a07srl5zw74zh84yjq4lyjmh    
+            # - wormhole14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9srrg465
             # - --accountantCheckEnabled=true
             # - --terraWS
             # - ws://terra-terrad:26657/websocket
@@ -199,5 +199,5 @@ metadata:
   name: node-wormchain-key
 type: Opaque
 data:
-  wormchainKey0: LS0tLS1CRUdJTiBURU5ERVJNSU5UIFBSSVZBVEUgS0VZLS0tLS0Ka2RmOiBiY3J5cHQKc2FsdDogNDc2ODc2NkE3OEZEN0ZBQjMwMUJGOTM5MUYwQ0Y2M0YKdHlwZTogc2VjcDI1NmsxCgpkbEZuN1ZqRk02RnJjYkdaVDRWeE5yRlE3SUhQS2RyVVBCRTYraW8yK0w0VFZqcis5emNIQTF3dzNubWtqNVFlCnVSekJWMjQyeUdTc3hNTTJZckI2Q1ZXdzlaWXJJY3JFeks1c0FuST0KPXB2aHkKLS0tLS1FTkQgVEVOREVSTUlOVCBQUklWQVRFIEtFWS0tLS0t 
+  wormchainKey0: LS0tLS1CRUdJTiBURU5ERVJNSU5UIFBSSVZBVEUgS0VZLS0tLS0Ka2RmOiBiY3J5cHQKc2FsdDogNDc2ODc2NkE3OEZEN0ZBQjMwMUJGOTM5MUYwQ0Y2M0YKdHlwZTogc2VjcDI1NmsxCgpkbEZuN1ZqRk02RnJjYkdaVDRWeE5yRlE3SUhQS2RyVVBCRTYraW8yK0w0VFZqcis5emNIQTF3dzNubWtqNVFlCnVSekJWMjQyeUdTc3hNTTJZckI2Q1ZXdzlaWXJJY3JFeks1c0FuST0KPXB2aHkKLS0tLS1FTkQgVEVOREVSTUlOVCBQUklWQVRFIEtFWS0tLS0t
   wormchainKey1: LS0tLS1CRUdJTiBURU5ERVJNSU5UIFBSSVZBVEUgS0VZLS0tLS0Ka2RmOiBiY3J5cHQKc2FsdDogMjMyRTU2NDMyMjBBNTcwRkVEQjFFMTFFOTNFM0E4NEIKdHlwZTogc2VjcDI1NmsxCgpBZjJ3aXNLdlBDOW4vaExYcDZaS1k5S091aVNYZG1lb3VvSzd3QVJ3cmNtTDV3MGs0YjFDSE5xTEp3ZXU1OEFGCkdTWGJsU3oySzNuWEl1V2hJZWtSNXE5WGRuUko4cGhSRWltbFNZST0KPU1vY1QKLS0tLS1FTkQgVEVOREVSTUlOVCBQUklWQVRFIEtFWS0tLS0tCg==

--- a/node/hack/accountant/send_obs.go
+++ b/node/hack/accountant/send_obs.go
@@ -34,7 +34,7 @@ func main() {
 
 	wormchainURL := string("localhost:9090")
 	wormchainKeyPath := string("./dev.wormchain.key")
-	contract := "wormhole1466nf3zuxpya8q9emxukd7vftaf6h4psr0a07srl5zw74zh84yjq4lyjmh"
+	contract := "wormhole14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9srrg465"
 	guardianKeyPath := string("./dev.guardian.key")
 
 	wormchainKey, err := wormconn.LoadWormchainPrivKey(wormchainKeyPath, "test0000")


### PR DESCRIPTION
Updates some node config values for wormchain - service name and accountant contract address.

The contract address is what it will be when the contract-deploy PR stack lands. This change is not in the deploy PR stack because there are no dependencies between changes in the stack and this change.