### PR TITLE
Node: Neon watcher fix

### DIFF
--- a/node/pkg/watchers/evm/connectors/logpoller.go
+++ b/node/pkg/watchers/evm/connectors/logpoller.go
@@ -114,6 +114,10 @@ func (l *LogPollConnector) processBlock(ctx context.Context, logger *zap.Logger,
 		FromBlock: l.prevBlockNum,
 		ToBlock:   block.Number,
 		Addresses: []ethCommon.Address{l.ContractAddress()},
+
+		// Although https://pkg.go.dev/github.com/ethereum/go-ethereum#FilterQuery says leaving Topics nil should give us everything,
+		// it has started returning "bad topics None" on Neon, so we need to pass in an empty slice instead.
+		Topics: [][]ethCommon.Hash{},
 	}
 
 	*l.prevBlockNum = *block.Number


### PR DESCRIPTION
Have started getting these errors from the Neon watcher:
`2023-03-06T20:10:29.360Z        ERROR   root.neonwatch.logPoller        GetLogsQuery: query of eth_getLogs failed       {"eth_network": "neon", "FromBlock": "200203424", "ToBlock": "200203424", "error": "bad topics None"}`