### PR TITLE
docs: remove README link to deprecated docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 This monorepo contains the reference implementation of the [Wormhole protocol](https://wormholenetwork.com).
 
-To learn about how to use and build on Wormhole read the [Docs](http://docs.wormholenetwork.com/) or take a look at the 
-[xApp Book](https://book.wormholenetwork.com/).
+To learn about how to use and build on Wormhole read the [docs](http://book.wormholenetwork.com/).
 
 ----
 


### PR DESCRIPTION
Replace link to docs with book.wormhole.com vs the deprecated docs site.