### PR TITLE
sui: update Move.toml rev to `0.27.1`

### DIFF
--- a/sui/token_bridge/Move.toml
+++ b/sui/token_bridge/Move.toml
@@ -5,7 +5,7 @@ version = "0.0.1"
 [dependencies.Sui]
 git = "https://github.com/MystenLabs/sui.git"
 subdir = "crates/sui-framework"
-rev = "0fe3e5c237f2f6410c66617cede5733015a17a36"
+rev = "157ac72030d014f17d76cefe81f3915b4afab2c9"
 
 [dependencies.Wormhole]
 local = "../wormhole"

--- a/sui/wormhole/Move.toml
+++ b/sui/wormhole/Move.toml
@@ -5,7 +5,7 @@ version = "0.0.1"
 [dependencies.Sui]
 git = "https://github.com/MystenLabs/sui.git"
 subdir = "crates/sui-framework"
-rev = "0fe3e5c237f2f6410c66617cede5733015a17a36"
+rev = "157ac72030d014f17d76cefe81f3915b4afab2c9"
 
 [addresses]
 wormhole = "_"

--- a/sui/wormhole/sources/datatypes/guardian_pubkey.move
+++ b/sui/wormhole/sources/datatypes/guardian_pubkey.move
@@ -4,7 +4,7 @@
 module wormhole::guardian_pubkey {
     use sui::ecdsa_k1::{Self as ecdsa};
     use std::vector;
-    use sui::ecdsa_k1::{keccak256};
+    use sui::hash::{keccak256};
 
     /// An error occurred while deserializing, for example due to wrong input size.
     const E_INVALID_FROM_EC_PUBKEY_LENGTH: u64 = 0;

--- a/sui/wormhole/sources/myvaa.move
+++ b/sui/wormhole/sources/myvaa.move
@@ -1,5 +1,5 @@
 module wormhole::myvaa {
-    use sui::ecdsa_k1::{keccak256};
+    use sui::hash::{keccak256};
     use sui::tx_context::{TxContext};
     use std::vector::{Self};
 


### PR DESCRIPTION
## Updates
- Make contracts compatible with latest Sui version `0.27.1` by fixing imports
- Update core and token bridge Move.toml files to use new `0.27.1` rev: `157ac72030d014f17d76cefe81f3915b4afab2c9` 
- Fix `make-docker` tests