### PR TITLE
clients/js: fix sui publish message

### DIFF
--- a/sui/scripts/deploy.sh
+++ b/sui/scripts/deploy.sh
@@ -49,9 +49,12 @@ if [ "$NETWORK" = devnet ]; then
   EXAMPLE_PUBLISH_OUTPUT=$(worm sui deploy $(realpath "$DIRNAME"/../examples/core_messages) -n "$NETWORK")
   EXAMPLE_PACKAGE_ID=$(echo "$EXAMPLE_PUBLISH_OUTPUT" | grep -oP 'Published to +\K.*')
   echo "$EXAMPLE_PUBLISH_OUTPUT"
+
   EXAMPLE_INIT_OUTPUT=$(sui client call --function init_with_params --module sender --package "$EXAMPLE_PACKAGE_ID" --gas-budget 20000 --args "$WORMHOLE_STATE_OBJECT_ID")
   EXAMPLE_INIT_CREATED_OBJECTS=$(echo "$EXAMPLE_INIT_OUTPUT" | grep -oPm1 ' +- ID: \K([a-z0-9]*) (?=.*)')
   echo "Core messages app state object ID: $EXAMPLE_INIT_CREATED_OBJECTS"
+
+  echo -e "\nPublish message command:" worm sui publish-message -n devnet -p "$EXAMPLE_PACKAGE_ID" -s "$EXAMPLE_INIT_CREATED_OBJECTS" -w "$WORMHOLE_STATE_OBJECT_ID" -m "hello"
 fi
 
 echo -e "\nDeployments successful!"


### PR DESCRIPTION
This PR allows for the publishing of messages through the `worm` CLI. The deploy script also now prints out the `publish-message` command with the args filled in from the rest of the script. This command can simply be copy and pasted into terminal to publish messages. The output of the publish command is also printed to the console.
