### PR TITLE
sui/token_bridge: test `wrapped_coin.move`

### DIFF
--- a/sui/token_bridge/sources/objects/wrapped_asset.move
+++ b/sui/token_bridge/sources/objects/wrapped_asset.move
@@ -90,7 +90,7 @@ module token_bridge::wrapped_asset_test {
 
     use wormhole::external_address::{Self};
 
-    use token_bridge::native_coin_witness_v3::{Self, NATIVE_COIN_WITNESS_V3};
+    use token_bridge::wrapped_coin_7_decimals::{Self, WRAPPED_COIN_7_DECIMALS};
     use token_bridge::wrapped_asset::{Self, token_chain, token_address,
         decimals};
 
@@ -102,10 +102,10 @@ module token_bridge::wrapped_asset_test {
         let test = scenario();
         let (admin, _, _) = people();
         next_tx(&mut test, admin); {
-            native_coin_witness_v3::test_init(ctx(&mut test));
+            wrapped_coin_7_decimals::test_init(ctx(&mut test));
         };
         next_tx(&mut test, admin);{
-            let tcap = take_from_address<TreasuryCap<NATIVE_COIN_WITNESS_V3>>(
+            let tcap = take_from_address<TreasuryCap<WRAPPED_COIN_7_DECIMALS>>(
                 &mut test,
                 admin
             );

--- a/sui/token_bridge/sources/objects/wrapped_asset.move
+++ b/sui/token_bridge/sources/objects/wrapped_asset.move
@@ -118,7 +118,7 @@ module token_bridge::wrapped_asset_test {
             assert!(token_chain(&wrapped_asset) == 2, 0);
             assert!(decimals(&wrapped_asset) == 6, 0);
             assert!(token_address(&wrapped_asset)==addr, 0);
-            let tcap = wrapped_asset::destroy<NATIVE_COIN_WITNESS_V3>(
+            let tcap = wrapped_asset::destroy(
                 wrapped_asset
             );
             transfer::transfer(tcap, admin);

--- a/sui/token_bridge/sources/objects/wrapped_asset.move
+++ b/sui/token_bridge/sources/objects/wrapped_asset.move
@@ -30,6 +30,17 @@ module token_bridge::wrapped_asset {
         }
     }
 
+    #[test_only]
+    public fun destroy<C>(wrapped_asset: WrappedAsset<C>): TreasuryCap<C>{
+        let WrappedAsset {
+            token_chain: _,
+            token_address: _,
+            treasury_cap: tcap,
+            decimals: _
+        } = wrapped_asset;
+        tcap
+    }
+
     public fun token_chain<C>(self: &WrappedAsset<C>): u16 {
         self.token_chain
     }
@@ -67,5 +78,51 @@ module token_bridge::wrapped_asset {
         ctx: &mut TxContext
     ): Coin<C> {
         coin::mint(&mut self.treasury_cap, amount, ctx)
+    }
+}
+
+#[test_only]
+module token_bridge::wrapped_asset_test {
+    use sui::transfer::{Self};
+    use sui::coin::{TreasuryCap};
+    use sui::test_scenario::{Self, Scenario, next_tx, ctx, take_from_address};
+
+    use wormhole::external_address::{Self};
+
+    use token_bridge::native_coin_witness_v3::{Self, NATIVE_COIN_WITNESS_V3};
+    use token_bridge::wrapped_asset::{Self, token_chain, token_address,
+        decimals};
+
+    fun scenario(): Scenario { test_scenario::begin(@0x123233) }
+    fun people(): (address, address, address) { (@0x124323, @0xE05, @0xFACE) }
+
+    #[test]
+    public fun test_wrapped_asset(){
+        let test = scenario();
+        let (admin, _, _) = people();
+        next_tx(&mut test, admin); {
+            native_coin_witness_v3::test_init(ctx(&mut test));
+        };
+        next_tx(&mut test, admin);{
+            let tcap = take_from_address<TreasuryCap<NATIVE_COIN_WITNESS_V3>>(
+                &mut test,
+                admin
+            );
+            let addr =  external_address::from_bytes(x"112233");
+            let wrapped_asset = wrapped_asset::new(
+                2, // token chain
+                addr, //token address
+                tcap, // treasury cap
+                6, // decimals
+            );
+            assert!(token_chain(&wrapped_asset) == 2, 0);
+            assert!(decimals(&wrapped_asset) == 6, 0);
+            assert!(token_address(&wrapped_asset)==addr, 0);
+            let tcap = wrapped_asset::destroy<NATIVE_COIN_WITNESS_V3>(
+                wrapped_asset
+            );
+            transfer::transfer(tcap, admin);
+        };
+        test_scenario::end(test);
     }
 }


### PR DESCRIPTION
## Updates
- write test for `wrapped_coin.move` in which we create and destroy a wrapped coin 