### PR TITLE
clients/js: refactor worm sui cli commands to prevent type becoming too large

### DIFF
--- a/clients/js/cmds/Yargs.ts
+++ b/clients/js/cmds/Yargs.ts
@@ -1,0 +1,18 @@
+import yargs from "yargs";
+
+export class Yargs {
+  yargs: typeof yargs;
+
+  constructor(y: typeof yargs) {
+    this.yargs = y;
+  }
+
+  addCommands = (addCommandsFn: YargsAddCommandsFn) => {
+    this.yargs = addCommandsFn(this.yargs);
+    return this;
+  };
+
+  y = () => this.yargs;
+}
+
+export type YargsAddCommandsFn = (y: typeof yargs) => typeof yargs;

--- a/clients/js/cmds/sui/deploy.ts
+++ b/clients/js/cmds/sui/deploy.ts
@@ -1,0 +1,50 @@
+import yargs from "yargs";
+import { config } from "../../config";
+import { NETWORK_OPTIONS, RPC_OPTIONS } from "../../consts";
+import { NETWORKS } from "../../networks";
+import { getProvider, getSigner, publishPackage } from "../../sui";
+import { assertNetwork, checkBinary } from "../../utils";
+import { YargsAddCommandsFn } from "../Yargs";
+
+export const addDeployCommands: YargsAddCommandsFn = (y: typeof yargs) =>
+  y.command(
+    "deploy <package-dir>",
+    "Deploy a Sui package",
+    (yargs) => {
+      return yargs
+        .positional("package-dir", {
+          type: "string",
+        })
+        .option("network", NETWORK_OPTIONS)
+        .option("private-key", {
+          alias: "k",
+          describe: "Custom private key to sign txs",
+          required: false,
+          type: "string",
+        })
+        .option("rpc", RPC_OPTIONS);
+    },
+    async (argv) => {
+      checkBinary("sui", "sui");
+
+      const packageDir = argv["package-dir"];
+      const network = argv.network.toUpperCase();
+      assertNetwork(network);
+      const privateKey = argv["private-key"];
+      const rpc = argv.rpc ?? NETWORKS[network].sui.rpc;
+
+      const provider = getProvider(network, rpc);
+      const signer = getSigner(provider, network, privateKey);
+
+      console.log("Package", packageDir);
+      console.log("RPC", rpc);
+
+      await publishPackage(
+        signer,
+        network,
+        packageDir.startsWith("/") // Allow absolute paths, otherwise assume relative to sui directory
+          ? packageDir
+          : `${config.wormholeDir}/sui/${packageDir}`
+      );
+    }
+  );

--- a/clients/js/cmds/sui/index.ts
+++ b/clients/js/cmds/sui/index.ts
@@ -1,0 +1,19 @@
+import yargs from "yargs";
+import { Yargs } from "../Yargs";
+import { addDeployCommands } from "./deploy";
+import { addInitCommands } from "./init";
+import { addPublishMessageCommands } from "./publish_message";
+import { addUtilsCommands } from "./utils";
+
+exports.command = "sui";
+exports.desc = "Sui utilities";
+exports.builder = function (y: typeof yargs) {
+  return new Yargs(y)
+    .addCommands(addDeployCommands)
+    .addCommands(addInitCommands)
+    .addCommands(addPublishMessageCommands)
+    .addCommands(addUtilsCommands)
+    .y()
+    .strict()
+    .demandCommand();
+};

--- a/clients/js/cmds/sui/init.ts
+++ b/clients/js/cmds/sui/init.ts
@@ -1,68 +1,24 @@
 import { TransactionBlock } from "@mysten/sui.js";
 import yargs from "yargs";
-import { config } from "../config";
 import {
   GOVERNANCE_CHAIN,
   GOVERNANCE_EMITTER,
   NETWORK_OPTIONS,
   RPC_OPTIONS,
-} from "../consts";
-import { NETWORKS } from "../networks";
+} from "../../consts";
+import { NETWORKS } from "../../networks";
 import {
   executeTransactionBlock,
   getOwnedObjectId,
   getProvider,
   getSigner,
   isSuiCreateEvent,
-  publishPackage,
-} from "../sui";
-import { assertNetwork, checkBinary } from "../utils";
+} from "../../sui";
+import { assertNetwork } from "../../utils";
+import { YargsAddCommandsFn } from "../Yargs";
 
-exports.command = "sui";
-exports.desc = "Sui utilities";
-exports.builder = function (y: typeof yargs) {
-  return y
-    .command(
-      "deploy <package-dir>",
-      "Deploy a Sui package",
-      (yargs) => {
-        return yargs
-          .positional("package-dir", {
-            type: "string",
-          })
-          .option("network", NETWORK_OPTIONS)
-          .option("private-key", {
-            alias: "k",
-            describe: "Custom private key to sign txs",
-            required: false,
-            type: "string",
-          })
-          .option("rpc", RPC_OPTIONS);
-      },
-      async (argv) => {
-        checkBinary("sui", "sui");
-
-        const packageDir = argv["package-dir"];
-        const network = argv.network.toUpperCase();
-        assertNetwork(network);
-        const privateKey = argv["private-key"];
-        const rpc = argv.rpc ?? NETWORKS[network].sui.rpc;
-
-        const provider = getProvider(network, rpc);
-        const signer = getSigner(provider, network, privateKey);
-
-        console.log("Package", packageDir);
-        console.log("RPC", rpc);
-
-        await publishPackage(
-          signer,
-          network,
-          packageDir.startsWith("/") // Allow absolute paths, otherwise assume relative to sui directory
-            ? packageDir
-            : `${config.wormholeDir}/sui/${packageDir}`
-        );
-      }
-    )
+export const addInitCommands: YargsAddCommandsFn = (y: typeof yargs) =>
+  y
     .command(
       "init-example-message-app",
       "Initialize example core message app",
@@ -306,126 +262,4 @@ exports.builder = function (y: typeof yargs) {
             .find((e) => e.objectType === `${packageId}::state::State`).objectId
         );
       }
-    )
-    .command(
-      "publish-example-message",
-      "Publish message from example app via core bridge",
-      (yargs) => {
-        return yargs
-          .option("network", NETWORK_OPTIONS)
-          .option("package-id", {
-            alias: "p",
-            describe: "Package ID/module address",
-            required: true,
-            type: "string",
-          })
-          .option("state", {
-            alias: "s",
-            describe: "Core messages app state object ID",
-            required: true,
-            type: "string",
-          })
-          .option("wormhole-state", {
-            alias: "w",
-            describe: "Wormhole state object ID",
-            required: true,
-            type: "string",
-          })
-          .option("message", {
-            alias: "m",
-            describe: "Message payload",
-            required: true,
-            type: "string",
-          })
-          .option("private-key", {
-            alias: "k",
-            describe: "Custom private key to sign txs",
-            required: false,
-            type: "string",
-          })
-          .option("rpc", RPC_OPTIONS);
-      },
-      async (argv) => {
-        const network = argv.network.toUpperCase();
-        assertNetwork(network);
-        const packageId = argv["package-id"];
-        const stateObjectId = argv["state"];
-        const wormholeStateObjectId = argv["wormhole-state"];
-        const message = argv["message"];
-        const privateKey = argv["private-key"];
-        const rpc = argv.rpc ?? NETWORKS[network].sui.rpc;
-
-        const provider = getProvider(network, rpc);
-        const signer = getSigner(provider, network, privateKey);
-
-        // Publish message
-        const transactionBlock = new TransactionBlock();
-        transactionBlock.moveCall({
-          target: `${packageId}::sender::send_message_entry`,
-          arguments: [
-            transactionBlock.object(stateObjectId),
-            transactionBlock.object(wormholeStateObjectId),
-            transactionBlock.pure(message),
-          ],
-        });
-        const res = await executeTransactionBlock(signer, transactionBlock);
-
-        // Hacky way to grab event since we don't require package ID of the
-        // core bridge as input. Doesn't really matter since this is a test
-        // command.
-        const event = res.events.find(
-          (e) =>
-            e.packageId === packageId &&
-            e.type.includes("publish_message::WormholeMessage")
-        );
-        if (!event) {
-          throw new Error(
-            "Couldn't find publish event. Events: " +
-              JSON.stringify(res.events, null, 2)
-          );
-        }
-
-        console.log("Publish message succeeded:", {
-          sender: event.sender,
-          type: event.type,
-          payload: Buffer.from(event.parsedJson.payload).toString(),
-          emitter: Buffer.from(event.parsedJson.sender).toString("hex"),
-          sequence: event.parsedJson.sequence,
-          nonce: event.parsedJson.nonce,
-        });
-      }
-    )
-    .strict()
-    .demandCommand();
-};
-
-// todo(aki): figure out "Type instantiation is excessively deep and possibly
-// infinite" error and then add the following cmd back in
-
-// .command(
-//   "get-owned-objects",
-//   "Get owned objects by owner",
-//   (yargs) => {
-//     return yargs
-//       .positional("owner", {
-//         describe: "Owner address",
-//         type: "string",
-//       })
-//       .option("network", NETWORK_OPTIONS)
-//       .option("rpc", RPC_OPTIONS);
-//   },
-//   async (argv) => {
-//     const network = argv.network.toUpperCase();
-//     assertNetwork(network);
-//     const rpc = argv.rpc ?? NETWORKS[network].sui.rpc;
-//     const owner = argv.owner;
-
-//     // todo(aki): handle pagination
-//     const provider = getProvider(network, rpc);
-//     const objects = await provider.getOwnedObjects({ owner });
-
-//     console.log("Network", network);
-//     console.log("Owner", owner);
-//     console.log("Objects", JSON.stringify(objects, null, 2));
-//   }
-// )
+    );

--- a/clients/js/cmds/sui/publish_message.ts
+++ b/clients/js/cmds/sui/publish_message.ts
@@ -1,0 +1,99 @@
+import { TransactionBlock } from "@mysten/sui.js";
+import yargs from "yargs";
+import { NETWORK_OPTIONS, RPC_OPTIONS } from "../../consts";
+import { NETWORKS } from "../../networks";
+import { executeTransactionBlock, getProvider, getSigner } from "../../sui";
+import { assertNetwork } from "../../utils";
+import { YargsAddCommandsFn } from "../Yargs";
+
+export const addPublishMessageCommands: YargsAddCommandsFn = (
+  y: typeof yargs
+) =>
+  y.command(
+    "publish-example-message",
+    "Publish message from example app via core bridge",
+    (yargs) => {
+      return yargs
+        .option("network", NETWORK_OPTIONS)
+        .option("package-id", {
+          alias: "p",
+          describe: "Package ID/module address",
+          required: true,
+          type: "string",
+        })
+        .option("state", {
+          alias: "s",
+          describe: "Core messages app state object ID",
+          required: true,
+          type: "string",
+        })
+        .option("wormhole-state", {
+          alias: "w",
+          describe: "Wormhole state object ID",
+          required: true,
+          type: "string",
+        })
+        .option("message", {
+          alias: "m",
+          describe: "Message payload",
+          required: true,
+          type: "string",
+        })
+        .option("private-key", {
+          alias: "k",
+          describe: "Custom private key to sign txs",
+          required: false,
+          type: "string",
+        })
+        .option("rpc", RPC_OPTIONS);
+    },
+    async (argv) => {
+      const network = argv.network.toUpperCase();
+      assertNetwork(network);
+      const packageId = argv["package-id"];
+      const stateObjectId = argv["state"];
+      const wormholeStateObjectId = argv["wormhole-state"];
+      const message = argv["message"];
+      const privateKey = argv["private-key"];
+      const rpc = argv.rpc ?? NETWORKS[network].sui.rpc;
+
+      const provider = getProvider(network, rpc);
+      const signer = getSigner(provider, network, privateKey);
+
+      // Publish message
+      const transactionBlock = new TransactionBlock();
+      transactionBlock.moveCall({
+        target: `${packageId}::sender::send_message_entry`,
+        arguments: [
+          transactionBlock.object(stateObjectId),
+          transactionBlock.object(wormholeStateObjectId),
+          transactionBlock.pure(message),
+        ],
+      });
+      const res = await executeTransactionBlock(signer, transactionBlock);
+
+      // Hacky way to grab event since we don't require package ID of the
+      // core bridge as input. Doesn't really matter since this is a test
+      // command.
+      const event = res.events.find(
+        (e) =>
+          e.packageId === packageId &&
+          e.type.includes("publish_message::WormholeMessage")
+      );
+      if (!event) {
+        throw new Error(
+          "Couldn't find publish event. Events: " +
+            JSON.stringify(res.events, null, 2)
+        );
+      }
+
+      console.log("Publish message succeeded:", {
+        sender: event.sender,
+        type: event.type,
+        payload: Buffer.from(event.parsedJson.payload).toString(),
+        emitter: Buffer.from(event.parsedJson.sender).toString("hex"),
+        sequence: event.parsedJson.sequence,
+        nonce: event.parsedJson.nonce,
+      });
+    }
+  );

--- a/clients/js/cmds/sui/utils.ts
+++ b/clients/js/cmds/sui/utils.ts
@@ -1,0 +1,35 @@
+import yargs from "yargs";
+import { NETWORK_OPTIONS, RPC_OPTIONS } from "../../consts";
+import { NETWORKS } from "../../networks";
+import { getProvider } from "../../sui";
+import { assertNetwork } from "../../utils";
+import { YargsAddCommandsFn } from "../Yargs";
+
+export const addUtilsCommands: YargsAddCommandsFn = (y: typeof yargs) =>
+  y.command(
+    "get-owned-objects",
+    "Get owned objects by owner",
+    (yargs) => {
+      return yargs
+        .positional("owner", {
+          describe: "Owner address",
+          type: "string",
+        })
+        .option("network", NETWORK_OPTIONS)
+        .option("rpc", RPC_OPTIONS);
+    },
+    async (argv) => {
+      const network = argv.network.toUpperCase();
+      assertNetwork(network);
+      const rpc = argv.rpc ?? NETWORKS[network].sui.rpc;
+      const owner = argv.owner;
+
+      // todo(aki): handle pagination
+      const provider = getProvider(network, rpc);
+      const objects = await provider.getOwnedObjects({ owner });
+
+      console.log("Network", network);
+      console.log("Owner", owner);
+      console.log("Objects", JSON.stringify(objects, null, 2));
+    }
+  );

--- a/clients/js/main.ts
+++ b/clients/js/main.ts
@@ -28,4 +28,7 @@ if (isOutdated()) {
   );
 }
 
-yargs(hideBin(process.argv)).commandDir("cmds").strict().demandCommand().argv;
+yargs(hideBin(process.argv))
+  .commandDir("cmds", { recurse: true })
+  .strict()
+  .demandCommand().argv;


### PR DESCRIPTION
It's not possible to add more subcommands or options to the `sui` command in `worm` CLI because the `yargs` type becomes too large and Typescript throws this error: `Type instantiation is excessively deep and possibly infinite`. As a result, this PR splits the `sui` subcommands across several files and coalesces them in `cmds/sui/index.ts`. A `Yargs` class has been added to enable chaining of these refactored subcommands.
