### PR TITLE
Log node version on watcher start

### DIFF
--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -1255,7 +1255,7 @@ func runNode(cmd *cobra.Command, args []string) {
 			common.MustRegisterReadinessSyncing(vaa.ChainIDTerra)
 			chainObsvReqC[vaa.ChainIDTerra] = make(chan *gossipv1.ObservationRequest, observationRequestBufferSize)
 			if err := supervisor.Run(ctx, "terrawatch",
-				common.WrapWithScissors(cosmwasm.NewWatcher(*terraWS, *terraLCD, *terraContract, chainMsgC[vaa.ChainIDTerra], chainObsvReqC[vaa.ChainIDTerra], vaa.ChainIDTerra).Run, "terrawatch")); err != nil {
+				common.WrapWithScissors(cosmwasm.NewWatcher(*terraWS, *terraLCD, *terraContract, chainMsgC[vaa.ChainIDTerra], chainObsvReqC[vaa.ChainIDTerra], vaa.ChainIDTerra, nil).Run, "terrawatch")); err != nil {
 				return err
 			}
 		}
@@ -1265,7 +1265,7 @@ func runNode(cmd *cobra.Command, args []string) {
 			common.MustRegisterReadinessSyncing(vaa.ChainIDTerra2)
 			chainObsvReqC[vaa.ChainIDTerra2] = make(chan *gossipv1.ObservationRequest, observationRequestBufferSize)
 			if err := supervisor.Run(ctx, "terra2watch",
-				common.WrapWithScissors(cosmwasm.NewWatcher(*terra2WS, *terra2LCD, *terra2Contract, chainMsgC[vaa.ChainIDTerra2], chainObsvReqC[vaa.ChainIDTerra2], vaa.ChainIDTerra2).Run, "terra2watch")); err != nil {
+				common.WrapWithScissors(cosmwasm.NewWatcher(*terra2WS, *terra2LCD, *terra2Contract, chainMsgC[vaa.ChainIDTerra2], chainObsvReqC[vaa.ChainIDTerra2], vaa.ChainIDTerra2, nil).Run, "terra2watch")); err != nil {
 				return err
 			}
 		}
@@ -1275,7 +1275,7 @@ func runNode(cmd *cobra.Command, args []string) {
 			common.MustRegisterReadinessSyncing(vaa.ChainIDXpla)
 			chainObsvReqC[vaa.ChainIDXpla] = make(chan *gossipv1.ObservationRequest, observationRequestBufferSize)
 			if err := supervisor.Run(ctx, "xplawatch",
-				common.WrapWithScissors(cosmwasm.NewWatcher(*xplaWS, *xplaLCD, *xplaContract, chainMsgC[vaa.ChainIDXpla], chainObsvReqC[vaa.ChainIDXpla], vaa.ChainIDXpla).Run, "xplawatch")); err != nil {
+				common.WrapWithScissors(cosmwasm.NewWatcher(*xplaWS, *xplaLCD, *xplaContract, chainMsgC[vaa.ChainIDXpla], chainObsvReqC[vaa.ChainIDXpla], vaa.ChainIDXpla, nil).Run, "xplawatch")); err != nil {
 				return err
 			}
 		}
@@ -1359,7 +1359,7 @@ func runNode(cmd *cobra.Command, args []string) {
 			common.MustRegisterReadinessSyncing(vaa.ChainIDInjective)
 			chainObsvReqC[vaa.ChainIDInjective] = make(chan *gossipv1.ObservationRequest, observationRequestBufferSize)
 			if err := supervisor.Run(ctx, "injectivewatch",
-				common.WrapWithScissors(cosmwasm.NewWatcher(*injectiveWS, *injectiveLCD, *injectiveContract, chainMsgC[vaa.ChainIDInjective], chainObsvReqC[vaa.ChainIDInjective], vaa.ChainIDInjective).Run, "injectivewatch")); err != nil {
+				common.WrapWithScissors(cosmwasm.NewWatcher(*injectiveWS, *injectiveLCD, *injectiveContract, chainMsgC[vaa.ChainIDInjective], chainObsvReqC[vaa.ChainIDInjective], vaa.ChainIDInjective, nil).Run, "injectivewatch")); err != nil {
 				return err
 			}
 		}

--- a/node/pkg/watchers/algorand/watcher.go
+++ b/node/pkg/watchers/algorand/watcher.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base32"
 	"encoding/binary"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -171,6 +172,9 @@ func (e *Watcher) Run(ctx context.Context) error {
 		return err
 	}
 
+	// Get the node version for troubleshooting
+	e.logVersion(ctx, logger, algodClient)
+
 	status, err := algodClient.StatusAfterBlock(0).Do(context.Background())
 	if err != nil {
 		logger.Error("StatusAfterBlock", zap.Error(err))
@@ -257,4 +261,35 @@ func (e *Watcher) Run(ctx context.Context) error {
 			readiness.SetReady(e.readinessSync)
 		}
 	}
+}
+
+// logVersion calls the versions rpc and logs the node version information.
+func (e *Watcher) logVersion(ctx context.Context, logger *zap.Logger, client *algod.Client) {
+	networkName := "algorand"
+
+	// From: https://developer.algorand.org/docs/rest-apis/algod/v2/#get-versions
+	versionRPC := client.Versions()
+	versionResult, err := versionRPC.Do(ctx)
+	if err != nil {
+		logger.Error("problem retrieving node version",
+			zap.Error(err),
+			zap.String("network", networkName),
+		)
+		return
+	}
+
+	// Marshal the BuildVersions struct into raw json to log cleanly.
+	version, err := json.Marshal(&versionResult.Build)
+	if err != nil {
+		logger.Error("problem retrieving node version when marshalling build info",
+			zap.Error(err),
+			zap.String("network", networkName),
+		)
+		return
+	}
+
+	logger.Info("node version",
+		zap.String("network", networkName),
+		zap.String("version", string(version)),
+	)
 }

--- a/node/pkg/watchers/cosmwasm/watcher.go
+++ b/node/pkg/watchers/cosmwasm/watcher.go
@@ -524,7 +524,17 @@ func (e *Watcher) logVersion(ctx context.Context, logger *zap.Logger) {
 		Result  versionResultResponse `json:"result"`
 	}
 
-	resp, err := http.NewRequest(http.MethodPost, e.urlWS, bytes.NewBuffer(queryJson))
+	req, err := http.NewRequest(http.MethodPost, e.urlWS, bytes.NewBuffer(queryJson))
+	if err != nil {
+		logger.Error("problem retrieving node version when building request",
+			zap.String("network", e.networkName),
+			zap.Error(err),
+		)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := e.client.Do(req)
 	if err != nil {
 		logger.Error("problem retrieving node version",
 			zap.String("network", e.networkName),
@@ -535,7 +545,7 @@ func (e *Watcher) logVersion(ctx context.Context, logger *zap.Logger) {
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		logger.Error("problem retrieving node version and reading response body",
+		logger.Error("problem retrieving node version when reading response body",
 			zap.String("network", e.networkName),
 			zap.Error(err),
 		)

--- a/node/pkg/watchers/cosmwasm/watcher.go
+++ b/node/pkg/watchers/cosmwasm/watcher.go
@@ -426,7 +426,7 @@ func EventsToMessagePublications(contract string, txHash string, events []gjson.
 			continue
 		}
 
-		logger.Info("new message detected on cosmwasm",
+		logger.Debug("new message detected on cosmwasm",
 			zap.String("network", networkName),
 			zap.String("chainId", chainId),
 			zap.String("txHash", txHash),


### PR DESCRIPTION
## Overview

This logs the version of the node software (as best as can be retrieved via an rpc) when each watcher is started. I tried to keep the log messages similar enough so that grepping for `node version` or `problem retrieving node version` will get all relevant log messages.

This makes operational troubleshooting now and for past guardian behavior a bit easier as the chain versions are upgraded often. I'm putting this up as a draft to ensure the approach is sensible. Also, I'm not sure it is worth the time to mock out the zap bits and do unit tests on logs, but can be convinced otherwise if someone is very passionate about it.

Fixes: #2132


### Finished

 - [X] algorand - [versions](https://developer.algorand.org/docs/rest-apis/algod/v2/#get-versions)
 - [X] evm compatible chains - [web3_clientVersion](https://ethereum.org/en/developers/docs/apis/json-rpc/#web3_clientversion) (not always implemented properly on all chains e.g.: aurora.js)
 - [X] solana - [getVersion](https://docs.solana.com/developing/clients/jsonrpc-api#getversion)
 - [X] cosmwasm chains - [abci_info](https://docs.tendermint.com/v0.34/rpc/#/ABCI/abci_info)


### Outstanding

- [ ] sui
- [ ] near
- [ ] wormchain (a copy & pasta of the cosmwasm watcher with some mods)
- [ ] aptos (doesn't appear to have a version rpc. I will file an issue upstream)