### PR TITLE
cosmwasm: bump k256 dependency to 0.11

### DIFF
--- a/cosmwasm/Cargo.lock
+++ b/cosmwasm/Cargo.lock
@@ -194,25 +194,19 @@ checksum = "591ff76ca0691bd91c1b0b5b987e5cf93b21ec810ad96665c5a569c60846dd93"
 
 [[package]]
 name = "const-oid"
-version = "0.6.2"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6f2aa4d0537bcc1c74df8755072bd31c1ef1a3a1b85a68e8404a8c353b7b8b"
-
-[[package]]
-name = "const-oid"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
+checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.0.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb0afef2325df81aadbf9be1233f522ed8f6e91df870c764bc44cca2b1415bd"
+checksum = "7fecd74d3a0041114110d1260f77fcb644c5d2403549b37096c44f0e643a5177"
 dependencies = [
- "digest 0.9.0",
+ "digest 0.10.6",
  "ed25519-zebra",
- "k256 0.10.4",
+ "k256",
  "rand_core 0.6.4",
  "thiserror",
 ]
@@ -292,7 +286,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.9.9",
  "thiserror",
  "wasmer",
  "wasmer-middlewares",
@@ -427,21 +421,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.2.11"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83bd3bb4314701c568e340cd8cf78c975aa0ca79e03d3f6d1677d5b0c9c0c03"
-dependencies = [
- "generic-array",
- "rand_core 0.6.4",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "crypto-bigint"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
+checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
 dependencies = [
  "generic-array",
  "rand_core 0.6.4",
@@ -457,16 +439,6 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
-]
-
-[[package]]
-name = "crypto-mac"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
-dependencies = [
- "generic-array",
- "subtle",
 ]
 
 [[package]]
@@ -626,20 +598,12 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.4.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79b71cca7d95d7681a4b3b9cdf63c8dbc3730d0584c2c74e31416d64a90493f4"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
- "const-oid 0.6.2",
-]
-
-[[package]]
-name = "der"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
-dependencies = [
- "const-oid 0.7.1",
+ "const-oid",
+ "zeroize",
 ]
 
 [[package]]
@@ -670,6 +634,7 @@ checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer 0.10.3",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -706,24 +671,12 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.12.4"
+version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43ee23aa5b4f68c7a092b5c3beb25f50c406adc75e2363634f242f28ab255372"
+checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
 dependencies = [
- "der 0.4.5",
- "elliptic-curve 0.10.6",
- "hmac",
- "signature",
-]
-
-[[package]]
-name = "ecdsa"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0d69ae62e0ce582d56380743515fefaf1a8c70cec685d9677636d7e30ae9dc9"
-dependencies = [
- "der 0.5.1",
- "elliptic-curve 0.11.12",
+ "der",
+ "elliptic-curve",
  "rfc6979",
  "signature",
 ]
@@ -739,7 +692,7 @@ dependencies = [
  "hex",
  "rand_core 0.6.4",
  "serde",
- "sha2",
+ "sha2 0.9.9",
  "zeroize",
 ]
 
@@ -751,32 +704,18 @@ checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.10.6"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beca177dcb8eb540133e7680baff45e7cc4d93bf22002676cec549f82343721b"
-dependencies = [
- "crypto-bigint 0.2.11",
- "ff 0.10.1",
- "generic-array",
- "group 0.10.0",
- "pkcs8 0.7.6",
- "rand_core 0.6.4",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "elliptic-curve"
-version = "0.11.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b477563c2bfed38a3b7a60964c49e058b2510ad3f12ba3483fd8f62c2306d6"
+checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
 dependencies = [
  "base16ct",
- "crypto-bigint 0.3.2",
- "der 0.5.1",
- "ff 0.11.1",
+ "crypto-bigint",
+ "der",
+ "digest 0.10.6",
+ "ff",
  "generic-array",
- "group 0.11.0",
+ "group",
+ "pkcs8",
  "rand_core 0.6.4",
  "sec1",
  "subtle",
@@ -841,19 +780,9 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.10.1"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f40b2dcd8bc322217a5f6559ae5f9e9d1de202a2ecee2e9eafcbece7562a4f"
-dependencies = [
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
-name = "ff"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "131655483be284720a17d74ff97592b8e76576dc25563148601df2d7c9080924"
+checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
 dependencies = [
  "rand_core 0.6.4",
  "subtle",
@@ -935,22 +864,11 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.10.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c363a5301b8f153d80747126a04b3c82073b9fe3130571a9d170cacdeaf7912"
+checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
- "ff 0.10.1",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
-name = "group"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5ac374b108929de78460075f3dc439fa66df9d8fc77e8f12caa5165fcf0c89"
-dependencies = [
- "ff 0.11.1",
+ "ff",
  "rand_core 0.6.4",
  "subtle",
 ]
@@ -993,12 +911,11 @@ dependencies = [
 
 [[package]]
 name = "hmac"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "crypto-mac",
- "digest 0.9.0",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -1053,28 +970,15 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.9.6"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "903ae2481bcdfdb7b68e0a9baa4b7c9aff600b9ae2e8e5bb5833b8c91ab851ea"
+checksum = "72c1e0b51e7ec0a97369623508396067a486bd0cbed95a2659a4b863d28cfc8b"
 dependencies = [
  "cfg-if",
- "ecdsa 0.12.4",
- "elliptic-curve 0.10.6",
- "sha2",
- "sha3 0.9.1",
-]
-
-[[package]]
-name = "k256"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19c3a5e0a0b8450278feda242592512e09f61c72e018b8cd5c859482802daf2d"
-dependencies = [
- "cfg-if",
- "ecdsa 0.13.4",
- "elliptic-curve 0.11.12",
- "sec1",
- "sha2",
+ "ecdsa",
+ "elliptic-curve",
+ "sha2 0.10.6",
+ "sha3 0.10.6",
 ]
 
 [[package]]
@@ -1263,23 +1167,12 @@ checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
 name = "pkcs8"
-version = "0.7.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee3ef9b64d26bad0536099c816c6734379e45bbd5f14798def6809e5cc350447"
+checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
 dependencies = [
- "der 0.4.5",
- "spki 0.4.1",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cabda3fb821068a9a4fab19a683eac3af12edf0f34b94a8be53c4972b8149d0"
-dependencies = [
- "der 0.5.1",
- "spki 0.5.4",
- "zeroize",
+ "der",
+ "spki",
 ]
 
 [[package]]
@@ -1473,11 +1366,11 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
-version = "0.1.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ef608575f6392792f9ecf7890c00086591d29a83910939d430753f7c050525"
+checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
 dependencies = [
- "crypto-bigint 0.3.2",
+ "crypto-bigint",
  "hmac",
  "zeroize",
 ]
@@ -1569,13 +1462,14 @@ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "sec1"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08da66b8b0965a5555b6bd6639e68ccba85e1e2506f5fbb089e93f8a04e1a2d1"
+checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
 dependencies = [
- "der 0.5.1",
+ "base16ct",
+ "der",
  "generic-array",
- "pkcs8 0.8.0",
+ "pkcs8",
  "subtle",
  "zeroize",
 ]
@@ -1665,6 +1559,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.6",
+]
+
+[[package]]
 name = "sha3"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1702,11 +1607,11 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.3.2"
+version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2807892cfa58e081aa1f1111391c7a0649d4fa127a4ffbe34bcbfb35a1171a4"
+checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 dependencies = [
- "digest 0.9.0",
+ "digest 0.10.6",
  "rand_core 0.6.4",
 ]
 
@@ -1718,21 +1623,12 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "spki"
-version = "0.4.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c01a0c15da1b0b0e1494112e7af814a678fec9bd157881b49beac661e9b6f32"
-dependencies = [
- "der 0.4.5",
-]
-
-[[package]]
-name = "spki"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d01ac02a6ccf3e07db148d2be087da624fea0221a16152ed01f0496a6b0a27"
+checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
 dependencies = [
  "base64ct",
- "der 0.5.1",
+ "der",
 ]
 
 [[package]]
@@ -2246,7 +2142,7 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-multi-test",
- "k256 0.9.6",
+ "k256",
  "schemars",
  "serde",
  "serde_wormhole",
@@ -2261,7 +2157,7 @@ dependencies = [
  "cosmwasm-storage",
  "generic-array",
  "hex",
- "k256 0.9.6",
+ "k256",
  "schemars",
  "serde",
  "sha3 0.9.1",
@@ -2283,6 +2179,6 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.4.3"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d68d9dcec5f9b43a30d38c49f91dfedfaac384cb8f085faca366c26207dd1619"
+checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"

--- a/cosmwasm/contracts/global-accountant/tests/chain_registration.rs
+++ b/cosmwasm/contracts/global-accountant/tests/chain_registration.rs
@@ -190,7 +190,7 @@ fn bad_signature() {
         .submit_vaas(vec![data])
         .expect_err("successfully executed chain registration with bad signature");
     assert_eq!(
-        "generic error: querier contract error: failed to verify signature",
+        "generic error: querier contract error: failed to recover verifying key",
         err.root_cause().to_string().to_lowercase()
     );
 }

--- a/cosmwasm/contracts/global-accountant/tests/submit_vaas.rs
+++ b/cosmwasm/contracts/global-accountant/tests/submit_vaas.rs
@@ -203,7 +203,7 @@ fn bad_signature() {
         .submit_vaas(vec![data])
         .expect_err("successfully submitted VAA with bad signature");
     assert_eq!(
-        "generic error: querier contract error: failed to recover verifying key",
+        "generic error: querier contract error: failed to verify signature",
         err.root_cause().to_string().to_lowercase()
     );
 }

--- a/cosmwasm/contracts/wormhole/Cargo.toml
+++ b/cosmwasm/contracts/wormhole/Cargo.toml
@@ -24,7 +24,7 @@ cosmwasm-storage = { version = "1.0.0" }
 schemars = "0.8.8"
 serde = { version = "1.0.137", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.31" }
-k256 = { version = "0.9.4", default-features = false, features = ["ecdsa"] }
+k256 = { version = "0.11", default-features = false, features = ["ecdsa"] }
 sha3 = { version = "0.9.1", default-features = false }
 generic-array = { version = "0.14.4" }
 hex = "0.4.2"

--- a/cosmwasm/contracts/wormhole/src/contract.rs
+++ b/cosmwasm/contracts/wormhole/src/contract.rs
@@ -426,7 +426,7 @@ mod test {
         // pass into function
         // verifying key should == addr
         let is_equal = keys_equal(&verifying_key, &addr);
-        assert_eq!(is_equal, true)
+        assert!(is_equal)
     }
 
     #[test]

--- a/cosmwasm/contracts/wormhole/src/contract.rs
+++ b/cosmwasm/contracts/wormhole/src/contract.rs
@@ -25,7 +25,8 @@ use k256::{
         recoverable::{Id as RecoverableId, Signature as RecoverableSignature},
         Signature, VerifyingKey,
     },
-    EncodedPoint,
+    elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint},
+    AffinePoint, EncodedPoint,
 };
 use sha3::{Digest, Keccak256};
 
@@ -208,7 +209,7 @@ fn parse_and_verify_vaa(
             .or_else(|_| ContractError::CannotDecodeSignature.std_err())?;
 
         let verify_key = recoverable_signature
-            .recover_verify_key_from_digest_bytes(GenericArray::from_slice(vaa.hash.as_slice()))
+            .recover_verifying_key_from_digest_bytes(GenericArray::from_slice(vaa.hash.as_slice()))
             .or_else(|_| ContractError::CannotRecoverKey.std_err())?;
 
         let index = index as usize;
@@ -377,13 +378,16 @@ pub fn query_state(deps: Deps) -> StdResult<GetStateResponse> {
 fn keys_equal(a: &VerifyingKey, b: &GuardianAddress) -> bool {
     let mut hasher = Keccak256::new();
 
-    let point = if let Some(p) = EncodedPoint::from(a).decompress() {
-        p
+    let affine_point_option = AffinePoint::from_encoded_point(&EncodedPoint::from(a));
+    let affine_point = if affine_point_option.is_some().into() {
+        affine_point_option.unwrap()
     } else {
         return false;
     };
 
-    hasher.update(&point.as_bytes()[1..]);
+    let decompressed_point = affine_point.to_encoded_point(false);
+
+    hasher.update(&decompressed_point.as_bytes()[1..]);
     let a = &hasher.finalize()[12..];
 
     let b = &b.bytes;
@@ -408,7 +412,8 @@ mod test {
     use super::keys_equal;
 
     const DECOMPRESSED_KEY: &str = "049678ad0aa2fbd7f212239e21ed1472e84ca558fecf70a54bbf7901d89c306191c52e7f10012960085ecdbbeeb22e63a8e86b58f788990b4db53cdf4e0a55ac1e";
-    const COMPRESSED_KEY: &str = "029678ad0aa2fbd7f212239e21ed1472e84ca558fecf70a54bbf7901d89c306191";
+    const COMPRESSED_KEY: &str =
+        "029678ad0aa2fbd7f212239e21ed1472e84ca558fecf70a54bbf7901d89c306191";
     const ADDRESS: &str = "54dbb737eac5007103e729e9ab7ce64a6850a310";
 
     fn test_keys_equal(point: Vec<u8>) {
@@ -432,9 +437,7 @@ mod test {
 
     #[test]
     fn keys_equal_compressed_point() {
-        let compressed_point =
-            hex::decode(COMPRESSED_KEY)
-                .unwrap();
+        let compressed_point = hex::decode(COMPRESSED_KEY).unwrap();
         test_keys_equal(compressed_point)
     }
 }

--- a/cosmwasm/contracts/wormhole/src/contract.rs
+++ b/cosmwasm/contracts/wormhole/src/contract.rs
@@ -397,3 +397,44 @@ fn keys_equal(a: &VerifyingKey, b: &GuardianAddress) -> bool {
     }
     true
 }
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        contract::{EncodedPoint, VerifyingKey},
+        state::GuardianAddress,
+    };
+
+    use super::keys_equal;
+
+    const DECOMPRESSED_KEY: &str = "049678ad0aa2fbd7f212239e21ed1472e84ca558fecf70a54bbf7901d89c306191c52e7f10012960085ecdbbeeb22e63a8e86b58f788990b4db53cdf4e0a55ac1e";
+    const COMPRESSED_KEY: &str = "029678ad0aa2fbd7f212239e21ed1472e84ca558fecf70a54bbf7901d89c306191";
+    const ADDRESS: &str = "54dbb737eac5007103e729e9ab7ce64a6850a310";
+
+    fn test_keys_equal(point: Vec<u8>) {
+        let addr = GuardianAddress::from(ADDRESS);
+
+        // get the verifying key for the point
+        let encoded_point = EncodedPoint::from_bytes(point).unwrap();
+        let verifying_key = VerifyingKey::from_encoded_point(&encoded_point).unwrap();
+
+        // pass into function
+        // verifying key should == addr
+        let is_equal = keys_equal(&verifying_key, &addr);
+        assert_eq!(is_equal, true)
+    }
+
+    #[test]
+    fn keys_equal_decompressed_point() {
+        let decompressed_point = hex::decode(DECOMPRESSED_KEY).unwrap();
+        test_keys_equal(decompressed_point)
+    }
+
+    #[test]
+    fn keys_equal_compressed_point() {
+        let compressed_point =
+            hex::decode(COMPRESSED_KEY)
+                .unwrap();
+        test_keys_equal(compressed_point)
+    }
+}

--- a/cosmwasm/packages/wormhole-bindings/Cargo.toml
+++ b/cosmwasm/packages/wormhole-bindings/Cargo.toml
@@ -15,5 +15,5 @@ schemars = "0.8.8"
 serde = { version = "1.0.137", default-features = false, features = ["derive"] }
 serde_wormhole = { version = "0.1.0", optional = true }
 cw-multi-test = { version = "0.13.2", optional = true }
-k256 = { version = "0.9.4", optional = true, features = ["ecdsa", "keccak256"] }
+k256 = { version = "0.11", optional = true, features = ["ecdsa", "keccak256"] }
 wormhole-core = "0.1.0"

--- a/cosmwasm/packages/wormhole-bindings/src/fake.rs
+++ b/cosmwasm/packages/wormhole-bindings/src/fake.rs
@@ -144,7 +144,7 @@ impl WormholeKeeper {
             let s = recoverable::Signature::try_from(&sig.signature[..])
                 .context("failed to decode signature")?;
             let verifying_key = s
-                .recover_verify_key_from_digest_bytes(&d.hash.into())
+                .recover_verifying_key_from_digest_bytes(&d.hash.into())
                 .context("failed to recover verifying key")?;
             ensure!(
                 g.verifying_key() == verifying_key,


### PR DESCRIPTION
See https://github.com/RustCrypto/elliptic-curves/blob/master/k256/CHANGELOG.md for changes to the `k256` library from `0.9.4` to `0.11`.

Most notable are:
1. The function renaming of `recover_verify_key_from_digest_bytes => recover_verifying_key_from_digest_bytes`
2. Using the `sec1` crate, which changes the `EncodedPoint` type. The `EncodedPoint` type no longer has a `decompress` method, so we use the affine point conversion: https://github.com/RustCrypto/elliptic-curves/pull/435/files