### PR TITLE
node: add request logging with --publicRpcLogDetail and --logPublicRpcToTelemetry

### DIFF
--- a/devnet/node.yaml
+++ b/devnet/node.yaml
@@ -165,6 +165,8 @@ spec:
             - /tmp/publicrpc.sock
             - --dataDir
             - /tmp/data
+            - --logPublicRPC
+            - 'true'
           # - --chainGovernorEnabled=true
           #            - --logLevel=debug
           securityContext:

--- a/devnet/node.yaml
+++ b/devnet/node.yaml
@@ -165,7 +165,7 @@ spec:
             - /tmp/publicrpc.sock
             - --dataDir
             - /tmp/data
-            - --logPublicRPC
+            - --publicRpcLogDetail
             - "full"
           # - --chainGovernorEnabled=true
           #            - --logLevel=debug

--- a/devnet/node.yaml
+++ b/devnet/node.yaml
@@ -166,7 +166,7 @@ spec:
             - --dataDir
             - /tmp/data
             - --logPublicRPC
-            - 'true'
+            - "full"
           # - --chainGovernorEnabled=true
           #            - --logLevel=debug
           securityContext:

--- a/node/cmd/guardiand/adminserver.go
+++ b/node/cmd/guardiand/adminserver.go
@@ -543,7 +543,7 @@ func adminServiceRunnable(
 
 	publicrpcService := publicrpc.NewPublicrpcServer(logger, db, gst, gov)
 
-	grpcServer := common.NewInstrumentedGRPCServer(logger)
+	grpcServer := common.NewInstrumentedGRPCServer(logger, common.GrpcLogDetailMinimal)
 	nodev1.RegisterNodePrivilegedServiceServer(grpcServer, nodeService)
 	publicrpcv1.RegisterPublicRPCServiceServer(grpcServer, publicrpcService)
 	return supervisor.GRPCServer(grpcServer, l, false), nil

--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -178,7 +178,9 @@ var (
 	baseRPC      *string
 	baseContract *string
 
-	logLevel *string
+	logLevel              *string
+	logLevel              *string
+	logPublicRPCTelemetry *bool
 
 	unsafeDevMode   *bool
 	testnetMode     *bool
@@ -329,6 +331,7 @@ func init() {
 	baseContract = NodeCmd.Flags().String("baseContract", "", "Base contract address")
 
 	logLevel = NodeCmd.Flags().String("logLevel", "info", "Logging level (debug, info, warn, error, dpanic, panic, fatal)")
+	logPublicRPCTelemetry = NodeCmd.Flags().Bool("logPublicRPCTelemetry", true, "false=do not include publicRpc request logs in telemetry")
 
 	unsafeDevMode = NodeCmd.Flags().Bool("unsafeDevMode", false, "Launch node in unsafe, deterministic devnet mode")
 	testnetMode = NodeCmd.Flags().Bool("testnetMode", false, "Launch node in testnet mode (enables testnet-only features)")
@@ -947,7 +950,7 @@ func runNode(cmd *cobra.Command, args []string) {
 			logger.Fatal("Failed to get peer ID from private key", zap.Error(err))
 		}
 
-		tm, err := telemetry.New(context.Background(), telemetryProject, creds, map[string]string{
+		tm, err := telemetry.New(context.Background(), telemetryProject, creds, *logPublicRPCTelemetry, map[string]string{
 			"node_name":     *nodeName,
 			"node_key":      peerID.Pretty(),
 			"guardian_addr": guardianAddr,

--- a/node/cmd/guardiand/publicrpc.go
+++ b/node/cmd/guardiand/publicrpc.go
@@ -15,7 +15,7 @@ import (
 	"google.golang.org/grpc"
 )
 
-func publicrpcTcpServiceRunnable(logger *zap.Logger, listenAddr string, logPublicRPC string, db *db.Database, gst *common.GuardianSetState, gov *governor.ChainGovernor) (supervisor.Runnable, error) {
+func publicrpcTcpServiceRunnable(logger *zap.Logger, listenAddr string, logPublicRPC common.GrpcLogDetail, db *db.Database, gst *common.GuardianSetState, gov *governor.ChainGovernor) (supervisor.Runnable, error) {
 	l, err := net.Listen("tcp", listenAddr)
 
 	if err != nil {
@@ -25,20 +25,14 @@ func publicrpcTcpServiceRunnable(logger *zap.Logger, listenAddr string, logPubli
 	logger.Info("publicrpc server listening", zap.String("addr", l.Addr().String()))
 
 	rpcServer := publicrpc.NewPublicrpcServer(logger, db, gst, gov)
-	var grpcServer *grpc.Server
-
-	if logPublicRPC == "false" {
-		grpcServer = common.NewInstrumentedGRPCServer(nil)
-	} else {
-		grpcServer = common.NewInstrumentedGRPCServer(logger)
-	}
+	grpcServer := common.NewInstrumentedGRPCServer(logger, logPublicRPC)
 
 	publicrpcv1.RegisterPublicRPCServiceServer(grpcServer, rpcServer)
 
 	return supervisor.GRPCServer(grpcServer, l, false), nil
 }
 
-func publicrpcUnixServiceRunnable(logger *zap.Logger, socketPath string, db *db.Database, gst *common.GuardianSetState, gov *governor.ChainGovernor) (supervisor.Runnable, *grpc.Server, error) {
+func publicrpcUnixServiceRunnable(logger *zap.Logger, socketPath string, logPublicRPC common.GrpcLogDetail, db *db.Database, gst *common.GuardianSetState, gov *governor.ChainGovernor) (supervisor.Runnable, *grpc.Server, error) {
 	// Delete existing UNIX socket, if present.
 	fi, err := os.Stat(socketPath)
 	if err == nil {
@@ -72,7 +66,7 @@ func publicrpcUnixServiceRunnable(logger *zap.Logger, socketPath string, db *db.
 
 	publicrpcService := publicrpc.NewPublicrpcServer(logger, db, gst, gov)
 
-	grpcServer := common.NewInstrumentedGRPCServer(logger)
+	grpcServer := common.NewInstrumentedGRPCServer(logger, logPublicRPC)
 	publicrpcv1.RegisterPublicRPCServiceServer(grpcServer, publicrpcService)
 	return supervisor.GRPCServer(grpcServer, l, false), grpcServer, nil
 }

--- a/node/cmd/guardiand/publicweb.go
+++ b/node/cmd/guardiand/publicweb.go
@@ -10,6 +10,7 @@ import (
 
 	publicrpcv1 "github.com/certusone/wormhole/node/pkg/proto/publicrpc/v1"
 	"github.com/certusone/wormhole/node/pkg/supervisor"
+	"github.com/google/uuid"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/improbable-eng/grpc-web/go/grpcweb"
 	"go.uber.org/zap"
@@ -17,6 +18,7 @@ import (
 	"golang.org/x/crypto/acme/autocert"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
 )
 
 func allowCORSWrapper(h http.Handler) http.Handler {
@@ -47,10 +49,18 @@ func corsPreflightHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Methods", strings.Join(methods, ","))
 }
 
+func cutStr(s string, maxLen int) string {
+	if len(s) > maxLen {
+		return s[0:maxLen] + "[...]"
+	}
+	return s
+}
+
 func publicwebServiceRunnable(
 	logger *zap.Logger,
 	listenAddr string,
 	upstreamAddr string,
+	logPublicRPC string,
 	grpcServer *grpc.Server,
 	tlsHostname string,
 	tlsProd bool,
@@ -76,11 +86,23 @@ func publicwebServiceRunnable(
 		grpcWebServer := grpcweb.WrapServer(grpcServer)
 		mux.Handle("/", allowCORSWrapper(http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 
-			logger.Info("public rpc request",
-				zap.String("method", req.Method),
-				zap.String("path", req.URL.Path),
-				zap.String("remote_addr", req.RemoteAddr),
-				zap.Any("headers", req.Header))
+			if logPublicRPC == "true" {
+				trace := uuid.New()
+
+				if md, ok := metadata.FromIncomingContext(ctx); ok {
+					md.Set("x-trace-id", trace.String())
+				}
+
+				req.Header.Set("Grpc-Metadata-x-trace-id", trace.String())
+
+				logger.Info("public rpc request",
+					zap.String("method", req.Method),
+					zap.String("path", cutStr(req.URL.Path, 100)),
+					zap.String("remote_addr", req.RemoteAddr),
+					zap.String("user-agent", cutStr(req.Header.Get("user-agent"), 200)),
+					zap.String("x-trace-id", trace.String()),
+				)
+			}
 
 			if grpcWebServer.IsGrpcWebRequest(req) {
 				grpcWebServer.ServeHTTP(resp, req)

--- a/node/cmd/spy/spy.go
+++ b/node/cmd/spy/spy.go
@@ -413,7 +413,7 @@ func spyServerRunnable(s *spyServer, logger *zap.Logger, listenAddr string) (sup
 
 	logger.Info("spy server listening", zap.String("addr", l.Addr().String()))
 
-	grpcServer := common.NewInstrumentedGRPCServer(logger)
+	grpcServer := common.NewInstrumentedGRPCServer(logger, common.GrpcLogDetailFull)
 	spyv1.RegisterSpyRPCServiceServer(grpcServer, s)
 
 	return supervisor.GRPCServer(grpcServer, l, false), grpcServer, nil

--- a/node/cmd/spy/spy_test.go
+++ b/node/cmd/spy/spy_test.go
@@ -227,7 +227,7 @@ func init() {
 
 	lis = bufconn.Listen(bufSize)
 
-	grpcServer := common.NewInstrumentedGRPCServer(logger)
+	grpcServer := common.NewInstrumentedGRPCServer(logger, common.GrpcLogDetailFull)
 
 	mockedSpyServer = newSpyServer(logger)
 	spyv1.RegisterSpyRPCServiceServer(grpcServer, mockedSpyServer)

--- a/node/pkg/common/grpc.go
+++ b/node/pkg/common/grpc.go
@@ -39,6 +39,9 @@ func xForwardedForServerInterceptor(ctx context.Context, req interface{}, info *
 }
 
 func NewInstrumentedGRPCServer(logger *zap.Logger) *grpc.Server {
+
+	logger = logger.With(zap.Bool("_privateLogEntry", true))
+
 	server := grpc.NewServer(
 		grpc.StreamInterceptor(grpc_middleware.ChainStreamServer(
 			grpc_ctxtags.StreamServerInterceptor(),

--- a/node/pkg/common/grpc.go
+++ b/node/pkg/common/grpc.go
@@ -19,7 +19,7 @@ import (
 type GrpcLogDetail string
 
 const (
-	GrpcLogDetailNone    GrpcLogDetail = "false"
+	GrpcLogDetailNone    GrpcLogDetail = "none"
 	GrpcLogDetailMinimal GrpcLogDetail = "minimal"
 	GrpcLogDetailFull    GrpcLogDetail = "full"
 )

--- a/node/pkg/common/grpc.go
+++ b/node/pkg/common/grpc.go
@@ -2,59 +2,111 @@ package common
 
 import (
 	"context"
+	"fmt"
 
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_zap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"
 	grpc_ctxtags "github.com/grpc-ecosystem/go-grpc-middleware/tags"
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
-// xForwardedForStreamServerInterceptor adds the `x-forwarded-for` metadata as a tag to cause it to be logged by grpc_zap.StreamServerInterceptor().
+// metadataStreamServerInterceptor adds the `x-forwarded-for` and `x-trace-id` metadata as a tag to cause it to be logged by grpc_zap.StreamServerInterceptor().
 // Note that `x-forwarded-for` can only be trusted if the latest hop in the proxy chain is trusted.
 // For JSON-Web requests, the latest hop is the guardian itself (`grpc-gateway`), which is listening on TCP and forwarding to the gRPC publicrpc UNIX socket.
 // This can be identified by `"peer.address": "@"` in the logs and `grpc-gateway` correctly sets the `x-forwarded-for` metadata.
-func xForwardedForStreamServerInterceptor(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+func metadataStreamServerInterceptor(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 	ctx := stream.Context()
 
 	if md, ok := metadata.FromIncomingContext(ctx); ok {
-		grpc_ctxtags.Extract(ctx).Set("x-forwarded-for", md.Get("x-forwarded-for"))
+		grpc_ctxtags.Extract(ctx).
+			Set("x-forwarded-for", md.Get("x-forwarded-for")).
+			Set("x-trace-id", md.Get("x-trace-id"))
 	}
 
 	err := handler(srv, stream)
 	return err
 }
 
-// xForwardedForServerInterceptor adds the `x-forwarded-for` metadata as a tag to cause it to be logged by grpc_zap.UnaryServerInterceptor().
+// metadataServerInterceptor adds the `x-forwarded-for` and `x-trace-id` metadata as a tag to cause it to be logged by grpc_zap.UnaryServerInterceptor().
 // Note that `x-forwarded-for` can only be trusted if the latest hop in the proxy chain is trusted.
 // For JSON-Web requests, the latest hop is the guardian itself (`grpc-gateway`), which is listening on TCP and forwarding to the gRPC publicrpc UNIX socket.
 // This can be identified by `"peer.address": "@"` in the logs and `grpc-gateway` correctly sets the `x-forwarded-for` metadata.
-func xForwardedForServerInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+func metadataServerInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 	if md, ok := metadata.FromIncomingContext(ctx); ok {
-		grpc_ctxtags.Extract(ctx).Set("x-forwarded-for", md.Get("x-forwarded-for"))
+		tags := grpc_ctxtags.Extract(ctx)
+		tags.Set("x-forwarded-for", md.Get("x-forwarded-for"))
+
+		if len(md.Get("x-trace-id")) > 0 {
+			tags.Set("x-trace-id", md.Get("x-trace-id"))
+		}
+	}
+	return handler(ctx, req)
+}
+
+type protojsonObjectMarshaler struct {
+	pb protoreflect.ProtoMessage
+}
+
+func (j *protojsonObjectMarshaler) MarshalLogObject(e zapcore.ObjectEncoder) error {
+	// ZAP jsonEncoder deals with AddReflect by using json.MarshalObject. The same thing applies for consoleEncoder.
+	return e.AddReflected("msg", j)
+}
+
+func (j *protojsonObjectMarshaler) MarshalJSON() ([]byte, error) {
+	b, err := protojson.Marshal(j.pb)
+	if err != nil {
+		return nil, fmt.Errorf("jsonpb serializer failed: %v", err)
+	}
+	return b, nil
+}
+
+func requestPayloadServerInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	if p, ok := req.(protoreflect.ProtoMessage); ok {
+		if b, err := protojson.Marshal(p); err == nil {
+			if len(b) <= 200 {
+				grpc_ctxtags.Extract(ctx).Set("grpc.requestbody", &protojsonObjectMarshaler{pb: p})
+			} else {
+				grpc_ctxtags.Extract(ctx).Set("grpc.requestbody", "too long")
+			}
+		}
 	}
 	return handler(ctx, req)
 }
 
 func NewInstrumentedGRPCServer(logger *zap.Logger) *grpc.Server {
+	streamInterceptors := []grpc.StreamServerInterceptor{
+		grpc_ctxtags.StreamServerInterceptor(),
+		grpc_prometheus.StreamServerInterceptor,
+	}
 
-	logger = logger.With(zap.Bool("_privateLogEntry", true))
+	unaryInterceptors := []grpc.UnaryServerInterceptor{
+		grpc_ctxtags.UnaryServerInterceptor(),
+		grpc_prometheus.UnaryServerInterceptor,
+	}
+
+	if logger != nil {
+		logger = logger.With(zap.Bool("_privateLogEntry", true))
+		streamInterceptors = append(streamInterceptors,
+			metadataStreamServerInterceptor,
+			grpc_zap.PayloadStreamServerInterceptor(logger, func(ctx context.Context, fullMethodName string, servingObject interface{}) bool { return true }),
+		)
+
+		unaryInterceptors = append(unaryInterceptors,
+			metadataServerInterceptor,
+			requestPayloadServerInterceptor,
+			grpc_zap.UnaryServerInterceptor(logger),
+		)
+	}
 
 	server := grpc.NewServer(
-		grpc.StreamInterceptor(grpc_middleware.ChainStreamServer(
-			grpc_ctxtags.StreamServerInterceptor(),
-			xForwardedForStreamServerInterceptor,
-			grpc_prometheus.StreamServerInterceptor,
-			grpc_zap.StreamServerInterceptor(logger),
-		)),
-		grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(
-			grpc_ctxtags.UnaryServerInterceptor(),
-			xForwardedForServerInterceptor,
-			grpc_prometheus.UnaryServerInterceptor,
-			grpc_zap.UnaryServerInterceptor(logger),
-		)),
+		grpc.StreamInterceptor(grpc_middleware.ChainStreamServer(streamInterceptors...)),
+		grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(unaryInterceptors...)),
 	)
 
 	grpc_prometheus.EnableHandlingTimeHistogram()

--- a/node/pkg/common/grpc.go
+++ b/node/pkg/common/grpc.go
@@ -16,54 +16,53 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
-// metadataStreamServerInterceptor adds the `x-forwarded-for` and `x-trace-id` metadata as a tag to cause it to be logged by grpc_zap.StreamServerInterceptor().
-// Note that `x-forwarded-for` can only be trusted if the latest hop in the proxy chain is trusted.
-// For JSON-Web requests, the latest hop is the guardian itself (`grpc-gateway`), which is listening on TCP and forwarding to the gRPC publicrpc UNIX socket.
-// This can be identified by `"peer.address": "@"` in the logs and `grpc-gateway` correctly sets the `x-forwarded-for` metadata.
-func metadataStreamServerInterceptor(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
-	ctx := stream.Context()
+type GrpcLogDetail string
 
-	if md, ok := metadata.FromIncomingContext(ctx); ok {
-		grpc_ctxtags.Extract(ctx).
-			Set("x-forwarded-for", md.Get("x-forwarded-for")).
-			Set("x-trace-id", md.Get("x-trace-id"))
+const (
+	GrpcLogDetailNone    GrpcLogDetail = "false"
+	GrpcLogDetailMinimal GrpcLogDetail = "minimal"
+	GrpcLogDetailFull    GrpcLogDetail = "full"
+)
+
+func addDetail(ctx context.Context, logDetail GrpcLogDetail) {
+	if logDetail == GrpcLogDetailNone {
+		return
 	}
-
-	err := handler(srv, stream)
-	return err
-}
-
-// metadataServerInterceptor adds the `x-forwarded-for` and `x-trace-id` metadata as a tag to cause it to be logged by grpc_zap.UnaryServerInterceptor().
-// Note that `x-forwarded-for` can only be trusted if the latest hop in the proxy chain is trusted.
-// For JSON-Web requests, the latest hop is the guardian itself (`grpc-gateway`), which is listening on TCP and forwarding to the gRPC publicrpc UNIX socket.
-// This can be identified by `"peer.address": "@"` in the logs and `grpc-gateway` correctly sets the `x-forwarded-for` metadata.
-func metadataServerInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 	if md, ok := metadata.FromIncomingContext(ctx); ok {
 		tags := grpc_ctxtags.Extract(ctx)
 		tags.Set("x-forwarded-for", md.Get("x-forwarded-for"))
 
-		if len(md.Get("x-trace-id")) > 0 {
-			tags.Set("x-trace-id", md.Get("x-trace-id"))
+		if logDetail == GrpcLogDetailFull {
+			if len(md.Get("grpcgateway-user-agent")) > 0 {
+				tags.Set("user-agent", md.Get("grpcgateway-user-agent"))
+			}
 		}
 	}
-	return handler(ctx, req)
 }
 
-type protojsonObjectMarshaler struct {
-	pb protoreflect.ProtoMessage
-}
-
-func (j *protojsonObjectMarshaler) MarshalLogObject(e zapcore.ObjectEncoder) error {
-	// ZAP jsonEncoder deals with AddReflect by using json.MarshalObject. The same thing applies for consoleEncoder.
-	return e.AddReflected("msg", j)
-}
-
-func (j *protojsonObjectMarshaler) MarshalJSON() ([]byte, error) {
-	b, err := protojson.Marshal(j.pb)
-	if err != nil {
-		return nil, fmt.Errorf("jsonpb serializer failed: %v", err)
+// newMetadataStreamServerInterceptor returns stream interceptor that
+// adds the `x-forwarded-for` and, if logDetail == "full", the `user-agent` metadata as a tag to cause it to be logged by grpc_zap.StreamServerInterceptor().
+// Note that `x-forwarded-for` can only be trusted if the latest hop in the proxy chain is trusted.
+// For JSON-Web requests, the latest hop is the guardian itself (`grpc-gateway`), which is listening on TCP and forwarding to the gRPC publicrpc UNIX socket.
+// This can be identified by `"peer.address": "@"` in the logs and `grpc-gateway` correctly sets the `x-forwarded-for` metadata.
+func newMetadataStreamServerInterceptor(logDetail GrpcLogDetail) func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		ctx := stream.Context()
+		addDetail(ctx, logDetail)
+		return handler(srv, stream)
 	}
-	return b, nil
+}
+
+// newMetadataServerInterceptor returns a unary interceptor that
+// adds the `x-forwarded-for` and, if logDetail == "full", the `user-agent` metadata as a tag to cause it to be logged by grpc_zap.StreamServerInterceptor().
+// Note that `x-forwarded-for` can only be trusted if the latest hop in the proxy chain is trusted.
+// For JSON-Web requests, the latest hop is the guardian itself (`grpc-gateway`), which is listening on TCP and forwarding to the gRPC publicrpc UNIX socket.
+// This can be identified by `"peer.address": "@"` in the logs and `grpc-gateway` correctly sets the `x-forwarded-for` metadata.
+func newMetadataServerInterceptor(logDetail GrpcLogDetail) func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		addDetail(ctx, logDetail)
+		return handler(ctx, req)
+	}
 }
 
 func requestPayloadServerInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
@@ -79,7 +78,7 @@ func requestPayloadServerInterceptor(ctx context.Context, req interface{}, info 
 	return handler(ctx, req)
 }
 
-func NewInstrumentedGRPCServer(logger *zap.Logger) *grpc.Server {
+func NewInstrumentedGRPCServer(logger *zap.Logger, rpcLogDetail GrpcLogDetail) *grpc.Server {
 	streamInterceptors := []grpc.StreamServerInterceptor{
 		grpc_ctxtags.StreamServerInterceptor(),
 		grpc_prometheus.StreamServerInterceptor,
@@ -90,16 +89,20 @@ func NewInstrumentedGRPCServer(logger *zap.Logger) *grpc.Server {
 		grpc_prometheus.UnaryServerInterceptor,
 	}
 
-	if logger != nil {
+	if rpcLogDetail != GrpcLogDetailNone {
 		logger = logger.With(zap.Bool("_privateLogEntry", true))
 		streamInterceptors = append(streamInterceptors,
-			metadataStreamServerInterceptor,
-			grpc_zap.PayloadStreamServerInterceptor(logger, func(ctx context.Context, fullMethodName string, servingObject interface{}) bool { return true }),
+			newMetadataStreamServerInterceptor(rpcLogDetail),
+			grpc_zap.StreamServerInterceptor(logger),
 		)
 
+		// if logging detail is "full", also log the request payload (only applicable to unary)
+		if rpcLogDetail == GrpcLogDetailFull {
+			unaryInterceptors = append(unaryInterceptors, requestPayloadServerInterceptor)
+		}
+
 		unaryInterceptors = append(unaryInterceptors,
-			metadataServerInterceptor,
-			requestPayloadServerInterceptor,
+			newMetadataServerInterceptor(rpcLogDetail),
 			grpc_zap.UnaryServerInterceptor(logger),
 		)
 	}
@@ -113,4 +116,23 @@ func NewInstrumentedGRPCServer(logger *zap.Logger) *grpc.Server {
 	grpc_prometheus.Register(server)
 
 	return server
+}
+
+// this helper type and associated functions are such that the ZAP jsonEncoder will properly encode the gRPC request payload.
+// We could instead just encode the payload to a string here, but then that string will be encoded again by the ZAP jsonEncoder, making downstream processing more difficult
+type protojsonObjectMarshaler struct {
+	pb protoreflect.ProtoMessage
+}
+
+func (j *protojsonObjectMarshaler) MarshalLogObject(e zapcore.ObjectEncoder) error {
+	// ZAP jsonEncoder deals with AddReflect by using json.MarshalObject. The same thing applies for consoleEncoder.
+	return e.AddReflected("msg", j)
+}
+
+func (j *protojsonObjectMarshaler) MarshalJSON() ([]byte, error) {
+	b, err := protojson.Marshal(j.pb)
+	if err != nil {
+		return nil, fmt.Errorf("jsonpb serializer failed: %v", err)
+	}
+	return b, nil
 }

--- a/node/pkg/common/grpc.go
+++ b/node/pkg/common/grpc.go
@@ -24,6 +24,13 @@ const (
 	GrpcLogDetailFull    GrpcLogDetail = "full"
 )
 
+func truncateStr(str string, maxLen int) string {
+	if len(str) > maxLen {
+		return str[:maxLen] + "..."
+	}
+	return str
+}
+
 func addDetail(ctx context.Context, logDetail GrpcLogDetail) {
 	if logDetail == GrpcLogDetailNone {
 		return
@@ -34,7 +41,7 @@ func addDetail(ctx context.Context, logDetail GrpcLogDetail) {
 
 		if logDetail == GrpcLogDetailFull {
 			if len(md.Get("grpcgateway-user-agent")) > 0 {
-				tags.Set("user-agent", md.Get("grpcgateway-user-agent"))
+				tags.Set("user-agent", truncateStr(md.Get("grpcgateway-user-agent")[0], 200))
 			}
 		}
 	}

--- a/node/pkg/telemetry/telemetry.go
+++ b/node/pkg/telemetry/telemetry.go
@@ -48,6 +48,7 @@ func (enc *guardianTelemetryEncoder) EncodeEntry(entry zapcore.Entry, fields []z
 			if f.Type == zapcore.BoolType {
 				if f.Key == "_privateLogEntry" {
 					if f.Integer == 1 {
+						// do not forward to telemetry by short-circuiting to the underlying encoder.
 						return enc.Encoder.EncodeEntry(entry, fields)
 					} else {
 						break
@@ -80,6 +81,8 @@ func (enc *guardianTelemetryEncoder) EncodeEntry(entry zapcore.Entry, fields []z
 	return buf, nil
 }
 
+// Clone() clones the encoder. This function is not used by the Guardian itself, but it is used by zapcore.
+// Without this implementation, a guardianTelemetryEncoder could get silently converted into the underlying zapcore.Encoder at some point, leading to missing telemetry logs.
 func (enc *guardianTelemetryEncoder) Clone() zapcore.Encoder {
 	return &guardianTelemetryEncoder{
 		Encoder: enc.Encoder.Clone(),


### PR DESCRIPTION
fixes #2370 

# Release Notes
## New `guardiand` cli options:
* `--publicRpcLogDetail [string]`
  * `none` -- no logging of gRPC requests at all
  * `minimal` -- only log gRPC methods
  * `full` (default) -- additionally log user-agent and gRPC request payload
* `--logPublicRpcToTelemetry [bool]`
  * `false` do not send publicrpc logs to Google Cloud Logging
  * `true` (default) -- (current behavior)