### PR TITLE
sui: wormhole message fee equality check, deposit into core bridge

### DIFF
--- a/sui/token_bridge/sources/bridge_state.move
+++ b/sui/token_bridge/sources/bridge_state.move
@@ -397,7 +397,7 @@ module token_bridge::bridge_state_test{
 
     public fun set_up_wormhole_core_and_token_bridges(admin: address, test: Scenario): Scenario {
         // init and share wormhole core bridge
-        test =  init_wormhole_state(test, admin);
+        test =  init_wormhole_state(test, admin, 0);
 
         // call init for token bridge to get deployer cap
         next_tx(&mut test, admin); {

--- a/sui/token_bridge/sources/bridge_state.move
+++ b/sui/token_bridge/sources/bridge_state.move
@@ -11,9 +11,9 @@ module token_bridge::bridge_state {
     use sui::sui::SUI;
 
     use token_bridge::string32;
-    use token_bridge::dynamic_set;
     use token_bridge::asset_meta::{Self, AssetMeta};
 
+    use wormhole::dynamic_set;
     use wormhole::external_address::{Self, ExternalAddress};
     use wormhole::myu16::{U16};
     use wormhole::wormhole::{Self};

--- a/sui/wormhole/sources/dynamic_set.move
+++ b/sui/wormhole/sources/dynamic_set.move
@@ -3,7 +3,7 @@
 ///
 /// Under the hood, it uses dynamic object fields, but set up in a way that the
 /// key is derived from the value's type.
-module token_bridge::dynamic_set {
+module wormhole::dynamic_set {
     use sui::dynamic_object_field as ofield;
     use sui::object::{UID};
 

--- a/sui/wormhole/sources/guardian_set_upgrade.move
+++ b/sui/wormhole/sources/guardian_set_upgrade.move
@@ -148,7 +148,7 @@ module wormhole::guardian_set_upgrade_test {
         use wormhole::test_state::{init_wormhole_state};
 
         let (admin, _, _) = people();
-        let test = init_wormhole_state(scenario(), admin);
+        let test = init_wormhole_state(scenario(), admin, 0);
 
         next_tx(&mut test, admin);{
             let state = take_shared<State>(&test);

--- a/sui/wormhole/sources/myvaa.move
+++ b/sui/wormhole/sources/myvaa.move
@@ -281,7 +281,7 @@ module wormhole::vaa_test {
 
     fun test_upgrade_guardian_(test: Scenario) {
         let (admin, _, _) = people();
-        test = init_wormhole_state(test, admin);
+        test = init_wormhole_state(test, admin, 0);
         next_tx(&mut test, admin);{
             let state = take_shared<State>(&mut test);
             let new_guardians = vector[structs::create_guardian(x"71aa1be1d36cafe3867910f99c09e347899c19c4")];
@@ -298,7 +298,7 @@ module wormhole::vaa_test {
     /// upgrade before expiry
     public fun test_guardian_set_not_expired() {
         let (admin, _, _) = people();
-        let test = init_wormhole_state(scenario(), admin);
+        let test = init_wormhole_state(scenario(), admin, 0);
 
         next_tx(&mut test, admin);{
             let state = take_shared<State>(&test);
@@ -327,7 +327,7 @@ module wormhole::vaa_test {
     /// upgrade after expiry
     public fun test_guardian_set_expired() {
         let (admin, _, _) = people();
-        let test = init_wormhole_state(scenario(), admin);
+        let test = init_wormhole_state(scenario(), admin, 0);
 
         next_tx(&mut test, admin);{
             let state = take_shared<State>(&test);
@@ -358,7 +358,7 @@ module wormhole::vaa_test {
     /// set, even if the signer hasn't expired yet
     public fun test_governance_guardian_set_latest() {
         let (admin, _, _) = people();
-        let test = init_wormhole_state(scenario(), admin);
+        let test = init_wormhole_state(scenario(), admin, 0);
 
         next_tx(&mut test, admin);{
             let state = take_shared<State>(&test);
@@ -392,7 +392,7 @@ module wormhole::vaa_test {
     /// Ensures that governance GOV_VAAs can only be sent from the correct governance emitter
     public fun test_invalid_governance_emitter() {
         let (admin, _, _) = people();
-        let test = init_wormhole_state(scenario(), admin);
+        let test = init_wormhole_state(scenario(), admin, 0);
 
         next_tx(&mut test, admin);{
             let state = take_shared<State>(&test);
@@ -416,7 +416,7 @@ module wormhole::vaa_test {
     /// Ensures that governance GOV_VAAs can only be sent from the correct governance chain
     public fun test_invalid_governance_chain() {
         let (admin, _, _) = people();
-        let test = init_wormhole_state(scenario(), admin);
+        let test = init_wormhole_state(scenario(), admin, 0);
 
         next_tx(&mut test, admin);{
             let state = take_shared<State>(&test);
@@ -438,7 +438,7 @@ module wormhole::vaa_test {
     #[test]
     public fun test_quorum() {
         let (admin, _, _) = people();
-        let test = init_wormhole_state(scenario(), admin);
+        let test = init_wormhole_state(scenario(), admin, 0);
 
         next_tx(&mut test, admin);{
             let state = take_shared<State>(&test);
@@ -465,7 +465,7 @@ module wormhole::vaa_test {
     #[expected_failure(abort_code = vaa::E_NO_QUORUM)]
     public fun test_no_quorum() {
         let (admin, _, _) = people();
-        let test = init_wormhole_state(scenario(), admin);
+        let test = init_wormhole_state(scenario(), admin, 0);
 
         next_tx(&mut test, admin);{
             let state = take_shared<State>(&test);
@@ -490,10 +490,10 @@ module wormhole::vaa_test {
     }
 
     #[test]
-    #[expected_failure(abort_code = vaa::E_NON_INCREASING_SIGNERS)]  
+    #[expected_failure(abort_code = vaa::E_NON_INCREASING_SIGNERS)]
     public fun test_double_signed() {
         let (admin, _, _) = people();
-        let test = init_wormhole_state(scenario(), admin);
+        let test = init_wormhole_state(scenario(), admin, 0);
 
         next_tx(&mut test, admin);{
             let state = take_shared<State>(&test);
@@ -521,7 +521,7 @@ module wormhole::vaa_test {
     #[expected_failure(abort_code = vaa::E_INVALID_SIGNATURE)]
     public fun test_out_of_order_signers() {
         let (admin, _, _) = people();
-        let test = init_wormhole_state(scenario(), admin);
+        let test = init_wormhole_state(scenario(), admin, 0);
 
         next_tx(&mut test, admin);{
             let state = take_shared<State>(&test);

--- a/sui/wormhole/sources/wormhole.move
+++ b/sui/wormhole/sources/wormhole.move
@@ -24,6 +24,7 @@ module wormhole::wormhole {
         let expected_fee = state::get_message_fee(state);
         let val = coin::value(&message_fee);
         if (expected_fee != val){
+            // if fee amount is not exactly equal to expected_fee, then throw one of two errors
             assert!(expected_fee < coin::value(&message_fee), E_TOO_MUCH_FEE);
             assert!(expected_fee > coin::value(&message_fee), E_INSUFFICIENT_FEE);
         };

--- a/sui/wormhole/sources/wormhole.move
+++ b/sui/wormhole/sources/wormhole.move
@@ -122,7 +122,7 @@ module wormhole::test_wormhole{
         next_tx(&mut test, admin); {
             let state = take_shared<State>(&test);
             let emitter = wormhole::register_emitter(&mut state, ctx(&mut test));
-            let message_fee = coin::mint_for_testing<SUI>(100000000, ctx(&mut test));
+            let message_fee = coin::mint_for_testing<SUI>(100000000, ctx(&mut test)); // fee amount == expected amount
             wormhole::publish_message(
                 &mut emitter,
                 &mut state,

--- a/sui/wormhole/sources/wormhole.move
+++ b/sui/wormhole/sources/wormhole.move
@@ -8,8 +8,8 @@ module wormhole::wormhole {
     use wormhole::state::{Self, State};
     use wormhole::emitter::{Self};
 
-    const E_INSUFFICIENT_FEE: u64 = 0;
-    const E_TOO_MUCH_FEE: u64 = 1;
+    const E_INSUFFICIENT_FEE: u64 = 3;
+    const E_TOO_MUCH_FEE: u64 = 4;
 
 // -----------------------------------------------------------------------------
 // Sending messages
@@ -24,11 +24,12 @@ module wormhole::wormhole {
         let expected_fee = state::get_message_fee(state);
         let val = coin::value(&message_fee);
         if (expected_fee != val){
-            // if fee amount is not exactly equal to expected_fee, then throw one of two errors
-            assert!(expected_fee < coin::value(&message_fee), E_TOO_MUCH_FEE);
-            assert!(expected_fee > coin::value(&message_fee), E_INSUFFICIENT_FEE);
+            if (expected_fee < val){
+                assert!(expected_fee > val, E_TOO_MUCH_FEE);
+            } else {
+                assert!(expected_fee < val, E_INSUFFICIENT_FEE);
+            }
         };
-
         // deposit the fees into wormhole
         state::deposit_fee_coins<SUI>(state, message_fee);
 
@@ -96,5 +97,88 @@ module wormhole::wormhole {
 
     public entry fun get_new_emitter(state: &mut State, ctx: &mut TxContext) {
         transfer::transfer(state::new_emitter(state, ctx), tx_context::sender(ctx));
+    }
+}
+
+#[test_only]
+module wormhole::test_wormhole{
+    use sui::test_scenario::{Self, Scenario, next_tx, ctx, take_shared, return_shared};
+    use sui::coin::{Self};
+    use sui::sui::{SUI};
+    use sui::transfer::{Self};
+
+    use wormhole::test_state::{init_wormhole_state};
+    use wormhole::state::{State};
+    use wormhole::wormhole::{Self, E_TOO_MUCH_FEE, E_INSUFFICIENT_FEE};
+
+    fun scenario(): Scenario { test_scenario::begin(@0x123233) }
+    fun people(): (address, address, address) { (@0x124323, @0xE05, @0xFACE) }
+
+    #[test] // precisely the right amount of fee
+    public fun test_publish_wormhole_message_nonzero_fee(){
+        let test = scenario();
+        let (admin, _, _) = people();
+        test = init_wormhole_state(test, admin, 100000000); // wormhole fee set to 100000000 SUI
+        next_tx(&mut test, admin); {
+            let state = take_shared<State>(&test);
+            let emitter = wormhole::register_emitter(&mut state, ctx(&mut test));
+            let message_fee = coin::mint_for_testing<SUI>(100000000, ctx(&mut test));
+            wormhole::publish_message(
+                &mut emitter,
+                &mut state,
+                0,
+                x"11223344556677889900",
+                message_fee
+            );
+            return_shared<State>(state);
+            transfer::transfer(emitter, admin);
+        };
+        test_scenario::end(test);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = E_TOO_MUCH_FEE)] // E_TOO_MUCH_FEE
+    public fun test_publish_wormhole_message_too_much_fee(){
+        let test = scenario();
+        let (admin, _, _) = people();
+        test = init_wormhole_state(test, admin, 100000000); // wormhole fee set to 100000000 SUI
+        next_tx(&mut test, admin); {
+            let state = take_shared<State>(&test);
+            let emitter = wormhole::register_emitter(&mut state, ctx(&mut test));
+            let message_fee = coin::mint_for_testing<SUI>(100000001, ctx(&mut test)); // fee amount > expected amount
+            wormhole::publish_message(
+                &mut emitter,
+                &mut state,
+                0,
+                x"11223344556677889900",
+                message_fee
+            );
+            return_shared<State>(state);
+            transfer::transfer(emitter, admin);
+        };
+        test_scenario::end(test);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = E_INSUFFICIENT_FEE)] // E_INSUFFICIENT_FEE
+    public fun test_publish_wormhole_message_insufficient_fee(){
+        let test = scenario();
+        let (admin, _, _) = people();
+        test = init_wormhole_state(test, admin, 100000000); // wormhole fee set to 100000000 SUI
+        next_tx(&mut test, admin); {
+            let state = take_shared<State>(&test);
+            let emitter = wormhole::register_emitter(&mut state, ctx(&mut test));
+            let message_fee = coin::mint_for_testing<SUI>(99999999, ctx(&mut test)); // fee amount < expected amount
+            wormhole::publish_message(
+                &mut emitter,
+                &mut state,
+                0,
+                x"11223344556677889900",
+                message_fee
+            );
+            return_shared<State>(state);
+            transfer::transfer(emitter, admin);
+        };
+        test_scenario::end(test);
     }
 }


### PR DESCRIPTION
## Updates
- Enforce _equality constraint_ for user-supplied fee coins. User now has to supply just the right amount of fee coins (formerly could supply more than necessary, core bridge would not give refund for surplus portion)
- Deposit fees into designated repository `FeeCustody` in the core bridge instead of deployer account `@wormhole`, because the deployer account should not have access to fees. 