### PR TITLE
terra: change nft-bridge name to nft-bridge-terra for compatibility w…

### DIFF
--- a/terra/Cargo.lock
+++ b/terra/Cargo.lock
@@ -940,7 +940,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
 
 [[package]]
-name = "nft-bridge"
+name = "nft-bridge-terra"
 version = "0.1.0"
 dependencies = [
  "bigint",

--- a/terra/contracts/nft-bridge/Cargo.toml
+++ b/terra/contracts/nft-bridge/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "nft-bridge"
+name = "nft-bridge-terra"
 version = "0.1.0"
 edition = "2018"
 description = "Wormhole NFT bridge"

--- a/terra/tools/deploy.js
+++ b/terra/tools/deploy.js
@@ -34,7 +34,7 @@ const artifacts = [
   "token_bridge_terra.wasm",
   "cw20_wrapped.wasm",
   "cw20_base.wasm",
-  "nft_bridge.wasm",
+  "nft_bridge_terra.wasm",
   "cw721_wrapped.wasm",
   "cw721_base.wasm",
   "mock_bridge_integration.wasm",
@@ -208,7 +208,7 @@ addresses["mock.wasm"] = await instantiate("cw20_base.wasm", {
   mint: null,
 });
 
-addresses["nft_bridge.wasm"] = await instantiate("nft_bridge.wasm", {
+addresses["nft_bridge_terra.wasm"] = await instantiate("nft_bridge_terra.wasm", {
   gov_chain: govChain,
   gov_address: Buffer.from(govAddress, "hex").toString("base64"),
   wormhole_contract: addresses["wormhole.wasm"],
@@ -279,7 +279,7 @@ const contract_registrations = {
     // APTOS
     process.env.REGISTER_APTOS_TOKEN_BRIDGE_VAA,
   ],
-  "nft_bridge.wasm": [
+  "nft_bridge_terra.wasm": [
     // Solana
     process.env.REGISTER_SOL_NFT_BRIDGE_VAA,
     // Ethereum


### PR DESCRIPTION
…ith solana nft-bridge package

The duplicate package name results in errors when trying to build externally with one of the cargo packages. 