### PR TITLE
Node/acct minor fixes

### DIFF
--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -1377,7 +1377,6 @@ func runNode(cmd *cobra.Command, args []string) {
 					return err
 				}
 			}
-			logger.Info("checking for base")
 			if shouldStart(baseRPC) {
 				logger.Info("Starting Base watcher")
 				readiness.RegisterComponent(common.ReadinessBaseSyncing)

--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -994,7 +994,7 @@ func runNode(cmd *cobra.Command, args []string) {
 		logger.Debug("acct: loading key file", zap.String("key path", wormchainKeyPathName))
 		wormchainKey, err = wormconn.LoadWormchainPrivKey(wormchainKeyPathName, *wormchainKeyPassPhrase)
 		if err != nil {
-			logger.Fatal("failed to load devnet wormchain private key", zap.Error(err))
+			logger.Fatal("failed to load wormchain private key", zap.Error(err))
 		}
 
 		// Connect to wormchain.

--- a/node/pkg/accountant/accountant.go
+++ b/node/pkg/accountant/accountant.go
@@ -240,11 +240,12 @@ func (acct *Accountant) SubmitObservation(msg *common.MessagePublication) (bool,
 				zap.String("msgID", msgId),
 				zap.String("oldDigest", oldEntry.digest),
 				zap.String("newDigest", digest),
+				zap.Bool("enforcing", acct.enforceFlag),
 			)
 		} else {
-			acct.logger.Info("acct: blocking transfer because it is already outstanding", zap.String("msgID", msgId))
+			acct.logger.Info("acct: blocking transfer because it is already outstanding", zap.String("msgID", msgId), zap.Bool("enforcing", acct.enforceFlag))
 		}
-		return false, nil
+		return !acct.enforceFlag, nil
 	}
 
 	// Add it to the pending map and the database.

--- a/node/pkg/accountant/audit.go
+++ b/node/pkg/accountant/audit.go
@@ -34,7 +34,8 @@ import (
 
 const (
 	// auditInterval indicates how often the audit runs.
-	auditInterval = 5 * time.Minute
+	// Make this bigger than the reobservation window (11 minutes).
+	auditInterval = 15 * time.Minute
 
 	// maxSubmitPendingTime indicates how long a transfer can be in the submit pending state before the audit starts complaining about it.
 	maxSubmitPendingTime = 30 * time.Minute

--- a/node/pkg/accountant/audit.go
+++ b/node/pkg/accountant/audit.go
@@ -263,9 +263,9 @@ func (acct *Accountant) handleMissingObservation(mo MissingObservation) {
 
 	select {
 	case acct.obsvReqWriteC <- msg:
-		acct.logger.Debug("acct: submitted local reobservation", zap.Stringer("moKey", mo))
+		acct.logger.Debug("acctaudit: submitted local reobservation", zap.Stringer("moKey", mo))
 	default:
-		acct.logger.Error("acct: unable to submit local reobservation because the channel is full, will try next interval", zap.Stringer("moKey", mo))
+		acct.logger.Error("acctaudit: unable to submit local reobservation because the channel is full, will try next interval", zap.Stringer("moKey", mo))
 	}
 }
 

--- a/node/pkg/watchers/evm/watcher.go
+++ b/node/pkg/watchers/evm/watcher.go
@@ -446,7 +446,8 @@ func (w *Watcher) Run(ctx context.Context) error {
 
 				if err != nil {
 					logger.Error("failed to process observation request",
-						zap.Error(err), zap.String("eth_network", w.networkName))
+						zap.Error(err), zap.String("eth_network", w.networkName),
+						zap.String("tx_hash", tx.Hex()))
 					continue
 				}
 


### PR DESCRIPTION
This PR addresses several small issues that were noticed while getting the accountant working in log-only mode. Some of them are not really related to accountant, but hopefully no one objects to them being included here.

Here's what's included:

- The accountant should not block reobservations off pending transfers when in log only mode.
- Increase the accountant audit interval to be greater than the reobservation window, since reobservations more often than that don't go through anyway.
- We are seeing reobservation requests that the accountant makes on polygon failing, and it would be helpful if the error message included the txHash.
- An unnecessary log message got committed in node.go. (This is the one thing that really is not related to the accountant!)