### PR TITLE
sui: bump rev for node_builder.sh

### DIFF
--- a/sui/scripts/node_builder.sh
+++ b/sui/scripts/node_builder.sh
@@ -4,7 +4,7 @@ source $HOME/.cargo/env
 
 git clone https://github.com/MystenLabs/sui.git --branch devnet
 cd sui
-git reset --hard 82c9c80c11488858f1d3930f47ec9f335a566683
+git reset --hard 81dbcf2b6cab07d623a1012bf31daf658963c765
 
 cargo --locked install --path crates/sui
 cargo --locked install --path crates/sui-faucet


### PR DESCRIPTION
Quick PR to bump rev to the one that corresponds to Sui 0.29.1 and is pinned in the `Move.toml` files in each of the contract directories.
