### PR TITLE
sui/token_bridge: test `transfer_tokens_with_payload` with check on tx_effects

### DIFF
--- a/sui/token_bridge/sources/state.move
+++ b/sui/token_bridge/sources/state.move
@@ -39,6 +39,8 @@ module token_bridge::state {
     friend token_bridge::complete_transfer_with_payload_test;
     #[test_only]
     friend token_bridge::transfer_token_test;
+    #[test_only]
+    friend token_bridge::transfer_tokens_with_payload_test;
 
     /// Capability for creating a bridge state object, granted to sender when
     /// this module is deployed.

--- a/sui/token_bridge/sources/transfer_tokens.move
+++ b/sui/token_bridge/sources/transfer_tokens.move
@@ -102,6 +102,7 @@ module token_bridge::transfer_tokens {
     }
 }
 
+
 #[test_only]
 module token_bridge::transfer_token_test {
     use sui::coin::{Self, CoinMetadata, TreasuryCap};

--- a/sui/token_bridge/sources/transfer_tokens_with_payload.move
+++ b/sui/token_bridge/sources/transfer_tokens_with_payload.move
@@ -12,8 +12,8 @@ module token_bridge::transfer_tokens_with_payload {
 
     public fun transfer_tokens_with_payload<CoinType>(
         emitter_cap: &EmitterCapability,
-        wormhole_state: &mut WormholeState,
         bridge_state: &mut State,
+        wormhole_state: &mut WormholeState,
         coins: Coin<CoinType>,
         wormhole_fee_coins: Coin<SUI>,
         recipient_chain: u16,
@@ -49,4 +49,183 @@ module token_bridge::transfer_tokens_with_payload {
     }
 }
 
-// TODO: write specific tests for `transfer_tokens_with_payload`.
+#[test_only]
+module token_bridge::transfer_tokens_with_payload_test {
+    use sui::coin::{Self, CoinMetadata, TreasuryCap};
+    use sui::sui::{SUI};
+    use sui::test_scenario::{
+        Self,
+        Scenario,
+        next_tx,
+        return_shared,
+        take_shared,
+        take_from_address,
+        ctx,
+        num_user_events
+    };
+    use sui::transfer::{Self};
+
+    use wormhole::external_address::{Self};
+    use wormhole::state::{State as WormholeState};
+    use wormhole::wormhole::{Self};
+
+    use token_bridge::bridge_state_test::{
+        set_up_wormhole_core_and_token_bridges
+    };
+    use token_bridge::create_wrapped::{Self};
+    use token_bridge::wrapped_coin_12_decimals::{Self, WRAPPED_COIN_12_DECIMALS};
+    use token_bridge::native_coin_4_decimals::{Self, NATIVE_COIN_4_DECIMALS};
+    use token_bridge::state::{Self, State};
+    use token_bridge::transfer_tokens_with_payload::{
+        transfer_tokens_with_payload
+    };
+    use token_bridge::wrapped_coin::{WrappedCoin};
+
+    fun scenario(): Scenario { test_scenario::begin(@0x123233) }
+    fun people(): (address, address, address) { (@0x124323, @0xE05, @0xFACE) }
+
+    #[test]
+    fun test_transfer_native_token_with_payload(){
+        let (admin, _, _) = people();
+        let test = scenario();
+        // Set up core and token bridges.
+        test = set_up_wormhole_core_and_token_bridges(admin, test);
+        // Initialize the coin.
+        native_coin_4_decimals::test_init(ctx(&mut test));
+        // Register native asset type with the token bridge, mint some coins,
+        // then initiate transfer.
+        next_tx(&mut test, admin);{
+            let bridge_state = take_shared<State>(&test);
+            let worm_state = take_shared<WormholeState>(&test);
+            let coin_meta = take_shared<CoinMetadata<NATIVE_COIN_4_DECIMALS>>(&test);
+            let treasury_cap = take_shared<TreasuryCap<NATIVE_COIN_4_DECIMALS>>(&test);
+            state::register_native_asset<NATIVE_COIN_4_DECIMALS>(
+                &mut bridge_state,
+                &coin_meta,
+            );
+            let coins = coin::mint<NATIVE_COIN_4_DECIMALS>(
+                &mut treasury_cap,
+                10000,
+                ctx(&mut test)
+            );
+            let payload = x"beef0000beef0000beef";
+
+            // Register and obtain a new wormhole emitter cap.
+            let emitter_cap =
+                wormhole::register_emitter(
+                    &mut worm_state, test_scenario::ctx(&mut test)
+                );
+
+            // Call transfer tokens with payload with args defined above.
+            transfer_tokens_with_payload<NATIVE_COIN_4_DECIMALS>(
+                &mut emitter_cap,
+                &mut bridge_state,
+                &mut worm_state,
+                coins,
+                coin::zero<SUI>(ctx(&mut test)), // zero fee paid to wormhole
+                3, // recipient chain id
+                external_address::from_bytes(x"deadbeef0000beef"), // recipient 
+                0, // relayer fee
+                payload, // unused field for now
+            );
+
+            // Clean up!
+            transfer::transfer(emitter_cap, admin);
+            return_shared<State>(bridge_state);
+            return_shared<WormholeState>(worm_state);
+            return_shared<CoinMetadata<NATIVE_COIN_4_DECIMALS>>(coin_meta);
+            return_shared<TreasuryCap<NATIVE_COIN_4_DECIMALS>>(treasury_cap);
+        };
+
+        let tx_effects = next_tx(&mut test, admin);
+        // A single user event should be emitted, corresponding to
+        // publishing a Wormhole message for the token transfer with payload
+        assert!(num_user_events(&tx_effects)==1, 0);
+
+        // Check that custody of the coins is indeed transferred to token bridge.
+        next_tx(&mut test, admin);{
+            let bridge_state = take_shared<State>(&test);
+            let cur_bal = state::balance<NATIVE_COIN_4_DECIMALS>(&mut bridge_state);
+            assert!(cur_bal==10000, 0);
+            return_shared<State>(bridge_state);
+        };
+        test_scenario::end(test);
+    }
+
+    #[test]
+    fun test_transfer_wrapped_token_with_payload(){
+        let (admin, _, _) = people();
+        let test = scenario();
+        // Set up core and token bridges.
+        test = set_up_wormhole_core_and_token_bridges(admin, test);
+        // Initialize the wrapped coin and register the eth chain.
+        wrapped_coin_12_decimals::test_init(ctx(&mut test));
+        // Register chain emitter (chain id x emitter address) that attested
+        // the wrapped token.
+        next_tx(&mut test, admin);{
+            let bridge_state = take_shared<State>(&test);
+            state::register_emitter(
+                &mut bridge_state,
+                2, // chain ID
+                external_address::from_bytes(
+                    x"00000000000000000000000000000000000000000000000000000000deadbeef"
+                )
+            );
+            return_shared<State>(bridge_state);
+        };
+        // register wrapped asset type with the token bridge, mint some coins, initiate transfer
+        next_tx(&mut test, admin);{
+            let bridge_state = take_shared<State>(&test);
+            let worm_state = take_shared<WormholeState>(&test);
+            let coin_meta = take_shared<CoinMetadata<WRAPPED_COIN_12_DECIMALS>>(&test);
+            let new_wrapped_coin =
+                take_from_address<WrappedCoin<WRAPPED_COIN_12_DECIMALS>>(&test, admin);
+            let payload = x"ddddaaaabbbb";
+            // register wrapped asset with the token bridge
+            create_wrapped::register_new_coin<WRAPPED_COIN_12_DECIMALS>(
+                &mut bridge_state,
+                &mut worm_state,
+                new_wrapped_coin,
+                &mut coin_meta,
+                ctx(&mut test)
+            );
+
+            let coins =
+                state::mint<WRAPPED_COIN_12_DECIMALS>(
+                    &mut bridge_state,
+                    1000, // amount
+                    ctx(&mut test)
+                );
+
+            // Register and obtain a new wormhole emitter cap.
+            let emitter_cap =
+                wormhole::register_emitter(
+                    &mut worm_state, test_scenario::ctx(&mut test)
+                );
+
+            // Call complete transfer with payload using previous args.
+            transfer_tokens_with_payload<WRAPPED_COIN_12_DECIMALS>(
+                &mut emitter_cap,
+                &mut bridge_state,
+                &mut worm_state,
+                coins,
+                coin::zero<SUI>(ctx(&mut test)), // zero fee paid to wormhole
+                3, // recipient chain id
+                external_address::from_bytes(x"deadbeef0000beef"), // recipient
+                0, // relayer fee
+                payload,
+            );
+
+            // Clean-up!
+            transfer::transfer(emitter_cap, admin);
+            return_shared<State>(bridge_state);
+            return_shared<WormholeState>(worm_state);
+            return_shared<CoinMetadata<WRAPPED_COIN_12_DECIMALS>>(coin_meta);
+        };
+        let tx_effects = next_tx(&mut test, admin);
+        // A single user event should be emitted, corresponding to
+        // publishing a Wormhole message for the token transfer with payload
+        assert!(num_user_events(&tx_effects)==1, 0);
+        test_scenario::end(test);
+    }
+}

--- a/sui/token_bridge/sources/transfer_tokens_with_payload.move
+++ b/sui/token_bridge/sources/transfer_tokens_with_payload.move
@@ -124,9 +124,9 @@ module token_bridge::transfer_tokens_with_payload_test {
                 coins,
                 coin::zero<SUI>(ctx(&mut test)), // zero fee paid to wormhole
                 3, // recipient chain id
-                external_address::from_bytes(x"deadbeef0000beef"), // recipient 
+                external_address::from_bytes(x"deadbeef0000beef"), // recipient
                 0, // relayer fee
-                payload, // unused field for now
+                payload,
             );
 
             // Clean up!

--- a/sui/token_bridge/sources/transfer_tokens_with_payload.move
+++ b/sui/token_bridge/sources/transfer_tokens_with_payload.move
@@ -124,7 +124,7 @@ module token_bridge::transfer_tokens_with_payload_test {
                 coins,
                 coin::zero<SUI>(ctx(&mut test)), // Zero fee paid to wormhole.
                 3, // Recipient chain id.
-                external_address::from_bytes(x"deadbeef0000beef"), // recipient
+                external_address::from_bytes(x"deadbeef0000beef"), // Recipient.
                 0, // Relayer fee.
                 payload,
             );
@@ -184,7 +184,7 @@ module token_bridge::transfer_tokens_with_payload_test {
             let payload = x"ddddaaaabbbb";
 
             // Register wrapped asset with the token bridge.
-            create_wrapped::register_wrapped_coin<COIN_WITNESS>(
+            create_wrapped::register_new_coin<WRAPPED_COIN_12_DECIMALS>(
                 &mut bridge_state,
                 &mut worm_state,
                 new_wrapped_coin,

--- a/sui/token_bridge/sources/transfer_tokens_with_payload.move
+++ b/sui/token_bridge/sources/transfer_tokens_with_payload.move
@@ -122,10 +122,10 @@ module token_bridge::transfer_tokens_with_payload_test {
                 &mut bridge_state,
                 &mut worm_state,
                 coins,
-                coin::zero<SUI>(ctx(&mut test)), // zero fee paid to wormhole
-                3, // recipient chain id
+                coin::zero<SUI>(ctx(&mut test)), // Zero fee paid to wormhole.
+                3, // Recipient chain id.
                 external_address::from_bytes(x"deadbeef0000beef"), // recipient
-                0, // relayer fee
+                0, // Relayer fee.
                 payload,
             );
 
@@ -139,7 +139,7 @@ module token_bridge::transfer_tokens_with_payload_test {
 
         let tx_effects = next_tx(&mut test, admin);
         // A single user event should be emitted, corresponding to
-        // publishing a Wormhole message for the token transfer with payload
+        // publishing a Wormhole message for the token transfer with payload.
         assert!(num_user_events(&tx_effects)==1, 0);
 
         // Check that custody of the coins is indeed transferred to token bridge.
@@ -166,14 +166,15 @@ module token_bridge::transfer_tokens_with_payload_test {
             let bridge_state = take_shared<State>(&test);
             state::register_emitter(
                 &mut bridge_state,
-                2, // chain ID
+                2, // Chain ID.
                 external_address::from_bytes(
                     x"00000000000000000000000000000000000000000000000000000000deadbeef"
                 )
             );
             return_shared<State>(bridge_state);
         };
-        // register wrapped asset type with the token bridge, mint some coins, initiate transfer
+        // Register wrapped asset type with the token bridge, mint some coins,
+        // initiate transfer.
         next_tx(&mut test, admin);{
             let bridge_state = take_shared<State>(&test);
             let worm_state = take_shared<WormholeState>(&test);
@@ -181,8 +182,9 @@ module token_bridge::transfer_tokens_with_payload_test {
             let new_wrapped_coin =
                 take_from_address<WrappedCoin<WRAPPED_COIN_12_DECIMALS>>(&test, admin);
             let payload = x"ddddaaaabbbb";
-            // register wrapped asset with the token bridge
-            create_wrapped::register_new_coin<WRAPPED_COIN_12_DECIMALS>(
+
+            // Register wrapped asset with the token bridge.
+            create_wrapped::register_wrapped_coin<COIN_WITNESS>(
                 &mut bridge_state,
                 &mut worm_state,
                 new_wrapped_coin,
@@ -193,7 +195,7 @@ module token_bridge::transfer_tokens_with_payload_test {
             let coins =
                 state::mint<WRAPPED_COIN_12_DECIMALS>(
                     &mut bridge_state,
-                    1000, // amount
+                    1000, // Amount.
                     ctx(&mut test)
                 );
 
@@ -209,10 +211,10 @@ module token_bridge::transfer_tokens_with_payload_test {
                 &mut bridge_state,
                 &mut worm_state,
                 coins,
-                coin::zero<SUI>(ctx(&mut test)), // zero fee paid to wormhole
-                3, // recipient chain id
-                external_address::from_bytes(x"deadbeef0000beef"), // recipient
-                0, // relayer fee
+                coin::zero<SUI>(ctx(&mut test)), // Zero fee paid to wormhole.
+                3, // Recipient chain id.
+                external_address::from_bytes(x"deadbeef0000beef"), // Recipient.
+                0, // Relayer fee.
                 payload,
             );
 


### PR DESCRIPTION
## Updates
- Add two tests `for transfer_tokens_with_payload` (one each for native and wrapped tokens). Previously there were no tests specific to this function.
- Inspect tx effects to make sure a single event was emitted corresponding to the publishing of a Wormhole message.