### PR TITLE
Node/Gov: Split up CoinGecko queries

### DIFF
--- a/node/pkg/governor/governor.go
+++ b/node/pkg/governor/governor.go
@@ -126,7 +126,7 @@ type ChainGovernor struct {
 	msgsSeen              map[string]bool // Key is hash, payload is consts transferComplete and transferEnqueued.
 	msgsToPublish         []*common.MessagePublication
 	dayLengthInMinutes    int
-	coinGeckoQuery        string
+	coinGeckoQueries      []string
 	env                   int
 	nextStatusPublishTime time.Time
 	nextConfigPublishTime time.Time

--- a/node/pkg/governor/governor_prices.go
+++ b/node/pkg/governor/governor_prices.go
@@ -113,7 +113,7 @@ func (gov *ChainGovernor) queryCoinGecko() error {
 	for queryIdx, query := range gov.coinGeckoQueries {
 		thisResult, err := gov.queryCoinGeckoChunk(query)
 		if err != nil {
-			gov.logger.Error("cgov: coin gecko query failed", zap.Int("queryIdx", queryIdx), zap.String("query", query), zap.Error(err))
+			gov.logger.Error("cgov: CoinGecko query failed", zap.Int("queryIdx", queryIdx), zap.String("query", query), zap.Error(err))
 			gov.revertAllPrices()
 			return err
 		}
@@ -144,7 +144,7 @@ func (gov *ChainGovernor) queryCoinGecko() error {
 				var ok bool
 				price, ok = m["usd"].(float64)
 				if !ok {
-					gov.logger.Error("cgov: failed to parse coin gecko response, reverting to configured price for this token", zap.String("coinGeckoId", coinGeckoId))
+					gov.logger.Error("cgov: failed to parse CoinGecko response, reverting to configured price for this token", zap.String("coinGeckoId", coinGeckoId))
 					// By continuing, we leave this one in the local map so the price will get reverted below.
 					continue
 				}
@@ -187,7 +187,7 @@ func (gov *ChainGovernor) queryCoinGecko() error {
 func (gov *ChainGovernor) queryCoinGeckoChunk(query string) (map[string]interface{}, error) {
 	var result map[string]interface{}
 
-	gov.logger.Debug("cgov: executing coin gecko query", zap.String("query", query))
+	gov.logger.Debug("cgov: executing CoinGecko query", zap.String("query", query))
 	response, err := http.Get(query) //nolint:gosec
 	if err != nil {
 		return result, fmt.Errorf("failed to query CoinGecko: %w", err)
@@ -196,7 +196,7 @@ func (gov *ChainGovernor) queryCoinGeckoChunk(query string) (map[string]interfac
 	defer func() {
 		err = response.Body.Close()
 		if err != nil {
-			gov.logger.Error("cgov: failed to close coin gecko query: %w", zap.Error(err))
+			gov.logger.Error("cgov: failed to close CoinGecko query: %w", zap.Error(err))
 		}
 	}()
 
@@ -207,11 +207,11 @@ func (gov *ChainGovernor) queryCoinGeckoChunk(query string) (map[string]interfac
 
 	resp := string(responseData)
 	if strings.Contains(resp, "error_code") {
-		return result, fmt.Errorf("coin gecko query failed: %s", resp)
+		return result, fmt.Errorf("CoinGecko query failed: %s", resp)
 	}
 
 	if err := json.Unmarshal(responseData, &result); err != nil {
-		return result, fmt.Errorf("failed to unmarshal coin gecko json: %w", err)
+		return result, fmt.Errorf("failed to unmarshal CoinGecko json: %w", err)
 	}
 
 	return result, nil

--- a/node/pkg/governor/governor_prices.go
+++ b/node/pkg/governor/governor_prices.go
@@ -73,7 +73,7 @@ func (gov *ChainGovernor) initCoinGecko(ctx context.Context, run bool) error {
 	return nil
 }
 
-// createCoinGeckoQuery creates a Coink Gecko query for the specified set of tokens and adds it to the list.
+// createCoinGeckoQuery creates a CoinGecko query for the specified set of tokens and adds it to the list.
 func (gov *ChainGovernor) createCoinGeckoQuery(queryIdx int, ids string) {
 	params := url.Values{}
 	params.Add("ids", ids)
@@ -183,7 +183,7 @@ func (gov *ChainGovernor) queryCoinGecko() error {
 	return nil
 }
 
-// queryCoinGeckoChunk sends a single Coin Gecko query and returns the result.
+// queryCoinGeckoChunk sends a single CoinGecko query and returns the result.
 func (gov *ChainGovernor) queryCoinGeckoChunk(query string) (map[string]interface{}, error) {
 	var result map[string]interface{}
 


### PR DESCRIPTION
As the number of tokens monitored by the governor increases (to something over 500), the CoinGecko query will eventually fail with a "rate limit exceeded" error. This PR breaks the queries up into chunks of 200 tokens, with a one second sleep between each query.