### PR TITLE
sui: add custom key support to deploy script

### DIFF
--- a/Dockerfile.const
+++ b/Dockerfile.const
@@ -47,6 +47,7 @@ COPY --from=const-build /scripts/.env.hex terra/tools/.env
 COPY --from=const-build /scripts/.env.hex cosmwasm/deployment/terra2/tools/.env
 COPY --from=const-build /scripts/.env.hex algorand/.env
 COPY --from=const-build /scripts/.env.hex near/.env
+COPY --from=const-build /scripts/.env.hex sui/.env
 COPY --from=const-build /scripts/.env.hex aptos/.env
 COPY --from=const-build /scripts/.env.hex wormchain/contracts/tools/.env
 

--- a/clients/js/cmds/generate.ts
+++ b/clients/js/cmds/generate.ts
@@ -11,7 +11,7 @@ import base58 from "bs58";
 import { sha3_256 } from "js-sha3";
 import yargs from "yargs";
 import { GOVERNANCE_CHAIN, GOVERNANCE_EMITTER } from "../consts";
-import { evm_address, hex } from "../utils";
+import { evm_address } from "../utils";
 import {
   ContractUpgrade,
   impossible,
@@ -283,11 +283,11 @@ function parseAddress(chain: ChainName, address: string): string {
     // TODO: is there a better native format for algorand?
     return "0x" + evm_address(address);
   } else if (chain === "near") {
-    return "0x" + hex(address).substring(2).padStart(64, "0");
+    return "0x" + evm_address(address);
   } else if (chain === "osmosis") {
     throw Error("OSMOSIS is not supported yet");
   } else if (chain === "sui") {
-    throw Error("SUI is not supported yet");
+    return "0x" + evm_address(address);
   } else if (chain === "aptos") {
     if (/^(0x)?[0-9a-fA-F]+$/.test(address)) {
       return "0x" + evm_address(address);

--- a/clients/js/cmds/submit.ts
+++ b/clients/js/cmds/submit.ts
@@ -1,13 +1,13 @@
-import yargs from "yargs";
 import {
-  CHAINS,
   assertChain,
-  toChainName,
   ChainName,
+  CHAINS,
+  coalesceChainName,
   isEVMChain,
   isTerraChain,
-  coalesceChainName,
+  toChainName,
 } from "@certusone/wormhole-sdk/lib/cjs/utils/consts";
+import yargs from "yargs";
 import * as vaa from "../vaa";
 
 exports.command = "submit <vaa>";
@@ -133,7 +133,15 @@ exports.handler = async (argv) => {
   } else if (chain === "osmosis") {
     throw Error("OSMOSIS is not supported yet");
   } else if (chain === "sui") {
-    throw Error("SUI is not supported yet");
+    const sui = require("../sui/utils");
+    await sui.execute_sui(
+      parsed_vaa.payload,
+      buf,
+      network,
+      argv["contract-address"],
+      undefined,
+      argv["rpc"]
+    );
   } else if (chain === "aptos") {
     const aptos = require("../aptos");
     await aptos.execute_aptos(

--- a/clients/js/cmds/sui/deploy.ts
+++ b/clients/js/cmds/sui/deploy.ts
@@ -1,5 +1,4 @@
 import yargs from "yargs";
-import { config } from "../../config";
 import { NETWORK_OPTIONS, RPC_OPTIONS } from "../../consts";
 import { NETWORKS } from "../../networks";
 import {
@@ -45,13 +44,12 @@ export const addDeployCommands: YargsAddCommandsFn = (y: typeof yargs) =>
       console.log("Package", packageDir);
       console.log("RPC", rpc);
 
-      const res = await publishPackage(
-        signer,
-        network,
-        packageDir.startsWith("/") // Allow absolute paths, otherwise assume relative to sui directory
-          ? packageDir
-          : `${config.wormholeDir}/sui/${packageDir}`
-      );
+      // Allow absolute paths, otherwise assume relative to directory `worm` command is run from
+      const dir = packageDir.startsWith("/")
+        ? packageDir
+        : `${process.cwd()}/${packageDir}`;
+      const packagePath = dir.endsWith("/") ? dir.slice(0, -1) : dir;
+      const res = await publishPackage(signer, network, packagePath);
 
       // Dump deployment info to console
       console.log("Transaction digest", res.digest);

--- a/clients/js/cmds/sui/init.ts
+++ b/clients/js/cmds/sui/init.ts
@@ -196,7 +196,7 @@ export const addInitCommands: YargsAddCommandsFn = (y: typeof yargs) =>
             type: "number",
             required: false,
           })
-          .option("governance-contract-address", {
+          .option("governance-address", {
             alias: "a",
             describe: "Governance contract address",
             type: "string",
@@ -217,7 +217,7 @@ export const addInitCommands: YargsAddCommandsFn = (y: typeof yargs) =>
         const packageId = argv["package-id"];
         const initialGuardian = argv["initial-guardian"];
         const governanceChainId = argv["governance-chain-id"];
-        const governanceContract = argv["governance-contract-address"];
+        const governanceContract = argv["governance-address"];
         const privateKey = argv["private-key"];
         const rpc = argv.rpc ?? NETWORKS[network].sui.rpc;
 

--- a/clients/js/consts.ts
+++ b/clients/js/consts.ts
@@ -5,6 +5,10 @@ import {
 
 const OVERRIDES = {
   MAINNET: {
+    sui: {
+      core: undefined,
+      token_bridge: undefined,
+    },
     aptos: {
       token_bridge:
         "0x576410486a2da45eee6c949c995670112ddf2fbeedab20350d506328eefc9d4f",
@@ -14,6 +18,10 @@ const OVERRIDES = {
     },
   },
   TESTNET: {
+    sui: {
+      core: undefined,
+      token_bridge: undefined,
+    },
     aptos: {
       token_bridge:
         "0x576410486a2da45eee6c949c995670112ddf2fbeedab20350d506328eefc9d4f",
@@ -23,6 +31,11 @@ const OVERRIDES = {
     },
   },
   DEVNET: {
+    sui: {
+      core: "0x3c2d3997e7230d07b457accf69013a501b7e9f7841ba2da37201b3bb85314fdc",
+      token_bridge:
+        "0x199993e108d321f96da1c1167677affbefce6b43f34d9a255cae08224901637e",
+    },
     aptos: {
       token_bridge:
         "0x84a5f374d29fc77e370014dce4fd6a55b58ad608de8074b0be5571701724da31",
@@ -33,6 +46,7 @@ const OVERRIDES = {
   },
 };
 
+// TODO(aki): move this to SDK at some point
 export const CONTRACTS = {
   MAINNET: { ...SDK_CONTRACTS.MAINNET, ...OVERRIDES.MAINNET },
   TESTNET: { ...SDK_CONTRACTS.TESTNET, ...OVERRIDES.TESTNET },

--- a/clients/js/sui/consts.ts
+++ b/clients/js/sui/consts.ts
@@ -1,0 +1,24 @@
+/**
+ * On Sui, we must hardcode both the package ID as well as the object IDs of
+ * the State objects created when we initialize the core and token bridges.
+ *
+ * TODO(aki): move this to SDK at some point
+ */
+export const SUI_OBJECT_IDS = {
+  MAINNET: {
+    core_state: undefined,
+    token_bridge_state: undefined,
+  },
+  TESTNET: {
+    core_state: undefined,
+    token_bridge_state: undefined,
+  },
+  DEVNET: {
+    core_state:
+      "0x363f879229a8c71bdf2c739864d236d30437acc01b664ffd4799037398861440",
+    token_bridge_state:
+      "0xd194d83e1e8839ec80179fd7b5f0d14de4a906adda3d8f119c24ee0c8f3964f9",
+  },
+};
+
+export type SuiAddresses = typeof SUI_OBJECT_IDS;

--- a/clients/js/sui/utils.ts
+++ b/clients/js/sui/utils.ts
@@ -18,13 +18,6 @@ export async function executeTransactionBlock(
   signer: RawSigner,
   transactionBlock: TransactionBlock
 ) {
-  const testRes = await signer.dryRunTransactionBlock({ transactionBlock });
-  if (testRes.effects.status.status !== "success") {
-    throw new Error(
-      `Failed to execute transaction: ${testRes.effects.status.error}`
-    );
-  }
-
   // Let caller handle parsing and logging info
   return signer.signAndExecuteTransactionBlock({
     transactionBlock,

--- a/devnet/sui-devnet.yaml
+++ b/devnet/sui-devnet.yaml
@@ -55,5 +55,17 @@ spec:
           readinessProbe:
             tcpSocket:
               port: 9000
-
-      restartPolicy: Always
+        - name: sui-contracts
+          image: sui-node
+          command: ["/bin/bash", "-c"]
+          args:
+            [
+              "cd /tmp/scripts && ./wait_for_devnet.sh && ./deploy.sh devnet && touch success && sleep infinity",
+            ]
+          readinessProbe:
+            periodSeconds: 1
+            failureThreshold: 300
+            exec:
+              command:
+                - cat
+                - /tmp/scripts/success

--- a/devnet/sui-devnet.yaml
+++ b/devnet/sui-devnet.yaml
@@ -60,7 +60,7 @@ spec:
           command: ["/bin/bash", "-c"]
           args:
             [
-              "cd /tmp/scripts && ./wait_for_devnet.sh && ./deploy.sh devnet && touch success && sleep infinity",
+              "cd /tmp/scripts && ./wait_for_devnet.sh && ./deploy.sh devnet && ./register_devnet.sh && touch success && sleep infinity",
             ]
           readinessProbe:
             periodSeconds: 1

--- a/scripts/devnet-consts.json
+++ b/scripts/devnet-consts.json
@@ -241,6 +241,17 @@
                 }
             }
         },
+        "21": {
+            "contracts": {
+                "tokenBridgeEmitterAddress": "0000000000000000000000000000000000000000000000000000000000000001"
+            }
+        },
+        "22": {
+            "contracts": {
+                "tokenBridgeEmitterAddress": "0000000000000000000000000000000000000000000000000000000000000001",
+                "nftBridgeEmitterAddress": "0000000000000000000000000000000000000000000000000000000000000002"
+            }
+        },
         "3104": {
             "rpcUrlTilt": "http://wormchain:1317",
             "rpcUrlLocal": "http://localhost:1319",
@@ -303,12 +314,6 @@
                     "symbol": "MCK",
                     "decimals": 6
                 }
-            }
-        },
-        "22": {
-            "contracts": {
-                "tokenBridgeEmitterAddress": "0000000000000000000000000000000000000000000000000000000000000001",
-                "nftBridgeEmitterAddress": "0000000000000000000000000000000000000000000000000000000000000002"
             }
         }
     },

--- a/scripts/guardian-set-init.sh
+++ b/scripts/guardian-set-init.sh
@@ -10,7 +10,7 @@ addressesJson="./scripts/devnet-consts.json"
 
 # working files for accumulating state
 envFile="./scripts/.env.hex" # for generic hex data, for solana, terra, etc
-ethFile="./scripts/.env.0x" # for "0x" prefixed data, for ethereum scripts
+ethFile="./scripts/.env.0x"  # for "0x" prefixed data, for ethereum scripts
 
 # copy the eth defaults so we can override just the things we need
 cp ./ethereum/.env.test $ethFile
@@ -59,7 +59,7 @@ guardiansPublicEth=$(jq -c --argjson lastIndex $numGuardians '.devnetGuardians[:
 # guardiansPublicHex does not have a leading "0x", just hex strings.
 guardiansPublicHex=$(jq -c --argjson lastIndex $numGuardians '.devnetGuardians[:$lastIndex] | [.[].public[2:]]' $addressesJson)
 # also make a CSV string of the hex addresses, so the client scripts that need that format don't have to.
-guardiansPublicHexCSV=$(echo ${guardiansPublicHex} | jq --raw-output -c  '. | join(",")')
+guardiansPublicHexCSV=$(echo ${guardiansPublicHex} | jq --raw-output -c '. | join(",")')
 
 # write the lists of addresses to the env files
 initSigners="INIT_SIGNERS"
@@ -73,7 +73,7 @@ echo "generating guardian set keys"
 # create an array of strings containing the private keys of the devnet guardians in the guardianset
 guardiansPrivate=$(jq -c --argjson lastIndex $numGuardians '.devnetGuardians[:$lastIndex] | [.[].private]' $addressesJson)
 # create a CSV string with the private keys of the guardians in the guardianset, that will be used to create registration VAAs
-guardiansPrivateCSV=$( echo ${guardiansPrivate} | jq --raw-output -c  '. | join(",")')
+guardiansPrivateCSV=$(echo ${guardiansPrivate} | jq --raw-output -c '. | join(",")')
 
 # write the lists of keys to the env files
 upsert_env_file $ethFile "INIT_SIGNERS_KEYS_JSON" $guardiansPrivate
@@ -90,8 +90,9 @@ bscTokenBridge=$(jq --raw-output '.chains."4".contracts.tokenBridgeEmitterAddres
 algoTokenBridge=$(jq --raw-output '.chains."8".contracts.tokenBridgeEmitterAddress' $addressesJson)
 nearTokenBridge=$(jq --raw-output '.chains."15".contracts.tokenBridgeEmitterAddress' $addressesJson)
 terra2TokenBridge=$(jq --raw-output '.chains."18".contracts.tokenBridgeEmitterAddress' $addressesJson)
-wormchainTokenBridge=$(jq --raw-output '.chains."3104".contracts.tokenBridgeEmitterAddress' $addressesJson)
+suiTokenBridge=$(jq --raw-output '.chains."21".contracts.tokenBridgeEmitterAddress' $addressesJson)
 aptosTokenBridge=$(jq --raw-output '.chains."22".contracts.tokenBridgeEmitterAddress' $addressesJson)
+wormchainTokenBridge=$(jq --raw-output '.chains."3104".contracts.tokenBridgeEmitterAddress' $addressesJson)
 
 solNFTBridge=$(jq --raw-output '.chains."1".contracts.nftBridgeEmitterAddress' $addressesJson)
 ethNFTBridge=$(jq --raw-output '.chains."2".contracts.nftBridgeEmitterAddress' $addressesJson)
@@ -102,14 +103,15 @@ aptosNFTBridge=$(jq --raw-output '.chains."22".contracts.nftBridgeEmitterAddress
 # 4) create token bridge registration VAAs
 # invoke CLI commands to create registration VAAs
 solTokenBridgeVAA=$(node ./clients/js/build/main.js generate registration -m TokenBridge -c solana -a ${solTokenBridge} -g ${guardiansPrivateCSV})
-ethTokenBridgeVAA=$(node ./clients/js/build/main.js generate registration -m TokenBridge -c ethereum -a ${ethTokenBridge} -g ${guardiansPrivateCSV} )
+ethTokenBridgeVAA=$(node ./clients/js/build/main.js generate registration -m TokenBridge -c ethereum -a ${ethTokenBridge} -g ${guardiansPrivateCSV})
 terraTokenBridgeVAA=$(node ./clients/js/build/main.js generate registration -m TokenBridge -c terra -a ${terraTokenBridge} -g ${guardiansPrivateCSV})
 bscTokenBridgeVAA=$(node ./clients/js/build/main.js generate registration -m TokenBridge -c bsc -a ${bscTokenBridge} -g ${guardiansPrivateCSV})
 algoTokenBridgeVAA=$(node ./clients/js/build/main.js generate registration -m TokenBridge -c algorand -a ${algoTokenBridge} -g ${guardiansPrivateCSV})
 nearTokenBridgeVAA=$(node ./clients/js/build/main.js generate registration -m TokenBridge -c near -a ${nearTokenBridge} -g ${guardiansPrivateCSV})
 terra2TokenBridgeVAA=$(node ./clients/js/build/main.js generate registration -m TokenBridge -c terra2 -a ${terra2TokenBridge} -g ${guardiansPrivateCSV})
-wormchainTokenBridgeVAA=$(node ./clients/js/build/main.js generate registration -m TokenBridge -c wormchain -a ${wormchainTokenBridge} -g ${guardiansPrivateCSV})
+suiTokenBridgeVAA=$(node ./clients/js/build/main.js generate registration -m TokenBridge -c sui -a ${suiTokenBridge} -g ${guardiansPrivateCSV})
 aptosTokenBridgeVAA=$(node ./clients/js/build/main.js generate registration -m TokenBridge -c aptos -a ${aptosTokenBridge} -g ${guardiansPrivateCSV})
+wormchainTokenBridgeVAA=$(node ./clients/js/build/main.js generate registration -m TokenBridge -c wormchain -a ${wormchainTokenBridge} -g ${guardiansPrivateCSV})
 
 
 # 5) create nft bridge registration VAAs
@@ -131,15 +133,15 @@ bscTokenBridge="REGISTER_BSC_TOKEN_BRIDGE_VAA"
 algoTokenBridge="REGISTER_ALGO_TOKEN_BRIDGE_VAA"
 terra2TokenBridge="REGISTER_TERRA2_TOKEN_BRIDGE_VAA"
 nearTokenBridge="REGISTER_NEAR_TOKEN_BRIDGE_VAA"
-wormchainTokenBridge="REGISTER_WORMCHAIN_TOKEN_BRIDGE_VAA"
+suiTokenBridge="REGISTER_SUI_TOKEN_BRIDGE_VAA"
 aptosTokenBridge="REGISTER_APTOS_TOKEN_BRIDGE_VAA"
+wormchainTokenBridge="REGISTER_WORMCHAIN_TOKEN_BRIDGE_VAA"
 
 solNFTBridge="REGISTER_SOL_NFT_BRIDGE_VAA"
 ethNFTBridge="REGISTER_ETH_NFT_BRIDGE_VAA"
 terraNFTBridge="REGISTER_TERRA_NFT_BRIDGE_VAA"
 nearNFTBridge="REGISTER_NEAR_NFT_BRIDGE_VAA"
 aptosNFTBridge="REGISTER_APTOS_NFT_BRIDGE_VAA"
-
 
 # solana token bridge
 upsert_env_file $ethFile $solTokenBridge $solTokenBridgeVAA
@@ -148,7 +150,6 @@ upsert_env_file $envFile $solTokenBridge $solTokenBridgeVAA
 upsert_env_file $ethFile $solNFTBridge $solNFTBridgeVAA
 upsert_env_file $envFile $solNFTBridge $solNFTBridgeVAA
 
-
 # ethereum token bridge
 upsert_env_file $ethFile $ethTokenBridge $ethTokenBridgeVAA
 upsert_env_file $envFile $ethTokenBridge $ethTokenBridgeVAA
@@ -156,14 +157,12 @@ upsert_env_file $envFile $ethTokenBridge $ethTokenBridgeVAA
 upsert_env_file $ethFile $ethNFTBridge $ethNFTBridgeVAA
 upsert_env_file $envFile $ethNFTBridge $ethNFTBridgeVAA
 
-
 # terra token bridge
 upsert_env_file $ethFile $terraTokenBridge $terraTokenBridgeVAA
 upsert_env_file $envFile $terraTokenBridge $terraTokenBridgeVAA
 # terra nft bridge
 upsert_env_file $ethFile $terraNFTBridge $terraNFTBridgeVAA
 upsert_env_file $envFile $terraNFTBridge $terraNFTBridgeVAA
-
 
 # bsc token bridge
 upsert_env_file $ethFile $bscTokenBridge $bscTokenBridgeVAA
@@ -177,21 +176,23 @@ upsert_env_file $envFile $algoTokenBridge $algoTokenBridgeVAA
 upsert_env_file $ethFile $terra2TokenBridge $terra2TokenBridgeVAA
 upsert_env_file $envFile $terra2TokenBridge $terra2TokenBridgeVAA
 
-# aptos token bridge
-upsert_env_file $ethFile $aptosTokenBridge $aptosTokenBridgeVAA
-upsert_env_file $envFile $aptosTokenBridge $aptosTokenBridgeVAA
-
-# aptos nft bridge
-upsert_env_file $ethFile $aptosNFTBridge $aptosNFTBridgeVAA
-upsert_env_file $envFile $aptosNFTBridge $aptosNFTBridgeVAA
-
 # near token bridge
 upsert_env_file $ethFile $nearTokenBridge $nearTokenBridgeVAA
 upsert_env_file $envFile $nearTokenBridge $nearTokenBridgeVAA
-
 # near nft bridge
 upsert_env_file $ethFile $nearNFTBridge $nearNFTBridgeVAA
 upsert_env_file $envFile $nearNFTBridge $nearNFTBridgeVAA
+
+# sui token bridge
+upsert_env_file $ethFile $suiTokenBridge $suiTokenBridgeVAA
+upsert_env_file $envFile $suiTokenBridge $suiTokenBridgeVAA
+
+# aptos token bridge
+upsert_env_file $ethFile $aptosTokenBridge $aptosTokenBridgeVAA
+upsert_env_file $envFile $aptosTokenBridge $aptosTokenBridgeVAA
+# aptos nft bridge
+upsert_env_file $ethFile $aptosNFTBridge $aptosNFTBridgeVAA
+upsert_env_file $envFile $aptosNFTBridge $aptosNFTBridgeVAA
 
 # wormchain token bridge
 upsert_env_file $ethFile $wormchainTokenBridge $wormchainTokenBridgeVAA
@@ -212,6 +213,8 @@ paths=(
     ./solana/.env
     ./terra/tools/.env
     ./cosmwasm/deployment/terra2/tools/.env
+    ./sui/.env
+    ./aptos/.env
     ./wormchain/contracts/tools/.env
 )
 

--- a/sui/Docker.md
+++ b/sui/Docker.md
@@ -4,10 +4,10 @@ cd ..; DOCKER_BUILDKIT=1 docker build --no-cache --progress plain -f sui/Dockerf
 
 # tag the image with the appropriate version
 
-docker tag sui:latest ghcr.io/wormhole-foundation/sui:0.29.1
+docker tag sui:latest ghcr.io/wormhole-foundation/sui:0.29.1_1
 
 # push to ghcr
 
-docker push ghcr.io/wormhole-foundation/sui:0.29.1
+docker push ghcr.io/wormhole-foundation/sui:0.29.1_1
 
 echo remember to update both Dockerfile and Dockerfile.export

--- a/sui/Docker.md
+++ b/sui/Docker.md
@@ -4,10 +4,10 @@ cd ..; DOCKER_BUILDKIT=1 docker build --no-cache --progress plain -f sui/Dockerf
 
 # tag the image with the appropriate version
 
-docker tag sui:latest ghcr.io/wormhole-foundation/sui:0.29.1_1
+docker tag sui:latest ghcr.io/wormhole-foundation/sui:0.29.1_2
 
 # push to ghcr
 
-docker push ghcr.io/wormhole-foundation/sui:0.29.1_1
+docker push ghcr.io/wormhole-foundation/sui:0.29.1_2
 
 echo remember to update both Dockerfile and Dockerfile.export

--- a/sui/Dockerfile
+++ b/sui/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/wormhole-foundation/sui:0.29.1@sha256:8508a601746c886a87ef5eec59b4154dc19a228c52bbd256473e1be98e6ee4be as sui
+FROM ghcr.io/wormhole-foundation/sui:0.29.1_1@sha256:e74f32df58f37dc5d536494e13707aafa7970e80d082a79111201a0a499cdcfc as sui
 
 RUN dnf -y install make git
 

--- a/sui/Dockerfile
+++ b/sui/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/wormhole-foundation/sui:0.29.1_1@sha256:e74f32df58f37dc5d536494e13707aafa7970e80d082a79111201a0a499cdcfc as sui
+FROM ghcr.io/wormhole-foundation/sui:0.29.1_2@sha256:8dbb724d39af8d1679bbeb9c0aaf7fbf2ebdfe6930d5c08e963061f3804f3f61 as sui
 
 RUN dnf -y install make git
 

--- a/sui/scripts/deploy.sh
+++ b/sui/scripts/deploy.sh
@@ -2,16 +2,38 @@
 
 set -euo pipefail
 
+# Help message
 function usage() {
 cat <<EOF >&2
-Usage:
-  $(basename "$0") <devnet|testnet|mainnet> -- Deploy the contracts
+Deploy and initialize Sui core bridge and token bridge contracts to the 
+specified network. Additionally deploys an example messaging contract in
+devnet.
+
+  Usage: $(basename "$0") <network> [options]
+
+  Positional args:
+    <network>          Network to deploy to (devnet, testnet, mainnet)
+
+  Options:
+    -k, --private-key  Use given key to sign transactions
+    -h, --help         Show this help message
 EOF
 exit 1
 }
 
-NETWORK=$1 || usage
+# If positional args are missing, print help message and exit
+if [ $# -lt 1 ]; then
+  usage
+fi
 
+# Default values
+PRIVATE_KEY_ARG=
+
+# Set network
+NETWORK=$1 || usage
+shift
+
+# Set guardian address
 if [ "$NETWORK" = mainnet ]; then
   echo "Mainnet not supported yet"
   exit 1
@@ -24,36 +46,60 @@ else
   usage
 fi
 
+# Parse short/long flags
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -k|--private-key)
+      PRIVATE_KEY_ARG="-k $2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1"
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+# Assumes this script is in a sibling directory to contract dirs
 DIRNAME=$(dirname "$0")
+WORMHOLE_PATH=$(realpath "$DIRNAME"/../wormhole)
+TOKEN_BRIDGE_PATH=$(realpath "$DIRNAME"/../token_bridge)
+EXAMPLE_APP_PATH=$(realpath "$DIRNAME"/../examples/core_messages)
 
 echo -e "[1/4] Publishing core bridge contracts..."
-WORMHOLE_PUBLISH_OUTPUT=$(worm sui deploy $(realpath "$DIRNAME"/../wormhole) -n "$NETWORK")
+WORMHOLE_PUBLISH_OUTPUT=$($(echo worm sui deploy "$WORMHOLE_PATH" -n "$NETWORK" "$PRIVATE_KEY_ARG"))
 echo "$WORMHOLE_PUBLISH_OUTPUT"
 
 echo -e "\n[2/4] Initializing core bridge..."
 WORMHOLE_PACKAGE_ID=$(echo "$WORMHOLE_PUBLISH_OUTPUT" | grep -oP 'Published to +\K.*')
-WORMHOLE_INIT_OUTPUT=$(worm sui init-wormhole -n "$NETWORK" --initial-guardian "$GUARDIAN_ADDR" -p "$WORMHOLE_PACKAGE_ID")
+WORMHOLE_INIT_OUTPUT=$($(echo worm sui init-wormhole -n "$NETWORK" --initial-guardian "$GUARDIAN_ADDR" -p "$WORMHOLE_PACKAGE_ID" "$PRIVATE_KEY_ARG"))
 WORMHOLE_STATE_OBJECT_ID=$(echo "$WORMHOLE_INIT_OUTPUT" | grep -oP 'Wormhole state object ID +\K.*')
 echo "$WORMHOLE_INIT_OUTPUT"
 
 echo -e "\n[3/4] Publishing token bridge contracts..."
-TOKEN_BRIDGE_PUBLISH_OUTPUT=$(worm sui deploy $(realpath "$DIRNAME"/../token_bridge) -n "$NETWORK")
+TOKEN_BRIDGE_PUBLISH_OUTPUT=$($(echo worm sui deploy "$TOKEN_BRIDGE_PATH" -n "$NETWORK" "$PRIVATE_KEY_ARG"))
 echo "$TOKEN_BRIDGE_PUBLISH_OUTPUT"
 
 echo -e "\n[4/4] Initializing token bridge..."
 TOKEN_BRIDGE_PACKAGE_ID=$(echo "$TOKEN_BRIDGE_PUBLISH_OUTPUT" | grep -oP 'Published to +\K.*')
-worm sui init-token-bridge -n "$NETWORK" -p "$TOKEN_BRIDGE_PACKAGE_ID" --wormhole-state "$WORMHOLE_STATE_OBJECT_ID"
+TOKEN_BRIDGE_INIT_OUTPUT=$($(echo worm sui init-token-bridge -n "$NETWORK" -p "$TOKEN_BRIDGE_PACKAGE_ID" --wormhole-state "$WORMHOLE_STATE_OBJECT_ID" "$PRIVATE_KEY_ARG"))
+echo "$TOKEN_BRIDGE_INIT_OUTPUT"
 
 if [ "$NETWORK" = devnet ]; then
   echo -e "\n[+1] Deploying and initializing example contract..."
-  EXAMPLE_PUBLISH_OUTPUT=$(worm sui deploy $(realpath "$DIRNAME"/../examples/core_messages) -n "$NETWORK")
+  EXAMPLE_PUBLISH_OUTPUT=$($(echo worm sui deploy "$EXAMPLE_APP_PATH" -n "$NETWORK" "$PRIVATE_KEY_ARG"))
   EXAMPLE_PACKAGE_ID=$(echo "$EXAMPLE_PUBLISH_OUTPUT" | grep -oP 'Published to +\K.*')
   echo "$EXAMPLE_PUBLISH_OUTPUT"
   
-  EXAMPLE_INIT_OUTPUT=$(worm sui init-example-message-app -n "$NETWORK" -p "$EXAMPLE_PACKAGE_ID" -w "$WORMHOLE_STATE_OBJECT_ID")
+  EXAMPLE_INIT_OUTPUT=$($(echo worm sui init-example-message-app -n "$NETWORK" -p "$EXAMPLE_PACKAGE_ID" -w "$WORMHOLE_STATE_OBJECT_ID" "$PRIVATE_KEY_ARG"))
   EXAMPLE_STATE_OBJECT_ID=$(echo "$EXAMPLE_INIT_OUTPUT" | grep -oP 'Example app state object ID +\K.*')
 
-  echo -e "\nPublish message command:" worm sui publish-example-message -n devnet -p "$EXAMPLE_PACKAGE_ID" -s "$EXAMPLE_STATE_OBJECT_ID" -w "$WORMHOLE_STATE_OBJECT_ID" -m "hello"
+  echo -e "\nPublish message command:" worm sui publish-example-message -n devnet -p "$EXAMPLE_PACKAGE_ID" -s "$EXAMPLE_STATE_OBJECT_ID" -w "$WORMHOLE_STATE_OBJECT_ID" -m "hello" "$PRIVATE_KEY_ARG"
 fi
 
 echo -e "\nDeployments successful!"

--- a/sui/scripts/register_devnet.sh
+++ b/sui/scripts/register_devnet.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+DOTENV=../.env
+[ -f $DOTENV ] || (echo "$DOTENV does not exist." >&2; exit 1)
+
+# 1. load variables from .env file
+. $DOTENV
+
+# 2. next we get all the token bridge registration VAAs from the environment
+# if a new VAA is added, this will automatically pick it up
+VAAS=$(set | grep "REGISTER_.*_TOKEN_BRIDGE_VAA" | grep -v SUI | cut -d '=' -f1)
+
+# 3. use 'worm' to submit each registration VAA
+for VAA in $VAAS
+do
+    VAA=${!VAA}
+    worm submit $VAA --chain sui --network devnet
+done
+
+echo "Registrations successful."

--- a/sui/scripts/start_node.sh
+++ b/sui/scripts/start_node.sh
@@ -2,11 +2,6 @@
 
 set -x
 
-sui start&
+sui start >/dev/null 2>&1 &
 sleep 10
 sui-faucet --write-ahead-log faucet.log
-
-#curl -X POST -d '{"FixedAmountRequest":{"recipient": "'"0x2acab6bb0e4722e528291bc6ca4f097e18ce9331"'"}}' -H 'Content-Type: application/json' http://127.0.0.1:5003/gas
-#sed -i -e 's/:9000/:9002/' ~/.sui/sui_config/fullnode.yaml
-#sui-node --config-path ~/.sui/sui_config/fullnode.yaml
-#sleep infinity

--- a/sui/scripts/wait_for_devnet.sh
+++ b/sui/scripts/wait_for_devnet.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+# Wait for sui to start
+while [[ "$(curl -X POST -H "Content-Type: application/json" -d '{ "jsonrpc":"2.0", "method":"rpc.discover","id":1 }' -s -o /dev/null -w '%{http_code}' 0.0.0.0:9000/)" != "200" ]]; do sleep 5; done
+
+# Wait for sui-faucet to start
+while [[ "$(curl -s -o /dev/null -w '%{http_code}' 0.0.0.0:5003/)" != "200" ]]; do sleep 5; done


### PR DESCRIPTION
This PR updates the Sui deploy script to accept an optional `private-key` flag to allow for the use of a custom private key to sign transactions with. This is especially useful for contributors who are using a local Sui validator instead of Tilt, so that they can substitute the hardcoded active key from Tilt with their own.

Resolves #2595
