### PR TITLE
sui: create mock upgrade cap in init

### DIFF
--- a/sui/wormhole/sources/dummy/dummy_sui_package.move
+++ b/sui/wormhole/sources/dummy/dummy_sui_package.move
@@ -131,6 +131,18 @@ module wormhole::dummy_sui_package {
         cap.version = cap.version + 1;
     }
 
+    public fun mock_new_upgrade_cap(
+        package: ID, 
+        ctx: &mut TxContext
+    ): UpgradeCap {
+        UpgradeCap {
+            id: object::new(ctx),
+            package,
+            version: 1,
+            policy: COMPATIBLE,
+        }
+    }
+
     #[test_only]
     /// Test-only function to simulate publishing a package at address
     /// `ID`, to create an `UpgradeCap`.

--- a/sui/wormhole/sources/setup.move
+++ b/sui/wormhole/sources/setup.move
@@ -10,7 +10,7 @@ module wormhole::setup {
     use wormhole::state::{Self};
 
     // NOTE: This exists to mock up sui::package for proposed upgrades.
-    use wormhole::dummy_sui_package::{UpgradeCap};
+    use wormhole::dummy_sui_package::{Self as package, UpgradeCap};
 
     /// Capability created at `init`, which will be destroyed once
     /// `init_and_share_state` is called. This ensures only the deployer can
@@ -26,21 +26,18 @@ module wormhole::setup {
     fun init(ctx: &mut TxContext) {
         let deployer = DeployerCap { id: object::new(ctx) };
         transfer::transfer(deployer, tx_context::sender(ctx));
+
+        // TODO: remove this once we have a proper upgrade mechanism in Sui 
+        // 0.28.0
+        let upgrade_cap = package::mock_new_upgrade_cap(
+            object::id_from_address(@wormhole), ctx
+        );
+        transfer::transfer(upgrade_cap, tx_context::sender(ctx));
     }
 
     #[test_only]
     public fun init_test_only(ctx: &mut TxContext) {
-        // NOTE: This exists to mock up sui::package for proposed upgrades.
-        use wormhole::dummy_sui_package::{Self as package};
-
         init(ctx);
-
-        // This will be created and sent to the transaction sender
-        // automatically when the contract is published.
-        transfer::transfer(
-            package::test_publish(object::id_from_address(@wormhole), ctx),
-            tx_context::sender(ctx)
-        );
     }
 
     /// Only the owner of the `DeployerCap` can call this method. This


### PR DESCRIPTION
Currently, because Mysten has not yet release the contract upgrade mechanism, this PR creates a dummy UpgradeCap in `init` so that we can keep the upgrade code paths introduced in #2494