### PR TITLE
sui: fix core_messages example contract

### DIFF
--- a/sui/Dockerfile
+++ b/sui/Dockerfile
@@ -16,6 +16,7 @@ COPY scripts/ scripts
 COPY wormhole/ wormhole
 COPY token_bridge/ token_bridge
 COPY testing/ testing
+COPY examples/ examples
 COPY Makefile Makefile
 
 FROM sui AS tests

--- a/sui/Makefile
+++ b/sui/Makefile
@@ -1,5 +1,5 @@
 BUILD_CONTRACT_DIRS := wormhole token_bridge
-TEST_CONTRACT_DIRS := wormhole token_bridge testing/coin_wrapped_12
+TEST_CONTRACT_DIRS := wormhole token_bridge testing/coin_wrapped_12 examples/core_messages
 
 .PHONY: test
 test:

--- a/sui/examples/core_messages/Makefile
+++ b/sui/examples/core_messages/Makefile
@@ -16,4 +16,5 @@ build:
 .PHONY: test
 # Run tests
 test:
+	sui move build -d || exit $?
 	sui move test -t 1

--- a/sui/examples/core_messages/Move.devnet.toml
+++ b/sui/examples/core_messages/Move.devnet.toml
@@ -1,5 +1,5 @@
 [package]
-name = "core_messages"
+name = "CoreMessages"
 version = "1.0.0"
 
 [dependencies.Sui]

--- a/sui/examples/core_messages/Move.lock
+++ b/sui/examples/core_messages/Move.lock
@@ -5,6 +5,9 @@ version = 0
 
 dependencies = [
   { name = "Sui" },
+]
+
+dev-dependencies = [
   { name = "Wormhole" },
 ]
 

--- a/sui/examples/core_messages/Move.toml
+++ b/sui/examples/core_messages/Move.toml
@@ -1,5 +1,5 @@
 [package]
-name = "core_messages"
+name = "CoreMessages"
 version = "1.0.0"
 
 [dependencies.Sui]
@@ -18,4 +18,4 @@ local = "../../wormhole"
 
 [dev-addresses]
 wormhole = "0x100"
-core_messages = "0x200"
+core_messages = "0x169"


### PR DESCRIPTION
- [x] Fix broken example contract.
- [ ] Fix worm CLI to account for additional `Clock` reference (0x6).
