### PR TITLE
node: add benchmarking capability

### DIFF
--- a/node/cmd/guardiand/adminverify.go
+++ b/node/cmd/guardiand/adminverify.go
@@ -1,20 +1,15 @@
 package guardiand
 
 import (
-	"encoding/hex"
-	"fmt"
 	"log"
 	"os"
-	"time"
 
-	"github.com/wormhole-foundation/wormhole/sdk/vaa"
+	"github.com/certusone/wormhole/node/pkg/adminrpc"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/encoding/prototext"
 
 	nodev1 "github.com/certusone/wormhole/node/pkg/proto/node/v1"
-	"github.com/status-im/keycard-go/hexutils"
 )
 
 var AdminClientGovernanceVAAVerifyCmd = &cobra.Command{
@@ -38,54 +33,5 @@ func runGovernanceVAAVerify(cmd *cobra.Command, args []string) {
 		log.Fatalf("failed to deserialize: %v", err)
 	}
 
-	timestamp := time.Unix(int64(req.Timestamp), 0)
-
-	for _, message := range req.Messages {
-		var (
-			v *vaa.VAA
-		)
-		switch payload := message.Payload.(type) {
-		case *nodev1.GovernanceMessage_GuardianSet:
-			v, err = adminGuardianSetUpdateToVAA(payload.GuardianSet, timestamp, req.CurrentSetIndex, message.Nonce, message.Sequence)
-		case *nodev1.GovernanceMessage_ContractUpgrade:
-			v, err = adminContractUpgradeToVAA(payload.ContractUpgrade, timestamp, req.CurrentSetIndex, message.Nonce, message.Sequence)
-		case *nodev1.GovernanceMessage_BridgeRegisterChain:
-			v, err = tokenBridgeRegisterChain(payload.BridgeRegisterChain, timestamp, req.CurrentSetIndex, message.Nonce, message.Sequence)
-		case *nodev1.GovernanceMessage_BridgeContractUpgrade:
-			v, err = tokenBridgeUpgradeContract(payload.BridgeContractUpgrade, timestamp, req.CurrentSetIndex, message.Nonce, message.Sequence)
-		case *nodev1.GovernanceMessage_AccountantModifyBalance:
-			v, err = accountantModifyBalance(payload.AccountantModifyBalance, timestamp, req.CurrentSetIndex, message.Nonce, message.Sequence)
-		case *nodev1.GovernanceMessage_WormchainStoreCode:
-			v, err = wormchainStoreCode(payload.WormchainStoreCode, timestamp, req.CurrentSetIndex, message.Nonce, message.Sequence)
-		case *nodev1.GovernanceMessage_WormchainInstantiateContract:
-			v, err = wormchainInstantiateContract(payload.WormchainInstantiateContract, timestamp, req.CurrentSetIndex, message.Nonce, message.Sequence)
-		case *nodev1.GovernanceMessage_WormchainMigrateContract:
-			v, err = wormchainMigrateContract(payload.WormchainMigrateContract, timestamp, req.CurrentSetIndex, message.Nonce, message.Sequence)
-		case *nodev1.GovernanceMessage_CircleIntegrationUpdateWormholeFinality:
-			v, err = circleIntegrationUpdateWormholeFinality(payload.CircleIntegrationUpdateWormholeFinality, timestamp, req.CurrentSetIndex, message.Nonce, message.Sequence)
-		case *nodev1.GovernanceMessage_CircleIntegrationRegisterEmitterAndDomain:
-			v, err = circleIntegrationRegisterEmitterAndDomain(payload.CircleIntegrationRegisterEmitterAndDomain, timestamp, req.CurrentSetIndex, message.Nonce, message.Sequence)
-		case *nodev1.GovernanceMessage_CircleIntegrationUpgradeContractImplementation:
-			v, err = circleIntegrationUpgradeContractImplementation(payload.CircleIntegrationUpgradeContractImplementation, timestamp, req.CurrentSetIndex, message.Nonce, message.Sequence)
-		default:
-			panic(fmt.Sprintf("unsupported VAA type: %T", payload))
-		}
-		if err != nil {
-			log.Fatalf("invalid update: %v", err)
-		}
-
-		digest := v.SigningDigest().Bytes()
-		if err != nil {
-			panic(err)
-		}
-
-		b, err := v.Marshal()
-		if err != nil {
-			panic(err)
-		}
-
-		log.Printf("Serialized: %v", hex.EncodeToString(b))
-
-		log.Printf("VAA with digest %s: %+v", hexutils.BytesToHex(digest), spew.Sdump(v))
-	}
+	adminrpc.VerifyReq(&req)
 }

--- a/node/pkg/accountant/accountant_test.go
+++ b/node/pkg/accountant/accountant_test.go
@@ -54,7 +54,7 @@ func newAccountantForTest(
 		gk,
 		gst,
 		acctWriteC,
-		GoTestMode,
+		common.GoTest,
 	)
 
 	err := acct.Start(ctx)

--- a/node/pkg/adminrpc/adminserver_test.go
+++ b/node/pkg/adminrpc/adminserver_test.go
@@ -1,4 +1,4 @@
-package guardiand
+package adminrpc
 
 import (
 	"context"

--- a/node/pkg/common/mode.go
+++ b/node/pkg/common/mode.go
@@ -1,0 +1,10 @@
+package common
+
+type Environment string
+
+const (
+	MainNet      Environment = "prod"
+	UnsafeDevNet Environment = "dev"  // local devnet; Keys are deterministic and many security controls are disabled
+	TestNet      Environment = "test" // public testnet (needs to be reliable, but run with less Guardians and faster finality)
+	GoTest       Environment = "unit-test"
+)

--- a/node/pkg/common/obsvReqSendC.go
+++ b/node/pkg/common/obsvReqSendC.go
@@ -6,8 +6,6 @@ import (
 	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
 )
 
-const ObsvReqChannelSize = 50
-
 var ErrChanFull = errors.New("channel is full")
 
 func PostObservationRequest(obsvReqSendC chan<- *gossipv1.ObservationRequest, req *gossipv1.ObservationRequest) error {

--- a/node/pkg/common/obsvReqSendC_test.go
+++ b/node/pkg/common/obsvReqSendC_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const ObsvReqChannelSize = 50
+
 func TestObsvReqSendLimitEnforced(t *testing.T) {
 	obsvReqSendC := make(chan *gossipv1.ObservationRequest, ObsvReqChannelSize)
 

--- a/node/pkg/db/open.go
+++ b/node/pkg/db/open.go
@@ -1,0 +1,21 @@
+package db
+
+import (
+	"os"
+	"path"
+
+	"go.uber.org/zap"
+)
+
+func OpenDb(logger *zap.Logger, dataDir *string) *Database {
+	dbPath := path.Join(*dataDir, "db")
+	if err := os.MkdirAll(dbPath, 0700); err != nil {
+		logger.Fatal("failed to create database directory", zap.Error(err))
+	}
+	db, err := Open(dbPath)
+	if err != nil {
+		logger.Fatal("failed to open database", zap.Error(err))
+	}
+
+	return db
+}

--- a/node/pkg/governor/governor.go
+++ b/node/pkg/governor/governor.go
@@ -43,11 +43,6 @@ import (
 )
 
 const (
-	MainNetMode = 1
-	TestNetMode = 2
-	DevNetMode  = 3
-	GoTestMode  = 4
-
 	transferComplete = true
 	transferEnqueued = false
 )
@@ -127,7 +122,7 @@ type ChainGovernor struct {
 	msgsToPublish         []*common.MessagePublication
 	dayLengthInMinutes    int
 	coinGeckoQuery        string
-	env                   int
+	env                   common.Environment
 	nextStatusPublishTime time.Time
 	nextConfigPublishTime time.Time
 	statusPublishCounter  int64
@@ -137,7 +132,7 @@ type ChainGovernor struct {
 func NewChainGovernor(
 	logger *zap.Logger,
 	db db.GovernorDB,
-	env int,
+	env common.Environment,
 ) *ChainGovernor {
 	return &ChainGovernor{
 		db:                  db,
@@ -157,7 +152,7 @@ func (gov *ChainGovernor) Run(ctx context.Context) error {
 		return err
 	}
 
-	if gov.env != GoTestMode {
+	if gov.env != common.GoTest {
 		if err := gov.loadFromDB(); err != nil {
 			return err
 		}
@@ -178,9 +173,9 @@ func (gov *ChainGovernor) initConfig() error {
 	configTokens := tokenList()
 	configChains := chainList()
 
-	if gov.env == DevNetMode {
+	if gov.env == common.UnsafeDevNet {
 		configTokens, configChains = gov.initDevnetConfig()
-	} else if gov.env == TestNetMode {
+	} else if gov.env == common.TestNet {
 		configTokens, configChains = gov.initTestnetConfig()
 	}
 
@@ -233,9 +228,9 @@ func (gov *ChainGovernor) initConfig() error {
 	}
 
 	emitterMap := &sdk.KnownTokenbridgeEmitters
-	if gov.env == TestNetMode {
+	if gov.env == common.TestNet {
 		emitterMap = &sdk.KnownTestnetTokenbridgeEmitters
-	} else if gov.env == DevNetMode {
+	} else if gov.env == common.UnsafeDevNet {
 		emitterMap = &sdk.KnownDevnetTokenbridgeEmitters
 	}
 

--- a/node/pkg/governor/governor_prices.go
+++ b/node/pkg/governor/governor_prices.go
@@ -19,6 +19,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/certusone/wormhole/node/pkg/common"
 	"github.com/certusone/wormhole/node/pkg/db"
 	"github.com/certusone/wormhole/node/pkg/supervisor"
 )
@@ -215,7 +216,7 @@ func CheckQuery(logger *zap.Logger) error {
 	logger.Info("Instantiating governor.")
 	ctx := context.Background()
 	var db db.MockGovernorDB
-	gov := NewChainGovernor(logger, &db, MainNetMode)
+	gov := NewChainGovernor(logger, &db, common.MainNet)
 
 	if err := gov.initConfig(); err != nil {
 		return err

--- a/node/pkg/governor/governor_test.go
+++ b/node/pkg/governor/governor_test.go
@@ -247,7 +247,7 @@ func newChainGovernorForTest(ctx context.Context) (*ChainGovernor, error) {
 
 	logger := zap.NewNop()
 	var db db.MockGovernorDB
-	gov := NewChainGovernor(logger, &db, GoTestMode)
+	gov := NewChainGovernor(logger, &db, common.GoTest)
 
 	err := gov.Run(ctx)
 	if err != nil {
@@ -1021,9 +1021,9 @@ func TestSmallerPendingTransfersAfterBigOneShouldGetReleased(t *testing.T) {
 func TestMainnetConfigIsValid(t *testing.T) {
 	logger := zap.NewNop()
 	var db db.MockGovernorDB
-	gov := NewChainGovernor(logger, &db, GoTestMode)
+	gov := NewChainGovernor(logger, &db, common.GoTest)
 
-	gov.env = MainNetMode
+	gov.env = common.MainNet
 	err := gov.initConfig()
 	require.NoError(t, err)
 }
@@ -1031,9 +1031,9 @@ func TestMainnetConfigIsValid(t *testing.T) {
 func TestTestnetConfigIsValid(t *testing.T) {
 	logger := zap.NewNop()
 	var db db.MockGovernorDB
-	gov := NewChainGovernor(logger, &db, GoTestMode)
+	gov := NewChainGovernor(logger, &db, common.GoTest)
 
-	gov.env = TestNetMode
+	gov.env = common.MainNet
 	err := gov.initConfig()
 	require.NoError(t, err)
 }

--- a/node/pkg/node/adminServiceRunnable.go
+++ b/node/pkg/node/adminServiceRunnable.go
@@ -1,0 +1,101 @@
+package node
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"fmt"
+	"net"
+	"os"
+	"time"
+
+	"github.com/certusone/wormhole/node/pkg/adminrpc"
+	"github.com/certusone/wormhole/node/pkg/common"
+	"github.com/certusone/wormhole/node/pkg/db"
+	"github.com/certusone/wormhole/node/pkg/governor"
+	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
+	nodev1 "github.com/certusone/wormhole/node/pkg/proto/node/v1"
+	publicrpcv1 "github.com/certusone/wormhole/node/pkg/proto/publicrpc/v1"
+	"github.com/certusone/wormhole/node/pkg/publicrpc"
+	"github.com/certusone/wormhole/node/pkg/supervisor"
+	"github.com/certusone/wormhole/node/pkg/watchers/evm/connectors"
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+	"github.com/wormhole-foundation/wormhole/sdk/vaa"
+	"go.uber.org/zap"
+)
+
+func adminServiceRunnable(
+	logger *zap.Logger,
+	socketPath string,
+	injectC chan<- *vaa.VAA,
+	signedInC chan<- *gossipv1.SignedVAAWithQuorum,
+	obsvReqSendC chan<- *gossipv1.ObservationRequest,
+	db *db.Database,
+	gst *common.GuardianSetState,
+	gov *governor.ChainGovernor,
+	gk *ecdsa.PrivateKey,
+	ethRpc *string,
+	ethContract *string,
+) (supervisor.Runnable, error) {
+	// Delete existing UNIX socket, if present.
+	fi, err := os.Stat(socketPath)
+	if err == nil {
+		fmode := fi.Mode()
+		if fmode&os.ModeType == os.ModeSocket {
+			err = os.Remove(socketPath)
+			if err != nil {
+				return nil, fmt.Errorf("failed to remove existing socket at %s: %w", socketPath, err)
+			}
+		} else {
+			return nil, fmt.Errorf("%s is not a UNIX socket", socketPath)
+		}
+	}
+
+	// Create a new UNIX socket and listen to it.
+
+	// The socket is created with the default umask. We set a restrictive umask in setRestrictiveUmask
+	// to ensure that any files we create are only readable by the user - this is much harder to mess up.
+	// The umask avoids a race condition between file creation and chmod.
+
+	laddr, err := net.ResolveUnixAddr("unix", socketPath)
+	if err != nil {
+		return nil, fmt.Errorf("invalid listen address: %v", err)
+	}
+	l, err := net.ListenUnix("unix", laddr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to listen on %s: %w", socketPath, err)
+	}
+
+	logger.Info("admin server listening on", zap.String("path", socketPath))
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+
+	var evmConnector connectors.Connector
+	if ethRpc != nil && ethContract != nil {
+		contract := ethcommon.HexToAddress(*ethContract)
+		evmConnector, err = connectors.NewEthereumConnector(ctx, "eth", *ethRpc, contract, logger)
+		if err != nil {
+			return nil, fmt.Errorf("failed to connecto to ethereum")
+		}
+	}
+
+	nodeService := adminrpc.NewPrivService(
+		db,
+		injectC,
+		obsvReqSendC,
+		logger.Named("adminservice"),
+		signedInC,
+		gov,
+		evmConnector,
+		gk,
+		ethcrypto.PubkeyToAddress(gk.PublicKey),
+	)
+
+	publicrpcService := publicrpc.NewPublicrpcServer(logger, db, gst, gov)
+
+	grpcServer := common.NewInstrumentedGRPCServer(logger, common.GrpcLogDetailMinimal)
+	nodev1.RegisterNodePrivilegedServiceServer(grpcServer, nodeService)
+	publicrpcv1.RegisterPublicRPCServiceServer(grpcServer, publicrpcService)
+	return supervisor.GRPCServer(grpcServer, l, false), nil
+}

--- a/node/pkg/node/guardianKey.go
+++ b/node/pkg/node/guardianKey.go
@@ -1,0 +1,12 @@
+package node
+
+import (
+	"crypto/ecdsa"
+
+	eth_common "github.com/ethereum/go-ethereum/common"
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+)
+
+func GuardianKeyToAddress(publicKey ecdsa.PublicKey) eth_common.Address {
+	return ethcrypto.PubkeyToAddress(publicKey)
+}

--- a/node/pkg/node/node.go
+++ b/node/pkg/node/node.go
@@ -1,0 +1,482 @@
+package node
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"errors"
+	"fmt"
+	"log"
+
+	"github.com/benbjohnson/clock"
+	"github.com/certusone/wormhole/node/pkg/accountant"
+	"github.com/certusone/wormhole/node/pkg/common"
+	"github.com/certusone/wormhole/node/pkg/db"
+	"github.com/certusone/wormhole/node/pkg/governor"
+	"github.com/certusone/wormhole/node/pkg/p2p"
+	"github.com/certusone/wormhole/node/pkg/processor"
+	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
+	"github.com/certusone/wormhole/node/pkg/reporter"
+	"github.com/certusone/wormhole/node/pkg/supervisor"
+	"github.com/certusone/wormhole/node/pkg/watchers"
+	"github.com/certusone/wormhole/node/pkg/watchers/interfaces"
+	"github.com/certusone/wormhole/node/pkg/wormconn"
+	libp2p_crypto "github.com/libp2p/go-libp2p-core/crypto"
+	"github.com/wormhole-foundation/wormhole/sdk/vaa"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+)
+
+const (
+	inboundObservationBufferSize         = 50
+	inboundSignedVaaBufferSize           = 50
+	observationRequestOutboundBufferSize = 50
+	observationRequestInboundBufferSize  = 50
+	// observationRequestBufferSize is the buffer size of the per-network reobservation channel
+	observationRequestBufferSize = 25
+)
+
+type GuardianOption struct {
+	name         string
+	dependencies []string                                                // Array of `componentName` of other components that need to be configured before this component. Dependencies are enforced at runtime.
+	f            func(context.Context, *zap.Logger, *GuardianNode) error // Function that is run by the constructor to initialize this component.
+}
+
+// GuardianOptionP2P configures p2p networking.
+// Dependencies: Accountant, Governor
+func GuardianOptionP2P(p2pKey libp2p_crypto.PrivKey, networkId string, bootstrapPeers string, nodeName string, disableHeartbeatVerify bool, port uint) GuardianOption {
+	return GuardianOption{
+		name:         "p2p",
+		dependencies: []string{"accountant", "governor"},
+		f: func(ctx context.Context, logger *zap.Logger, g *GuardianNode) error {
+			components := p2p.DefaultComponents()
+			components.Port = port
+
+			g.runnables["p2p"] = p2p.Run(
+				g.obsvC,
+				g.obsvReqC.writeC,
+				g.obsvReqSendC.readC,
+				g.gossipSendC,
+				g.signedInC.writeC,
+				p2pKey,
+				g.gk,
+				g.gst,
+				networkId,
+				bootstrapPeers,
+				nodeName,
+				disableHeartbeatVerify,
+				g.rootCtxCancel,
+				g.acct,
+				g.gov,
+				nil,
+				nil,
+				components,
+			)
+
+			return nil
+		}}
+}
+
+// GuardianOptionAccountant configures the Accountant module.
+// Requires: wormchainConn
+func GuardianOptionAccountant(contract string, websocket string, enforcing bool) GuardianOption {
+	return GuardianOption{
+		name: "accountant",
+		f: func(ctx context.Context, logger *zap.Logger, g *GuardianNode) error {
+			// Set up the accountant. If the accountant smart contract is configured, we will instantiate the accountant and VAAs
+			// will be passed to it for processing. It will forward all token bridge transfers to the accountant contract.
+			// If accountantCheckEnabled is set to true, token bridge transfers will not be signed and published until they
+			// are approved by the accountant smart contract.
+			if contract != "" {
+				if websocket == "" {
+					return errors.New("acct: if accountantContract is specified, accountantWS is required")
+				}
+				if g.wormchainConn == nil {
+					return errors.New("acct: if accountantContract is specified, the wormchain sending connection must be enabled before.")
+				}
+				if enforcing {
+					logger.Info("acct: accountant is enabled and will be enforced")
+				} else {
+					logger.Info("acct: accountant is enabled but will not be enforced")
+				}
+
+				g.acct = accountant.NewAccountant(
+					g.ctx,
+					logger,
+					g.db,
+					g.obsvReqC.writeC,
+					contract,
+					websocket,
+					g.wormchainConn,
+					enforcing,
+					g.gk,
+					g.gst,
+					g.acctC.writeC,
+					g.env,
+				)
+			} else {
+				logger.Info("acct: accountant is disabled")
+			}
+
+			return nil
+		}}
+}
+
+func GuardianOptionGovernor(governorEnabled bool) GuardianOption {
+	return GuardianOption{
+		name: "governor",
+		f: func(ctx context.Context, logger *zap.Logger, g *GuardianNode) error {
+			if governorEnabled {
+				logger.Info("chain governor is enabled")
+				g.gov = governor.NewChainGovernor(logger, g.db, g.env)
+			} else {
+				logger.Info("chain governor is disabled")
+			}
+			return nil
+		}}
+}
+
+func GuardianOptionWatchers(watcherConfigs []watchers.WatcherConfig) GuardianOption {
+	return GuardianOption{
+		name: "watchers",
+		f: func(ctx context.Context, logger *zap.Logger, g *GuardianNode) error {
+
+			// Per-chain observation requests
+			chainObsvReqC := make(map[vaa.ChainID]chan *gossipv1.ObservationRequest)
+
+			// multiplex reobservation requests
+			go handleReobservationRequests(g.ctx, clock.New(), logger, g.obsvReqC.readC, chainObsvReqC)
+
+			// Per-chain msgC
+			chainMsgC := make(map[vaa.ChainID]chan *common.MessagePublication)
+			// aggregate per-chain msgC into msgC.
+			// SECURITY defense-in-depth: This way we enforce that a watcher must set the msg.EmitterChain to its chainId, which makes the code easier to audit
+			for _, chainId := range vaa.GetAllNetworkIDs() {
+				chainMsgC[chainId] = make(chan *common.MessagePublication)
+				go func(c <-chan *common.MessagePublication, chainId vaa.ChainID) {
+					for {
+						select {
+						case <-g.ctx.Done():
+							return
+						case msg := <-c:
+							if msg.EmitterChain == chainId {
+								g.msgC.writeC <- msg
+							} else {
+								// SECURITY: This should never happen. If it does, a watcher has been compromised.
+								logger.Fatal("SECURITY CRITICAL: Received observation from a chain that was not marked as originating from that chain",
+									zap.Stringer("tx", msg.TxHash),
+									zap.Stringer("emitter_address", msg.EmitterAddress),
+									zap.Uint64("sequence", msg.Sequence),
+									zap.Stringer("msgChainId", msg.EmitterChain),
+									zap.Stringer("watcherChainId", chainId),
+								)
+							}
+						}
+					}
+				}(chainMsgC[chainId], chainId)
+			}
+
+			watchers := make(map[watchers.NetworkID]interfaces.L1Finalizer)
+
+			for _, w := range watcherConfigs {
+				watcherName := string(w.GetNetworkID()) + "watch"
+				logger.Info("Starting watcher: " + watcherName)
+				common.MustRegisterReadinessSyncing(w.GetChainID())
+				chainObsvReqC[w.GetChainID()] = make(chan *gossipv1.ObservationRequest, observationRequestBufferSize)
+
+				l1finalizer, runnable, err := w.Create(chainMsgC[w.GetChainID()], chainObsvReqC[w.GetChainID()], g.setC.writeC, g.env)
+
+				if err != nil {
+					logger.Fatal("error creating watcher", zap.Error(err))
+				}
+
+				if w.RequiredL1Finalizer() != "" {
+					l1watcher, ok := watchers[w.RequiredL1Finalizer()]
+					if !ok || l1watcher == nil {
+						logger.Fatal("L1finalizer does not exist. Please check the order of the watcher configuration. The L1 must be configured before this one.",
+							zap.String("ChainID", w.GetChainID().String()),
+							zap.String("L1ChainID", string(w.RequiredL1Finalizer())))
+					}
+					w.SetL1Finalizer(l1watcher)
+				}
+
+				g.runnablesWithScissors[watcherName] = runnable
+				watchers[w.GetNetworkID()] = l1finalizer
+			}
+
+			return nil
+		}}
+}
+
+func GuardianOptionAdminService(socketPath string, ethRpc *string, ethContract *string) GuardianOption {
+	return GuardianOption{
+		name:         "admin-service",
+		dependencies: []string{"governor"},
+		f: func(ctx context.Context, logger *zap.Logger, g *GuardianNode) error {
+			adminService, err := adminServiceRunnable(
+				logger,
+				socketPath,
+				g.injectC.writeC,
+				g.signedInC.writeC,
+				g.obsvReqSendC.writeC,
+				g.db,
+				g.gst,
+				g.gov,
+				g.gk,
+				ethRpc,
+				ethContract,
+			)
+			if err != nil {
+				logger.Fatal("failed to create admin service socket", zap.Error(err))
+			}
+			g.runnables["admin"] = adminService
+
+			return nil
+		}}
+}
+
+func GuardianOptionPublicRpcSocket(publicGRPCSocketPath string, publicRpcLogDetail common.GrpcLogDetail) GuardianOption {
+	return GuardianOption{
+		name:         "publicrpcsocket",
+		dependencies: []string{"governor"},
+		f: func(ctx context.Context, logger *zap.Logger, g *GuardianNode) error {
+			// local public grpc service socket
+			publicrpcUnixService, publicrpcServer, err := publicrpcUnixServiceRunnable(logger, publicGRPCSocketPath, publicRpcLogDetail, g.db, g.gst, g.gov)
+			if err != nil {
+				logger.Fatal("failed to create publicrpc service socket", zap.Error(err))
+			}
+
+			g.runnables["publicrpcsocket"] = publicrpcUnixService
+			g.publicrpcServer = publicrpcServer
+			return nil
+		}}
+}
+
+func GuardianOptionPublicrpcTcpService(publicRpc string, publicRpcLogDetail common.GrpcLogDetail) GuardianOption {
+	return GuardianOption{
+		name:         "publicrpc",
+		dependencies: []string{"governor", "publicrpcsocket"},
+		f: func(ctx context.Context, logger *zap.Logger, g *GuardianNode) error {
+			publicrpcService, err := publicrpcTcpServiceRunnable(logger, publicRpc, publicRpcLogDetail, g.db, g.gst, g.gov)
+			if err != nil {
+				return err
+			}
+			g.runnables["publicrpc"] = publicrpcService
+			return nil
+		}}
+}
+
+func GuardianOptionPublicWeb(listenAddr string, publicGRPCSocketPath string, tlsHostname string, tlsProdEnv bool, tlsCacheDir string) GuardianOption {
+	return GuardianOption{
+		name:         "publicweb",
+		dependencies: []string{"publicrpcsocket"},
+		f: func(ctx context.Context, logger *zap.Logger, g *GuardianNode) error {
+			publicwebService, err := publicwebServiceRunnable(logger, listenAddr, publicGRPCSocketPath, g.publicrpcServer,
+				tlsHostname, tlsProdEnv, tlsCacheDir)
+			if err != nil {
+				log.Fatal("failed to create publicrpc web service", zap.Error(err))
+			}
+			g.runnables["publicweb"] = publicwebService
+			return nil
+		}}
+}
+
+func GuardianOptionBigTablePersistence(config *reporter.BigTableConnectionConfig) GuardianOption {
+	return GuardianOption{
+		name: "bigtable",
+		f: func(ctx context.Context, logger *zap.Logger, g *GuardianNode) error {
+			g.runnables["bigtable"] = reporter.BigTableWriter(g.attestationEvents, config)
+			return nil
+		}}
+}
+
+type GuardianNode struct {
+	ctx           context.Context
+	rootCtxCancel context.CancelFunc
+	env           common.Environment
+
+	// keys
+	gk *ecdsa.PrivateKey
+
+	// components
+	db                *db.Database
+	gst               *common.GuardianSetState
+	acct              *accountant.Accountant
+	gov               *governor.ChainGovernor
+	attestationEvents *reporter.AttestationEventReporter
+	wormchainConn     *wormconn.ClientConn
+	publicrpcServer   *grpc.Server
+
+	// runnables
+	runnablesWithScissors map[string]supervisor.Runnable
+	runnables             map[string]supervisor.Runnable
+
+	// various channels
+	// Outbound gossip message queue (needs to be read/write because p2p needs read/write)
+	gossipSendC chan []byte
+	// Inbound observations (TODO: why is this a read/write channel instead of channelPair?)
+	obsvC chan *gossipv1.SignedObservation
+	// Finalized guardian observations aggregated across all chains
+	msgC channelPair[*common.MessagePublication]
+	// Ethereum incoming guardian set updates
+	setC channelPair[*common.GuardianSet]
+	// Inbound signed VAAs
+	signedInC channelPair[*gossipv1.SignedVAAWithQuorum]
+	// Inbound observation requests from the p2p service (for all chains)
+	obsvReqC channelPair[*gossipv1.ObservationRequest]
+	// Outbound observation requests
+	obsvReqSendC channelPair[*gossipv1.ObservationRequest]
+	// Injected VAAs (manually generated rather than created via observation)
+	injectC channelPair[*vaa.VAA]
+	// TODO describe
+	acctC channelPair[*common.MessagePublication]
+}
+
+func NewGuardianNode(
+	ctx context.Context,
+	rootCtxCancel context.CancelFunc,
+	env common.Environment,
+	db *db.Database,
+	gk *ecdsa.PrivateKey,
+	wormchainConn *wormconn.ClientConn,
+) *GuardianNode {
+	g := GuardianNode{
+		ctx:           ctx,
+		rootCtxCancel: rootCtxCancel,
+		env:           env,
+		db:            db,
+		gk:            gk,
+		wormchainConn: wormchainConn,
+	}
+	return &g
+}
+
+// initializeBasic sets up everything that every GuardianNode needs before any options can be applied.
+func (g *GuardianNode) initializeBasic(logger *zap.Logger) {
+	// Setup various channels...
+	g.gossipSendC = make(chan []byte)
+	g.obsvC = make(chan *gossipv1.SignedObservation, inboundObservationBufferSize)
+	g.msgC = makeChannelPair[*common.MessagePublication](0)
+	g.setC = makeChannelPair[*common.GuardianSet](0)
+	g.signedInC = makeChannelPair[*gossipv1.SignedVAAWithQuorum](inboundSignedVaaBufferSize)
+	g.obsvReqC = makeChannelPair[*gossipv1.ObservationRequest](observationRequestOutboundBufferSize)
+	g.obsvReqSendC = makeChannelPair[*gossipv1.ObservationRequest](observationRequestInboundBufferSize)
+	g.injectC = makeChannelPair[*vaa.VAA](0)
+	g.acctC = makeChannelPair[*common.MessagePublication](0)
+
+	// Guardian set state managed by processor
+	g.gst = common.NewGuardianSetState(nil)
+
+	// provides methods for reporting progress toward message attestation, and channels for receiving attestation lifecyclye events.
+	g.attestationEvents = reporter.EventListener(logger)
+
+	// allocate maps
+	g.runnablesWithScissors = make(map[string]supervisor.Runnable)
+	g.runnables = make(map[string]supervisor.Runnable)
+}
+
+// applyOptions applies `options` to the GuardianNode.
+// Each option must have a unique option.name.
+// If an option has `dependencies`, they must be defined before that option.
+func (g *GuardianNode) applyOptions(ctx context.Context, logger *zap.Logger, options []GuardianOption) error {
+	configuredComponents := make(map[string]struct{}) // using `map[string]struct{}` to implement a set here
+
+	for _, option := range options {
+		// check that this component has not been configured yet
+		if _, ok := configuredComponents[option.name]; ok {
+			return errors.New(fmt.Sprintf("Component %s has been configured already and cannot be configured a second time.", option.name))
+		}
+
+		// check that all dependencies have been met
+		for _, dep := range option.dependencies {
+			if _, ok := configuredComponents[dep]; !ok {
+				return errors.New(fmt.Sprintf("Component %s requires %s to be configured first. Check the order of your options.", option.name, dep))
+			}
+		}
+
+		// run the config
+		option.f(ctx, logger, g)
+
+		// mark the component as configured
+		configuredComponents[option.name] = struct{}{}
+	}
+
+	return nil
+}
+
+func (g *GuardianNode) Run(options ...GuardianOption) supervisor.Runnable {
+	return func(ctx context.Context) error {
+		logger := supervisor.Logger(ctx)
+
+		g.initializeBasic(logger)
+		if err := g.applyOptions(ctx, logger, options); err != nil {
+			logger.Fatal("failed to initialize GuardianNode", zap.Error(err))
+		}
+
+		// Start the watchers
+		for watcherName, runnable := range g.runnablesWithScissors {
+			if err := supervisor.Run(ctx, watcherName, common.WrapWithScissors(runnable, watcherName)); err != nil {
+				return err
+			}
+		}
+
+		if g.acct != nil {
+			if err := g.acct.Start(ctx); err != nil {
+				logger.Fatal("acct: failed to start accountant", zap.Error(err))
+			}
+		}
+
+		if g.gov != nil {
+			err := g.gov.Run(ctx)
+			if err != nil {
+				logger.Fatal("failed to create chain governor", zap.Error(err))
+			}
+		}
+
+		if err := supervisor.Run(ctx, "processor", processor.NewProcessor(ctx,
+			g.db,
+			g.msgC.readC,
+			g.setC.readC,
+			g.gossipSendC,
+			g.obsvC,
+			g.obsvReqSendC.writeC,
+			g.injectC.readC,
+			g.signedInC.readC,
+			g.gk,
+			g.gst,
+			g.attestationEvents,
+			g.gov,
+			g.acct,
+			g.acctC.readC,
+		).Run); err != nil {
+			return err
+		}
+
+		// Start any other runnables
+		for name, runnable := range g.runnables {
+			if err := supervisor.Run(ctx, name, runnable); err != nil {
+				return err
+			}
+		}
+
+		logger.Info("Started internal services")
+
+		<-ctx.Done()
+
+		return nil
+	}
+}
+
+type channelPair[T any] struct {
+	readC  <-chan T
+	writeC chan<- T
+}
+
+func makeChannelPairDEPRECATED[T any](cap int) (<-chan T, chan<- T) {
+	out := make(chan T, cap)
+	return out, out
+}
+
+func makeChannelPair[T any](cap int) channelPair[T] {
+	out := make(chan T, cap)
+	return channelPair[T]{out, out}
+}

--- a/node/pkg/node/node_test.go
+++ b/node/pkg/node/node_test.go
@@ -1,0 +1,120 @@
+package node
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/certusone/wormhole/node/pkg/common"
+	"github.com/certusone/wormhole/node/pkg/db"
+	"github.com/certusone/wormhole/node/pkg/devnet"
+	"github.com/certusone/wormhole/node/pkg/readiness"
+	"github.com/certusone/wormhole/node/pkg/supervisor"
+	"github.com/certusone/wormhole/node/pkg/watchers"
+	"github.com/certusone/wormhole/node/pkg/watchers/mock"
+	eth_crypto "github.com/ethereum/go-ethereum/crypto"
+	libp2p_crypto "github.com/libp2p/go-libp2p/core/crypto"
+	libp2p_peer "github.com/libp2p/go-libp2p/core/peer"
+	"github.com/test-go/testify/assert"
+	"github.com/wormhole-foundation/wormhole/sdk/vaa"
+	"go.uber.org/zap"
+)
+
+type mockGuardianSet struct {
+	p2pKeys []libp2p_crypto.PrivKey
+}
+
+func newMockGuardianSet(n int) *mockGuardianSet {
+	p2pKeys := make([]libp2p_crypto.PrivKey, n)
+	for i := 0; i < n; i++ {
+		p2pKeys[i] = devnet.DeterministicP2PPrivKeyByIndex(int64(i))
+	}
+
+	return &mockGuardianSet{p2pKeys}
+}
+
+func (gs *mockGuardianSet) addMockGuardian(ctx context.Context, mockGuardianIndex uint) error {
+	// Node's main lifecycle context.
+	rootCtx, rootCtxCancel := context.WithCancel(ctx)
+	defer rootCtxCancel()
+	logger := supervisor.Logger(ctx)
+
+	// setup db
+	dataDir := fmt.Sprintf("/tmp/testguardian_%d", mockGuardianIndex)
+	db := db.OpenDb(logger, &dataDir)
+
+	// generate guardian key
+	gk, err := ecdsa.GenerateKey(eth_crypto.S256(), rand.Reader)
+	if err != nil {
+		return err
+	}
+
+	// set environment
+	env := common.GoTest
+
+	// setup a mock watcher
+	var watcherConfigs = []watchers.WatcherConfig{
+		&mock.WatcherConfig{
+			NetworkID: "eth",
+			ChainID:   vaa.ChainIDEthereum,
+		},
+	}
+
+	// configure p2p
+	nodeName := fmt.Sprintf("g-%d", mockGuardianIndex)
+	networkID := "/wormhole/localdev"
+	zeroPeerId, err := libp2p_peer.IDFromPublicKey(gs.p2pKeys[0].GetPublic())
+	if err != nil {
+		return err
+	}
+	bootstrapPeers := fmt.Sprintf("/ip4/127.0.0.1/udp/11000/quic/p2p/%s", zeroPeerId.String())
+	p2pPort := uint(11000 + mockGuardianIndex)
+
+	guardianOptions := []GuardianOption{
+		GuardianOptionWatchers(watcherConfigs),
+		GuardianOptionAccountant("", "", false), // effectively disable accountant
+		GuardianOptionGovernor(false),           // disable governor
+		GuardianOptionP2P(gs.p2pKeys[mockGuardianIndex], networkID, bootstrapPeers, nodeName, false, p2pPort),
+	}
+
+	guardianNode := NewGuardianNode(
+		rootCtx,
+		rootCtxCancel,
+		env,
+		db,
+		gk,
+		nil,
+	)
+
+	if err := supervisor.Run(rootCtx, nodeName, guardianNode.Run(guardianOptions...)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func TestNodes(t *testing.T) {
+	readiness.NoPanic = true // otherwise we'd panic when running multiple guardians
+
+	rootCtx := context.Background()
+	logger, err := zap.NewDevelopment()
+	assert.NoError(t, err)
+
+	supervisor.New(rootCtx, logger, func(ctx context.Context) error {
+		gs := newMockGuardianSet(19)
+
+		for i := 0; i < 19; i++ {
+			err := gs.addMockGuardian(ctx, uint(i))
+			assert.NoError(t, err)
+		}
+
+		timer := time.NewTimer(time.Second * 10)
+		<-timer.C
+		return nil
+	})
+
+	<-rootCtx.Done()
+}

--- a/node/pkg/node/publicrpcRunnable.go
+++ b/node/pkg/node/publicrpcRunnable.go
@@ -1,4 +1,4 @@
-package guardiand
+package node
 
 import (
 	"fmt"

--- a/node/pkg/node/publicwebRunnable.go
+++ b/node/pkg/node/publicwebRunnable.go
@@ -1,4 +1,4 @@
-package guardiand
+package node
 
 import (
 	"context"

--- a/node/pkg/node/reobserve.go
+++ b/node/pkg/node/reobserve.go
@@ -1,4 +1,4 @@
-package guardiand
+package node
 
 import (
 	"context"

--- a/node/pkg/node/reobserve_test.go
+++ b/node/pkg/node/reobserve_test.go
@@ -1,4 +1,4 @@
-package guardiand
+package node
 
 import (
 	"context"

--- a/node/pkg/node/systemd.go
+++ b/node/pkg/node/systemd.go
@@ -1,4 +1,4 @@
-package guardiand
+package node
 
 import (
 	"fmt"

--- a/node/pkg/readiness/health.go
+++ b/node/pkg/readiness/health.go
@@ -12,6 +12,9 @@ import (
 )
 
 var (
+	// TODO is a hack to support running multiple guardians in one process;
+	// This should be rewritten to support multiple registries in one process instead of using a global registry
+	NoPanic  = false
 	mu       = sync.Mutex{}
 	registry = map[string]bool{}
 )
@@ -23,7 +26,10 @@ func RegisterComponent(component Component) {
 	mu.Lock()
 	defer mu.Unlock()
 	if _, ok := registry[string(component)]; ok {
-		panic("component already registered")
+		if !NoPanic {
+			panic("component already registered")
+		}
+		return
 	}
 	registry[string(component)] = false
 }

--- a/node/pkg/watchers/algorand/algorandWatcherConfig.go
+++ b/node/pkg/watchers/algorand/algorandWatcherConfig.go
@@ -1,0 +1,45 @@
+package algorand
+
+import (
+	"github.com/certusone/wormhole/node/pkg/common"
+	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
+	"github.com/certusone/wormhole/node/pkg/supervisor"
+	"github.com/certusone/wormhole/node/pkg/watchers"
+	"github.com/certusone/wormhole/node/pkg/watchers/interfaces"
+	"github.com/wormhole-foundation/wormhole/sdk/vaa"
+)
+
+type WatcherConfig struct {
+	NetworkID    watchers.NetworkID // human readable name
+	ChainID      vaa.ChainID        // ChainID
+	IndexerRPC   string
+	IndexerToken string
+	AlgodRPC     string
+	AlgodToken   string
+	AppID        uint64
+}
+
+func (wc *WatcherConfig) GetNetworkID() watchers.NetworkID {
+	return wc.NetworkID
+}
+
+func (wc *WatcherConfig) GetChainID() vaa.ChainID {
+	return wc.ChainID
+}
+
+func (wc *WatcherConfig) RequiredL1Finalizer() watchers.NetworkID {
+	return ""
+}
+
+func (wc *WatcherConfig) SetL1Finalizer(l1finalizer interfaces.L1Finalizer) {
+	// empty
+}
+
+func (wc *WatcherConfig) Create(
+	msgC chan<- *common.MessagePublication,
+	obsvReqC <-chan *gossipv1.ObservationRequest,
+	_ chan<- *common.GuardianSet,
+	env common.Environment,
+) (interfaces.L1Finalizer, supervisor.Runnable, error) {
+	return nil, NewWatcher(wc.IndexerRPC, wc.IndexerToken, wc.AlgodRPC, wc.AlgodToken, wc.AppID, msgC, obsvReqC).Run, nil
+}

--- a/node/pkg/watchers/aptos/aptosWatcherConfig.go
+++ b/node/pkg/watchers/aptos/aptosWatcherConfig.go
@@ -1,0 +1,43 @@
+package aptos
+
+import (
+	"github.com/certusone/wormhole/node/pkg/common"
+	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
+	"github.com/certusone/wormhole/node/pkg/supervisor"
+	"github.com/certusone/wormhole/node/pkg/watchers"
+	"github.com/certusone/wormhole/node/pkg/watchers/interfaces"
+	"github.com/wormhole-foundation/wormhole/sdk/vaa"
+)
+
+type WatcherConfig struct {
+	NetworkID watchers.NetworkID // human readable name
+	ChainID   vaa.ChainID        // ChainID
+	Rpc       string
+	Account   string
+	Handle    string
+}
+
+func (wc *WatcherConfig) GetNetworkID() watchers.NetworkID {
+	return wc.NetworkID
+}
+
+func (wc *WatcherConfig) GetChainID() vaa.ChainID {
+	return wc.ChainID
+}
+
+func (wc *WatcherConfig) RequiredL1Finalizer() watchers.NetworkID {
+	return ""
+}
+
+func (wc *WatcherConfig) SetL1Finalizer(l1finalizer interfaces.L1Finalizer) {
+	// empty
+}
+
+func (wc *WatcherConfig) Create(
+	msgC chan<- *common.MessagePublication,
+	obsvReqC <-chan *gossipv1.ObservationRequest,
+	_ chan<- *common.GuardianSet,
+	env common.Environment,
+) (interfaces.L1Finalizer, supervisor.Runnable, error) {
+	return nil, NewWatcher(wc.Rpc, wc.Account, wc.Handle, msgC, obsvReqC).Run, nil
+}

--- a/node/pkg/watchers/cosmwasm/cosmWatcherConfig.go
+++ b/node/pkg/watchers/cosmwasm/cosmWatcherConfig.go
@@ -1,0 +1,43 @@
+package cosmwasm
+
+import (
+	"github.com/certusone/wormhole/node/pkg/common"
+	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
+	"github.com/certusone/wormhole/node/pkg/supervisor"
+	"github.com/certusone/wormhole/node/pkg/watchers"
+	"github.com/certusone/wormhole/node/pkg/watchers/interfaces"
+	"github.com/wormhole-foundation/wormhole/sdk/vaa"
+)
+
+type WatcherConfig struct {
+	NetworkID watchers.NetworkID // human readable name
+	ChainID   vaa.ChainID        // ChainID
+	Websocket string             // Websocket URL
+	Lcd       string             // LCD
+	Contract  string             // hex representation of the contract address
+}
+
+func (wc *WatcherConfig) GetNetworkID() watchers.NetworkID {
+	return wc.NetworkID
+}
+
+func (wc *WatcherConfig) GetChainID() vaa.ChainID {
+	return wc.ChainID
+}
+
+func (wc *WatcherConfig) RequiredL1Finalizer() watchers.NetworkID {
+	return ""
+}
+
+func (wc *WatcherConfig) SetL1Finalizer(l1finalizer interfaces.L1Finalizer) {
+	// empty
+}
+
+func (wc *WatcherConfig) Create(
+	msgC chan<- *common.MessagePublication,
+	obsvReqC <-chan *gossipv1.ObservationRequest,
+	_ chan<- *common.GuardianSet,
+	env common.Environment,
+) (interfaces.L1Finalizer, supervisor.Runnable, error) {
+	return nil, NewWatcher(wc.Websocket, wc.Lcd, wc.Contract, msgC, obsvReqC, wc.ChainID).Run, nil
+}

--- a/node/pkg/watchers/evm/evmWatcherConfig.go
+++ b/node/pkg/watchers/evm/evmWatcherConfig.go
@@ -1,0 +1,63 @@
+package evm
+
+import (
+	"github.com/certusone/wormhole/node/pkg/common"
+	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
+	"github.com/certusone/wormhole/node/pkg/supervisor"
+	"github.com/certusone/wormhole/node/pkg/watchers"
+	"github.com/certusone/wormhole/node/pkg/watchers/interfaces"
+	eth_common "github.com/ethereum/go-ethereum/common"
+	"github.com/wormhole-foundation/wormhole/sdk/vaa"
+)
+
+type WatcherConfig struct {
+	NetworkID              watchers.NetworkID // human readable name
+	ChainID                vaa.ChainID        // ChainID
+	Rpc                    string             // RPC URL
+	Contract               string             // hex representation of the contract address
+	GuardianSetUpdateChain bool               // if `true`, we will retrieve the GuardianSet from this chain and watch this chain for GuardianSet updates
+	WaitForConfirmations   bool               // (optional)
+	RootChainRpc           string             // (optional)
+	RootChainContract      string             // (optional)
+	L1FinalizerRequired    watchers.NetworkID // (optional)
+	l1Finalizer            interfaces.L1Finalizer
+}
+
+func (wc *WatcherConfig) GetNetworkID() watchers.NetworkID {
+	return wc.NetworkID
+}
+
+func (wc *WatcherConfig) GetChainID() vaa.ChainID {
+	return wc.ChainID
+}
+
+func (wc *WatcherConfig) RequiredL1Finalizer() watchers.NetworkID {
+	return ""
+}
+
+func (wc *WatcherConfig) SetL1Finalizer(l1finalizer interfaces.L1Finalizer) {
+	wc.l1Finalizer = l1finalizer
+}
+
+func (wc *WatcherConfig) Create(
+	msgC chan<- *common.MessagePublication,
+	obsvReqC <-chan *gossipv1.ObservationRequest,
+	setC chan<- *common.GuardianSet,
+	env common.Environment,
+) (interfaces.L1Finalizer, supervisor.Runnable, error) {
+
+	// only actually use the guardian set channel if wc.GuardianSetUpdateChain == true
+	var setWriteC chan<- *common.GuardianSet = nil
+	if wc.GuardianSetUpdateChain {
+		setWriteC = setC
+	}
+
+	var devMode bool = (env == common.UnsafeDevNet)
+
+	watcher := NewEthWatcher(wc.Rpc, eth_common.HexToAddress(wc.Contract), string(wc.NetworkID), wc.ChainID, msgC, setWriteC, obsvReqC, devMode)
+	watcher.SetWaitForConfirmations(wc.WaitForConfirmations)
+	if err := watcher.SetRootChainParams(wc.RootChainRpc, wc.RootChainContract); err != nil {
+		return nil, nil, err
+	}
+	return watcher, watcher.Run, nil
+}

--- a/node/pkg/watchers/mock/mockWatcherConfig.go
+++ b/node/pkg/watchers/mock/mockWatcherConfig.go
@@ -1,0 +1,40 @@
+package mock
+
+import (
+	"github.com/certusone/wormhole/node/pkg/common"
+	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
+	"github.com/certusone/wormhole/node/pkg/supervisor"
+	"github.com/certusone/wormhole/node/pkg/watchers"
+	"github.com/certusone/wormhole/node/pkg/watchers/interfaces"
+	"github.com/wormhole-foundation/wormhole/sdk/vaa"
+)
+
+type WatcherConfig struct {
+	NetworkID watchers.NetworkID // human readable name
+	ChainID   vaa.ChainID        // ChainID
+}
+
+func (wc *WatcherConfig) GetNetworkID() watchers.NetworkID {
+	return wc.NetworkID
+}
+
+func (wc *WatcherConfig) GetChainID() vaa.ChainID {
+	return wc.ChainID
+}
+
+func (wc *WatcherConfig) RequiredL1Finalizer() watchers.NetworkID {
+	return ""
+}
+
+func (wc *WatcherConfig) SetL1Finalizer(l1finalizer interfaces.L1Finalizer) {
+	// empty
+}
+
+func (wc *WatcherConfig) Create(
+	msgC chan<- *common.MessagePublication,
+	obsvReqC <-chan *gossipv1.ObservationRequest,
+	_ chan<- *common.GuardianSet,
+	env common.Environment,
+) (interfaces.L1Finalizer, supervisor.Runnable, error) {
+	return nil, NewWatcherRunnable(msgC, obsvReqC), nil
+}

--- a/node/pkg/watchers/mock/watcher.go
+++ b/node/pkg/watchers/mock/watcher.go
@@ -1,0 +1,80 @@
+package mock
+
+import (
+	"context"
+	"math/rand"
+	"time"
+
+	"github.com/certusone/wormhole/node/pkg/common"
+	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
+	"github.com/certusone/wormhole/node/pkg/supervisor"
+	eth_common "github.com/ethereum/go-ethereum/common"
+	"github.com/wormhole-foundation/wormhole/sdk/vaa"
+)
+
+func NewWatcherRunnable(
+	msgC chan<- *common.MessagePublication,
+	obsvReqC <-chan *gossipv1.ObservationRequest,
+) supervisor.Runnable {
+	return func(ctx context.Context) error {
+
+		msgStream := createMessageStream(ctx)
+
+		var obsvReqCounter uint64 = 0
+
+		for {
+			select {
+			case <-ctx.Done():
+				return nil
+			case m := <-msgStream:
+				msgC <- m
+			case o := <-obsvReqC:
+				msgC <- createMessageFromObsvReq(o, obsvReqCounter)
+				obsvReqCounter++
+			}
+		}
+	}
+}
+
+func createMessageFromObsvReq(o *gossipv1.ObservationRequest, sequence uint64) *common.MessagePublication {
+	return &common.MessagePublication{
+		TxHash:           eth_common.BytesToHash(o.TxHash),
+		Timestamp:        time.Now(),
+		Nonce:            rand.Uint32(), //#nosec G404 test code
+		Sequence:         sequence,
+		ConsistencyLevel: 1,
+		EmitterChain:     vaa.ChainID(o.ChainId),
+		EmitterAddress:   [32]byte{1, 0, 1},
+		Payload:          []byte{},
+		Unreliable:       false,
+	}
+}
+
+func createMessageStream(ctx context.Context) chan *common.MessagePublication {
+	c := make(chan *common.MessagePublication)
+
+	go func() {
+		timer := time.NewTimer(time.Second)
+
+		for i := 0; ; i++ {
+			select {
+			case <-ctx.Done():
+				return
+			case t := <-timer.C:
+				c <- &common.MessagePublication{
+					TxHash:           [32]byte{1, 2, 3},
+					Timestamp:        t,
+					Nonce:            rand.Uint32(), //#nosec G404 test code
+					Sequence:         uint64(i),
+					ConsistencyLevel: 1,
+					EmitterChain:     vaa.ChainIDEthereum,
+					EmitterAddress:   [32]byte{1, 2, 3},
+					Payload:          []byte{},
+					Unreliable:       false,
+				}
+			}
+		}
+	}()
+
+	return c
+}

--- a/node/pkg/watchers/near/nearWatcherConfig.go
+++ b/node/pkg/watchers/near/nearWatcherConfig.go
@@ -1,0 +1,43 @@
+package near
+
+import (
+	"github.com/certusone/wormhole/node/pkg/common"
+	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
+	"github.com/certusone/wormhole/node/pkg/supervisor"
+	"github.com/certusone/wormhole/node/pkg/watchers"
+	"github.com/certusone/wormhole/node/pkg/watchers/interfaces"
+	"github.com/wormhole-foundation/wormhole/sdk/vaa"
+)
+
+type WatcherConfig struct {
+	NetworkID watchers.NetworkID // human readable name
+	ChainID   vaa.ChainID        // ChainID
+	Rpc       string
+	Contract  string
+}
+
+func (wc *WatcherConfig) GetNetworkID() watchers.NetworkID {
+	return wc.NetworkID
+}
+
+func (wc *WatcherConfig) GetChainID() vaa.ChainID {
+	return wc.ChainID
+}
+
+func (wc *WatcherConfig) RequiredL1Finalizer() watchers.NetworkID {
+	return ""
+}
+
+func (wc *WatcherConfig) SetL1Finalizer(l1finalizer interfaces.L1Finalizer) {
+	// empty
+}
+
+func (wc *WatcherConfig) Create(
+	msgC chan<- *common.MessagePublication,
+	obsvReqC <-chan *gossipv1.ObservationRequest,
+	_ chan<- *common.GuardianSet,
+	env common.Environment,
+) (interfaces.L1Finalizer, supervisor.Runnable, error) {
+	var mainnet bool = (env == common.MainNet)
+	return nil, NewWatcher(wc.Rpc, wc.Contract, msgC, obsvReqC, mainnet).Run, nil
+}

--- a/node/pkg/watchers/solana/solanaWatcherConfig.go
+++ b/node/pkg/watchers/solana/solanaWatcherConfig.go
@@ -1,0 +1,56 @@
+package solana
+
+import (
+	"github.com/certusone/wormhole/node/pkg/common"
+	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
+	"github.com/certusone/wormhole/node/pkg/supervisor"
+	"github.com/certusone/wormhole/node/pkg/watchers"
+	"github.com/certusone/wormhole/node/pkg/watchers/interfaces"
+	solana_types "github.com/gagliardetto/solana-go"
+	solana_rpc "github.com/gagliardetto/solana-go/rpc"
+	"github.com/wormhole-foundation/wormhole/sdk/vaa"
+)
+
+type WatcherConfig struct {
+	NetworkID     watchers.NetworkID // unique identifier of the network
+	ChainID       vaa.ChainID        // ChainID
+	ReceiveObsReq bool               // if false, this watcher will not get access to the observation request channel
+	Rpc           string             // RPC URL
+	Websocket     string             // Websocket URL
+	Contract      string             // hex representation of the contract address
+	Commitment    solana_rpc.CommitmentType
+}
+
+func (wc *WatcherConfig) GetNetworkID() watchers.NetworkID {
+	return wc.NetworkID
+}
+
+func (wc *WatcherConfig) GetChainID() vaa.ChainID {
+	return wc.ChainID
+}
+
+func (wc *WatcherConfig) RequiredL1Finalizer() watchers.NetworkID {
+	return ""
+}
+
+func (wc *WatcherConfig) SetL1Finalizer(l1finalizer interfaces.L1Finalizer) {
+	// empty
+}
+
+func (wc *WatcherConfig) Create(
+	msgC chan<- *common.MessagePublication,
+	obsvReqC <-chan *gossipv1.ObservationRequest,
+	_ chan<- *common.GuardianSet,
+	env common.Environment,
+) (interfaces.L1Finalizer, supervisor.Runnable, error) {
+	solAddress, err := solana_types.PublicKeyFromBase58(wc.Contract)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if wc.ReceiveObsReq == false {
+		obsvReqC = nil
+	}
+
+	return nil, NewSolanaWatcher(wc.Rpc, &wc.Websocket, solAddress, wc.Contract, msgC, obsvReqC, wc.Commitment, wc.ChainID).Run, nil
+}

--- a/node/pkg/watchers/sui/suiWatcherConfig.go
+++ b/node/pkg/watchers/sui/suiWatcherConfig.go
@@ -1,0 +1,46 @@
+package sui
+
+import (
+	"github.com/certusone/wormhole/node/pkg/common"
+	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
+	"github.com/certusone/wormhole/node/pkg/supervisor"
+	"github.com/certusone/wormhole/node/pkg/watchers"
+	"github.com/certusone/wormhole/node/pkg/watchers/interfaces"
+	"github.com/wormhole-foundation/wormhole/sdk/vaa"
+)
+
+type WatcherConfig struct {
+	NetworkID watchers.NetworkID // human readable name
+	ChainID   vaa.ChainID        // ChainID
+	Rpc       string
+	Websocket string
+	Account   string
+	Package   string
+}
+
+func (wc *WatcherConfig) GetNetworkID() watchers.NetworkID {
+	return wc.NetworkID
+}
+
+func (wc *WatcherConfig) GetChainID() vaa.ChainID {
+	return wc.ChainID
+}
+
+func (wc *WatcherConfig) RequiredL1Finalizer() watchers.NetworkID {
+	return ""
+}
+
+func (wc *WatcherConfig) SetL1Finalizer(l1finalizer interfaces.L1Finalizer) {
+	// empty
+}
+
+func (wc *WatcherConfig) Create(
+	msgC chan<- *common.MessagePublication,
+	obsvReqC <-chan *gossipv1.ObservationRequest,
+	_ chan<- *common.GuardianSet,
+	env common.Environment,
+) (interfaces.L1Finalizer, supervisor.Runnable, error) {
+	var devMode bool = (env == common.UnsafeDevNet)
+
+	return nil, NewWatcher(wc.Rpc, wc.Websocket, wc.Account, wc.Package, devMode, msgC, obsvReqC).Run, nil
+}

--- a/node/pkg/watchers/sui/watcher.go
+++ b/node/pkg/watchers/sui/watcher.go
@@ -42,8 +42,8 @@ type (
 
 		unsafeDevMode bool
 
-		msgChan       chan *common.MessagePublication
-		obsvReqC      chan *gossipv1.ObservationRequest
+		msgChan       chan<- *common.MessagePublication
+		obsvReqC      <-chan *gossipv1.ObservationRequest
 		readinessSync readiness.Component
 
 		subId      int64
@@ -126,8 +126,8 @@ func NewWatcher(
 	suiAccount string,
 	suiPackage string,
 	unsafeDevMode bool,
-	messageEvents chan *common.MessagePublication,
-	obsvReqC chan *gossipv1.ObservationRequest,
+	messageEvents chan<- *common.MessagePublication,
+	obsvReqC <-chan *gossipv1.ObservationRequest,
 ) *Watcher {
 	return &Watcher{
 		suiRPC:        suiRPC,

--- a/node/pkg/watchers/watchers.go
+++ b/node/pkg/watchers/watchers.go
@@ -1,0 +1,26 @@
+package watchers
+
+import (
+	"github.com/certusone/wormhole/node/pkg/common"
+	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
+	"github.com/certusone/wormhole/node/pkg/supervisor"
+	"github.com/certusone/wormhole/node/pkg/watchers/interfaces"
+	"github.com/wormhole-foundation/wormhole/sdk/vaa"
+)
+
+// NetworkID is a unique identifier of a watcher that is used to link watchers together for the purpose of L1 Finalizers.
+// This is different from vaa.ChainID because there could be multiple watchers for a single chain (e.g. solana-confirmed and solana-finalized)
+type NetworkID string
+
+type WatcherConfig interface {
+	GetNetworkID() NetworkID
+	GetChainID() vaa.ChainID
+	RequiredL1Finalizer() NetworkID // returns NetworkID of the L1 Finalizer that should be used for this Watcher.
+	SetL1Finalizer(l1finalizer interfaces.L1Finalizer)
+	Create(
+		msgC chan<- *common.MessagePublication,
+		obsvReqC <-chan *gossipv1.ObservationRequest,
+		setC chan<- *common.GuardianSet,
+		env common.Environment,
+	) (interfaces.L1Finalizer, supervisor.Runnable, error)
+}

--- a/node/pkg/watchers/wormchain/wormchainWatcherConfig.go
+++ b/node/pkg/watchers/wormchain/wormchainWatcherConfig.go
@@ -1,0 +1,42 @@
+package wormchain
+
+import (
+	"github.com/certusone/wormhole/node/pkg/common"
+	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
+	"github.com/certusone/wormhole/node/pkg/supervisor"
+	"github.com/certusone/wormhole/node/pkg/watchers"
+	"github.com/certusone/wormhole/node/pkg/watchers/interfaces"
+	"github.com/wormhole-foundation/wormhole/sdk/vaa"
+)
+
+type WatcherConfig struct {
+	NetworkID watchers.NetworkID // human readable name
+	ChainID   vaa.ChainID        // ChainID
+	Websocket string
+	Lcd       string
+}
+
+func (wc *WatcherConfig) GetNetworkID() watchers.NetworkID {
+	return wc.NetworkID
+}
+
+func (wc *WatcherConfig) GetChainID() vaa.ChainID {
+	return wc.ChainID
+}
+
+func (wc *WatcherConfig) RequiredL1Finalizer() watchers.NetworkID {
+	return ""
+}
+
+func (wc *WatcherConfig) SetL1Finalizer(l1finalizer interfaces.L1Finalizer) {
+	// empty
+}
+
+func (wc *WatcherConfig) Create(
+	msgC chan<- *common.MessagePublication,
+	obsvReqC <-chan *gossipv1.ObservationRequest,
+	_ chan<- *common.GuardianSet,
+	env common.Environment,
+) (interfaces.L1Finalizer, supervisor.Runnable, error) {
+	return nil, NewWatcher(wc.Websocket, wc.Lcd, msgC, obsvReqC).Run, nil
+}


### PR DESCRIPTION
Goals
* refactor the Guardian Node into its own package such that it can be tested through golang unit-tests.

Non-goals
* Any kind of refactoring beyond the stated goal is not in-scope. The interfaces of the various components could probably be further cleaned up and the handling of the configuration flags could probably be improved (e.g. with `viper`). 

High-level overview
* The `node` package is added with `type GuardianNode`. This allows creating multiple `GuardianNode` in the unit tests. 
* Configuration of `GuardianNode` is implemented through currying. This helps to separate the *specification* of the configuration from the *application* of the configuration. 
    * The configuration of the Guardian previously took 710 lines (https://github.com/wormhole-foundation/wormhole/blob/main/node/cmd/guardiand/node.go#L783-L1493). It is now reduced to 501 lines which are much more clear and less error-prone. 
    * Watchers are now configured through the `WatcherConfig` interface, which I implemented for each watcher. This can probably be cleaned up further, but is not in scope of this PR. 

Functional changes
* *All* watchers will be run with `common.WrapWithScissors`. Before, the following ran without: Wormchain, Aptos, Sui.
* A few log messages might've been changed
* Other than that, there should be no functional changes in this PR! 