### PR TITLE
sui: normalize addresses and types in comparisons

### DIFF
--- a/clients/js/cmds/sui/init.ts
+++ b/clients/js/cmds/sui/init.ts
@@ -13,6 +13,7 @@ import {
   getProvider,
   getSigner,
   getUpgradeCapObjectId,
+  isSameType,
   isSuiCreateEvent,
 } from "../../sui";
 import { assertNetwork } from "../../utils";
@@ -76,8 +77,9 @@ export const addInitCommands: YargsAddCommandsFn = (y: typeof yargs) =>
           "Example app state object ID",
           res.objectChanges
             .filter(isSuiCreateEvent)
-            .find((e) => e.objectType === `${packageId}::sender::State`)
-            .objectId
+            .find((e) =>
+              isSameType(e.objectType, `${packageId}::sender::State`)
+            ).objectId
         );
       }
     )
@@ -146,7 +148,7 @@ export const addInitCommands: YargsAddCommandsFn = (y: typeof yargs) =>
 
         if (!upgradeCapObjectId) {
           throw new Error(
-            `Wormhole cannot be initialized because upgrade capability cannot be found under ${owner}. Is the package published?`
+            `Token bridge cannot be initialized because upgrade capability cannot be found under ${owner}. Is the package published?`
           );
         }
 
@@ -167,7 +169,8 @@ export const addInitCommands: YargsAddCommandsFn = (y: typeof yargs) =>
           "Token bridge state object ID",
           res.objectChanges
             .filter(isSuiCreateEvent)
-            .find((e) => e.objectType === `${packageId}::state::State`).objectId
+            .find((e) => isSameType(e.objectType, `${packageId}::state::State`))
+            .objectId
         );
       }
     )
@@ -280,7 +283,8 @@ export const addInitCommands: YargsAddCommandsFn = (y: typeof yargs) =>
           "Wormhole state object ID",
           res.objectChanges
             .filter(isSuiCreateEvent)
-            .find((e) => e.objectType === `${packageId}::state::State`).objectId
+            .find((e) => isSameType(e.objectType, `${packageId}::state::State`))
+            .objectId
         );
       }
     );

--- a/clients/js/cmds/sui/publish_message.ts
+++ b/clients/js/cmds/sui/publish_message.ts
@@ -1,4 +1,8 @@
-import { SUI_CLOCK_OBJECT_ID, TransactionBlock } from "@mysten/sui.js";
+import {
+  normalizeSuiAddress,
+  SUI_CLOCK_OBJECT_ID,
+  TransactionBlock,
+} from "@mysten/sui.js";
 import yargs from "yargs";
 import { NETWORK_OPTIONS, RPC_OPTIONS } from "../../consts";
 import { NETWORKS } from "../../networks";
@@ -78,7 +82,7 @@ export const addPublishMessageCommands: YargsAddCommandsFn = (
       // command.
       const event = res.events.find(
         (e) =>
-          e.packageId === packageId &&
+          normalizeSuiAddress(e.packageId) === normalizeSuiAddress(packageId) &&
           e.type.includes("publish_message::WormholeMessage")
       );
       if (!event) {

--- a/clients/js/sui/utils.ts
+++ b/clients/js/sui/utils.ts
@@ -21,6 +21,14 @@ import { SuiCreateEvent, SuiPublishEvent } from "./types";
 
 const UPGRADE_CAP_TYPE = "0x2::package::UpgradeCap";
 
+export const isSameType = (a: string, b: string) => {
+  try {
+    return normalizeSuiType(a) === normalizeSuiType(b);
+  } catch (e) {
+    return false;
+  }
+};
+
 export const execute_sui = async (
   payload: Payload,
   vaa: Buffer,
@@ -257,6 +265,8 @@ export const isSuiCreateEvent = (event: any): event is SuiCreateEvent => {
   return event.type === "created";
 };
 
+// todo(aki): this needs to correctly handle types such as
+// 0x2::dynamic_field::Field<0x3c6d386861470e6f9cb35f3c91f69e6c1f1737bd5d217ca06a15f582e1dc1ce3::state::MigrationControl, bool>
 export const normalizeSuiType = (type: string): string => {
   const tokens = type.split("::");
   if (tokens.length !== 3 || !isValidSuiAddress(tokens[0])) {


### PR DESCRIPTION
This PR normalizes Sui types and addresses in comparisons to guard against missing prefixes and leading 0s. It is the case that the Sui RPC returns some addresses with leading 0s and others without.
