### PR TITLE
clients/js: reflect token-bridge-cleanup updates in worm CLI

### DIFF
--- a/clients/js/cmds/sui/init.ts
+++ b/clients/js/cmds/sui/init.ts
@@ -12,6 +12,7 @@ import {
   getOwnedObjectId,
   getProvider,
   getSigner,
+  getUpgradeCapObjectId,
   isSuiCreateEvent,
 } from "../../sui";
 import { assertNetwork } from "../../utils";
@@ -121,12 +122,10 @@ export const addInitCommands: YargsAddCommandsFn = (y: typeof yargs) =>
           "setup",
           "DeployerCap"
         );
-        const upgradeCapObjectId = await getOwnedObjectId(
+        const upgradeCapObjectId = await getUpgradeCapObjectId(
           provider,
           owner,
-          "0x2",
-          "package",
-          "UpgradeCap"
+          packageId
         );
 
         console.log("Owner", owner);
@@ -228,12 +227,10 @@ export const addInitCommands: YargsAddCommandsFn = (y: typeof yargs) =>
           "setup",
           "DeployerCap"
         );
-        const upgradeCapObjectId = await getOwnedObjectId(
+        const upgradeCapObjectId = await getUpgradeCapObjectId(
           provider,
           owner,
-          "0x2",
-          "package",
-          "UpgradeCap"
+          packageId
         );
 
         console.log("Network", network);

--- a/clients/js/cmds/sui/publish_message.ts
+++ b/clients/js/cmds/sui/publish_message.ts
@@ -1,4 +1,4 @@
-import { TransactionBlock } from "@mysten/sui.js";
+import { SUI_CLOCK_OBJECT_ID, TransactionBlock } from "@mysten/sui.js";
 import yargs from "yargs";
 import { NETWORK_OPTIONS, RPC_OPTIONS } from "../../consts";
 import { NETWORKS } from "../../networks";
@@ -68,6 +68,7 @@ export const addPublishMessageCommands: YargsAddCommandsFn = (
           transactionBlock.object(stateObjectId),
           transactionBlock.object(wormholeStateObjectId),
           transactionBlock.pure(message),
+          transactionBlock.object(SUI_CLOCK_OBJECT_ID),
         ],
       });
       const res = await executeTransactionBlock(signer, transactionBlock);

--- a/clients/js/sui/error.ts
+++ b/clients/js/sui/error.ts
@@ -1,0 +1,7 @@
+export class SuiRpcValidationError extends Error {
+  constructor(response: any) {
+    super(
+      `Sui RPC returned an unexpected response: ${JSON.stringify(response)}`
+    );
+  }
+}

--- a/sui/examples/core_messages/Move.lock
+++ b/sui/examples/core_messages/Move.lock
@@ -5,9 +5,6 @@ version = 0
 
 dependencies = [
   { name = "Sui" },
-]
-
-dev-dependencies = [
   { name = "Wormhole" },
 ]
 

--- a/sui/scripts/deploy.sh
+++ b/sui/scripts/deploy.sh
@@ -30,15 +30,15 @@ echo -e "[1/4] Publishing core bridge contracts..."
 WORMHOLE_PUBLISH_OUTPUT=$(worm sui deploy $(realpath "$DIRNAME"/../wormhole) -n "$NETWORK")
 echo "$WORMHOLE_PUBLISH_OUTPUT"
 
-echo -e "\n[2/4] Publishing token bridge contracts..."
-TOKEN_BRIDGE_PUBLISH_OUTPUT=$(worm sui deploy $(realpath "$DIRNAME"/../token_bridge) -n "$NETWORK")
-echo "$TOKEN_BRIDGE_PUBLISH_OUTPUT"
-
-echo -e "\n[3/4] Initializing core bridge..."
+echo -e "\n[2/4] Initializing core bridge..."
 WORMHOLE_PACKAGE_ID=$(echo "$WORMHOLE_PUBLISH_OUTPUT" | grep -oP 'Published to +\K.*')
 WORMHOLE_INIT_OUTPUT=$(worm sui init-wormhole -n "$NETWORK" --initial-guardian "$GUARDIAN_ADDR" -p "$WORMHOLE_PACKAGE_ID")
 WORMHOLE_STATE_OBJECT_ID=$(echo "$WORMHOLE_INIT_OUTPUT" | grep -oP 'Wormhole state object ID +\K.*')
 echo "$WORMHOLE_INIT_OUTPUT"
+
+echo -e "\n[3/4] Publishing token bridge contracts..."
+TOKEN_BRIDGE_PUBLISH_OUTPUT=$(worm sui deploy $(realpath "$DIRNAME"/../token_bridge) -n "$NETWORK")
+echo "$TOKEN_BRIDGE_PUBLISH_OUTPUT"
 
 echo -e "\n[4/4] Initializing token bridge..."
 TOKEN_BRIDGE_PACKAGE_ID=$(echo "$TOKEN_BRIDGE_PUBLISH_OUTPUT" | grep -oP 'Published to +\K.*')

--- a/sui/token_bridge/Move.lock
+++ b/sui/token_bridge/Move.lock
@@ -5,9 +5,6 @@ version = 0
 
 dependencies = [
   { name = "Sui" },
-]
-
-dev-dependencies = [
   { name = "Wormhole" },
 ]
 


### PR DESCRIPTION
The token bridge upgradeability refactor in #2516 caused some things to break in the `worm` CLI. This PR fixes a few changed func and struct names.

Additionally, although `getOwnedObjects` returns all objects of a given type owned by a given address, a user may own multiple structs with the same type, such as `0x2::package::UpgradeCap`. The `UpgradeCaps` specifically (and possible other such structs) have a couple of fields in the fetched data that we use to differentiate between them.