### PR TITLE
sui: formatting, slashes, comments

### DIFF
--- a/sui/token_bridge/sources/attest_token.move
+++ b/sui/token_bridge/sources/attest_token.move
@@ -134,12 +134,12 @@ module token_bridge::attest_token_test{
         test_scenario::end(test);
     }
 
-    // TODO: consider throwing token bridge error instead of sui::dynamic_field
     #[test]
     #[expected_failure(
         abort_code = token_bridge::registered_tokens::E_ALREADY_REGISTERED,
         location=token_bridge::registered_tokens
     )]
+    /// TODO: consider throwing token bridge error instead of sui::dynamic_field
     fun test_attest_token_twice_fails(){
         let test = scenario();
         let (admin, _, _) = people();

--- a/sui/token_bridge/sources/datatypes/native_id_registry.move
+++ b/sui/token_bridge/sources/datatypes/native_id_registry.move
@@ -6,7 +6,7 @@ module token_bridge::native_id_registry {
     friend token_bridge::state;
 
     struct NativeIdRegistry has store {
-        /// Integer label for coin types registered with Wormhole
+        // Integer label for coin types registered with Wormhole
         index: u64
     }
 

--- a/sui/token_bridge/sources/datatypes/transfer_result.move
+++ b/sui/token_bridge/sources/datatypes/transfer_result.move
@@ -4,14 +4,14 @@ module token_bridge::transfer_result {
     use token_bridge::normalized_amount::NormalizedAmount;
 
     struct TransferResult {
-        /// Chain ID of the token
+        // Chain ID of the token
         token_chain: u16,
-        /// Address of the token. Left-zero-padded if shorter than 32 bytes
+        // Address of the token. Left-zero-padded if shorter than 32 bytes
         token_address: ExternalAddress,
-        /// Amount being transferred
+        // Amount being transferred
         amount: NormalizedAmount,
-        /// Amount of tokens that the user is willing to pay as relayer fee.
-        /// Must be <= Amount.
+        // Amount of tokens that the user is willing to pay as relayer fee.
+        // Must be <= Amount.
         relayer_fee: NormalizedAmount,
     }
 

--- a/sui/token_bridge/sources/governance/register_chain.move
+++ b/sui/token_bridge/sources/governance/register_chain.move
@@ -17,9 +17,9 @@ module token_bridge::register_chain {
     const E_INVALID_TARGET: u64 = 2;
 
     struct RegisterChain has copy, drop {
-        /// Chain ID
+        // Chain ID
         emitter_chain_id: u16,
-        /// Emitter address. Left-zero-padded if shorter than 32 bytes
+        // Emitter address. Left-zero-padded if shorter than 32 bytes
         emitter_address: ExternalAddress,
     }
 

--- a/sui/token_bridge/sources/messages/asset_meta.move
+++ b/sui/token_bridge/sources/messages/asset_meta.move
@@ -17,15 +17,15 @@ module token_bridge::asset_meta {
     const PAYLOAD_ID: u8 = 2;
 
     struct AssetMeta has copy, store, drop {
-        /// Address of the token. Left-zero-padded if shorter than 32 bytes
+        // Address of the token. Left-zero-padded if shorter than 32 bytes
         token_address: ExternalAddress,
-        /// Chain ID of the token
+        // Chain ID of the token
         token_chain: u16,
-        /// Number of decimals of the token (big-endian uint256)
+        // Number of decimals of the token (big-endian uint256)
         native_decimals: u8,
-        /// Symbol of the token (UTF-8)
+        // Symbol of the token (UTF-8)
         symbol: String32,
-        /// Name of the token (UTF-8)
+        // Name of the token (UTF-8)
         name: String32,
     }
 

--- a/sui/token_bridge/sources/messages/transfer.move
+++ b/sui/token_bridge/sources/messages/transfer.move
@@ -18,18 +18,18 @@ module token_bridge::transfer {
     const PAYLOAD_ID: u8 = 1;
 
     struct Transfer has drop {
-        /// Amount being transferred
+        // Amount being transferred
         amount: NormalizedAmount,
-        /// Address of the token. Left-zero-padded if shorter than 32 bytes
+        // Address of the token. Left-zero-padded if shorter than 32 bytes
         token_address: ExternalAddress,
-        /// Chain ID of the token
+        // Chain ID of the token
         token_chain: u16,
-        /// Address of the recipient. Left-zero-padded if shorter than 32 bytes
+        // Address of the recipient. Left-zero-padded if shorter than 32 bytes
         recipient: ExternalAddress,
-        /// Chain ID of the recipient
+        // Chain ID of the recipient
         recipient_chain: u16,
-        /// Amount of tokens that the user is willing to pay as relayer fee.
-        /// Must be <= amount.
+        // Amount of tokens that the user is willing to pay as relayer fee.
+        // Must be <= amount.
         relayer_fee: NormalizedAmount,
     }
 

--- a/sui/token_bridge/sources/messages/transfer_with_payload.move
+++ b/sui/token_bridge/sources/messages/transfer_with_payload.move
@@ -20,19 +20,19 @@ module token_bridge::transfer_with_payload {
     const PAYLOAD_ID: u8 = 3;
 
     struct TransferWithPayload has store, drop {
-        /// Amount being transferred (big-endian uint256)
+        // Amount being transferred (big-endian uint256)
         amount: NormalizedAmount,
-        /// Address of the token. Left-zero-padded if shorter than 32 bytes
+        // Address of the token. Left-zero-padded if shorter than 32 bytes
         token_address: ExternalAddress,
-        /// Chain ID of the token
+        // Chain ID of the token
         token_chain: u16,
-        /// Address of the recipient. Left-zero-padded if shorter than 32 bytes
+        // Address of the recipient. Left-zero-padded if shorter than 32 bytes
         recipient: ExternalAddress,
-        /// Chain ID of the recipient
+        // Chain ID of the recipient
         recipient_chain: u16,
-        /// Address of the message sender. Left-zero-padded if shorter than 32 bytes
+        // Address of the message sender. Left-zero-padded if shorter than 32 bytes
         sender: ExternalAddress,
-        /// An arbitrary payload
+        // An arbitrary payload
         payload: vector<u8>,
     }
 

--- a/sui/token_bridge/sources/objects/native_asset.move
+++ b/sui/token_bridge/sources/objects/native_asset.move
@@ -35,7 +35,7 @@ module token_bridge::native_asset {
     ){
         assert!(coin::value<C>(&self.custody)==0, 0);
         let NativeAsset<C>{
-            custody: custody,
+            custody,
             token_address: _,
             decimals: _
         } = self;
@@ -97,10 +97,10 @@ module token_bridge::native_asset_test{
     fun scenario(): Scenario { test_scenario::begin(@0x123233) }
     fun people(): (address, address, address) { (@0x124323, @0xE05, @0xFACE) }
 
-    // in this test, we exercise all the functionalities of a native asset
-    // object, including new, deposit, withdraw, to_token_info, as well as
-    // getting fields token_address, decimals, balan.ce
     #[test]
+    /// in this test, we exercise all the functionalities of a native asset
+    /// object, including new, deposit, withdraw, to_token_info, as well as
+    /// getting fields token_address, decimals, balan.ce
     fun test_native_asset(){
         let test = scenario();
         let (admin, _, _) = people();

--- a/sui/token_bridge/sources/state.move
+++ b/sui/token_bridge/sources/state.move
@@ -46,15 +46,15 @@ module token_bridge::state {
         id: UID
     }
 
-    // Treasury caps, token stores, consumed VAAs, registered emitters, etc.
-    // are stored as dynamic fields of bridge state.
+    /// Treasury caps, token stores, consumed VAAs, registered emitters, etc.
+    /// are stored as dynamic fields of bridge state.
     struct State has key, store {
         id: UID,
 
-        /// Set of consumed VAA hashes
+        // Set of consumed VAA hashes
         consumed_vaas: Set<vector<u8>>,
 
-        /// Token bridge owned emitter capability
+        // Token bridge owned emitter capability
         emitter_cap: EmitterCapability,
 
         registered_tokens: RegisteredTokens,
@@ -74,8 +74,8 @@ module token_bridge::state {
         init(ctx)
     }
 
-    // converts owned state object into a shared object, so that anyone can get
-    // a reference to &mut State and pass it into various functions
+    /// converts owned state object into a shared object, so that anyone can get
+    /// a reference to &mut State and pass it into various functions
     public entry fun init_and_share_state(
         deployer: DeployerCapability,
         worm_state: &mut WormholeState,
@@ -83,7 +83,7 @@ module token_bridge::state {
     ) {
         let DeployerCapability{ id } = deployer;
         object::delete(id);
-    
+
         let state = State {
             id: object::new(ctx),
             consumed_vaas: set::new(ctx),
@@ -165,8 +165,8 @@ module token_bridge::state {
         mint(self, amount, ctx)
     }
 
-    // We only examine the balance of native assets, because the token
-    // bridge does not custody wrapped assets (only mints and burns them).
+    /// We only examine the balance of native assets, because the token
+    /// bridge does not custody wrapped assets (only mints and burns them).
     public fun balance<CoinType>(self: &State): u64 {
         registered_tokens::balance<CoinType>(&self.registered_tokens)
     }

--- a/sui/token_bridge/sources/testing/native_coin_10_decimals.move
+++ b/sui/token_bridge/sources/testing/native_coin_10_decimals.move
@@ -1,18 +1,18 @@
 #[test_only]
-module token_bridge::native_coin_witness {
+module token_bridge::native_coin_10_decimals {
     use std::option::{Self};
     use sui::tx_context::{TxContext};
     use sui::coin::{Self};
     use sui::transfer::{Self};
 
-    struct NATIVE_COIN_WITNESS has drop {}
+    struct NATIVE_COIN_10_DECIMALS has drop {}
 
     /// This module creates a Sui-native token for testing purposes,
     /// for example in complete_transfer, where we create a native coin,
     /// mint some and deposit in the token bridge, then complete transfer
     /// and ultimately transfer a portion of those native coins to a recipient.
-    fun init(coin_witness: NATIVE_COIN_WITNESS, ctx: &mut TxContext) {
-        let (treasury_cap, coin_metadata) = coin::create_currency<NATIVE_COIN_WITNESS>(
+    fun init(coin_witness: NATIVE_COIN_10_DECIMALS, ctx: &mut TxContext) {
+        let (treasury_cap, coin_metadata) = coin::create_currency<NATIVE_COIN_10_DECIMALS>(
             coin_witness,
             10,
             x"00",
@@ -27,6 +27,6 @@ module token_bridge::native_coin_witness {
 
     #[test_only]
     public fun test_init(ctx: &mut TxContext) {
-        init(NATIVE_COIN_WITNESS {}, ctx)
+        init(NATIVE_COIN_10_DECIMALS {}, ctx)
     }
 }

--- a/sui/token_bridge/sources/testing/native_coin_v2.move
+++ b/sui/token_bridge/sources/testing/native_coin_v2.move
@@ -7,10 +7,10 @@ module token_bridge::native_coin_witness_v2 {
 
     struct NATIVE_COIN_WITNESS_V2 has drop {}
 
-    // This module creates a Sui-native token for testing purposes,
-    // for example in complete_transfer, where we create a native coin,
-    // mint some and deposit in the token bridge, then complete transfer
-    // and ultimately transfer a portion of those native coins to a recipient.
+    /// This module creates a Sui-native token for testing purposes,
+    /// for example in complete_transfer, where we create a native coin,
+    /// mint some and deposit in the token bridge, then complete transfer
+    /// and ultimately transfer a portion of those native coins to a recipient.
     fun init(coin_witness: NATIVE_COIN_WITNESS_V2, ctx: &mut TxContext) {
         let (treasury_cap, coin_metadata) = coin::create_currency<NATIVE_COIN_WITNESS_V2>(
             coin_witness,

--- a/sui/token_bridge/sources/testing/wrapped_coin.move
+++ b/sui/token_bridge/sources/testing/wrapped_coin.move
@@ -46,8 +46,9 @@ module token_bridge::coin_witness_test {
     /// Registration VAA for the etheruem token bridge 0xdeadbeef
     const ETHEREUM_TOKEN_REG: vector<u8> = x"0100000000010015d405c74be6d93c3c33ed6b48d8db70dfb31e0981f8098b2a6c7583083e0c3343d4a1abeb3fc1559674fa067b0c0e2e9de2fafeaecdfeae132de2c33c9d27cc0100000001000000010001000000000000000000000000000000000000000000000000000000000000000400000000016911ae00000000000000000000000000000000000000000000546f6b656e427269646765010000000200000000000000000000000000000000000000000000000000000000deadbeef";
 
-    // call coin init to create wrapped coin and traasfer to sender
     #[test]
+    /// this helper function calls coin init to create wrapped coin and
+    /// subsequently traasfers it to sender
     fun test_create_wrapped() {
         let test = scenario();
         let (admin, _, _) = people();
@@ -57,8 +58,8 @@ module token_bridge::coin_witness_test {
         test_scenario::end(test);
     }
 
-    // call token bridge register wrapped coin
     #[test]
+    /// this helper function calls token bridge register wrapped coin
     fun test_register_wrapped() {
         let (admin, _, _) = people();
         let scenario = scenario();

--- a/sui/token_bridge/sources/transfer_tokens.move
+++ b/sui/token_bridge/sources/transfer_tokens.move
@@ -227,8 +227,8 @@ module token_bridge::transfer_token_test {
         test_scenario::end(test);
     }
 
-    // check transfer result for native token transfer is constructed properly
     #[test]
+    /// check transfer result for native token transfer is constructed properly
     fun test_transfer_native_token_internal(){
         let (admin, _, _) = people();
         let test = scenario();
@@ -333,7 +333,7 @@ module token_bridge::transfer_token_test {
         test_scenario::end(test);
     }
 
-     #[test]
+    #[test]
     fun test_transfer_wrapped_token_internal(){
         let (admin, _, _) = people();
         let test = scenario();

--- a/sui/token_bridge/sources/vaa.move
+++ b/sui/token_bridge/sources/vaa.move
@@ -81,7 +81,7 @@ module token_bridge::token_bridge_vaa_test{
         Self,
         Scenario,
         next_tx,
-        ctx, 
+        ctx,
         take_shared,
         return_shared
     };


### PR DESCRIPTION
## Updates
- follow the convention of using `///` before function, struct, and module definitions, and `//` inside of functions
- in native_asset destructor, just write `custody` instead of `custody: custody`