### PR TITLE
sui/token_bridge: check transfer tokens tx effects 

### DIFF
--- a/sui/token_bridge/sources/transfer_tokens.move
+++ b/sui/token_bridge/sources/transfer_tokens.move
@@ -145,12 +145,9 @@ module token_bridge::transfer_token_test {
         let test = scenario();
         // Set up core and token bridges.
         test = set_up_wormhole_core_and_token_bridges(admin, test);
-        // Initialize the coin.
-        next_tx(&mut test, admin);{
-            native_coin_witness::test_init(ctx(&mut test));
-        };
-        // Register native asset type with the token bridge, mint some coins,
-        // and initiate transfer.
+        // initialize the coin
+        native_coin_witness::test_init(ctx(&mut test));
+        // register native asset type with the token bridge, mint some coins, initiate transfer
         next_tx(&mut test, admin);{
             let bridge_state = take_shared<State>(&test);
             let worm_state = take_shared<WormholeState>(&test);
@@ -186,12 +183,9 @@ module token_bridge::transfer_token_test {
         let test = scenario();
         // Set up core and token bridges.
         test = set_up_wormhole_core_and_token_bridges(admin, test);
-        // Initialize the coin.
-        next_tx(&mut test, admin);{
-            native_coin_witness::test_init(ctx(&mut test));
-        };
-        // Register native asset type with the token bridge, mint some coins,
-        // and finally initiate transfer.
+        // initialize the coin
+        native_coin_witness::test_init(ctx(&mut test));
+        // register native asset type with the token bridge, mint some coins, initiate transfer
         next_tx(&mut test, admin);{
             let bridge_state = take_shared<State>(&test);
             let worm_state = take_shared<WormholeState>(&test);
@@ -240,12 +234,9 @@ module token_bridge::transfer_token_test {
         let test = scenario();
         // Set up core and token bridges.
         test = set_up_wormhole_core_and_token_bridges(admin, test);
-        // Initialize the coin.
-        next_tx(&mut test, admin);{
-            native_coin_witness::test_init(ctx(&mut test));
-        };
-        // Register native asset type with the token bridge, mint some coins,
-        // and finally initiate transfer.
+        // initialize the coin
+        native_coin_witness::test_init(ctx(&mut test));
+        // register native asset type with the token bridge, mint some coins, initiate transfer
         next_tx(&mut test, admin);{
             let bridge_state = take_shared<State>(&test);
             let worm_state = take_shared<WormholeState>(&test);
@@ -288,12 +279,9 @@ module token_bridge::transfer_token_test {
         let test = scenario();
         // Set up core and token bridges.
         test = set_up_wormhole_core_and_token_bridges(admin, test);
-        // Initialize the wrapped coin and register the eth chain.
-        next_tx(&mut test, admin);{
-            coin_witness::test_init(ctx(&mut test));
-        };
-        // Register chain emitter (chain id x emitter address) that attested
-        // the wrapped token.
+        // initialize the wrapped coin and register the eth chain
+        coin_witness::test_init(ctx(&mut test));
+        // register chain emitter (chain id x emitter address) that attested the wrapped token
         next_tx(&mut test, admin);{
             let bridge_state = take_shared<State>(&test);
             state::register_emitter(
@@ -343,6 +331,10 @@ module token_bridge::transfer_token_test {
             return_shared<WormholeState>(worm_state);
             return_shared<CoinMetadata<COIN_WITNESS>>(coin_meta);
         };
+        let tx_effects = next_tx(&mut test, admin);
+        // A single user event should be emitted, corresponding to
+        // publishing a Wormhole message for the token transfer
+        assert!(num_user_events(&tx_effects)==1, 0);
         // How to check if token was actually burned?
         test_scenario::end(test);
     }
@@ -353,12 +345,9 @@ module token_bridge::transfer_token_test {
         let test = scenario();
         // Set up core and token bridges.
         test = set_up_wormhole_core_and_token_bridges(admin, test);
-        // Initialize the wrapped coin and register the eth chain.
-        next_tx(&mut test, admin);{
-            coin_witness::test_init(ctx(&mut test));
-        };
-        // Register chain emitter (chain id x emitter address) that attested
-        // the wrapped token.
+        // initialize the wrapped coin and register the eth chain
+        coin_witness::test_init(ctx(&mut test));
+        // register chain emitter (chain id x emitter address) that attested the wrapped token
         next_tx(&mut test, admin);{
             let bridge_state = take_shared<State>(&test);
             state::register_emitter(


### PR DESCRIPTION
### Update
- examine transaction effects of `transfer_token` and assert that number of emitted user events is 1 (corresponding to publishing of Wormhole message for that transfer),
- delete some instances of `next_tx`