### PR TITLE
relayer: update docs on running a spy

### DIFF
--- a/relayer/spy_relayer/README.md
+++ b/relayer/spy_relayer/README.md
@@ -136,7 +136,7 @@ docker run \
     -p 7073:7073 \
     --entrypoint /guardiand \
     ghcr.io/wormhole-foundation/guardiand:latest \
-spy --nodeKey /node.key --spyRPC "[::]:7073" --network /wormhole/mainnet/2 --bootstrap /dns4/wormhole-mainnet-v2-bootstrap.certus.one/udp/8999/quic/p2p/12D3KooWQp644DK27fd3d4Km3jr7gHiuJJ5ZGmy8hH4py7fP4FP7
+spy --nodeKey /node.key --spyRPC "[::]:7073" --network /wormhole/mainnet/2 --bootstrap /dns4/wormhole-mainnet-v2-bootstrap.certus.one/udp/8999/quic/p2p/12D3KooWQp644DK27fd3d4Km3jr7gHiuJJ5ZGmy8hH4py7fP4FP7,/dns4/wormhole-v2-mainnet-bootstrap.xlabs.xyz/udp/8999/quic/p2p/12D3KooWNQ9tVrcb64tw6bNs2CaNrUGPM7yRrKvBBheQ5yCyPHKC
 ```
 
 ### Run The Apps


### PR DESCRIPTION
Having two bootstrap nodes allows an outage of the certus one guardian to not cause too much hassle with existing spy instances or new guardians restarting.

Thanks @fchantada and the xLabs team for adding the dns and helping set this up.