### PR TITLE
sui: test update registered coin metadata

### DIFF
--- a/sui/token_bridge/sources/create_wrapped.move
+++ b/sui/token_bridge/sources/create_wrapped.move
@@ -24,7 +24,7 @@ module token_bridge::create_wrapped {
     const E_COIN_NOT_REGISTERED_AS_WRAPPED: u64 = 4;
     const E_ORIGIN_ADDRESS_MISMATCH: u64 = 5;
     const E_ORIGIN_CHAIN_MISMATCH: u64 = 6;
-    const E_CAN_ONLY_UPDATE_METADATA_FOR_REGISTERED_WRAPPED_ASSET: u64 = 7;
+    const E_UNREGISTERED_WRAPPED_ASSET: u64 = 7;
 
     /// The amounts in the token bridge payload are truncated to 8 decimals
     /// in each of the contracts when sending tokens out, so there's no
@@ -105,11 +105,11 @@ module token_bridge::create_wrapped {
         let payload = core_vaa::destroy(vaa);
 
         let meta = asset_meta::deserialize(payload);
-        let origin_chain = asset_meta::token_chain(&meta);
-        let external_address = asset_meta::token_address(&meta);
+        let token_chain = asset_meta::token_chain(&meta);
+        let token_address = asset_meta::token_address(&meta);
 
         assert!(
-            origin_chain != wormhole_state::chain_id(),
+            token_chain != wormhole_state::chain_id(),
             E_WRAPPING_NATIVE_COIN
         );
         assert!(
@@ -119,8 +119,8 @@ module token_bridge::create_wrapped {
 
         state::register_wrapped_asset<CoinType>(
             token_bridge_state,
-            origin_chain,
-            external_address,
+            token_chain,
+            token_address,
             treasury_cap,
             decimals,
         );
@@ -141,33 +141,34 @@ module token_bridge::create_wrapped {
         );
         let payload = core_vaa::destroy(vaa);
         let meta = asset_meta::deserialize(payload);
-        let origin_chain = asset_meta::token_chain(&meta);
-        let origin_address = asset_meta::token_address(&meta);
 
+        // Verify that the token info agrees with the info encoded in this
+        // transfer. Checking whether this asset is wrapped may be superfluous,
+        // but we want to ensure that this VAA was not generated from a native
+        // Sui coin.
         let info = state::token_info<CoinType>(token_bridge_state);
+        assert!(
+            (
+                token_info::is_wrapped(&info) &&
+                token_info::equals(
+                    &info,
+                    asset_meta::token_chain(&meta),
+                    asset_meta::token_address(&meta)
+                )
+            ),
+            E_UNREGISTERED_WRAPPED_ASSET
+        );
 
-        // The following two assertions check that CoinType indeed corresponds
-        // to the coin specified in vaa_bytes.
-        assert!(token_info::addr(&info)==origin_address,
-            E_ORIGIN_ADDRESS_MISMATCH);
-        assert!(token_info::chain(&info)==origin_chain,
-            E_ORIGIN_CHAIN_MISMATCH);
-
-        // The following assertions ensures that we are updating metadata for
-        // a previously registered wrapped asset
-        assert!(state::is_wrapped_asset<CoinType>(token_bridge_state),
-            E_CAN_ONLY_UPDATE_METADATA_FOR_REGISTERED_WRAPPED_ASSET);
-
-        // Obtain a read-only reference to the treasury cap for CoinType.
-        let tcap = state::treasury_cap<CoinType>(token_bridge_state);
-
-        coin::update_symbol<CoinType>(
-            tcap,
+        // We need `TreasuryCap` to grant us access to update the symbol and
+        // name for a given `CoinType`.
+        let treasury_cap = state::treasury_cap<CoinType>(token_bridge_state);
+        coin::update_symbol(
+            treasury_cap,
             metadata,
             asset_meta::symbol_to_string(&meta)
         );
-        coin::update_name<CoinType>(
-            tcap,
+        coin::update_name(
+            treasury_cap,
             metadata,
             asset_meta::name_to_string(&meta)
         );

--- a/sui/token_bridge/sources/create_wrapped.move
+++ b/sui/token_bridge/sources/create_wrapped.move
@@ -153,12 +153,8 @@ module token_bridge::create_wrapped {
         assert!(token_info::chain(&info)==origin_chain,
             E_ORIGIN_CHAIN_MISMATCH);
 
-        // The following two assertions make sure that we are updating metadata
-        // for a previously registered non-native asset.
-        assert!(
-            origin_chain != wormhole_state::chain_id(),
-            E_UPDATING_NATIVE_COIN_META
-        );
+        // The following assertions ensures that we are updating metadata for
+        // a previously registered wrapped asset
         assert!(state::is_wrapped_asset<CoinType>(token_bridge_state),
             E_CAN_ONLY_UPDATE_METADATA_FOR_REGISTERED_WRAPPED_ASSET);
 

--- a/sui/token_bridge/sources/testing/wrapped_coin_12_decimals.move
+++ b/sui/token_bridge/sources/testing/wrapped_coin_12_decimals.move
@@ -116,7 +116,7 @@ module token_bridge::wrapped_coin_12_decimals_test {
 
     #[test]
     #[expected_failure(
-        abort_code = token_bridge::create_wrapped::E_ORIGIN_ADDRESS_MISMATCH,
+        abort_code = token_bridge::create_wrapped::E_UNREGISTERED_WRAPPED_ASSET,
         location=token_bridge::create_wrapped
     )]
     /// In this test, we attempt to update coin metadata for an asset that
@@ -157,7 +157,7 @@ module token_bridge::wrapped_coin_12_decimals_test {
 
     #[test]
     #[expected_failure(
-        abort_code = token_bridge::create_wrapped::E_ORIGIN_CHAIN_MISMATCH,
+        abort_code = token_bridge::create_wrapped::E_UNREGISTERED_WRAPPED_ASSET,
         location=token_bridge::create_wrapped
     )]
     /// In this test, we attempt to update coin metadata for an asset that

--- a/sui/token_bridge/sources/testing/wrapped_coin_12_decimals.move
+++ b/sui/token_bridge/sources/testing/wrapped_coin_12_decimals.move
@@ -26,7 +26,11 @@ module token_bridge::wrapped_coin_12_decimals {
 
 #[test_only]
 module token_bridge::wrapped_coin_12_decimals_test {
+    use std::string::{Self};
+    use std::ascii::{Self};
+
     use sui::test_scenario::{Self, Scenario, ctx, next_tx, take_from_address, return_shared, take_shared};
+    use sui::coin::{Self, CoinMetadata};
 
     use wormhole::state::{State as WormholeState};
     use wormhole::external_address::{Self};
@@ -39,6 +43,7 @@ module token_bridge::wrapped_coin_12_decimals_test {
 
     use token_bridge::wrapped_coin_12_decimals::{test_init, WRAPPED_COIN_12_DECIMALS};
     use token_bridge::token_info::{Self};
+    use token_bridge::create_wrapped::{Self};
 
     fun scenario(): Scenario { test_scenario::begin(@0x123233) }
     fun people(): (address, address, address) { (@0x124323, @0xE05, @0xFACE) }
@@ -66,6 +71,183 @@ module token_bridge::wrapped_coin_12_decimals_test {
         test_scenario::end(test);
     }
 
+    #[test]
+    /// In this test, we first call test_register_wrapped_ to register a
+    /// wrapped asset with the name "BEEF face Token" and symbol "BEEF".
+    /// We then modify the CoinMetadata associated with this token to update
+    /// the name to "BEEAA" and symbol to "BEE" by calling the function
+    /// update_registered_wrapped_coin_metadata with a new vaa.
+    fun test_update_registered_wrapped_coin_metadata() {
+        // New vaa corresponding to beefface token but with updated name
+        // and symbol.
+        let new_vaa = x"01000000000100d4229a3b38107f198d82003447cadb396392abc86c8d8244b7457e0a0aeb8ca92d1493419ce0049f41ed9e32c5fb653ee516db02feb92fa259ec75499cd2ad4e010000000100000001000200000000000000000000000000000000000000000000000000000000deadbeef0000000003309538000200000000000000000000000000000000000000000000000000000000beefface00020c42454500000000000000000000000000000000000000000000000000000000004245454141000000000000000000000000000000000000000000000000000000";
+        let (admin, _, _) = people();
+        let scenario = scenario();
+        // First, register the wrapped coin corresponding to the VAA defined
+        // above for the beefface token.
+        let test = test_register_wrapped_(admin, scenario);
+        // Second, call create_wrapped::update_registered_wrapped_coin_metadata
+        // to update token metadata.
+        next_tx(&mut test, admin); {
+            let bridge_state = take_shared<State>(&test);
+            let worm_state = take_shared<WormholeState>(&test);
+            let coin_meta = take_shared<CoinMetadata<WRAPPED_COIN_12_DECIMALS>>(&test);
+            create_wrapped::update_registered_wrapped_coin_metadata<WRAPPED_COIN_12_DECIMALS>(
+                &mut bridge_state,
+                &mut worm_state,
+                new_vaa,
+                &mut coin_meta,
+                ctx(&mut test)
+            );
+            return_shared<State>(bridge_state);
+            return_shared<WormholeState>(worm_state);
+            return_shared<CoinMetadata<WRAPPED_COIN_12_DECIMALS>>(coin_meta);
+        };
+        // Check that the name and symbol in the coin metadata have indeed been
+        // updated.
+        next_tx(&mut test, admin); {
+            let coin_meta = take_shared<CoinMetadata<WRAPPED_COIN_12_DECIMALS>>(&test);
+            assert!(coin::get_symbol(&coin_meta)==ascii::string(b"BEE"), 0);
+            assert!(coin::get_name(&coin_meta)==string::utf8(b"BEEAA"), 0);
+            return_shared<CoinMetadata<WRAPPED_COIN_12_DECIMALS>>(coin_meta);
+        };
+        test_scenario::end(test);
+    }
+
+    #[test]
+    #[expected_failure(
+        abort_code = token_bridge::create_wrapped::E_ORIGIN_ADDRESS_MISMATCH,
+        location=token_bridge::create_wrapped
+    )]
+    /// In this test, we attempt to update coin metadata for an asset that
+    /// does not correspond to WRAPPED_COIN_12_DECIMALS, namely an Ethereum token
+    /// with the address "0x00000000000000000000000000000000000000000000000000000000beeffaaa"
+    /// instead of "0x00000000000000000000000000000000000000000000000000000000beefface".
+    fun test_update_registered_wrapped_coin_metadata_wrong_origin_address () {
+        // New vaa corresponding to beefface token but with updated name
+        // and symbol.
+        let new_vaa = x"01000000000100e19f642c8b23459f0bf85a8bf3e5b0f5181b4f94ab6a4f5c290720a070021f0e6d7faa2e1d5113d40b686e6afd0899bd62110d81e6800a9e6bc8c3f22d68e6c8010000000100000001000200000000000000000000000000000000000000000000000000000000deadbeef0000000005afeb99000200000000000000000000000000000000000000000000000000000000beeffaaa00020c42454500000000000000000000000000000000000000000000000000000000004245454141000000000000000000000000000000000000000000000000000000";
+        let (admin, _, _) = people();
+        let scenario = scenario();
+        // First, register the wrapped coin corresponding to the VAA defined
+        // above for the beefface token.
+        let test = test_register_wrapped_(admin, scenario);
+        // Second, call create_wrapped::update_registered_wrapped_coin_metadata
+        // to update token metadata.
+        next_tx(&mut test, admin); {
+            let bridge_state = take_shared<State>(&test);
+            let worm_state = take_shared<WormholeState>(&test);
+            let coin_meta = take_shared<CoinMetadata<WRAPPED_COIN_12_DECIMALS>>(&test);
+            // This call fails because we cannot update the Coinmetadata for
+            // WRAPPED_COIN_12_DECIMALS using a vaa that does not correspond to
+            // it (origin address mismatch).
+            create_wrapped::update_registered_wrapped_coin_metadata<WRAPPED_COIN_12_DECIMALS>(
+                &mut bridge_state,
+                &mut worm_state,
+                new_vaa,
+                &mut coin_meta,
+                ctx(&mut test)
+            );
+            return_shared<State>(bridge_state);
+            return_shared<WormholeState>(worm_state);
+            return_shared<CoinMetadata<WRAPPED_COIN_12_DECIMALS>>(coin_meta);
+        };
+        test_scenario::end(test);
+    }
+
+    #[test]
+    #[expected_failure(
+        abort_code = token_bridge::create_wrapped::E_ORIGIN_CHAIN_MISMATCH,
+        location=token_bridge::create_wrapped
+    )]
+    /// In this test, we attempt to update coin metadata for an asset that
+    /// does not correspond to WRAPPED_COIN_12_DECIMALS, namely a token
+    /// with origin chain of Acala instead of Ethereum.
+    fun test_update_registered_wrapped_coin_metadata_wrong_origin_chain () {
+        // New vaa corresponding to beefface token but with updated name
+        // and symbol.
+        let new_vaa = x"01000000000100c25dedd249b73b6f53c0f63152fa17e393e437561c05a31d8d8cb259e11f49fd1f1b723eabc728d1bec32848c3c268c38935e6f3419a51ce1ec147fd18c5aabf000000000100000001000200000000000000000000000000000000000000000000000000000000deadbeef0000000003380b11000200000000000000000000000000000000000000000000000000000000beefface000c0c42454500000000000000000000000000000000000000000000000000000000004245454141000000000000000000000000000000000000000000000000000000";
+        let (admin, _, _) = people();
+        let scenario = scenario();
+        // First, register the wrapped coin corresponding to the VAA defined
+        // above for the beefface token.
+        let test = test_register_wrapped_(admin, scenario);
+        // Second, call create_wrapped::update_registered_wrapped_coin_metadata
+        // to update token metadata.
+        next_tx(&mut test, admin); {
+            let bridge_state = take_shared<State>(&test);
+            let worm_state = take_shared<WormholeState>(&test);
+            let coin_meta = take_shared<CoinMetadata<WRAPPED_COIN_12_DECIMALS>>(&test);
+            // This call fails because we cannot update the Coinmetadata for
+            // WRAPPED_COIN_12_DECIMALS using a vaa that does not correspond to
+            // it (origin chain mismatch).
+            create_wrapped::update_registered_wrapped_coin_metadata<WRAPPED_COIN_12_DECIMALS>(
+                &mut bridge_state,
+                &mut worm_state,
+                new_vaa,
+                &mut coin_meta,
+                ctx(&mut test)
+            );
+            return_shared<State>(bridge_state);
+            return_shared<WormholeState>(worm_state);
+            return_shared<CoinMetadata<WRAPPED_COIN_12_DECIMALS>>(coin_meta);
+        };
+        test_scenario::end(test);
+    }
+
+    #[test]
+    #[expected_failure(
+        abort_code = token_bridge::registered_tokens::E_UNREGISTERED,
+        location=token_bridge::registered_tokens
+    )]
+    /// In this test, we attempt to update coin metadata for an asset that
+    /// has not been previously registered at all (neither a registered wrapped
+    /// or native asset).
+    fun test_update_registered_wrapped_coin_metadata_not_registered () {
+        // New vaa corresponding to beefface token but with updated name
+        // and symbol.
+        let new_vaa = x"01000000000100d4229a3b38107f198d82003447cadb396392abc86c8d8244b7457e0a0aeb8ca92d1493419ce0049f41ed9e32c5fb653ee516db02feb92fa259ec75499cd2ad4e010000000100000001000200000000000000000000000000000000000000000000000000000000deadbeef0000000003309538000200000000000000000000000000000000000000000000000000000000beefface00020c42454500000000000000000000000000000000000000000000000000000000004245454141000000000000000000000000000000000000000000000000000000";
+        let (admin, _, _) = people();
+        let scenario = scenario();
+        // First, set up wormhole and token bridges, and register eth token bridge
+        let test = set_up_wormhole_core_and_token_bridges(admin, scenario);
+        // create and transfer new wrapped coin to sender
+        next_tx(&mut test, admin); {
+            test_init(ctx(&mut test))
+        };
+        // Second, register chain.
+        next_tx(&mut test, admin); {
+            let wormhole_state = take_shared<WormholeState>(&test);
+            let bridge_state = take_shared<State>(&test);
+            submit_vaa(&mut wormhole_state, &mut bridge_state, ETHEREUM_TOKEN_REG, ctx(&mut test));
+            return_shared<WormholeState>(wormhole_state);
+            return_shared<State>(bridge_state);
+        };
+        // Third, attempt to call create_wrapped::update_registered_wrapped_coin_metadata
+        // to update token metadata.
+        next_tx(&mut test, admin); {
+            let bridge_state = take_shared<State>(&test);
+            let worm_state = take_shared<WormholeState>(&test);
+            let coin_meta = take_shared<CoinMetadata<WRAPPED_COIN_12_DECIMALS>>(&test);
+            // This call fails because we WRAPPED_COIN_12_DECIMALS has not been
+            // previously registered with the token bridge either as a native
+            // or wrapped asset.
+            create_wrapped::update_registered_wrapped_coin_metadata<WRAPPED_COIN_12_DECIMALS>(
+                &mut bridge_state,
+                &mut worm_state,
+                new_vaa,
+                &mut coin_meta,
+                ctx(&mut test)
+            );
+            return_shared<State>(bridge_state);
+            return_shared<WormholeState>(worm_state);
+            return_shared<CoinMetadata<WRAPPED_COIN_12_DECIMALS>>(coin_meta);
+        };
+        test_scenario::end(test);
+    }
+
+    /// This is a helper function that is called in a variety of test files.
+    /// It is not meant to be a standalone test!
     public fun test_register_wrapped_(admin: address, test: Scenario): Scenario {
         test = set_up_wormhole_core_and_token_bridges(admin, test);
         // create and transfer new wrapped coin to sender

--- a/sui/wormhole/sources/myvaa.move
+++ b/sui/wormhole/sources/myvaa.move
@@ -182,9 +182,7 @@ module wormhole::myvaa {
 
             let cur_guardian = vector::borrow<Guardian>(&guardians, (guardian_index as u64));
             let cur_address = get_address(cur_guardian);
-
             assert!(address == cur_address, E_INVALID_SIGNATURE);
-
             sig_i = sig_i + 1;
         };
     }


### PR DESCRIPTION
## Update
- add tests for update registered coin metadata, including negative test cases for each assertion 