### PR TITLE
sui: test token bridge `dynamic/registered_emitters`

### DIFF
--- a/sui/token_bridge/sources/complete_transfer_with_payload.move
+++ b/sui/token_bridge/sources/complete_transfer_with_payload.move
@@ -127,7 +127,7 @@ module token_bridge::complete_transfer_with_payload_test {
     fun scenario(): Scenario { test_scenario::begin(@0x123233) }
     fun people(): (address, address, address) { (@0x124323, @0xE05, @0xFACE) }
 
-     #[test]
+    #[test]
     fun test_complete_native_transfer(){
         let (admin, _, _) = people();
         let test = scenario();

--- a/sui/token_bridge/sources/dynamic/registered_emitters.move
+++ b/sui/token_bridge/sources/dynamic/registered_emitters.move
@@ -52,8 +52,8 @@ module token_bridge::registered_emitters {
 #[test_only]
 module token_bridge::registered_emitters_test{
     use std::vector::{Self};
-    use sui::test_scenario::{Self, Scenario, ctx};
     use sui::object::{Self, UID};
+    use sui::tx_context::{dummy};
 
     use wormhole::external_address::{from_bytes};
     use wormhole::bytes::{Self};
@@ -68,7 +68,6 @@ module token_bridge::registered_emitters_test{
         E_REGISTERED_EMITTER_TABLE_ALREADY_EXISTS
     };
 
-    fun scenario(): Scenario { test_scenario::begin(@0x123233) }
     fun people(): (address, address, address) { (@0x124323, @0xE05, @0xFACE) }
 
     struct MockState has key {
@@ -84,12 +83,11 @@ module token_bridge::registered_emitters_test{
     // and adding several (chain_id, external_address) key-value pairs to it
     #[test]
     fun test_registered_emitters(){
-        let test = scenario();
-        let mock_state = MockState{id: object::new(ctx(&mut test))};
+        let mock_state = MockState{id: object::new(&mut dummy())};
 
         // create table of registered emitters as a dynamic field of our
         // mock state
-        new(&mut mock_state.id, ctx(&mut test));
+        new(&mut mock_state.id, &mut dummy());
 
         // add many (chain id, external address) key-value pairs to the
         // registered emitters table attached to mock state
@@ -128,7 +126,6 @@ module token_bridge::registered_emitters_test{
             i = i + 1;
         };
         destroy_mock_state(mock_state);
-        test_scenario::end(test);
     }
 
     // test that creating two registered emitter tables for the same UID
@@ -139,20 +136,18 @@ module token_bridge::registered_emitters_test{
         location=token_bridge::registered_emitters
     )]
     fun test_registered_emitters_table_already_exists(){
-        let test = scenario();
-        let mock_state = MockState{id: object::new(ctx(&mut test))};
+        let mock_state = MockState{id: object::new(&mut dummy())};
 
         // create table of registered emitters as a dynamic field of our
         // mock state
-        new(&mut mock_state.id, ctx(&mut test));
+        new(&mut mock_state.id, &mut dummy());
 
         // attempt to create another table for storing registered
         // emitters and attach it to mock_state under key b"registered_emitters"
         // resulting in failure, because that key already exists
-        new(&mut mock_state.id, ctx(&mut test));
+        new(&mut mock_state.id, &mut dummy());
 
         destroy_mock_state(mock_state);
-        test_scenario::end(test);
     }
 
     // test that only one external address can be registered for a chain
@@ -162,12 +157,11 @@ module token_bridge::registered_emitters_test{
         location=token_bridge::registered_emitters
     )]
     fun test_register_chain_id_twice(){
-        let test = scenario();
-        let mock_state = MockState{id: object::new(ctx(&mut test))};
+        let mock_state = MockState{id: object::new(&mut dummy())};
 
         // create table of registered emitters as a dynamic field of our
         // mock state
-        new(&mut mock_state.id, ctx(&mut test));
+        new(&mut mock_state.id, &mut dummy());
 
         // try to add chain_id 1 more than once, resulting in failure
         let i = 1;
@@ -181,7 +175,6 @@ module token_bridge::registered_emitters_test{
             );
         };
         destroy_mock_state(mock_state);
-        test_scenario::end(test);
     }
 
     #[test]
@@ -190,12 +183,11 @@ module token_bridge::registered_emitters_test{
         location=token_bridge::registered_emitters
     )]
     fun test_registered_emitters_nonexistent_external_address(){
-        let test = scenario();
-        let mock_state = MockState{id: object::new(ctx(&mut test))};
+        let mock_state = MockState{id: object::new(&mut dummy())};
 
         // create table of registered emitters as a dynamic field of our
         // mock state
-        new(&mut mock_state.id, ctx(&mut test));
+        new(&mut mock_state.id, &mut dummy());
 
         // register chain ids 1-100
         let i = 1;
@@ -214,6 +206,5 @@ module token_bridge::registered_emitters_test{
             10022 // this chain id is not registered (only 1-100 are registered)
         );
         destroy_mock_state(mock_state);
-        test_scenario::end(test);
     }
 }

--- a/sui/token_bridge/sources/dynamic/registered_emitters.move
+++ b/sui/token_bridge/sources/dynamic/registered_emitters.move
@@ -7,7 +7,15 @@ module token_bridge::registered_emitters {
 
     const KEY: vector<u8> = b"registered_emitters";
 
+    const E_EMITTER_EXTERNAL_ADDRESS_ALREADY_EXISTS_FOR_CHAIN: u64 = 0;
+    const E_EMITTER_EXTERNAL_ADDRESS_DOES_NOT_EXIST_FOR_CHAIN: u64 = 1;
+    const E_REGISTERED_EMITTER_TABLE_ALREADY_EXISTS: u64 = 2;
+
     public fun new(parent_id: &mut UID, ctx: &mut TxContext) {
+        assert!(
+            !dynamic_object_field::exists_(parent_id, KEY),
+            E_REGISTERED_EMITTER_TABLE_ALREADY_EXISTS
+        );
         dynamic_object_field::add(
             parent_id,
             KEY,
@@ -16,6 +24,10 @@ module token_bridge::registered_emitters {
     }
 
     public fun add(parent_id: &mut UID, chain: u16, addr: ExternalAddress) {
+        assert!(
+            !has(parent_id, chain),
+            E_EMITTER_EXTERNAL_ADDRESS_ALREADY_EXISTS_FOR_CHAIN
+        );
         table::add(
             dynamic_object_field::borrow_mut(parent_id, KEY),
             chain,
@@ -29,6 +41,169 @@ module token_bridge::registered_emitters {
     }
 
     public fun external_address(parent_id: &UID, chain: u16): ExternalAddress {
+        assert!(
+            has(parent_id, chain),
+            E_EMITTER_EXTERNAL_ADDRESS_DOES_NOT_EXIST_FOR_CHAIN
+        );
         *table::borrow(dynamic_object_field::borrow(parent_id, KEY), chain)
+    }
+}
+
+#[test_only]
+module token_bridge::registered_emitters_test{
+    use std::vector::{Self};
+    use sui::test_scenario::{Self, Scenario, ctx};
+    use sui::object::{Self, UID};
+
+    use wormhole::external_address::{from_bytes};
+    use wormhole::bytes::{Self};
+
+    use token_bridge::registered_emitters::{
+        new,
+        add,
+        has,
+        external_address,
+        E_EMITTER_EXTERNAL_ADDRESS_ALREADY_EXISTS_FOR_CHAIN,
+        E_EMITTER_EXTERNAL_ADDRESS_DOES_NOT_EXIST_FOR_CHAIN,
+        E_REGISTERED_EMITTER_TABLE_ALREADY_EXISTS
+    };
+
+    fun scenario(): Scenario { test_scenario::begin(@0x123233) }
+    fun people(): (address, address, address) { (@0x124323, @0xE05, @0xFACE) }
+
+    struct MockState has key {
+        id: UID
+    }
+
+    public fun destroy_mock_state(m: MockState) {
+        let MockState {id} = m;
+        object::delete(id);
+    }
+
+    // write a test exercising the creation of a new registered emitters table,
+    // and adding several (chain_id, external_address) key-value pairs to it
+    #[test]
+    fun test_registered_emitters(){
+        let test = scenario();
+        let mock_state = MockState{id: object::new(ctx(&mut test))};
+
+        // create table of registered emitters as a dynamic field of our
+        // mock state
+        new(&mut mock_state.id, ctx(&mut test));
+
+        // add many (chain id, external address) key-value pairs to the
+        // registered emitters table attached to mock state
+        let i = 1;
+        while (i < 1000) {
+            let cur_external_addr = vector::empty<u8>();
+            bytes::serialize_u16_be(&mut cur_external_addr, i);
+            add(
+                &mut mock_state.id,
+                i,
+                from_bytes(cur_external_addr)
+            );
+            i = i + 1;
+        };
+
+        // check that the key-value pairs we just added to the registered
+        // emitters table were indeed added
+        i = 1;
+        while (i < 1000) {
+            let cur_external_addr = vector::empty<u8>();
+            bytes::serialize_u16_be(&mut cur_external_addr, i);
+            assert!(
+                has(
+                    &mock_state.id,
+                    i
+                ),
+                0
+            );
+            i = i + 1;
+        };
+        destroy_mock_state(mock_state);
+        test_scenario::end(test);
+    }
+
+    #[test]
+    #[expected_failure(
+        abort_code = E_REGISTERED_EMITTER_TABLE_ALREADY_EXISTS,
+        location=token_bridge::registered_emitters
+    )]
+    fun test_registered_emitters_table_already_exists(){
+        let test = scenario();
+        let mock_state = MockState{id: object::new(ctx(&mut test))};
+
+        // create table of registered emitters as a dynamic field of our
+        // mock state
+        new(&mut mock_state.id, ctx(&mut test));
+
+        // attempt to create another table for storing registered
+        // emitters and attach it to mock_state under key b"registered_emitters"
+        // resulting in failure, because that key already exists
+        new(&mut mock_state.id, ctx(&mut test));
+
+        destroy_mock_state(mock_state);
+        test_scenario::end(test);
+    }
+
+    #[test]
+    #[expected_failure(
+        abort_code = E_EMITTER_EXTERNAL_ADDRESS_ALREADY_EXISTS_FOR_CHAIN,
+        location=token_bridge::registered_emitters
+    )]
+    fun test_register_chain_id_twice(){
+        let test = scenario();
+        let mock_state = MockState{id: object::new(ctx(&mut test))};
+
+        // create table of registered emitters as a dynamic field of our
+        // mock state
+        new(&mut mock_state.id, ctx(&mut test));
+
+        // try to add chain_id 1 more than once, resulting in failure
+        let i = 1;
+        while (i < 2) {
+            let cur_external_addr = vector::empty<u8>();
+            bytes::serialize_u16_be(&mut cur_external_addr, i);
+            add(
+                &mut mock_state.id,
+                i,
+                from_bytes(cur_external_addr)
+            );
+        };
+        destroy_mock_state(mock_state);
+        test_scenario::end(test);
+    }
+
+    #[test]
+    #[expected_failure(
+        abort_code = E_EMITTER_EXTERNAL_ADDRESS_DOES_NOT_EXIST_FOR_CHAIN,
+        location=token_bridge::registered_emitters
+    )]
+    fun test_registered_emitters_nonexistent_external_address(){
+        let test = scenario();
+        let mock_state = MockState{id: object::new(ctx(&mut test))};
+
+        // create table of registered emitters as a dynamic field of our
+        // mock state
+        new(&mut mock_state.id, ctx(&mut test));
+
+        // register chain ids 1-100
+        let i = 1;
+        while (i < 100) {
+            let cur_external_addr = vector::empty<u8>();
+            bytes::serialize_u16_be(&mut cur_external_addr, i);
+            add(
+                &mut mock_state.id,
+                i,
+                from_bytes(cur_external_addr)
+            );
+            i = i + 1;
+        };
+        let _nonexistent_external_address = external_address(
+            &mut mock_state.id,
+            10022 // this chain id is not registered
+        );
+        destroy_mock_state(mock_state);
+        test_scenario::end(test);
     }
 }

--- a/sui/token_bridge/sources/dynamic/registered_emitters.move
+++ b/sui/token_bridge/sources/dynamic/registered_emitters.move
@@ -80,7 +80,7 @@ module token_bridge::registered_emitters_test{
         object::delete(id);
     }
 
-    // write a test exercising the creation of a new registered emitters table,
+    // write a test exercising the creation of a new registered emitters table
     // and adding several (chain_id, external_address) key-value pairs to it
     #[test]
     fun test_registered_emitters(){
@@ -109,8 +109,7 @@ module token_bridge::registered_emitters_test{
         // emitters table were indeed added
         i = 1;
         while (i < 1000) {
-            let cur_external_addr = vector::empty<u8>();
-            bytes::serialize_u16_be(&mut cur_external_addr, i);
+            // check that key (chain id) exists
             assert!(
                 has(
                     &mock_state.id,
@@ -118,12 +117,22 @@ module token_bridge::registered_emitters_test{
                 ),
                 0
             );
+
+            // check that values (external addresses) are correct
+            let cur_external_addr = vector::empty<u8>();
+            bytes::serialize_u16_be(&mut cur_external_addr, i);
+            assert!(
+                external_address(&mock_state.id,i) ==
+                from_bytes(cur_external_addr),
+            0);
             i = i + 1;
         };
         destroy_mock_state(mock_state);
         test_scenario::end(test);
     }
 
+    // test that creating two registered emitter tables for the same UID
+    // fails
     #[test]
     #[expected_failure(
         abort_code = E_REGISTERED_EMITTER_TABLE_ALREADY_EXISTS,
@@ -146,6 +155,7 @@ module token_bridge::registered_emitters_test{
         test_scenario::end(test);
     }
 
+    // test that only one external address can be registered for a chain
     #[test]
     #[expected_failure(
         abort_code = E_EMITTER_EXTERNAL_ADDRESS_ALREADY_EXISTS_FOR_CHAIN,
@@ -201,7 +211,7 @@ module token_bridge::registered_emitters_test{
         };
         let _nonexistent_external_address = external_address(
             &mut mock_state.id,
-            10022 // this chain id is not registered
+            10022 // this chain id is not registered (only 1-100 are registered)
         );
         destroy_mock_state(mock_state);
         test_scenario::end(test);


### PR DESCRIPTION
## Updates
- add custom, more informative error types, so we don't throw uninformative standard library errors
- assert preconditions in `registered_emitter.move` `new`, `add`, `external_address` functions
- write tests exercising intended function behavior as well as individual assertions (negative test cases)