### PR TITLE
Node/Acct: Logging changes

### DIFF
--- a/node/pkg/accountant/accountant.go
+++ b/node/pkg/accountant/accountant.go
@@ -127,7 +127,7 @@ func NewAccountant(
 
 // Run initializes the accountant and starts the watcher runnable.
 func (acct *Accountant) Start(ctx context.Context) error {
-	acct.logger.Debug("acct: entering Start", zap.Bool("enforceFlag", acct.enforceFlag))
+	acct.logger.Debug("gacct: entering Start", zap.Bool("enforceFlag", acct.enforceFlag))
 	acct.pendingTransfersLock.Lock()
 	defer acct.pendingTransfersLock.Unlock()
 
@@ -153,7 +153,7 @@ func (acct *Accountant) Start(ctx context.Context) error {
 
 		tbe := &tokenBridgeEntry{}
 		acct.tokenBridges[tbk] = tbe
-		acct.logger.Info("acct: will monitor token bridge:", zap.Stringer("emitterChainId", tbk.emitterChainId), zap.Stringer("emitterAddr", tbk.emitterAddr))
+		acct.logger.Info("gacct: will monitor token bridge:", zap.Stringer("emitterChainId", tbk.emitterChainId), zap.Stringer("emitterAddr", tbk.emitterAddr))
 	}
 
 	// Load any existing pending transfers from the db.
@@ -201,7 +201,7 @@ func (acct *Accountant) IsMessageCoveredByAccountant(msg *common.MessagePublicat
 	tbk := tokenBridgeKey{emitterChainId: msg.EmitterChain, emitterAddr: msg.EmitterAddress}
 	if _, exists := acct.tokenBridges[tbk]; !exists {
 		if msg.EmitterChain != vaa.ChainIDPythNet {
-			acct.logger.Debug("acct: ignoring vaa because it is not a token bridge", zap.String("msgID", msgId))
+			acct.logger.Debug("gacct: ignoring vaa because it is not a token bridge", zap.String("msgID", msgId))
 		}
 
 		return false
@@ -209,7 +209,7 @@ func (acct *Accountant) IsMessageCoveredByAccountant(msg *common.MessagePublicat
 
 	// We only care about transfers.
 	if !vaa.IsTransfer(msg.Payload) {
-		acct.logger.Info("acct: ignoring vaa because it is not a transfer", zap.String("msgID", msgId))
+		acct.logger.Info("gacct: ignoring vaa because it is not a transfer", zap.String("msgID", msgId))
 		return false
 	}
 
@@ -221,7 +221,7 @@ func (acct *Accountant) IsMessageCoveredByAccountant(msg *common.MessagePublicat
 // false if not (because it has been submitted to accountant).
 func (acct *Accountant) SubmitObservation(msg *common.MessagePublication) (bool, error) {
 	msgId := msg.MessageIDString()
-	acct.logger.Debug("acct: in SubmitObservation", zap.String("msgID", msgId))
+	acct.logger.Debug("gacct: in SubmitObservation", zap.String("msgID", msgId))
 
 	if !acct.IsMessageCoveredByAccountant(msg) {
 		return true, nil
@@ -236,14 +236,14 @@ func (acct *Accountant) SubmitObservation(msg *common.MessagePublication) (bool,
 	if oldEntry, exists := acct.pendingTransfers[msgId]; exists {
 		if oldEntry.digest != digest {
 			digestMismatches.Inc()
-			acct.logger.Error("acct: digest in pending transfer has changed, dropping it",
+			acct.logger.Error("gacct: digest in pending transfer has changed, dropping it",
 				zap.String("msgID", msgId),
 				zap.String("oldDigest", oldEntry.digest),
 				zap.String("newDigest", digest),
 				zap.Bool("enforcing", acct.enforceFlag),
 			)
 		} else {
-			acct.logger.Info("acct: blocking transfer because it is already outstanding", zap.String("msgID", msgId), zap.Bool("enforcing", acct.enforceFlag))
+			acct.logger.Info("gacct: blocking transfer because it is already outstanding", zap.String("msgID", msgId), zap.Bool("enforcing", acct.enforceFlag))
 		}
 		return !acct.enforceFlag, nil
 	}
@@ -251,13 +251,13 @@ func (acct *Accountant) SubmitObservation(msg *common.MessagePublication) (bool,
 	// Add it to the pending map and the database.
 	pe := &pendingEntry{msg: msg, msgId: msgId, digest: digest}
 	if err := acct.addPendingTransferAlreadyLocked(pe); err != nil {
-		acct.logger.Error("acct: failed to persist pending transfer, blocking publishing", zap.String("msgID", msgId), zap.Error(err))
+		acct.logger.Error("gacct: failed to persist pending transfer, blocking publishing", zap.String("msgID", msgId), zap.Error(err))
 		return false, err
 	}
 
 	// This transaction may take a while. Pass it off to the worker so we don't block the processor.
 	if acct.env != GoTestMode {
-		acct.logger.Info("acct: submitting transfer to accountant for approval", zap.String("msgID", msgId), zap.Bool("canPublish", !acct.enforceFlag))
+		acct.logger.Info("gacct: submitting transfer to accountant for approval", zap.String("msgID", msgId), zap.Bool("canPublish", !acct.enforceFlag))
 		_ = acct.submitObservation(pe)
 	}
 
@@ -268,7 +268,7 @@ func (acct *Accountant) SubmitObservation(msg *common.MessagePublication) (bool,
 // publishTransferAlreadyLocked publishes a pending transfer to the accountant channel and updates the timestamp. It assumes the caller holds the lock.
 func (acct *Accountant) publishTransferAlreadyLocked(pe *pendingEntry) {
 	if acct.enforceFlag {
-		acct.logger.Debug("acct: publishTransferAlreadyLocked: notifying the processor", zap.String("msgId", pe.msgId))
+		acct.logger.Debug("gacct: publishTransferAlreadyLocked: notifying the processor", zap.String("msgId", pe.msgId))
 		acct.msgChan <- pe.msg
 	}
 
@@ -277,7 +277,7 @@ func (acct *Accountant) publishTransferAlreadyLocked(pe *pendingEntry) {
 
 // addPendingTransferAlreadyLocked adds a pending transfer to both the map and the database. It assumes the caller holds the lock.
 func (acct *Accountant) addPendingTransferAlreadyLocked(pe *pendingEntry) error {
-	acct.logger.Debug("acct: addPendingTransferAlreadyLocked", zap.String("msgId", pe.msgId))
+	acct.logger.Debug("gacct: addPendingTransferAlreadyLocked", zap.String("msgId", pe.msgId))
 	pe.setUpdTime()
 	if err := acct.db.AcctStorePendingTransfer(pe.msg); err != nil {
 		return err
@@ -297,13 +297,13 @@ func (acct *Accountant) deletePendingTransfer(msgId string) {
 
 // deletePendingTransferAlreadyLocked deletes the transfer from both the map and the database. It assumes the caller holds the lock.
 func (acct *Accountant) deletePendingTransferAlreadyLocked(msgId string) {
-	acct.logger.Debug("acct: deletePendingTransfer", zap.String("msgId", msgId))
+	acct.logger.Debug("gacct: deletePendingTransfer", zap.String("msgId", msgId))
 	if _, exists := acct.pendingTransfers[msgId]; exists {
 		delete(acct.pendingTransfers, msgId)
 		transfersOutstanding.Set(float64(len(acct.pendingTransfers)))
 	}
 	if err := acct.db.AcctDeletePendingTransfer(msgId); err != nil {
-		acct.logger.Error("acct: failed to delete pending transfer from the db", zap.String("msgId", msgId), zap.Error(err))
+		acct.logger.Error("gacct: failed to delete pending transfer from the db", zap.String("msgId", msgId), zap.Error(err))
 		// Ignore this error and keep going.
 	}
 }
@@ -317,7 +317,7 @@ func (acct *Accountant) loadPendingTransfers() error {
 
 	for _, msg := range pendingTransfers {
 		msgId := msg.MessageIDString()
-		acct.logger.Info("acct: reloaded pending transfer", zap.String("msgID", msgId))
+		acct.logger.Info("gacct: reloaded pending transfer", zap.String("msgID", msgId))
 
 		digest := msg.CreateDigest()
 		pe := &pendingEntry{msg: msg, msgId: msgId, digest: digest}
@@ -327,9 +327,9 @@ func (acct *Accountant) loadPendingTransfers() error {
 
 	transfersOutstanding.Set(float64(len(acct.pendingTransfers)))
 	if len(acct.pendingTransfers) != 0 {
-		acct.logger.Info("acct: reloaded pending transfers", zap.Int("total", len(acct.pendingTransfers)))
+		acct.logger.Info("gacct: reloaded pending transfers", zap.Int("total", len(acct.pendingTransfers)))
 	} else {
-		acct.logger.Info("acct: no pending transfers to be reloaded")
+		acct.logger.Info("gacct: no pending transfers to be reloaded")
 	}
 
 	return nil
@@ -352,9 +352,9 @@ func (acct *Accountant) submitObservation(pe *pendingEntry) bool {
 
 	select {
 	case acct.subChan <- pe.msg:
-		acct.logger.Debug("acct: submitted observation to channel", zap.String("msgId", pe.msgId))
+		acct.logger.Debug("gacct: submitted observation to channel", zap.String("msgId", pe.msgId))
 	default:
-		acct.logger.Error("acct: unable to submit observation because the channel is full, will try next interval", zap.String("msgId", pe.msgId))
+		acct.logger.Error("gacct: unable to submit observation because the channel is full, will try next interval", zap.String("msgId", pe.msgId))
 		pe.state.submitPending = false
 	}
 

--- a/node/pkg/accountant/audit.go
+++ b/node/pkg/accountant/audit.go
@@ -129,9 +129,9 @@ func (acct *Accountant) audit(ctx context.Context) error {
 // runAudit is the entry point for the audit of the pending transfer map. It creates a temporary map of all pending transfers and invokes the main audit function.
 func (acct *Accountant) runAudit() {
 	tmpMap := acct.createAuditMap()
-	acct.logger.Debug("acctaudit: in AuditPendingTransfers: starting audit", zap.Int("numPending", len(tmpMap)))
+	acct.logger.Debug("gacctaudit: in AuditPendingTransfers: starting audit", zap.Int("numPending", len(tmpMap)))
 	acct.performAudit(tmpMap)
-	acct.logger.Debug("acctaudit: leaving AuditPendingTransfers")
+	acct.logger.Debug("gacctaudit: leaving AuditPendingTransfers")
 }
 
 // createAuditMap creates a temporary map of all pending transfers. It grabs the pending transfer lock.
@@ -143,10 +143,10 @@ func (acct *Accountant) createAuditMap() map[string]*pendingEntry {
 	for _, pe := range acct.pendingTransfers {
 		if pe.hasBeenPendingForTooLong() {
 			auditErrors.Inc()
-			acct.logger.Error("acctaudit: transfer has been in the submit pending state for too long", zap.Stringer("lastUpdateTime", pe.updTime()))
+			acct.logger.Error("gacctaudit: transfer has been in the submit pending state for too long", zap.Stringer("lastUpdateTime", pe.updTime()))
 		}
 		key := pe.makeAuditKey()
-		acct.logger.Debug("acctaudit: will audit pending transfer", zap.String("msgId", pe.msgId), zap.String("moKey", key), zap.Bool("submitPending", pe.submitPending()), zap.Stringer("lastUpdateTime", pe.updTime()))
+		acct.logger.Debug("gacctaudit: will audit pending transfer", zap.String("msgId", pe.msgId), zap.String("moKey", key), zap.Bool("submitPending", pe.submitPending()), zap.Stringer("lastUpdateTime", pe.updTime()))
 		tmpMap[key] = pe
 	}
 
@@ -163,12 +163,12 @@ func (pe *pendingEntry) hasBeenPendingForTooLong() bool {
 // performAudit audits the temporary map against the smart contract. It is meant to be run in a go routine. It takes a temporary map of all pending transfers
 // and validates that against what is reported by the smart contract. For more details, please see the prologue of this file.
 func (acct *Accountant) performAudit(tmpMap map[string]*pendingEntry) {
-	acct.logger.Debug("acctaudit: entering performAudit")
+	acct.logger.Debug("gacctaudit: entering performAudit")
 	missingObservations, err := acct.queryMissingObservations()
 	if err != nil {
-		acct.logger.Error("acctaudit: unable to perform audit, failed to query missing observations", zap.Error(err))
+		acct.logger.Error("gacctaudit: unable to perform audit, failed to query missing observations", zap.Error(err))
 		for _, pe := range tmpMap {
-			acct.logger.Error("acctaudit: unsure of status of pending transfer due to query error", zap.String("msgId", pe.msgId))
+			acct.logger.Error("gacctaudit: unsure of status of pending transfer due to query error", zap.String("msgId", pe.msgId))
 		}
 		return
 	}
@@ -179,9 +179,9 @@ func (acct *Accountant) performAudit(tmpMap map[string]*pendingEntry) {
 		if exists {
 			if acct.submitObservation(pe) {
 				auditErrors.Inc()
-				acct.logger.Error("acctaudit: contract reported pending observation as missing, resubmitted it", zap.String("msgID", pe.msgId))
+				acct.logger.Error("gacctaudit: contract reported pending observation as missing, resubmitted it", zap.String("msgID", pe.msgId))
 			} else {
-				acct.logger.Info("acctaudit: contract reported pending observation as missing but it is queued up to be submitted, skipping it", zap.String("msgID", pe.msgId))
+				acct.logger.Info("gacctaudit: contract reported pending observation as missing but it is queued up to be submitted, skipping it", zap.String("msgID", pe.msgId))
 			}
 
 			delete(tmpMap, key)
@@ -200,9 +200,9 @@ func (acct *Accountant) performAudit(tmpMap map[string]*pendingEntry) {
 
 		transferDetails, err := acct.queryBatchTransferStatus(keys)
 		if err != nil {
-			acct.logger.Error("acctaudit: unable to finish audit, failed to query for transfer statuses", zap.Error(err))
+			acct.logger.Error("gacctaudit: unable to finish audit, failed to query for transfer statuses", zap.Error(err))
 			for _, pe := range tmpMap {
-				acct.logger.Error("acctaudit: unsure of status of pending transfer due to query error", zap.String("msgId", pe.msgId))
+				acct.logger.Error("gacctaudit: unsure of status of pending transfer due to query error", zap.String("msgId", pe.msgId))
 			}
 			return
 		}
@@ -212,9 +212,9 @@ func (acct *Accountant) performAudit(tmpMap map[string]*pendingEntry) {
 			if !exists {
 				if acct.submitObservation(pe) {
 					auditErrors.Inc()
-					acct.logger.Error("acctaudit: query did not return status for transfer, this should not happen, resubmitted it", zap.String("msgId", pe.msgId))
+					acct.logger.Error("gacctaudit: query did not return status for transfer, this should not happen, resubmitted it", zap.String("msgId", pe.msgId))
 				} else {
-					acct.logger.Info("acctaudit: query did not return status for transfer we have not submitted yet, ignoring it", zap.String("msgId", pe.msgId))
+					acct.logger.Info("gacctaudit: query did not return status for transfer we have not submitted yet, ignoring it", zap.String("msgId", pe.msgId))
 				}
 
 				continue
@@ -224,48 +224,48 @@ func (acct *Accountant) performAudit(tmpMap map[string]*pendingEntry) {
 				// This is the case when the contract does not know about a transfer. Resubmit it.
 				if acct.submitObservation(pe) {
 					auditErrors.Inc()
-					acct.logger.Error("acctaudit: contract does not know about pending transfer, resubmitted it", zap.String("msgId", pe.msgId))
+					acct.logger.Error("gacctaudit: contract does not know about pending transfer, resubmitted it", zap.String("msgId", pe.msgId))
 				}
 			} else if status.Committed != nil {
 				digest := hex.EncodeToString(status.Committed.Digest)
 				if pe.digest == digest {
-					acct.logger.Error("acctaudit: audit determined that transfer has been committed, publishing it", zap.String("msgId", pe.msgId))
+					acct.logger.Warn("gacctaudit: audit determined that transfer has been committed, publishing it", zap.String("msgId", pe.msgId))
 					acct.handleCommittedTransfer(pe.msgId)
 				} else {
 					digestMismatches.Inc()
-					acct.logger.Error("acctaudit: audit detected a digest mismatch, dropping transfer", zap.String("msgId", pe.msgId), zap.String("ourDigest", pe.digest), zap.String("reportedDigest", digest))
+					acct.logger.Error("gacctaudit: audit detected a digest mismatch, dropping transfer", zap.String("msgId", pe.msgId), zap.String("ourDigest", pe.digest), zap.String("reportedDigest", digest))
 					acct.deletePendingTransfer(pe.msgId)
 				}
 			} else if status.Pending != nil {
-				acct.logger.Debug("acctaudit: contract says transfer is still pending", zap.String("msgId", pe.msgId))
+				acct.logger.Debug("gacctaudit: contract says transfer is still pending", zap.String("msgId", pe.msgId))
 			} else {
 				// This is the case when the contract does not know about a transfer. Resubmit it.
 				if acct.submitObservation(pe) {
 					auditErrors.Inc()
 					bytes, err := json.Marshal(*status)
 					if err != nil {
-						acct.logger.Error("acctaudit: unknown status returned for pending transfer, resubmitted it", zap.String("msgId", pe.msgId), zap.Error(err))
+						acct.logger.Error("gacctaudit: unknown status returned for pending transfer, resubmitted it", zap.String("msgId", pe.msgId), zap.Error(err))
 					} else {
-						acct.logger.Error("acctaudit: unknown status returned for pending transfer, resubmitted it", zap.String("msgId", pe.msgId), zap.String("status", string(bytes)))
+						acct.logger.Error("gacctaudit: unknown status returned for pending transfer, resubmitted it", zap.String("msgId", pe.msgId), zap.String("status", string(bytes)))
 					}
 				}
 			}
 		}
 	}
 
-	acct.logger.Debug("acctaudit: exiting performAudit")
+	acct.logger.Debug("gacctaudit: exiting performAudit")
 }
 
 // handleMissingObservation submits a local reobservation request. It relies on the reobservation code to throttle requests.
 func (acct *Accountant) handleMissingObservation(mo MissingObservation) {
-	acct.logger.Error("acctaudit: contract reported unknown observation as missing, requesting local reobservation", zap.Stringer("moKey", mo))
+	acct.logger.Warn("gacctaudit: contract reported unknown observation as missing, requesting local reobservation", zap.Stringer("moKey", mo))
 	msg := &gossipv1.ObservationRequest{ChainId: uint32(mo.ChainId), TxHash: mo.TxHash}
 
 	select {
 	case acct.obsvReqWriteC <- msg:
-		acct.logger.Debug("acctaudit: submitted local reobservation", zap.Stringer("moKey", mo))
+		acct.logger.Debug("gacctaudit: submitted local reobservation", zap.Stringer("moKey", mo))
 	default:
-		acct.logger.Error("acctaudit: unable to submit local reobservation because the channel is full, will try next interval", zap.Stringer("moKey", mo))
+		acct.logger.Error("gacctaudit: unable to submit local reobservation because the channel is full, will try next interval", zap.Stringer("moKey", mo))
 	}
 }
 
@@ -282,7 +282,7 @@ func (acct *Accountant) queryMissingObservations() ([]MissingObservation, error)
 	}
 
 	query := fmt.Sprintf(`{"missing_observations":{"guardian_set": %d, "index": %d}}`, gs.Index, guardianIndex)
-	acct.logger.Debug("acctaudit: submitting missing_observations query", zap.String("query", query))
+	acct.logger.Debug("gacctaudit: submitting missing_observations query", zap.String("query", query))
 	respBytes, err := acct.wormchainConn.SubmitQuery(acct.ctx, acct.contract, []byte(query))
 	if err != nil {
 		return nil, fmt.Errorf("missing_observations query failed: %w, %s", err, query)
@@ -293,7 +293,7 @@ func (acct *Accountant) queryMissingObservations() ([]MissingObservation, error)
 		return nil, fmt.Errorf("failed to parse missing_observations response: %w, resp: %s", err, string(respBytes))
 	}
 
-	acct.logger.Debug("acctaudit: missing_observations query response", zap.Int("numEntries", len(ret.Missing)), zap.String("result", string(respBytes)))
+	acct.logger.Debug("gacctaudit: missing_observations query response", zap.Int("numEntries", len(ret.Missing)), zap.String("result", string(respBytes)))
 	return ret.Missing, nil
 }
 
@@ -357,7 +357,7 @@ func queryBatchTransferStatusForChunk(
 	}
 
 	query := fmt.Sprintf(`{"batch_transfer_status":%s}`, string(bytes))
-	logger.Debug("acctaudit: submitting batch_transfer_status query", zap.String("query", query))
+	logger.Debug("gacctaudit: submitting batch_transfer_status query", zap.String("query", query))
 	respBytes, err := qc.SubmitQuery(ctx, contract, []byte(query))
 	if err != nil {
 		return nil, fmt.Errorf("batch_transfer_status query failed: %w, %s", err, query)
@@ -373,6 +373,6 @@ func queryBatchTransferStatusForChunk(
 		ret[item.Key.String()] = item.Status
 	}
 
-	logger.Debug("acctaudit: batch_transfer_status query response", zap.Int("numEntries", len(ret)), zap.String("result", string(respBytes)))
+	logger.Debug("gacctaudit: batch_transfer_status query response", zap.Int("numEntries", len(ret)), zap.String("result", string(respBytes)))
 	return ret, nil
 }

--- a/node/pkg/accountant/submit_obs.go
+++ b/node/pkg/accountant/submit_obs.go
@@ -197,9 +197,9 @@ func (acct *Accountant) submitObservationsToContract(msgs []*common.MessagePubli
 	txResp, err := SubmitObservationsToContract(acct.ctx, acct.logger, acct.gk, gsIndex, guardianIndex, acct.wormchainConn, acct.contract, msgs)
 	if err != nil {
 		// This means the whole batch failed. They will all get retried the next audit cycle.
-		acct.logger.Error("acct: failed to submit any observations in batch", zap.Int("numMsgs", len(msgs)), zap.Error(err))
+		acct.logger.Error("gacct: failed to submit any observations in batch", zap.Int("numMsgs", len(msgs)), zap.Error(err))
 		for idx, msg := range msgs {
-			acct.logger.Error("acct: failed to submit observation", zap.Int("idx", idx), zap.String("msgId", msg.MessageIDString()))
+			acct.logger.Error("gacct: failed to submit observation", zap.Int("idx", idx), zap.String("msgId", msg.MessageIDString()))
 		}
 
 		submitFailures.Add(float64(len(msgs)))
@@ -210,9 +210,9 @@ func (acct *Accountant) submitObservationsToContract(msgs []*common.MessagePubli
 	responses, err := GetObservationResponses(txResp)
 	if err != nil {
 		// This means the whole batch failed. They will all get retried the next audit cycle.
-		acct.logger.Error("acct: failed to get responses from batch", zap.Error(err), zap.String("txResp", acct.wormchainConn.BroadcastTxResponseToString(txResp)))
+		acct.logger.Error("gacct: failed to get responses from batch", zap.Error(err), zap.String("txResp", acct.wormchainConn.BroadcastTxResponseToString(txResp)))
 		for idx, msg := range msgs {
-			acct.logger.Error("acct: need to retry observation", zap.Int("idx", idx), zap.String("msgId", msg.MessageIDString()))
+			acct.logger.Error("gacct: need to retry observation", zap.Int("idx", idx), zap.String("msgId", msg.MessageIDString()))
 		}
 
 		submitFailures.Add(float64(len(msgs)))
@@ -222,9 +222,9 @@ func (acct *Accountant) submitObservationsToContract(msgs []*common.MessagePubli
 
 	if len(responses) != len(msgs) {
 		// This means the whole batch failed. They will all get retried the next audit cycle.
-		acct.logger.Error("acct: number of responses does not match number of messages", zap.Int("numMsgs", len(msgs)), zap.Int("numResp", len(responses)), zap.Error(err))
+		acct.logger.Error("gacct: number of responses does not match number of messages", zap.Int("numMsgs", len(msgs)), zap.Int("numResp", len(responses)), zap.Error(err))
 		for idx, msg := range msgs {
-			acct.logger.Error("acct: need to retry observation", zap.Int("idx", idx), zap.String("msgId", msg.MessageIDString()))
+			acct.logger.Error("gacct: need to retry observation", zap.Int("idx", idx), zap.String("msgId", msg.MessageIDString()))
 		}
 
 		submitFailures.Add(float64(len(msgs)))
@@ -238,22 +238,22 @@ func (acct *Accountant) submitObservationsToContract(msgs []*common.MessagePubli
 		status, exists := responses[msgId]
 		if !exists {
 			// This will get retried next audit interval.
-			acct.logger.Error("acct: did not receive an observation response for message", zap.String("msgId", msgId))
+			acct.logger.Error("gacct: did not receive an observation response for message", zap.String("msgId", msgId))
 			submitFailures.Inc()
 			continue
 		}
 
 		switch status.Type {
 		case "pending":
-			acct.logger.Info("acct: transfer is pending", zap.String("msgId", msgId))
+			acct.logger.Info("gacct: transfer is pending", zap.String("msgId", msgId))
 		case "committed":
 			acct.handleCommittedTransfer(msgId)
 		case "error":
 			submitFailures.Inc()
-			acct.handleTransferError(msgId, status.Data, "acct: transfer failed")
+			acct.handleTransferError(msgId, status.Data, "gacct: transfer failed")
 		default:
 			// This will get retried next audit interval.
-			acct.logger.Error("acct: unexpected status response on observation", zap.String("msgId", msgId), zap.String("status", status.Type), zap.String("text", status.Data))
+			acct.logger.Error("gacct: unexpected status response on observation", zap.String("msgId", msgId), zap.String("status", status.Type), zap.String("text", status.Data))
 			submitFailures.Inc()
 		}
 	}
@@ -267,11 +267,11 @@ func (acct *Accountant) handleCommittedTransfer(msgId string) {
 	defer acct.pendingTransfersLock.Unlock()
 	pe, exists := acct.pendingTransfers[msgId]
 	if exists {
-		acct.logger.Info("acct: transfer has been committed, publishing it", zap.String("msgId", msgId))
+		acct.logger.Info("gacct: transfer has been committed, publishing it", zap.String("msgId", msgId))
 		acct.publishTransferAlreadyLocked(pe)
 		transfersApproved.Inc()
 	} else {
-		acct.logger.Debug("acct: transfer has been committed but it is no longer in our map", zap.String("msgId", msgId))
+		acct.logger.Debug("gacct: transfer has been committed but it is no longer in our map", zap.String("msgId", msgId))
 	}
 }
 
@@ -279,7 +279,7 @@ func (acct *Accountant) handleCommittedTransfer(msgId string) {
 func (acct *Accountant) handleTransferError(msgId string, errText string, logText string) {
 	if strings.Contains(errText, "insufficient balance") {
 		balanceErrors.Inc()
-		acct.logger.Error("acct: insufficient balance error detected, dropping transfer", zap.String("msgId", msgId), zap.String("text", errText))
+		acct.logger.Error("gacct: insufficient balance error detected, dropping transfer", zap.String("msgId", msgId), zap.String("text", errText))
 		acct.deletePendingTransfer(msgId)
 	} else {
 		// This will get retried next audit interval.
@@ -313,7 +313,7 @@ func SubmitObservationsToContract(
 			Payload:          msg.Payload,
 		}
 
-		logger.Debug("acct: in SubmitObservationsToContract, encoding observation",
+		logger.Debug("gacct: in SubmitObservationsToContract, encoding observation",
 			zap.Int("idx", idx),
 			zap.String("txHash", msg.TxHash.String()), zap.String("encTxHash", hex.EncodeToString(obs[idx].TxHash[:])),
 			zap.Stringer("timeStamp", msg.Timestamp), zap.Uint32("encTimestamp", obs[idx].Timestamp),
@@ -328,17 +328,17 @@ func SubmitObservationsToContract(
 
 	bytes, err := json.Marshal(obs)
 	if err != nil {
-		return nil, fmt.Errorf("acct: failed to marshal accountant observation request: %w", err)
+		return nil, fmt.Errorf("gacct: failed to marshal accountant observation request: %w", err)
 	}
 
 	digest, err := vaa.MessageSigningDigest(submitObservationPrefix, bytes)
 	if err != nil {
-		return nil, fmt.Errorf("acct: failed to sign accountant Observation request: %w", err)
+		return nil, fmt.Errorf("gacct: failed to sign accountant Observation request: %w", err)
 	}
 
 	sigBytes, err := ethCrypto.Sign(digest.Bytes(), gk)
 	if err != nil {
-		return nil, fmt.Errorf("acct: failed to sign accountant Observation request: %w", err)
+		return nil, fmt.Errorf("gacct: failed to sign accountant Observation request: %w", err)
 	}
 
 	sig := SignatureType{Index: guardianIndex, Signature: sigBytes}
@@ -353,7 +353,7 @@ func SubmitObservationsToContract(
 
 	msgBytes, err := json.Marshal(msgData)
 	if err != nil {
-		return nil, fmt.Errorf("acct: failed to marshal accountant observation request: %w", err)
+		return nil, fmt.Errorf("gacct: failed to marshal accountant observation request: %w", err)
 	}
 
 	subMsg := wasmdtypes.MsgExecuteContract{
@@ -363,7 +363,7 @@ func SubmitObservationsToContract(
 		Funds:    sdktypes.Coins{},
 	}
 
-	logger.Debug("acct: in SubmitObservationsToContract, sending broadcast",
+	logger.Debug("gacct: in SubmitObservationsToContract, sending broadcast",
 		zap.Int("numObs", len(obs)),
 		zap.String("observations", string(bytes)),
 		zap.Uint32("gsIndex", gsIndex), zap.Uint32("guardianIndex", guardianIndex),
@@ -395,8 +395,8 @@ func SubmitObservationsToContract(
 		return txResp, fmt.Errorf("failed to submit observations: %s", txResp.TxResponse.RawLog)
 	}
 
-	logger.Info("acct: done sending broadcast", zap.Int("numObs", len(obs)), zap.Int64("gasUsed", txResp.TxResponse.GasUsed), zap.Stringer("elapsedTime", time.Since(start)))
-	logger.Debug("acct: in SubmitObservationsToContract, done sending broadcast", zap.String("resp", wormchainConn.BroadcastTxResponseToString(txResp)))
+	logger.Info("gacct: done sending broadcast", zap.Int("numObs", len(obs)), zap.Int64("gasUsed", txResp.TxResponse.GasUsed), zap.Stringer("elapsedTime", time.Since(start)))
+	logger.Debug("gacct: in SubmitObservationsToContract, done sending broadcast", zap.String("resp", wormchainConn.BroadcastTxResponseToString(txResp)))
 	return txResp, nil
 }
 

--- a/node/pkg/accountant/watcher.go
+++ b/node/pkg/accountant/watcher.go
@@ -80,7 +80,7 @@ func (acct *Accountant) handleEvents(ctx context.Context, evts <-chan tmCoreType
 		case e := <-evts:
 			tx, ok := e.Data.(tmTypes.EventDataTx)
 			if !ok {
-				acct.logger.Error("acctwatcher: unknown data from event subscription", zap.Stringer("e.Data", reflect.TypeOf(e.Data)), zap.Any("event", e))
+				acct.logger.Error("gacctwatcher: unknown data from event subscription", zap.Stringer("e.Data", reflect.TypeOf(e.Data)), zap.Any("event", e))
 				continue
 			}
 
@@ -88,7 +88,7 @@ func (acct *Accountant) handleEvents(ctx context.Context, evts <-chan tmCoreType
 				if event.Type == "wasm-Observation" {
 					evt, err := parseEvent[WasmObservation](acct.logger, event, "wasm-Observation", acct.contract)
 					if err != nil {
-						acct.logger.Error("acctwatcher: failed to parse wasm transfer event", zap.Error(err), zap.Stringer("e.Data", reflect.TypeOf(e.Data)), zap.Any("event", event))
+						acct.logger.Error("gacctwatcher: failed to parse wasm transfer event", zap.Error(err), zap.Stringer("e.Data", reflect.TypeOf(e.Data)), zap.Any("event", event))
 						continue
 					}
 
@@ -97,14 +97,14 @@ func (acct *Accountant) handleEvents(ctx context.Context, evts <-chan tmCoreType
 				} else if event.Type == "wasm-ObservationError" {
 					evt, err := parseEvent[WasmObservationError](acct.logger, event, "wasm-ObservationError", acct.contract)
 					if err != nil {
-						acct.logger.Error("acctwatcher: failed to parse wasm observation error event", zap.Error(err), zap.Stringer("e.Data", reflect.TypeOf(e.Data)), zap.Any("event", event))
+						acct.logger.Error("gacctwatcher: failed to parse wasm observation error event", zap.Error(err), zap.Stringer("e.Data", reflect.TypeOf(e.Data)), zap.Any("event", event))
 						continue
 					}
 
 					errorEventsReceived.Inc()
-					acct.handleTransferError(evt.Key.String(), evt.Error, "acct: transfer error event received")
+					acct.handleTransferError(evt.Key.String(), evt.Error, "gacctwatcher: transfer error event received")
 				} else {
-					acct.logger.Debug("acctwatcher: ignoring uninteresting event", zap.String("eventType", event.Type))
+					acct.logger.Debug("gacctwatcher: ignoring uninteresting event", zap.String("eventType", event.Type))
 				}
 			}
 		}
@@ -130,7 +130,7 @@ func parseEvent[T any](logger *zap.Logger, event tmAbci.Event, name string, cont
 				return nil, fmt.Errorf("%s event from unexpected contract: %s", name, string(attr.Value))
 			}
 		} else {
-			logger.Debug("acctwatcher: event attribute", zap.String("event", name), zap.String("key", string(attr.Key)), zap.String("value", string(attr.Value)))
+			logger.Debug("gacctwatcher: event attribute", zap.String("event", name), zap.String("key", string(attr.Key)), zap.String("value", string(attr.Value)))
 			attrs[string(attr.Key)] = attr.Value
 		}
 	}


### PR DESCRIPTION
This PR makes the following changes to make it easier to sift through the accountant logs:

- Changes a couple of errors that are not really errors to warnings.
- Changes the "acct:", "acctaudit:" and "acctwatcher:" log prefixs to add a "g" on the front so we can search for "gacct" rather than "acct" (which gives lots of messages not related to accountant.