### PR TITLE
sui: make deploy script use worm CLI

### DIFF
--- a/clients/js/cmds/sui.ts
+++ b/clients/js/cmds/sui.ts
@@ -1,3 +1,4 @@
+import { TransactionEffects } from "@mysten/sui.js";
 import yargs from "yargs";
 import { config } from "../config";
 import {
@@ -31,7 +32,7 @@ function findDeployerCapability(
 }
 
 exports.command = "sui";
-exports.desc = "Sui utilities ";
+exports.desc = "Sui utilities";
 exports.builder = function (y: typeof yargs) {
   return y
     .command(
@@ -137,7 +138,7 @@ exports.builder = function (y: typeof yargs) {
         console.log("Deployer object ID:       ", deployer);
         console.log("Wormhole state object ID: ", wormState);
 
-        await executeEntry(
+        const effects: TransactionEffects = await executeEntry(
           provider,
           network,
           packageId,
@@ -145,6 +146,13 @@ exports.builder = function (y: typeof yargs) {
           "init_and_share_state",
           [],
           [deployer, wormState]
+        );
+
+        console.log(
+          "Token bridge state object ID: ",
+          effects["created"].find(
+            (o) => typeof o.owner === "object" && "Shared" in o.owner
+          ).reference.objectId
         );
       }
     )
@@ -219,7 +227,7 @@ exports.builder = function (y: typeof yargs) {
         console.log("Governance contract: ", governanceContract);
         console.log("Initial guardian:    ", initialGuardian);
 
-        await executeEntry(
+        const effects: TransactionEffects = await executeEntry(
           provider,
           network,
           packageId,
@@ -233,6 +241,13 @@ exports.builder = function (y: typeof yargs) {
             [[...Buffer.from(initialGuardian, "hex")]],
             "0", // Message fee
           ]
+        );
+
+        console.log(
+          "Wormhole state object ID: ",
+          effects["created"].find(
+            (o) => typeof o.owner === "object" && "Shared" in o.owner
+          ).reference.objectId
         );
       }
     )

--- a/clients/js/sui.ts
+++ b/clients/js/sui.ts
@@ -102,11 +102,6 @@ export async function executeEntry(
   args: any[]
 ) {
   const signer = getSigner(provider, network);
-
-  console.log("Network:           ", network);
-  console.log("Package Object ID: ", packageObjectId);
-  console.log("Module:            ", moduleName);
-
   const moveCallTxn = await signer.executeMoveCall({
     packageObjectId,
     module: moduleName,
@@ -116,9 +111,17 @@ export async function executeEntry(
     gasBudget: 50000,
   });
 
-  // todo(aki): only output useful info
-  console.log("moveCallTxn: ", moveCallTxn);
-  console.log("effects: ", JSON.stringify(moveCallTxn["effects"]["effects"]));
+  console.log(
+    "Transaction digest: ",
+    moveCallTxn["certificate"]["transactionDigest"]
+  );
+  console.log(
+    "Sender:             ",
+    moveCallTxn["certificate"]["data"]["sender"]
+  );
+
+  // Let caller handle parsing and logging effects
+  return moveCallTxn["effects"]["effects"];
 }
 
 const setupToml = (

--- a/sui/scripts/deploy
+++ b/sui/scripts/deploy
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+function usage() {
+cat <<EOF >&2
+Usage:
+  $(basename "$0") <devnet|testnet|mainnet> -- Deploy the contracts
+EOF
+exit 1
+}
+
+NETWORK=$1 || usage
+
+if [ "$NETWORK" = mainnet ]; then
+  echo "Mainnet not supported yet"
+  exit 1
+elif [ "$NETWORK" = testnet ]; then
+  echo "Testnet not supported yet"
+  exit 1
+elif [ "$NETWORK" = devnet ]; then
+  GUARDIAN_ADDR=befa429d57cd18b7f8a4d91a2da9ab4af05d0fbe
+else
+  usage
+fi
+
+echo -e "[1/4] Publishing core bridge contracts..."
+WORMHOLE_PUBLISH_OUTPUT=$(worm sui deploy wormhole -n "$NETWORK")
+echo "$WORMHOLE_PUBLISH_OUTPUT"
+
+echo -e "\n[2/4] Publishing token bridge contracts..."
+WORMHOLE_PACKAGE_ID=$(echo "$WORMHOLE_PUBLISH_OUTPUT" | grep -oP 'Deployed to: +\K.*')
+TOKEN_BRIDGE_PUBLISH_OUTPUT=$(worm sui deploy token_bridge -n "$NETWORK" --named-addresses "wormhole=$WORMHOLE_PACKAGE_ID")
+echo "$TOKEN_BRIDGE_PUBLISH_OUTPUT"
+
+echo -e "\n[3/4] Initializing core bridge..."
+WORMHOLE_INIT_OUTPUT=$(worm sui init-wormhole -n "$NETWORK" --initial-guardian "$GUARDIAN_ADDR" --package-id "$WORMHOLE_PACKAGE_ID")
+echo "$WORMHOLE_INIT_OUTPUT"
+
+echo -e "\n[4/4] Initializing token bridge..."
+TOKEN_BRIDGE_PACKAGE_ID=$(echo "$TOKEN_BRIDGE_PUBLISH_OUTPUT" | grep -oP 'Deployed to: +\K.*')
+WORMHOLE_STATE_OBJECT_ID=$(echo "$WORMHOLE_INIT_OUTPUT" | grep -oP 'Wormhole state object ID: +\K.*')
+worm sui init-token-bridge -n "$NETWORK" --package-id "$TOKEN_BRIDGE_PACKAGE_ID" --worm-state "$WORMHOLE_STATE_OBJECT_ID"
+
+echo -e "\nDeployments successful!"

--- a/sui/wormhole/sources/dummy/dummy_sui_package.move
+++ b/sui/wormhole/sources/dummy/dummy_sui_package.move
@@ -131,6 +131,18 @@ module wormhole::dummy_sui_package {
         cap.version = cap.version + 1;
     }
 
+    public fun mock_new_upgrade_cap(
+        package: ID, 
+        ctx: &mut TxContext
+    ): UpgradeCap {
+        UpgradeCap {
+            id: object::new(ctx),
+            package,
+            version: 1,
+            policy: COMPATIBLE,
+        }
+    }
+
     #[test_only]
     /// Test-only function to simulate publishing a package at address
     /// `ID`, to create an `UpgradeCap`.

--- a/sui/wormhole/sources/setup.move
+++ b/sui/wormhole/sources/setup.move
@@ -10,7 +10,7 @@ module wormhole::setup {
     use wormhole::state::{Self};
 
     // NOTE: This exists to mock up sui::package for proposed upgrades.
-    use wormhole::dummy_sui_package::{UpgradeCap};
+    use wormhole::dummy_sui_package::{Self as package, UpgradeCap};
 
     /// Capability created at `init`, which will be destroyed once
     /// `init_and_share_state` is called. This ensures only the deployer can
@@ -26,21 +26,18 @@ module wormhole::setup {
     fun init(ctx: &mut TxContext) {
         let deployer = DeployerCap { id: object::new(ctx) };
         transfer::transfer(deployer, tx_context::sender(ctx));
+
+        // TODO: remove this once we have a proper upgrade mechanism in Sui 
+        // 0.28.0
+        let upgrade_cap = package::mock_new_upgrade_cap(
+            object::id_from_address(@wormhole), ctx
+        );
+        transfer::transfer(upgrade_cap, tx_context::sender(ctx));
     }
 
     #[test_only]
     public fun init_test_only(ctx: &mut TxContext) {
-        // NOTE: This exists to mock up sui::package for proposed upgrades.
-        use wormhole::dummy_sui_package::{Self as package};
-
         init(ctx);
-
-        // This will be created and sent to the transaction sender
-        // automatically when the contract is published.
-        transfer::transfer(
-            package::test_publish(object::id_from_address(@wormhole), ctx),
-            tx_context::sender(ctx)
-        );
     }
 
     /// Only the owner of the `DeployerCap` can call this method. This


### PR DESCRIPTION
The deploy script, which previously wrote output of sui CLI commands to files and manually parsed that output, now simply relies on worm CLI commands. This PR introduces a new script called deploy to match the functionality from Aptos; the older deploy.sh script may be deprecated and removed in a future PR.

Points of consideration:

The deploy script still necessarily relies on output of worm CLI commands. This can be avoided by creating a worm CLI command that deploys and initializes the core and token bridge in one command, but it's not immediately obvious to me that it's worth writing something like that.
This new deploy script no longer writes values such as WH package ID to an env file at the end. If this is truly necessary, I think it would be more elegant to find a way to query the on-chain contracts for this info
Resolves https://github.com/wormhole-foundation/wormhole/issues/2047