### PR TITLE
sui: fix tilt & build CLI in main sui Dockerfile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -207,16 +207,12 @@ jobs:
   sui:
     name: Sui
     runs-on: ubuntu-20.04
-    defaults:
-      run:
-        shell: bash
-        working-directory: ./sui
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
 
       - name: Run tests via docker
-        run: make test-docker
+        run: cd sui && make test-docker
 
   terra:
     runs-on: ubuntu-20.04

--- a/Tiltfile
+++ b/Tiltfile
@@ -716,10 +716,10 @@ if sui:
     docker_build(
         ref = "sui-node",
         target = "sui",
-        context = "sui",
+        context = ".",
         dockerfile = "sui/Dockerfile",
         ignore = ["./sui/sui.log*", "sui/sui.log*", "sui.log.*"],
-        only = [],
+        only = ["./sui", "./clients/js"],
     )
 
     k8s_resource(

--- a/clients/js/consts.ts
+++ b/clients/js/consts.ts
@@ -32,9 +32,9 @@ const OVERRIDES = {
   },
   DEVNET: {
     sui: {
-      core: "0x3c2d3997e7230d07b457accf69013a501b7e9f7841ba2da37201b3bb85314fdc",
+      core: "0x7483d0db53a140eed72bd6cb133daa59c539844f4c053924b9e3f0d2d7ba146d",
       token_bridge:
-        "0x199993e108d321f96da1c1167677affbefce6b43f34d9a255cae08224901637e",
+        "0x4fa45cbe562fdbd8acf882addfedf6406c2770bf7f93cef1eebf8a3fb497c35e",
     },
     aptos: {
       token_bridge:

--- a/clients/js/sui/consts.ts
+++ b/clients/js/sui/consts.ts
@@ -15,9 +15,9 @@ export const SUI_OBJECT_IDS = {
   },
   DEVNET: {
     core_state:
-      "0x363f879229a8c71bdf2c739864d236d30437acc01b664ffd4799037398861440",
+      "0x3f1cf66ea19cbef95205a36c69b6bc04a6097174f47a84944072b63983a0a63c",
     token_bridge_state:
-      "0xd194d83e1e8839ec80179fd7b5f0d14de4a906adda3d8f119c24ee0c8f3964f9",
+      "0x92c5755e78b9462a9f0cef556dc8e5b3d80d81bc7738bd8104bcabcf50a4a3c6",
   },
 };
 

--- a/clients/js/sui/publish.ts
+++ b/clients/js/sui/publish.ts
@@ -28,7 +28,7 @@ export const publishPackage = async (
       dependencies: string[];
     } = JSON.parse(
       execSync(
-        `sui move build --dump-bytecode-as-base64 --path ${packagePath}`,
+        `sui move build --dump-bytecode-as-base64 --path ${packagePath} 2> /dev/null`,
         {
           encoding: "utf-8",
         }

--- a/sui/Docker.md
+++ b/sui/Docker.md
@@ -4,10 +4,10 @@ cd ..; DOCKER_BUILDKIT=1 docker build --no-cache --progress plain -f sui/Dockerf
 
 # tag the image with the appropriate version
 
-docker tag sui:latest ghcr.io/wormhole-foundation/sui:0.31.0_1
+docker tag sui:latest ghcr.io/wormhole-foundation/sui:0.31.0_2
 
 # push to ghcr
 
-docker push ghcr.io/wormhole-foundation/sui:0.31.0_1
+docker push ghcr.io/wormhole-foundation/sui:0.31.0_2
 
 echo remember to update both Dockerfile and Dockerfile.export

--- a/sui/Docker.md
+++ b/sui/Docker.md
@@ -4,10 +4,10 @@ cd ..; DOCKER_BUILDKIT=1 docker build --no-cache --progress plain -f sui/Dockerf
 
 # tag the image with the appropriate version
 
-docker tag sui:latest ghcr.io/wormhole-foundation/sui:0.31.0
+docker tag sui:latest ghcr.io/wormhole-foundation/sui:0.31.0_1
 
 # push to ghcr
 
-docker push ghcr.io/wormhole-foundation/sui:0.31.0
+docker push ghcr.io/wormhole-foundation/sui:0.31.0_1
 
 echo remember to update both Dockerfile and Dockerfile.export

--- a/sui/Dockerfile
+++ b/sui/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/wormhole-foundation/sui:0.31.0@sha256:4e11eb50ee8dcc2a7325c682cee6726c7851c0ef1de3edbd3a2661d0cf9fd944 as sui
+FROM ghcr.io/wormhole-foundation/sui:0.31.0_1@sha256:5df513dc4fa0317f3068929811b4fa205d55d9378ca0e12721512486471bf6a9 as sui
 
 RUN dnf -y install make git
 

--- a/sui/Dockerfile
+++ b/sui/Dockerfile
@@ -1,24 +1,31 @@
-FROM ghcr.io/wormhole-foundation/sui:0.31.0_1@sha256:5df513dc4fa0317f3068929811b4fa205d55d9378ca0e12721512486471bf6a9 as sui
+FROM ghcr.io/wormhole-foundation/sui:0.31.0_2@sha256:64c47edd2ab6e6146c07e8835bb9e6d56bb64b4023903e9ff00205cafbeb0fc8 as sui
 
-RUN dnf -y install make git
+RUN dnf -y install make git npm
 
-COPY README.md cert.pem* /certs/
+COPY sui/README.md sui/cert.pem* /certs/
 RUN if [ -e /certs/cert.pem ]; then cp /certs/cert.pem /etc/ssl/certs/ca-certificates.crt; fi
 RUN if [ -e /certs/cert.pem ]; then git config --global http.sslCAInfo /certs/cert.pem; fi
 
 RUN sui genesis -f
 
-COPY devnet/ /root/.sui/sui_config/
+COPY sui/devnet/ /root/.sui/sui_config/
+
+# Build CLI, TODO(aki): move this to base image before merging into main
+RUN npm install -g n typescript ts-node
+RUN n stable
+COPY clients/js /tmp/clients/js
+WORKDIR /tmp/clients/js
+RUN make install
 
 WORKDIR /tmp
 
-COPY scripts/ scripts
-COPY wormhole/ wormhole
-COPY token_bridge/ token_bridge
-COPY testing/ testing
-COPY examples/ examples
-COPY Makefile Makefile
-COPY .env* .
+COPY sui/scripts/ scripts
+COPY sui/wormhole/ wormhole
+COPY sui/token_bridge/ token_bridge
+COPY sui/testing/ testing
+COPY sui/examples/ examples
+COPY sui/Makefile Makefile
+COPY sui/.env* .
 
 FROM sui AS tests
 

--- a/sui/Dockerfile.base
+++ b/sui/Dockerfile.base
@@ -16,19 +16,8 @@ RUN /tmp/node_builder.sh
 FROM docker.io/redhat/ubi8@sha256:56c374376a42da40f3aec753c4eab029b5ea162d70cb5f0cda24758780c31d81 as export-stage
 
 RUN dnf -y update
-RUN dnf -y install jq curl git make npm
+RUN dnf -y install jq curl git
 
 COPY --from=sui-node /root/.cargo/bin/sui /bin/sui
 COPY --from=sui-node /root/.cargo/bin/sui-faucet /bin/sui-faucet
 COPY --from=sui-node /root/.cargo/bin/sui-node /bin/sui-node
-
-WORKDIR /tmp
-
-RUN npm install -g n typescript ts-node
-RUN n stable
-
-COPY clients/js /tmp/clients/js
-
-WORKDIR /tmp/clients/js
-
-RUN make install

--- a/sui/Makefile
+++ b/sui/Makefile
@@ -6,7 +6,4 @@ test:
 	$(foreach dir,$(TEST_CONTRACT_DIRS), make -C $(dir) $@ &&) true
 
 test-docker:
-	DOCKER_BUILDKIT=1 docker build -f Dockerfile .
-
-sui_export:
-	DOCKER_BUILDKIT=1 docker build --progress plain -f Dockerfile.export -t near-export -o type=local,dest=$$HOME/.cargo/bin .
+	DOCKER_BUILDKIT=1 docker build -f Dockerfile ..


### PR DESCRIPTION
This PR fixes an incorrect Sui version in a previously pushed image and builds `clients/js` in the main Dockerfile instead of the base image that it uses. This should significantly speed up local development but we will have to mindful to revert this change before we merge `sui/integration_v2` into `main`.