### PR TITLE
cosmwasm: clean up unused dependencies

### DIFF
--- a/cosmwasm/Cargo.lock
+++ b/cosmwasm/Cargo.lock
@@ -93,16 +93,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
 
 [[package]]
-name = "bigint"
-version = "4.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0e8c8a600052b52482eff2cf4d810e462fdff1f656ac1ecb6232132a1ed7def"
-dependencies = [
- "byteorder",
- "crunchy 0.1.6",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -431,12 +421,6 @@ dependencies = [
 
 [[package]]
 name = "crunchy"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2f4a431c5c9f662e1200b7c7f02c34e91361150e382089a8f2dec3ba680cbda"
-
-[[package]]
-name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
@@ -586,7 +570,6 @@ version = "0.1.0"
 dependencies = [
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw-storage-plus",
  "cw2",
  "cw20",
  "cw20-base",
@@ -935,7 +918,6 @@ dependencies = [
  "base64",
  "cosmwasm-schema",
  "cosmwasm-std",
- "cosmwasm-storage",
  "cw-multi-test",
  "cw-storage-plus",
  "cw2",
@@ -947,7 +929,6 @@ dependencies = [
  "serde_wormhole",
  "thiserror",
  "tinyvec",
- "token-bridge-terra-2",
  "wormhole-bindings",
  "wormhole-core",
 ]
@@ -1209,23 +1190,12 @@ dependencies = [
 name = "mock-bridge-integration-2"
 version = "0.1.0"
 dependencies = [
- "bigint",
  "cosmwasm-std",
  "cosmwasm-storage",
  "cosmwasm-vm",
- "cw20",
- "cw20-base",
- "cw20-wrapped-2",
- "generic-array",
- "hex",
- "k256 0.9.6",
- "lazy_static",
  "schemars",
  "serde",
  "serde_json",
- "sha3 0.9.1",
- "terraswap",
- "thiserror",
  "token-bridge-terra-2",
  "wormhole-bridge-terra-2",
 ]
@@ -1868,19 +1838,14 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 name = "token-bridge-terra-2"
 version = "0.1.0"
 dependencies = [
- "bigint",
  "cosmwasm-std",
  "cosmwasm-storage",
  "cw20",
  "cw20-base",
  "cw20-wrapped-2",
- "generic-array",
  "hex",
- "k256 0.9.6",
- "lazy_static",
  "schemars",
  "serde",
- "serde_json",
  "sha3 0.9.1",
  "terraswap",
  "thiserror",
@@ -1933,7 +1898,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a45526d29728d135c2900b0d30573fe3ee79fceb12ef534c7bb30e810a91b601"
 dependencies = [
  "byteorder",
- "crunchy 0.2.2",
+ "crunchy",
  "hex",
  "static_assertions",
 ]
@@ -2294,17 +2259,11 @@ version = "0.1.0"
 dependencies = [
  "cosmwasm-std",
  "cosmwasm-storage",
- "cw20",
- "cw20-base",
- "cw20-wrapped-2",
  "generic-array",
- "getrandom",
  "hex",
  "k256 0.9.6",
- "lazy_static",
  "schemars",
  "serde",
- "serde_json",
  "sha3 0.9.1",
  "thiserror",
 ]

--- a/cosmwasm/contracts/cw20-wrapped/Cargo.toml
+++ b/cosmwasm/contracts/cw20-wrapped/Cargo.toml
@@ -21,5 +21,4 @@ serde = { version = "1.0.137", default-features = false, features = ["derive"] }
 cw2 = { version = "0.13.2" } 
 cw20 = { version = "0.13.2" } 
 cw20-base = { version = "0.13.2", features = ["library"] } 
-cw-storage-plus  = { version = "0.13.2" }
 thiserror = { version = "1.0.31" }

--- a/cosmwasm/contracts/global-accountant/Cargo.toml
+++ b/cosmwasm/contracts/global-accountant/Cargo.toml
@@ -18,7 +18,6 @@ anyhow = "1"
 base64 = "0.13"
 cosmwasm-schema = "1"
 cosmwasm-std = "1"
-cosmwasm-storage = "1"
 cw-storage-plus = "0.13.2"
 cw_transcode = "0.1.0"
 cw2 = "0.13.2"
@@ -28,7 +27,6 @@ serde = { version = "1.0.137", default-features = false, features = ["derive"] }
 serde_wormhole = "0.1.0"
 thiserror = { version = "1.0.31" }
 tinyvec = { version = "1.6", default-features = false, features = ["alloc", "serde"]}
-tokenbridge = { package = "token-bridge-terra-2", version = "0.1.0", features = ["library"] }
 wormhole-bindings = "0.1.0"
 wormhole-core = { version = "0.1.0", features = ["schemars"] }
 

--- a/cosmwasm/contracts/mock-bridge-integration/Cargo.toml
+++ b/cosmwasm/contracts/mock-bridge-integration/Cargo.toml
@@ -17,17 +17,6 @@ cosmwasm-std = { version = "1.0.0" }
 cosmwasm-storage = { version = "1.0.0" }
 schemars = "0.8.8"
 serde = { version = "1.0.137", default-features = false, features = ["derive"] }
-cw20 = "0.13.2"
-cw20-base = { version = "0.13.2", features = ["library"] }
-cw20-wrapped-2 = { version = "0.1.0", features = ["library"] }
-terraswap = "2.6.1"
-thiserror = { version = "1.0.31" }
-k256 = { version = "0.9.4", default-features = false, features = ["ecdsa"] }
-sha3 = { version = "0.9.1", default-features = false }
-generic-array = { version = "0.14.4" }
-hex = "0.4.2"
-lazy_static = "1.4.0"
-bigint = "4"
 
 wormhole-bridge-terra-2 = { version = "0.1.0", features = ["library"] }
 token-bridge-terra-2 = { version = "0.1.0", features = ["library"] }

--- a/cosmwasm/contracts/mock-bridge-integration/src/lib.rs
+++ b/cosmwasm/contracts/mock-bridge-integration/src/lib.rs
@@ -1,6 +1,3 @@
-#[cfg(test)]
-extern crate lazy_static;
-
 pub mod contract;
 pub mod msg;
 pub mod state;

--- a/cosmwasm/contracts/token-bridge/Cargo.toml
+++ b/cosmwasm/contracts/token-bridge/Cargo.toml
@@ -28,12 +28,5 @@ cw20-wrapped-2 = { version = "0.1.0", features = ["library"] }
 terraswap = "2.6.1"
 wormhole-bridge-terra-2 = { version = "0.1.0", default-features = false, features = ["library"] }
 thiserror = { version = "1.0.31" }
-k256 = { version = "0.9.4", default-features = false, features = ["ecdsa"] }
 sha3 = { version = "0.9.1", default-features = false }
-generic-array = { version = "0.14.4" }
 hex = "0.4.2"
-lazy_static = "1.4.0"
-bigint = "4"
-
-[dev-dependencies]
-serde_json = "1.0"

--- a/cosmwasm/contracts/token-bridge/src/lib.rs
+++ b/cosmwasm/contracts/token-bridge/src/lib.rs
@@ -1,6 +1,3 @@
-#[cfg(test)]
-extern crate lazy_static;
-
 pub mod contract;
 pub mod msg;
 pub mod state;

--- a/cosmwasm/contracts/wormhole/Cargo.toml
+++ b/cosmwasm/contracts/wormhole/Cargo.toml
@@ -23,16 +23,8 @@ cosmwasm-std = { version = "1.0.0" }
 cosmwasm-storage = { version = "1.0.0" }
 schemars = "0.8.8"
 serde = { version = "1.0.137", default-features = false, features = ["derive"] }
-cw20 = "0.13.2"
-cw20-base = { version = "0.13.2", features = ["library"] }
-cw20-wrapped-2 = { version = "0.1.0", features = ["library"] }
 thiserror = { version = "1.0.31" }
 k256 = { version = "0.9.4", default-features = false, features = ["ecdsa"] }
-getrandom = { version = "0.2", features = ["custom"] }
 sha3 = { version = "0.9.1", default-features = false }
 generic-array = { version = "0.14.4" }
 hex = "0.4.2"
-lazy_static = "1.4.0"
-
-[dev-dependencies]
-serde_json = "1.0"


### PR DESCRIPTION
Seems like a lot of dependencies have been copy/pasted — would be good to stop this practice in the future so we avoid any unnecessary compatibility issues, which makes it harder for others to import these libs and build on top of wormhole.