### PR TITLE
sui: worm support

### DIFF
--- a/sui/Docker.md
+++ b/sui/Docker.md
@@ -1,8 +1,13 @@
 # first build the image
+
 cd ..; DOCKER_BUILDKIT=1 docker build --no-cache --progress plain -f sui/Dockerfile.base -t sui .
+
 # tag the image with the appropriate version
-docker tag sui:latest ghcr.io/wormhole-foundation/sui:0.27.1
+
+docker tag sui:latest ghcr.io/wormhole-foundation/sui:0.29.1
+
 # push to ghcr
-docker push ghcr.io/wormhole-foundation/sui:0.27.1
+
+docker push ghcr.io/wormhole-foundation/sui:0.29.1
 
 echo remember to update both Dockerfile and Dockerfile.export

--- a/sui/Dockerfile
+++ b/sui/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/wormhole-foundation/sui:0.29.0@sha256:e6da5712374e59c75a72f9b5393c81e5abe1867a09d5190f0d04bf365aaf67e5 as sui
+FROM ghcr.io/wormhole-foundation/sui:0.29.1@sha256:8508a601746c886a87ef5eec59b4154dc19a228c52bbd256473e1be98e6ee4be as sui
 
 RUN dnf -y install make git
 

--- a/sui/Dockerfile.base
+++ b/sui/Dockerfile.base
@@ -13,13 +13,22 @@ COPY sui/scripts/node_builder.sh  /tmp
 
 RUN /tmp/node_builder.sh
 
-WORKDIR /tmp
-
 FROM docker.io/redhat/ubi8@sha256:56c374376a42da40f3aec753c4eab029b5ea162d70cb5f0cda24758780c31d81 as export-stage
 
 RUN dnf -y update
-RUN dnf -y install jq curl git make
+RUN dnf -y install jq curl git make npm
 
 COPY --from=sui-node /root/.cargo/bin/sui /bin/sui
 COPY --from=sui-node /root/.cargo/bin/sui-faucet /bin/sui-faucet
 COPY --from=sui-node /root/.cargo/bin/sui-node /bin/sui-node
+
+WORKDIR /tmp
+
+RUN npm install -g n typescript ts-node
+RUN n stable
+
+COPY clients/js /tmp/clients/js
+
+WORKDIR /tmp/clients/js
+
+RUN make install


### PR DESCRIPTION
This PR adds `worm` support to the Sui container so that we can deploy contracts to Tilt on startup (since this depends on `worm` CLI commands). Support is added to the base Docker image so as to not increase build times and a new release has been cut and published.
