### PR TITLE
accountant fixes

### DIFF
--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -1016,9 +1016,6 @@ func runNode(cmd *cobra.Command, args []string) {
 		if *accountantWS == "" {
 			logger.Fatal("acct: if accountantContract is specified, accountantWS is required")
 		}
-		if *wormchainLCD == "" {
-			logger.Fatal("acct: if accountantContract is specified, wormchainLCD is required")
-		}
 		if wormchainConn == nil {
 			logger.Fatal("acct: if accountantContract is specified, the wormchain sending connection must be enabled")
 		}

--- a/node/pkg/accountant/accountant.go
+++ b/node/pkg/accountant/accountant.go
@@ -87,7 +87,8 @@ type Accountant struct {
 	env                  int
 }
 
-const subChanSize = 50
+// On startup, there can be a large number of re-submission requests.
+const subChanSize = 500
 
 // NewAccountant creates a new instance of the Accountant object.
 func NewAccountant(


### PR DESCRIPTION
This PR fixes two issues identified in the roll out of log only mode.
1. A check was left in for `wormchainLCD`, even though it isn't used.
2. There can be a burst of resubmissions on startup, resulting in a channel overflow. So this increases the submission channel size to attempt to avoid that.