### PR TITLE
node: fix aptos reobservation

### DIFF
--- a/node/pkg/watchers/aptos/watcher.go
+++ b/node/pkg/watchers/aptos/watcher.go
@@ -98,7 +98,8 @@ func (e *Watcher) Run(ctx context.Context) error {
 				panic("invalid chain ID")
 			}
 
-			nativeSeq := binary.BigEndian.Uint64(r.TxHash)
+			// uint64 will read the *first* 8 bytes, but the sequence is stored in the *last* 8.
+			nativeSeq := binary.BigEndian.Uint64(r.TxHash[24:])
 
 			logger.Info("Received obsv request", zap.Uint64("tx_hash", nativeSeq))
 


### PR DESCRIPTION
The aptos reobservation code is always parsing the "transaction hash" (which is really the native event sequence number) as 0.

I used https://replit.com/languages/go to test
```go
package main
import "fmt"
import "encoding/binary"
import "encoding/hex"

func main() {
  txHash, err := hex.DecodeString("00000000000000000000000000000000000000000000000000000000000026f1")
  if err != nil {
    fmt.Printf("ERROR")
    return
  }
  
  wrongSeq := binary.BigEndian.Uint64(txHash)
  fmt.Printf("WRONG: %d\n", wrongSeq)
  nativeSeq := binary.BigEndian.Uint64(txHash[24:])
  fmt.Printf("RIGHT: %d\n", nativeSeq)
}
```

result
```
WRONG: 0
RIGHT: 9969
```