### PR TITLE
Node: Rename Arbitrum connector

### DIFF
--- a/node/pkg/watchers/evm/connectors/get_time_of_block.go
+++ b/node/pkg/watchers/evm/connectors/get_time_of_block.go
@@ -1,4 +1,4 @@
-// On Arbitrum we are unable to get blocks by transaction hash using the go-ethereum library
+// On some chains we are unable to get blocks by transaction hash using the go-ethereum library
 // because it fails with "transaction type not supported". However, calling the underlying
 // eth_getBlockByHash directly works. The sole function of this connector is to implement
 // TimeOfBlockByHash using the raw connection.
@@ -13,16 +13,16 @@ import (
 	ethCommon "github.com/ethereum/go-ethereum/common"
 )
 
-type ArbitrumConnector struct {
+type ConnectorWithGetTimeOfBlock struct {
 	Connector
 }
 
-func NewArbitrumConnector(ctx context.Context, baseConnector Connector) (*ArbitrumConnector, error) {
-	connector := &ArbitrumConnector{Connector: baseConnector}
+func NewConnectorWithGetTimeOfBlock(ctx context.Context, baseConnector Connector) (*ConnectorWithGetTimeOfBlock, error) {
+	connector := &ConnectorWithGetTimeOfBlock{Connector: baseConnector}
 	return connector, nil
 }
 
-func (a *ArbitrumConnector) TimeOfBlockByHash(ctx context.Context, hash ethCommon.Hash) (uint64, error) {
+func (a *ConnectorWithGetTimeOfBlock) TimeOfBlockByHash(ctx context.Context, hash ethCommon.Hash) (uint64, error) {
 	type Marshaller struct {
 		Time string `json:"timestamp"        gencodec:"required"`
 	}

--- a/node/pkg/watchers/evm/connectors/get_time_of_block.go
+++ b/node/pkg/watchers/evm/connectors/get_time_of_block.go
@@ -1,8 +1,3 @@
-// On some chains we are unable to get blocks by transaction hash using the go-ethereum library
-// because it fails with "transaction type not supported". However, calling the underlying
-// eth_getBlockByHash directly works. The sole function of this connector is to implement
-// TimeOfBlockByHash using the raw connection.
-
 package connectors
 
 import (
@@ -13,16 +8,19 @@ import (
 	ethCommon "github.com/ethereum/go-ethereum/common"
 )
 
-type ConnectorWithGetTimeOfBlock struct {
+// ConnectorWithGetTimeOfBlockOverride is used to override the implementation of TimeOfBlockByHash() as defined in
+// the go-ethereum library because on some chains it fails with "transaction type not supported". Calling the underlying
+// eth_getBlockByHash directly works, so the sole function of this connector is to implement TimeOfBlockByHash() using the raw connection.
+type ConnectorWithGetTimeOfBlockOverride struct {
 	Connector
 }
 
-func NewConnectorWithGetTimeOfBlock(ctx context.Context, baseConnector Connector) (*ConnectorWithGetTimeOfBlock, error) {
-	connector := &ConnectorWithGetTimeOfBlock{Connector: baseConnector}
+func NewConnectorWithGetTimeOfBlockOverride(ctx context.Context, baseConnector Connector) (*ConnectorWithGetTimeOfBlockOverride, error) {
+	connector := &ConnectorWithGetTimeOfBlockOverride{Connector: baseConnector}
 	return connector, nil
 }
 
-func (a *ConnectorWithGetTimeOfBlock) TimeOfBlockByHash(ctx context.Context, hash ethCommon.Hash) (uint64, error) {
+func (a *ConnectorWithGetTimeOfBlockOverride) TimeOfBlockByHash(ctx context.Context, hash ethCommon.Hash) (uint64, error) {
 	type Marshaller struct {
 		Time string `json:"timestamp"        gencodec:"required"`
 	}

--- a/node/pkg/watchers/evm/watcher.go
+++ b/node/pkg/watchers/evm/watcher.go
@@ -272,7 +272,8 @@ func (w *Watcher) Run(ctx context.Context) error {
 			p2p.DefaultRegistry.AddErrorCount(w.chainID, 1)
 			return fmt.Errorf("creating block poll connector failed: %w", err)
 		}
-		w.ethConn, err = connectors.NewArbitrumConnector(ctx, pollConnector)
+		// The standard geth BlockByHash() does not work on Arbitrum.
+		w.ethConn, err = connectors.NewConnectorWithGetTimeOfBlock(ctx, pollConnector)
 		if err != nil {
 			ethConnectionErrors.WithLabelValues(w.networkName, "dial_error").Inc()
 			p2p.DefaultRegistry.AddErrorCount(w.chainID, 1)
@@ -318,9 +319,8 @@ func (w *Watcher) Run(ctx context.Context) error {
 				p2p.DefaultRegistry.AddErrorCount(w.chainID, 1)
 				return fmt.Errorf("creating block poll connector failed: %w", err)
 			}
-			// I know this says Arbitrum.  That's just what the type is called.
-			// But we need it the TimeOfBlockByHash() implementation.
-			w.ethConn, err = connectors.NewArbitrumConnector(ctx, pollConnector)
+			// The standard geth BlockByHash() does not work on Optimism Bedrock.
+			w.ethConn, err = connectors.NewConnectorWithGetTimeOfBlock(ctx, pollConnector)
 			if err != nil {
 				ethConnectionErrors.WithLabelValues(w.networkName, "dial_error").Inc()
 				p2p.DefaultRegistry.AddErrorCount(w.chainID, 1)
@@ -357,8 +357,8 @@ func (w *Watcher) Run(ctx context.Context) error {
 			p2p.DefaultRegistry.AddErrorCount(w.chainID, 1)
 			return fmt.Errorf("creating block poll connector failed: %w", err)
 		}
-		// Use the Arbitrum connector to get the TimeOfBlockByHash() implementation.
-		w.ethConn, err = connectors.NewArbitrumConnector(ctx, pollConnector)
+		// The standard geth BlockByHash() does not work on Base.
+		w.ethConn, err = connectors.NewConnectorWithGetTimeOfBlock(ctx, pollConnector)
 		if err != nil {
 			ethConnectionErrors.WithLabelValues(w.networkName, "dial_error").Inc()
 			p2p.DefaultRegistry.AddErrorCount(w.chainID, 1)

--- a/node/pkg/watchers/evm/watcher.go
+++ b/node/pkg/watchers/evm/watcher.go
@@ -273,7 +273,7 @@ func (w *Watcher) Run(ctx context.Context) error {
 			return fmt.Errorf("creating block poll connector failed: %w", err)
 		}
 		// The standard geth BlockByHash() does not work on Arbitrum.
-		w.ethConn, err = connectors.NewConnectorWithGetTimeOfBlock(ctx, pollConnector)
+		w.ethConn, err = connectors.NewConnectorWithGetTimeOfBlockOverride(ctx, pollConnector)
 		if err != nil {
 			ethConnectionErrors.WithLabelValues(w.networkName, "dial_error").Inc()
 			p2p.DefaultRegistry.AddErrorCount(w.chainID, 1)
@@ -320,7 +320,7 @@ func (w *Watcher) Run(ctx context.Context) error {
 				return fmt.Errorf("creating block poll connector failed: %w", err)
 			}
 			// The standard geth BlockByHash() does not work on Optimism Bedrock.
-			w.ethConn, err = connectors.NewConnectorWithGetTimeOfBlock(ctx, pollConnector)
+			w.ethConn, err = connectors.NewConnectorWithGetTimeOfBlockOverride(ctx, pollConnector)
 			if err != nil {
 				ethConnectionErrors.WithLabelValues(w.networkName, "dial_error").Inc()
 				p2p.DefaultRegistry.AddErrorCount(w.chainID, 1)
@@ -358,7 +358,7 @@ func (w *Watcher) Run(ctx context.Context) error {
 			return fmt.Errorf("creating block poll connector failed: %w", err)
 		}
 		// The standard geth BlockByHash() does not work on Base.
-		w.ethConn, err = connectors.NewConnectorWithGetTimeOfBlock(ctx, pollConnector)
+		w.ethConn, err = connectors.NewConnectorWithGetTimeOfBlockOverride(ctx, pollConnector)
 		if err != nil {
 			ethConnectionErrors.WithLabelValues(w.networkName, "dial_error").Inc()
 			p2p.DefaultRegistry.AddErrorCount(w.chainID, 1)


### PR DESCRIPTION
The `ArbitrumConnector` in the EVM watcher is now also being used for Optimism Bedrock and Base, so this PR renames it to `ConnectorWithGetTimeOfBlock` since that is what it really provides.