### PR TITLE
sui: update to more stable 0.25.0 version 

### DIFF
--- a/sui/Docker.md
+++ b/sui/Docker.md
@@ -1,8 +1,8 @@
 # first build the image
 cd ..; DOCKER_BUILDKIT=1 docker build --no-cache --progress plain -f sui/Dockerfile.base -t sui .
 # tag the image with the appropriate version
-docker tag sui:latest ghcr.io/wormhole-foundation/sui:0.25.0
+docker tag sui:latest ghcr.io/wormhole-foundation/sui:0.25.0_stable
 # push to ghcr
-docker push ghcr.io/wormhole-foundation/sui:0.25.0
+docker push ghcr.io/wormhole-foundation/sui:0.25.0_stable
 
 echo remember to update both Dockerfile and Dockerfile.export

--- a/sui/Dockerfile
+++ b/sui/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/wormhole-foundation/sui:0.25.0@sha256:a5bcdba3a12b1d6ea1f87ff88e3d02e222740f1b069c12c3d31026b6cc538d47 as sui
+FROM ghcr.io/wormhole-foundation/sui:0.25.0_stable@sha256:e65a97286b6ea9aac7569d9169d93c35debc36dbc140089988c79730eb945901 as sui
 
 RUN dnf -y install make git
 


### PR DESCRIPTION
- previously deploy wormhole was giving the error `Local version of dependency 0000000000000000000000000000000000000002::ecvrf was not found.`
- this update attempts to fix it by updating the Sui Docker image in [ghcr](https://github.com/orgs/wormhole-foundation/packages/container/package/sui) to a newer `0.25.0` version