### PR TITLE
sui: use `Balance` instead of `Coin` for `NativeAsset.custody`

### DIFF
--- a/sui/token_bridge/sources/attest_token.move
+++ b/sui/token_bridge/sources/attest_token.move
@@ -1,7 +1,6 @@
 module token_bridge::attest_token {
     use sui::sui::SUI;
     use sui::coin::{Coin, CoinMetadata};
-    use sui::tx_context::TxContext;
 
     use wormhole::state::{State as WormholeState};
 
@@ -14,12 +13,10 @@ module token_bridge::attest_token {
         coin_meta: &CoinMetadata<CoinType>,
         fee_coins: Coin<SUI>,
         nonce: u32,
-        ctx: &mut TxContext
     ) {
         let asset_meta = handle_attest_token(
             token_bridge_state,
             coin_meta,
-            ctx
         );
 
         state::publish_wormhole_message(
@@ -34,12 +31,10 @@ module token_bridge::attest_token {
     fun handle_attest_token<CoinType>(
         token_bridge_state: &mut State,
         coin_metadata: &CoinMetadata<CoinType>,
-        ctx: &mut TxContext
     ): AssetMeta {
         state::register_native_asset<CoinType>(
             token_bridge_state,
             coin_metadata,
-            ctx
         )
     }
 
@@ -48,12 +43,10 @@ module token_bridge::attest_token {
         token_bridge_state: &mut State,
         _worm_state: &mut WormholeState,
         coin_metadata: &CoinMetadata<CoinType>,
-        ctx: &mut TxContext
     ): AssetMeta {
         handle_attest_token(
             token_bridge_state,
             coin_metadata,
-            ctx
         )
     }
 }
@@ -99,7 +92,6 @@ module token_bridge::attest_token_test{
                 &mut bridge_state,
                 &mut wormhole_state,
                 &coin_meta,
-                ctx(&mut test)
             );
 
             assert!(asset_meta::native_decimals(&asset_meta) == 10, 0);
@@ -158,13 +150,11 @@ module token_bridge::attest_token_test{
                 &mut bridge_state,
                 &mut wormhole_state,
                 &coin_meta,
-                ctx(&mut test)
             );
             let _asset_meta_2 = test_handle_attest_token<NATIVE_COIN_WITNESS>(
                 &mut bridge_state,
                 &mut wormhole_state,
                 &coin_meta,
-                ctx(&mut test)
             );
             return_shared<WormholeState>(wormhole_state);
             return_shared<State>(bridge_state);

--- a/sui/token_bridge/sources/complete_transfer.move
+++ b/sui/token_bridge/sources/complete_transfer.move
@@ -209,7 +209,6 @@ module token_bridge::complete_transfer_test {
             state::register_native_asset<NATIVE_COIN_WITNESS>(
                 &mut bridge_state,
                 &coin_meta,
-                ctx(&mut test)
             );
             return_shared<State>(bridge_state);
             return_shared<WormholeState>(worm_state);
@@ -289,7 +288,6 @@ module token_bridge::complete_transfer_test {
             state::register_native_asset<NATIVE_COIN_WITNESS>(
                 &mut bridge_state,
                 &coin_meta,
-                ctx(&mut test)
             );
             native_coin_witness::test_init(ctx(&mut test));
             return_shared<CoinMetadata<NATIVE_COIN_WITNESS>>(coin_meta);
@@ -371,7 +369,6 @@ module token_bridge::complete_transfer_test {
             state::register_native_asset<NATIVE_COIN_WITNESS_V2>(
                 &mut bridge_state,
                 &coin_meta,
-                ctx(&mut test)
             );
             return_shared<CoinMetadata<NATIVE_COIN_WITNESS_V2>>(coin_meta);
             return_shared<State>(bridge_state);
@@ -454,8 +451,7 @@ module token_bridge::complete_transfer_test {
             let worm_state = take_shared<WormholeState>(&test);
             state::register_native_asset<NATIVE_COIN_WITNESS>(
                 &mut bridge_state,
-                &coin_meta,
-                ctx(&mut test)
+                &coin_meta
             );
             native_coin_witness::test_init(ctx(&mut test));
             return_shared<CoinMetadata<NATIVE_COIN_WITNESS>>(coin_meta);
@@ -534,7 +530,6 @@ module token_bridge::complete_transfer_test {
             state::register_native_asset<NATIVE_COIN_WITNESS>(
                 &mut bridge_state,
                 &coin_meta,
-                ctx(&mut test)
             );
             native_coin_witness::test_init(ctx(&mut test));
             return_shared<CoinMetadata<NATIVE_COIN_WITNESS>>(coin_meta);
@@ -606,7 +601,6 @@ module token_bridge::complete_transfer_test {
             state::register_native_asset<NATIVE_COIN_WITNESS>(
                 &mut bridge_state,
                 &coin_meta,
-                ctx(&mut test)
             );
             native_coin_witness::test_init(ctx(&mut test));
             return_shared<CoinMetadata<NATIVE_COIN_WITNESS>>(coin_meta);
@@ -683,7 +677,6 @@ module token_bridge::complete_transfer_test {
             state::register_native_asset<NATIVE_COIN_WITNESS>(
                 &mut bridge_state,
                 &coin_meta,
-                ctx(&mut test)
             );
             native_coin_witness::test_init(ctx(&mut test));
             return_shared<CoinMetadata<NATIVE_COIN_WITNESS>>(coin_meta);

--- a/sui/token_bridge/sources/complete_transfer_with_payload.move
+++ b/sui/token_bridge/sources/complete_transfer_with_payload.move
@@ -144,7 +144,6 @@ module token_bridge::complete_transfer_with_payload_test {
             state::register_native_asset<NATIVE_COIN_WITNESS>(
                 &mut bridge_state,
                 &coin_meta,
-                test_scenario::ctx(&mut test)
             );
             test_scenario::return_shared<State>(bridge_state);
             test_scenario::return_shared<WormholeState>(worm_state);

--- a/sui/token_bridge/sources/objects/registered_tokens.move
+++ b/sui/token_bridge/sources/objects/registered_tokens.move
@@ -77,13 +77,12 @@ module token_bridge::registered_tokens {
     public(friend) fun add_new_native<C>(
         self: &mut RegisteredTokens,
         decimals: u8,
-        ctx: &mut TxContext
     ) {
         assert!(!has<C>(self), E_ALREADY_REGISTERED);
         let addr = native_id_registry::next_id(&mut self.native_id_registry);
         add_native<C>(
             self,
-            native_asset::new(addr, decimals, ctx)
+            native_asset::new(addr, decimals)
         )
     }
 

--- a/sui/token_bridge/sources/state.move
+++ b/sui/token_bridge/sources/state.move
@@ -270,14 +270,12 @@ module token_bridge::state {
     public(friend) fun register_native_asset<CoinType>(
         self: &mut State,
         coin_metadata: &CoinMetadata<CoinType>,
-        ctx: &mut TxContext
     ): AssetMeta {
         let decimals = coin::get_decimals(coin_metadata);
 
         registered_tokens::add_new_native<CoinType>(
             &mut self.registered_tokens,
             decimals,
-            ctx
         );
 
         asset_meta::new(
@@ -396,7 +394,6 @@ module token_bridge::bridge_state_test{
             state::register_native_asset<NATIVE_COIN_WITNESS>(
                 &mut bridge_state,
                 &coin_meta,
-                ctx(&mut test)
             );
             let info = state::token_info<NATIVE_COIN_WITNESS>(&bridge_state);
             let expected_addr = external_address::from_bytes(x"01");
@@ -407,7 +404,6 @@ module token_bridge::bridge_state_test{
             state::register_native_asset<NATIVE_COIN_WITNESS_V2>(
                 &mut bridge_state,
                 &coin_meta_v2,
-                ctx(&mut test)
             );
             let info =
                 state::token_info<NATIVE_COIN_WITNESS_V2>(&bridge_state);
@@ -440,7 +436,6 @@ module token_bridge::bridge_state_test{
             state::register_native_asset<NATIVE_COIN_WITNESS>(
                 &mut bridge_state,
                 &coin_meta,
-                ctx(&mut test)
             );
             let info = state::token_info<NATIVE_COIN_WITNESS>(&bridge_state);
             let expected_addr = external_address::from_bytes(x"01");
@@ -450,7 +445,6 @@ module token_bridge::bridge_state_test{
             state::register_native_asset<NATIVE_COIN_WITNESS>(
                 &mut bridge_state,
                 &coin_meta,
-                ctx(&mut test)
             );
 
             return_shared<WormholeState>(wormhole_state);

--- a/sui/token_bridge/sources/transfer_tokens.move
+++ b/sui/token_bridge/sources/transfer_tokens.move
@@ -157,7 +157,6 @@ module token_bridge::transfer_token_test {
             state::register_native_asset<NATIVE_COIN_WITNESS>(
                 &mut bridge_state,
                 &coin_meta,
-                ctx(&mut test)
             );
             let coins = coin::mint<NATIVE_COIN_WITNESS>(&mut treasury_cap, 10000, ctx(&mut test));
 
@@ -198,7 +197,6 @@ module token_bridge::transfer_token_test {
             state::register_native_asset<NATIVE_COIN_WITNESS>(
                 &mut bridge_state,
                 &coin_meta,
-                ctx(&mut test)
             );
             let coins = coin::mint<NATIVE_COIN_WITNESS>(&mut treasury_cap, 10000, ctx(&mut test));
 
@@ -247,7 +245,6 @@ module token_bridge::transfer_token_test {
             state::register_native_asset<NATIVE_COIN_WITNESS>(
                 &mut bridge_state,
                 &coin_meta,
-                ctx(&mut test)
             );
             let coins = coin::mint<NATIVE_COIN_WITNESS>(&mut treasury_cap, 10000, ctx(&mut test));
 


### PR DESCRIPTION
## Updates
- It is unnecessary for the coin `custody` embedded in the `NativeAsset` object to have the `key` ability, because it never exists in the global object store and instead is stored within another object. Therefore it makes more sense for it to be a `sui::balance::Balance`, which only has a `store` ability, instead of a `sui::coin::Coin`, which has both `key` and `store` abilities.
```
  struct NativeAsset<phantom C> has store {
        custody: Balance<C>,
        token_address: ExternalAddress,
        decimals: u8
    }
```
- Using `Balance` in `native_asset.move` also has the added benefit that creation of a new balance object does not require `ctx` as an input arg. This simplification propagates to several other areas of the codebase, including `attest_token` and `register_native_token`.  
