### PR TITLE
Node: Initialize scissors metrics

### DIFF
--- a/node/pkg/common/scissors.go
+++ b/node/pkg/common/scissors.go
@@ -20,6 +20,7 @@ var (
 // Start a go routine with recovering from any panic by sending an error to a error channel
 func RunWithScissors(ctx context.Context, errC chan error, name string, runnable supervisor.Runnable) {
 	go func() {
+		ScissorsErrors.WithLabelValues("scissors", name).Add(0)
 		defer func() {
 			if r := recover(); r != nil {
 				switch x := r.(type) {
@@ -41,6 +42,7 @@ func RunWithScissors(ctx context.Context, errC chan error, name string, runnable
 
 func WrapWithScissors(runnable supervisor.Runnable, name string) supervisor.Runnable {
 	return func(ctx context.Context) (result error) {
+		ScissorsErrors.WithLabelValues("scissors", name).Add(0)
 		defer func() {
 			if r := recover(); r != nil {
 				switch x := r.(type) {

--- a/node/pkg/common/scissors.go
+++ b/node/pkg/common/scissors.go
@@ -19,8 +19,8 @@ var (
 
 // Start a go routine with recovering from any panic by sending an error to a error channel
 func RunWithScissors(ctx context.Context, errC chan error, name string, runnable supervisor.Runnable) {
+	ScissorsErrors.WithLabelValues("scissors", name).Add(0)
 	go func() {
-		ScissorsErrors.WithLabelValues("scissors", name).Add(0)
 		defer func() {
 			if r := recover(); r != nil {
 				switch x := r.(type) {
@@ -41,8 +41,8 @@ func RunWithScissors(ctx context.Context, errC chan error, name string, runnable
 }
 
 func WrapWithScissors(runnable supervisor.Runnable, name string) supervisor.Runnable {
+	ScissorsErrors.WithLabelValues("scissors", name).Add(0)
 	return func(ctx context.Context) (result error) {
-		ScissorsErrors.WithLabelValues("scissors", name).Add(0)
 		defer func() {
 			if r := recover(); r != nil {
 				switch x := r.(type) {


### PR DESCRIPTION
This PR initializes the "run with scissors" metrics so that they will show up even if there have not been any errors.

Change-Id: I018a663aa5b9ea902f934ab71c23b1786c8aeeb0