### PR TITLE
tilt: solana deploy fix

### DIFF
--- a/solana/devnet_setup.sh
+++ b/solana/devnet_setup.sh
@@ -100,6 +100,9 @@ retry token-bridge-client create-bridge "$nft_bridge_address" "$bridge_address"
 echo "Waiting for worm to finish building"
 wait $worm_build_pid
 
+# Trigger wormhole config file before running in parallel
+worm --help
+
 # next we get all the registration VAAs from the environment
 # if a new VAA is added, this will automatically pick it up
 VAAS=$(set | grep "REGISTER_.*_VAA" | grep -v SOL | cut -d '=' -f1)


### PR DESCRIPTION
Fixes a flakiness in the solana deploy when starting multiple worm commands in parallel without a config present.