### PR TITLE
wormchain: dont remove v in tag name for release

### DIFF
--- a/wormchain/Makefile
+++ b/wormchain/Makefile
@@ -3,7 +3,7 @@ GO_FILES=$(shell find . -name "*.go")
 # Address of the main tilt validator that the others should connect to
 TILT_VALADDRESS=wormholevaloper1cyyzpxplxdzkeea7kwsydadg87357qna87hzv8
 
-VERSION := $(shell echo $(shell git describe --tags 2> /dev/null || echo v0.0.1) | sed 's/^v//')
+VERSION := $(shell echo $(shell git describe --tags 2> /dev/null || echo v0.0.1))
 COMMIT := $(shell git log -1 --format='%h' 2> /dev/null || echo 'abc123')
 
 ldflags = \


### PR DESCRIPTION
More feedback: would be better to include the "v" in the tag name so the version matches the tag exactly.  Sorry would have been better to include with #2519.