### PR TITLE
wormchain/ts-sdk: add wasm

### DIFF
--- a/wormchain/docs/exampleTendermint.json
+++ b/wormchain/docs/exampleTendermint.json
@@ -13,7 +13,7 @@
               {
                 "events": [
                   {
-                    "type": "certusone.wormholechain.wormhole.EventPostedMessage",
+                    "type": "wormhole_foundation.wormchain.wormhole.EventPostedMessage",
                     "attributes": [
                       {
                         "key": "emitter",
@@ -178,7 +178,7 @@
                 ]
               },
               {
-                "type": "certusone.wormholechain.wormhole.EventPostedMessage",
+                "type": "wormhole_foundation.wormchain.wormhole.EventPostedMessage",
                 "attributes": [
                   {
                     "key": "ZW1pdHRlcg==",
@@ -213,7 +213,7 @@
       "transfer.amount": ["100uworm"],
       "tx.acc_seq": ["wormhole1wqwywkce50mg6077huy4j9y8lt80943ks5udzr/13"],
       "message.action": ["Transfer"],
-      "certusone.wormholechain.wormhole.EventPostedMessage.nonce": ["0"],
+      "wormhole_foundation.wormchain.wormhole.EventPostedMessage.nonce": ["0"],
       "tx.hash": [
         "0A623859DCEBE1DCAC077D6D8B459BBF6FB199B18FCC5A3B9518EB3F36F25BE5"
       ],
@@ -223,18 +223,20 @@
         "wormhole1zugu6cajc4z7ue29g9wnes9a5ep9cs7yu7rn3z"
       ],
       "transfer.recipient": ["wormhole1zugu6cajc4z7ue29g9wnes9a5ep9cs7yu7rn3z"],
-      "certusone.wormholechain.wormhole.EventPostedMessage.sequence": ["13"],
+      "wormhole_foundation.wormchain.wormhole.EventPostedMessage.sequence": [
+        "13"
+      ],
       "tx.height": ["8583"],
       "tx.signature": [
         "7S2taziRjKoisL0iSt1wq6VJixB+t+9YMOOD1F5lm/hvG1uxOOxM90c+QNWpwIq3O4FwyjG6IrodNN+uNOIX0A=="
       ],
       "coin_spent.amount": ["100uworm"],
-      "certusone.wormholechain.wormhole.EventPostedMessage.payload": [
+      "wormhole_foundation.wormchain.wormhole.EventPostedMessage.payload": [
         "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAdWhvbGUMIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
       ],
       "tm.event": ["Tx"],
       "transfer.sender": ["wormhole1wqwywkce50mg6077huy4j9y8lt80943ks5udzr"],
-      "certusone.wormholechain.wormhole.EventPostedMessage.emitter": [
+      "wormhole_foundation.wormchain.wormhole.EventPostedMessage.emitter": [
         "AAAAAAAAAAAAAAAAFxHNY7LFRe5lRUFdPMC9pkJcQ8Q="
       ]
     }

--- a/wormchain/ts-sdk/src/core/queryClient.ts
+++ b/wormchain/ts-sdk/src/core/queryClient.ts
@@ -1,16 +1,3 @@
-import { GovernorCompatibilityBravo } from "@certusone/wormhole-sdk";
-import {
-  QueryClient,
-  setupAuthExtension,
-  setupBankExtension,
-  setupGovExtension,
-  setupIbcExtension,
-  setupMintExtension,
-  setupStakingExtension,
-  setupTxExtension,
-} from "@cosmjs/stargate";
-import { Tendermint34Client } from "@cosmjs/tendermint-rpc";
-import { Api as coreApi } from "../modules/wormhole_foundation.wormchain.wormhole/rest";
 import { Api as authApi } from "../modules/cosmos.auth.v1beta1/rest";
 import { Api as bankApi } from "../modules/cosmos.bank.v1beta1/rest";
 import { Api as baseApi } from "../modules/cosmos.base.tendermint.v1beta1/rest";
@@ -26,6 +13,8 @@ import { Api as stakingApi } from "../modules/cosmos.staking.v1beta1/rest";
 import { Api as txApi } from "../modules/cosmos.tx.v1beta1/rest";
 import { Api as upgradeApi } from "../modules/cosmos.upgrade.v1beta1/rest";
 import { Api as vestingApi } from "../modules/cosmos.vesting.v1beta1/rest";
+import { Api as wasmApi } from "../modules/cosmwasm.wasm.v1/rest";
+import { Api as coreApi } from "../modules/wormhole_foundation.wormchain.wormhole/rest";
 
 export type WormchainQueryClient = {
   core: coreApi<any>;
@@ -44,6 +33,7 @@ export type WormchainQueryClient = {
   tx: txApi<any>;
   upgrade: upgradeApi<any>;
   vesting: vestingApi<any>;
+  wasm: wasmApi<any>;
 };
 
 export function getWormholeQueryClient(
@@ -71,6 +61,7 @@ export function getWormholeQueryClient(
   const tx = new txApi({ baseUrl: lcdAddress });
   const upgrade = new upgradeApi({ baseUrl: lcdAddress });
   const vesting = new vestingApi({ baseUrl: lcdAddress });
+  const wasm = new wasmApi({ baseUrl: lcdAddress });
 
   return {
     core,
@@ -89,6 +80,7 @@ export function getWormholeQueryClient(
     tx,
     upgrade,
     vesting,
+    wasm,
   };
 }
 

--- a/wormchain/ts-sdk/src/core/signingClient.ts
+++ b/wormchain/ts-sdk/src/core/signingClient.ts
@@ -1,12 +1,8 @@
 import { OfflineSigner, Registry } from "@cosmjs/proto-signing";
 import {
-  defaultRegistryTypes,
   SigningStargateClient,
   SigningStargateClientOptions,
-  StargateClient,
 } from "@cosmjs/stargate";
-import { getTypeParameterOwner } from "typescript";
-import * as coreModule from "../modules/wormhole_foundation.wormchain.wormhole";
 import * as authModule from "../modules/cosmos.auth.v1beta1";
 import * as bankModule from "../modules/cosmos.bank.v1beta1";
 import * as baseModule from "../modules/cosmos.base.tendermint.v1beta1";
@@ -22,6 +18,8 @@ import * as stakingModule from "../modules/cosmos.staking.v1beta1";
 import * as txModule from "../modules/cosmos.tx.v1beta1";
 import * as upgradeModule from "../modules/cosmos.upgrade.v1beta1";
 import * as vestingModule from "../modules/cosmos.vesting.v1beta1";
+import * as wasmModule from "../modules/cosmwasm.wasm.v1";
+import * as coreModule from "../modules/wormhole_foundation.wormchain.wormhole";
 
 //protobuf isn't guaranteed to have long support, which is used by the stargate signing client,
 //so we're going to use an independent long module and shove it into the globals of protobuf
@@ -63,6 +61,8 @@ const txTypes = txModule.registry.types;
 const upgradeTypes = upgradeModule.registry.types;
 //@ts-ignore
 const vestingTypes = vestingModule.registry.types;
+//@ts-ignore
+const wasmTypes = wasmModule.registry.types;
 
 const aggregateTypes = [
   ...coreTypes,
@@ -81,6 +81,7 @@ const aggregateTypes = [
   ...txTypes,
   ...upgradeTypes,
   ...vestingTypes,
+  ...wasmTypes,
 ];
 
 export const MissingWalletError = new Error("wallet is required");
@@ -155,6 +156,10 @@ export const getWormchainSigningClient = async (
   });
 
   const vestingClient = await vestingModule.txClient(wallet, {
+    addr: tendermintAddress,
+  });
+
+  const wasmClient = await wasmModule.txClient(wallet, {
     addr: tendermintAddress,
   });
 
@@ -268,6 +273,12 @@ export const getWormchainSigningClient = async (
   };
   delete vestingShell.signAndBroadcast;
 
+  const wasmShell = {
+    ...wasmClient,
+    signAndBroadcast: undefined,
+  };
+  delete wasmShell.signAndBroadcast;
+
   type CoreType = Omit<typeof coreShell, "signAndBroadcast">;
   type AuthzType = Omit<typeof authShell, "signAndBroadcast">;
   type BankType = Omit<typeof bankShell, "signAndBroadcast">;
@@ -284,6 +295,7 @@ export const getWormchainSigningClient = async (
   type TxType = Omit<typeof txShell, "signAndBroadcast">;
   type UpgradeType = Omit<typeof upgradeShell, "signAndBroadcast">;
   type VestingType = Omit<typeof vestingShell, "signAndBroadcast">;
+  type WasmType = Omit<typeof wasmShell, "signAndBroadcast">;
   type WormholeFunctions = {
     core: CoreType;
     auth: AuthzType;
@@ -301,6 +313,7 @@ export const getWormchainSigningClient = async (
     tx: TxType;
     upgrade: UpgradeType;
     vesting: VestingType;
+    wasm: WasmType;
   };
   type WormholeSigningClient = SigningStargateClient & WormholeFunctions;
 
@@ -322,6 +335,7 @@ export const getWormchainSigningClient = async (
   output.tx = txShell;
   output.upgrade = upgradeShell;
   output.vesting = vestingShell;
+  output.wasm = wasmShell;
 
   return output;
 };


### PR DESCRIPTION
This PR fixes a difference between #2990 and the stacked commit in #2298, which did not include the addition of wasm to the query and signing clients. You can see this working in #2314.