### PR TITLE
sui: fix upgrade logic

### DIFF
--- a/sui/examples/core_messages/Move.lock
+++ b/sui/examples/core_messages/Move.lock
@@ -5,6 +5,9 @@ version = 0
 
 dependencies = [
   { name = "Sui" },
+]
+
+dev-dependencies = [
   { name = "Wormhole" },
 ]
 

--- a/sui/token_bridge/Move.lock
+++ b/sui/token_bridge/Move.lock
@@ -5,6 +5,9 @@ version = 0
 
 dependencies = [
   { name = "Sui" },
+]
+
+dev-dependencies = [
   { name = "Wormhole" },
 ]
 

--- a/sui/token_bridge/sources/governance/upgrade_contract.move
+++ b/sui/token_bridge/sources/governance/upgrade_contract.move
@@ -17,7 +17,7 @@ module token_bridge::upgrade_contract {
     use wormhole::governance_message::{Self, GovernanceMessage};
     use wormhole::state::{State as WormholeState};
 
-    use token_bridge::state::{Self, State};
+    use token_bridge::state::{Self, MigrationKey, State};
 
     /// Digest is all zeros.
     const E_DIGEST_ZERO_BYTES: u64 = 0;
@@ -68,8 +68,11 @@ module token_bridge::upgrade_contract {
     public fun commit_upgrade(
         self: &mut State,
         receipt: UpgradeReceipt,
-    ) {
-        let latest_package_id = state::commit_upgrade(self, receipt);
+    ): MigrationKey {
+        let (
+            migration_key,
+            latest_package_id
+        ) = state::commit_upgrade(self, receipt);
 
         // Emit an event reflecting package ID change.
         event::emit(
@@ -78,6 +81,9 @@ module token_bridge::upgrade_contract {
                 new_contract: latest_package_id
             }
         );
+
+        // Either destroy via `state` or mutate State via `migrate`.
+        migration_key
     }
 
     fun handle_upgrade_contract(

--- a/sui/token_bridge/sources/migrate.move
+++ b/sui/token_bridge/sources/migrate.move
@@ -8,22 +8,23 @@
 /// any of Token Bridge's methods by enforcing the current build version as
 /// their required minimum version.
 module token_bridge::migrate {
-    use token_bridge::state::{Self, State};
+    use token_bridge::state::{Self, MigrationKey, State};
+    use token_bridge::version_control::{Migrate as MigrateControl};
 
     // This import is only used when `state::require_current_version` is used.
     //use token_bridge::version_control::{Self as control};
 
-    /// Upgrade procedure is not complete (most likely due to an upgrade not
-    /// being initialized since upgrades can only be performed via programmable
-    /// transaction).
-    const E_CANNOT_MIGRATE: u64 = 0;
+    /// Execute migration logic. See `token_bridge::migrate` description for
+    /// more info.
+    public fun migrate(
+        token_bridge_state: &mut State,
+        migration_key: MigrationKey
+    ) {
+        state::check_minimum_requirement<MigrateControl>(token_bridge_state);
 
-    /// Execute migration logic. See `wormhole::migrate` description for more
-    /// info.
-    public entry fun migrate(token_bridge_state: &mut State) {
-        // Wormhole `State` only allows one to call `migrate` after the upgrade
-        // procedure completed.
-        assert!(state::can_migrate(token_bridge_state), E_CANNOT_MIGRATE);
+        // Token Bridge `State` destroys the `MigrationKey` as the final
+        // step.
+        state::destroy_migration_key(migration_key);
 
         ////////////////////////////////////////////////////////////////////////
         //
@@ -34,14 +35,14 @@ module token_bridge::migrate {
         //
         ////////////////////////////////////////////////////////////////////////
 
-        // state::require_current_version<control::AttestToken>(wormhole_state);
-        // state::require_current_version<control::CompleteTransfer>(wormhole_state);
-        // state::require_current_version<control::CompleteTransferWithPayload>(wormhole_state);
-        // state::require_current_version<control::CreateWrapped>(wormhole_state);
-        // state::require_current_version<control::RegisterChain>(wormhole_state);
-        // state::require_current_version<control::TransferTokens>(wormhole_state);
-        // state::require_current_version<control::TransferTokensWithPayload>(wormhole_state);
-        // state::require_current_version<control::Vaa>(wormhole_state);
+        // state::require_current_version<control::AttestToken>(token_bridge_state);
+        // state::require_current_version<control::CompleteTransfer>(token_bridge_state);
+        // state::require_current_version<control::CompleteTransferWithPayload>(token_bridge_state);
+        // state::require_current_version<control::CreateWrapped>(token_bridge_state);
+        // state::require_current_version<control::RegisterChain>(token_bridge_state);
+        // state::require_current_version<control::TransferTokens>(token_bridge_state);
+        // state::require_current_version<control::TransferTokensWithPayload>(token_bridge_state);
+        // state::require_current_version<control::Vaa>(token_bridge_state);
 
         ////////////////////////////////////////////////////////////////////////
         //
@@ -62,7 +63,7 @@ module token_bridge::migrate {
 
 
         ////////////////////////////////////////////////////////////////////////
-        // Ensure that `migrate` cannot be called again.
-        state::disable_migration(token_bridge_state);
+        // Done.
+        ////////////////////////////////////////////////////////////////////////
     }
 }

--- a/sui/token_bridge/sources/version_control.move
+++ b/sui/token_bridge/sources/version_control.move
@@ -29,6 +29,9 @@ module token_bridge::version_control {
     /// module.
     struct CreateWrapped {}
 
+    /// Key used to check minimum version requirement for `migrate` module.
+    struct Migrate {}
+
     /// Key used to check minimum version requirement for `register_chain`
     /// module.
     struct RegisterChain {}

--- a/sui/wormhole/sources/governance/upgrade_contract.move
+++ b/sui/wormhole/sources/governance/upgrade_contract.move
@@ -17,7 +17,7 @@ module wormhole::upgrade_contract {
     use wormhole::consumed_vaas::{Self};
     use wormhole::cursor::{Self};
     use wormhole::governance_message::{Self, GovernanceMessage};
-    use wormhole::state::{Self, State};
+    use wormhole::state::{Self, MigrationKey, State};
 
     /// Digest is all zeros.
     const E_DIGEST_ZERO_BYTES: u64 = 0;
@@ -70,8 +70,11 @@ module wormhole::upgrade_contract {
     public fun commit_upgrade(
         self: &mut State,
         receipt: UpgradeReceipt,
-    ) {
-        let latest_package_id = state::commit_upgrade(self, receipt);
+    ): MigrationKey {
+        let (
+            migration_key,
+            latest_package_id
+        ) = state::commit_upgrade(self, receipt);
 
         // Emit an event reflecting package ID change.
         event::emit(
@@ -80,6 +83,9 @@ module wormhole::upgrade_contract {
                 new_contract: latest_package_id
             }
         );
+
+        // Either destroy via `state` or mutate State via `migrate`.
+        migration_key
     }
 
     fun handle_upgrade_contract(

--- a/sui/wormhole/sources/migrate.move
+++ b/sui/wormhole/sources/migrate.move
@@ -8,22 +8,22 @@
 /// any of Wormhole's methods by enforcing the current build version as their
 /// required minimum version.
 module wormhole::migrate {
-    use wormhole::state::{Self, State};
+    use wormhole::state::{Self, MigrationKey, State};
+    use wormhole::version_control::{Migrate as MigrateControl};
 
     // This import is only used when `state::require_current_version` is used.
     //use wormhole::version_control::{Self as control};
 
-    /// Upgrade procedure is not complete (most likely due to an upgrade not
-    /// being initialized since upgrades can only be performed via programmable
-    /// transaction).
-    const E_CANNOT_MIGRATE: u64 = 0;
-
     /// Execute migration logic. See `wormhole::migrate` description for more
     /// info.
-    public entry fun migrate(wormhole_state: &mut State) {
-        // Wormhole `State` only allows one to call `migrate` after the upgrade
-        // procedure completed.
-        assert!(state::can_migrate(wormhole_state), E_CANNOT_MIGRATE);
+    public fun migrate(
+        wormhole_state: &mut State,
+        migration_key: MigrationKey
+    ) {
+        state::check_minimum_requirement<MigrateControl>(wormhole_state);
+
+        // Wormhole `State` destroys the `MigrationKey` as the final step.
+        state::destroy_migration_key(migration_key);
 
         ////////////////////////////////////////////////////////////////////////
         //
@@ -60,7 +60,7 @@ module wormhole::migrate {
 
 
         ////////////////////////////////////////////////////////////////////////
-        // Ensure that `migrate` cannot be called again.
-        state::disable_migration(wormhole_state);
+        // Done.
+        ////////////////////////////////////////////////////////////////////////
     }
 }

--- a/sui/wormhole/sources/test/wormhole_scenario.move
+++ b/sui/wormhole/sources/test/wormhole_scenario.move
@@ -94,8 +94,6 @@ module wormhole::wormhole_scenario {
     /// Perform an upgrade (which just upticks the current version of what the
     /// `State` believes is true).
     public fun upgrade_wormhole(scenario: &mut Scenario) {
-        use wormhole::migrate::{migrate};
-
         // Clean up from activity prior.
         test_scenario::next_tx(scenario, person());
 
@@ -105,9 +103,6 @@ module wormhole::wormhole_scenario {
             state::current_version(&worm_state) > control::version(),
             0
         );
-
-        // Call `migrate` to wrap things up.
-        migrate(&mut worm_state);
 
         // Clean up.
         test_scenario::return_shared(worm_state);

--- a/sui/wormhole/sources/version_control.move
+++ b/sui/wormhole/sources/version_control.move
@@ -21,6 +21,9 @@ module wormhole::version_control {
     /// module.
     struct GovernanceMessage {}
 
+    /// Key used to check minimum version requirement for `migrate` module.
+    struct Migrate {}
+
     /// Key used to check minimum version requirement for `publish_module`
     /// module.
     struct PublishMessage {}


### PR DESCRIPTION
## Objective
This change requires that an additional step after `commit_upgrade` be called in both Wormhole and Token Bridge. This change also moves the build version check to the `authorize_upgrade` part of the upgrade procedure so an upgrade can fail faster if the latest build isn't used to initiate the upgrade.

The original implementation had calling `migrate` optional via `entry` method. Now we require a `MigrationKey` be passed after `commit_upgrade` is called so the caller of the transaction block is required to call `state::destroy_migration_key` or `migrate::migrate` by consuming this `MigrationKey`. If a given upgrade does not require any state changes, `migrate` does not have to be called and the `MigrationKey` can be destroyed immediately after committing the upgrade.

This change also ensures that only the latest build can call `migrate`. This prevents an old build's `migrate` method be called, which can alter the State unexpectedly.

## How to Review
- Make sure tests run.
- Check that `MigrationKey` can only be destroyed via `destroy_migration_key` (which also exists in the `migrate` module).
- Verify that only the latest package can call `migrate`.