### PR TITLE
Node/Gov: add is governed check

### DIFF
--- a/node/pkg/governor/governor.go
+++ b/node/pkg/governor/governor.go
@@ -297,39 +297,12 @@ func (gov *ChainGovernor) ProcessMsgForTime(msg *common.MessagePublication, now 
 	gov.mutex.Lock()
 	defer gov.mutex.Unlock()
 
-	ce, exists := gov.chains[msg.EmitterChain]
-
-	// If we don't care about this chain, the VAA can be published.
-	if !exists {
-		if msg.EmitterChain != vaa.ChainIDPythNet {
-			gov.logger.Info("cgov: ignoring vaa because the emitter chain is not configured", zap.String("msgID", msg.MessageIDString()))
-		}
-		return true, nil
-	}
-
-	// If we don't care about this emitter, the VAA can be published.
-	if msg.EmitterAddress != ce.emitterAddr {
-		gov.logger.Info("cgov: ignoring vaa because the emitter address is not configured", zap.String("msgID", msg.MessageIDString()))
-		return true, nil
-	}
-
-	// We only care about transfers.
-	if !vaa.IsTransfer(msg.Payload) {
-		gov.logger.Info("cgov: ignoring vaa because it is not a transfer", zap.String("msgID", msg.MessageIDString()))
-		return true, nil
-	}
-
-	payload, err := vaa.DecodeTransferPayloadHdr(msg.Payload)
+	msgIsGoverned, ce, token, payload, err := gov.parseMsgAlreadyLocked(msg)
 	if err != nil {
-		gov.logger.Error("cgov: failed to decode vaa", zap.String("msgID", msg.MessageIDString()), zap.Error(err))
-		return true, err
+		return false, err
 	}
 
-	// If we don't care about this token, the VAA can be published.
-	tk := tokenKey{chain: payload.OriginChain, addr: payload.OriginAddress}
-	token, exists := gov.tokens[tk]
-	if !exists {
-		gov.logger.Info("cgov: ignoring vaa because the token is not in the list", zap.String("msgID", msg.MessageIDString()))
+	if !msgIsGoverned {
 		return true, nil
 	}
 
@@ -466,6 +439,55 @@ func (gov *ChainGovernor) ProcessMsgForTime(msg *common.MessagePublication, now 
 	ce.transfers = append(ce.transfers, &xfer)
 	gov.msgsSeen[hash] = transferComplete
 	return true, nil
+}
+
+// IsGovernedMsg determines if the message applies to the governor. It grabs the lock.
+func (gov *ChainGovernor) IsGovernedMsg(msg *common.MessagePublication) (msgIsGoverned bool, err error) {
+	gov.mutex.Lock()
+	defer gov.mutex.Unlock()
+	msgIsGoverned, _, _, _, err = gov.parseMsgAlreadyLocked(msg)
+	return
+}
+
+// parseMsgAlreadyLocked determines if the message applies to the governor and also returns data useful to the governor. It assumes the caller holds the lock.
+func (gov *ChainGovernor) parseMsgAlreadyLocked(msg *common.MessagePublication) (msgIsGoverned bool, ce *chainEntry, token *tokenEntry, payload *vaa.TransferPayloadHdr, err error) {
+	// If we don't care about this chain, the VAA can be published.
+	ce, exists := gov.chains[msg.EmitterChain]
+	if !exists {
+		if msg.EmitterChain != vaa.ChainIDPythNet {
+			gov.logger.Info("cgov: ignoring vaa because the emitter chain is not configured", zap.String("msgID", msg.MessageIDString()))
+		}
+		return
+	}
+
+	// If we don't care about this emitter, the VAA can be published.
+	if msg.EmitterAddress != ce.emitterAddr {
+		gov.logger.Info("cgov: ignoring vaa because the emitter address is not configured", zap.String("msgID", msg.MessageIDString()))
+		return
+	}
+
+	// We only care about transfers.
+	if !vaa.IsTransfer(msg.Payload) {
+		gov.logger.Info("cgov: ignoring vaa because it is not a transfer", zap.String("msgID", msg.MessageIDString()))
+		return
+	}
+
+	payload, err = vaa.DecodeTransferPayloadHdr(msg.Payload)
+	if err != nil {
+		gov.logger.Error("cgov: failed to decode vaa", zap.String("msgID", msg.MessageIDString()), zap.Error(err))
+		return
+	}
+
+	// If we don't care about this token, the VAA can be published.
+	tk := tokenKey{chain: payload.OriginChain, addr: payload.OriginAddress}
+	token, exists = gov.tokens[tk]
+	if !exists {
+		gov.logger.Info("cgov: ignoring vaa because the token is not in the list", zap.String("msgID", msg.MessageIDString()))
+		return
+	}
+
+	msgIsGoverned = true
+	return
 }
 
 func (gov *ChainGovernor) CheckPending() ([]*common.MessagePublication, error) {


### PR DESCRIPTION
This PR addresses a theoretical security issue in the governor where a message that should not be governed is somehow injected into the governor and then played out by the governor after the window expires.

Fixes #2335