### PR TITLE
node/cmd: add optimism

### DIFF
--- a/node/cmd/guardiand/adminserver.go
+++ b/node/cmd/guardiand/adminserver.go
@@ -786,6 +786,7 @@ func (s *nodePrivilegedService) DumpRPCs(ctx context.Context, req *nodev1.DumpRP
 	rpcMap["nearRPC"] = *nearRPC
 	rpcMap["neonRPC"] = *neonRPC
 	rpcMap["oasisRPC"] = *oasisRPC
+	rpcMap["optimismRPC"] = *optimismRPC
 	rpcMap["polygonRPC"] = *polygonRPC
 	rpcMap["pythnetRPC"] = *pythnetRPC
 	rpcMap["pythnetWS"] = *pythnetWS


### PR DESCRIPTION
This PR simply adds the Optimism RPC to the dump_rpcs command.
In the future, we'll figure out a way to do this automatically.