### PR TITLE
wormchain: make recipe easier to use for making release build

### DIFF
--- a/wormchain/Makefile
+++ b/wormchain/Makefile
@@ -17,12 +17,14 @@ BUILD_FLAGS := -ldflags '$(ldflags)'
 .PHONY: all
 all: client
 
-.PHONY: client
+.PHONY: client build/wormchaind
 client: build/wormchaind
 
 
 build/wormchaind: cmd/wormchaind/main.go $(GO_FILES)
+	@echo building "wormchaind-$(VERSION)"
 	go build -v $(BUILD_FLAGS) -tags ledger -o $@ $<
+	cp "$@" "$@"-"$(VERSION)"
 
 proto: $(PROTO_FILES)
 	DOCKER_BUILDKIT=1 docker build --target go-export -f Dockerfile.proto -o type=local,dest=. ..
@@ -74,5 +76,5 @@ bootstrap:
 
 .PHONY: clean
 clean:
-	rm -rf build/wormchaind build/**/*.db build/**/*.wal vue
+	rm -rf build/wormchaind build/wormchaind-* build/**/*.db build/**/*.wal vue
 	echo "{\"height\":\"0\",\"round\":0,\"step\":0}" > build/data/priv_validator_state.json


### PR DESCRIPTION
Guardians provided some feedback that the binary could get out of date and the makefile recipe sometimes wouldn't rebuild it.  This helps make it a little more foolproof.