### PR TITLE
Node: RunWithScissors should not hang on error if no listener

### DIFF
--- a/node/pkg/common/scissors.go
+++ b/node/pkg/common/scissors.go
@@ -10,38 +10,56 @@ import (
 )
 
 var (
-	ScissorsErrors = promauto.NewCounterVec(
+	ScissorsErrorsCaught = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "scissor_errors_caught",
 			Help: "Total number of unhandled errors caught",
-		}, []string{"scissors", "name"})
+		}, []string{"name"})
+	ScissorsPanicsCaught = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "scissor_panics_caught",
+			Help: "Total number of panics caught",
+		}, []string{"name"})
 )
 
 // Start a go routine with recovering from any panic by sending an error to a error channel
 func RunWithScissors(ctx context.Context, errC chan error, name string, runnable supervisor.Runnable) {
-	ScissorsErrors.WithLabelValues("scissors", name).Add(0)
+	ScissorsErrorsCaught.WithLabelValues(name).Add(0)
+	ScissorsPanicsCaught.WithLabelValues(name).Add(0)
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {
+				var err error
 				switch x := r.(type) {
 				case error:
-					errC <- fmt.Errorf("%s: %w", name, x)
+					err = fmt.Errorf("%s: %w", name, x)
 				default:
-					errC <- fmt.Errorf("%s: %v", name, x)
+					err = fmt.Errorf("%s: %v", name, x)
 				}
-				ScissorsErrors.WithLabelValues("scissors", name).Inc()
+				// We don't want this to hang if the listener has already gone away.
+				select {
+				case errC <- err:
+				default:
+				}
+				ScissorsPanicsCaught.WithLabelValues(name).Inc()
 
 			}
 		}()
 		err := runnable(ctx)
 		if err != nil {
-			errC <- err
+			// We don't want this to hang if the listener has already gone away.
+			select {
+			case errC <- err:
+			default:
+			}
+			ScissorsErrorsCaught.WithLabelValues(name).Inc()
 		}
 	}()
 }
 
 func WrapWithScissors(runnable supervisor.Runnable, name string) supervisor.Runnable {
-	ScissorsErrors.WithLabelValues("scissors", name).Add(0)
+	ScissorsErrorsCaught.WithLabelValues(name).Add(0)
+	ScissorsPanicsCaught.WithLabelValues(name).Add(0)
 	return func(ctx context.Context) (result error) {
 		defer func() {
 			if r := recover(); r != nil {
@@ -51,7 +69,7 @@ func WrapWithScissors(runnable supervisor.Runnable, name string) supervisor.Runn
 				default:
 					result = fmt.Errorf("%s: %v", name, x)
 				}
-				ScissorsErrors.WithLabelValues("scissors", name).Inc()
+				ScissorsPanicsCaught.WithLabelValues(name).Inc()
 			}
 		}()
 

--- a/node/pkg/common/scissors_test.go
+++ b/node/pkg/common/scissors_test.go
@@ -5,9 +5,22 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 )
+
+func getCounterValue(metric *prometheus.CounterVec, runnableName string) float64 {
+	var m = &dto.Metric{}
+	if err := metric.WithLabelValues(runnableName).Write(m); err != nil {
+		return 0
+	}
+	return m.Counter.GetValue()
+}
 
 func throwNil(ctx context.Context) error {
 	var x *int = nil
@@ -77,4 +90,100 @@ func TestSupervisor(t *testing.T) {
 		},
 		)
 	}
+}
+
+func TestRunWithScissorsCleanExit(t *testing.T) {
+	ctx := context.Background()
+	errC := make(chan error)
+
+	itRan := false
+	RunWithScissors(ctx, errC, "TestRunWithScissorsCleanExit", func(ctx context.Context) error {
+		itRan = true
+		return nil
+	})
+
+	time.Sleep(100 * time.Millisecond)
+	require.Equal(t, true, itRan)
+	assert.Equal(t, 0.0, getCounterValue(ScissorsErrorsCaught, "TestRunWithScissorsCleanExit"))
+	assert.Equal(t, 0.0, getCounterValue(ScissorsPanicsCaught, "TestRunWithScissorsCleanExit"))
+}
+
+func TestRunWithScissorsPanicReturned(t *testing.T) {
+	ctx := context.Background()
+	errC := make(chan error)
+
+	itRan := false
+	RunWithScissors(ctx, errC, "TestRunWithScissorsPanicReturned", func(ctx context.Context) error {
+		itRan = true
+		panic("Some random panic")
+	})
+
+	var err error
+	select {
+	case <-ctx.Done():
+		break
+	case err = <-errC:
+		break
+	}
+
+	require.Equal(t, true, itRan)
+	assert.Error(t, err)
+	assert.Equal(t, 0.0, getCounterValue(ScissorsErrorsCaught, "TestRunWithScissorsPanicReturned"))
+	assert.Equal(t, 1.0, getCounterValue(ScissorsPanicsCaught, "TestRunWithScissorsPanicReturned"))
+}
+
+func TestRunWithScissorsPanicDoesNotBlockWhenNoListener(t *testing.T) {
+	ctx := context.Background()
+	errC := make(chan error)
+
+	itRan := false
+	RunWithScissors(ctx, errC, "TestRunWithScissorsPanicDoesNotBlockWhenNoListener", func(ctx context.Context) error {
+		itRan = true
+		panic("Some random panic")
+	})
+
+	time.Sleep(100 * time.Millisecond)
+	require.Equal(t, true, itRan)
+	assert.Equal(t, 0.0, getCounterValue(ScissorsErrorsCaught, "TestRunWithScissorsPanicDoesNotBlockWhenNoListener"))
+	assert.Equal(t, 1.0, getCounterValue(ScissorsPanicsCaught, "TestRunWithScissorsPanicDoesNotBlockWhenNoListener"))
+}
+
+func TestRunWithScissorsErrorReturned(t *testing.T) {
+	ctx := context.Background()
+	errC := make(chan error)
+
+	itRan := false
+	RunWithScissors(ctx, errC, "TestRunWithScissorsErrorReturned", func(ctx context.Context) error {
+		itRan = true
+		return fmt.Errorf("Some random error")
+	})
+
+	var err error
+	select {
+	case <-ctx.Done():
+		break
+	case err = <-errC:
+		break
+	}
+
+	require.Equal(t, true, itRan)
+	assert.Error(t, err)
+	assert.Equal(t, 1.0, getCounterValue(ScissorsErrorsCaught, "TestRunWithScissorsErrorReturned"))
+	assert.Equal(t, 0.0, getCounterValue(ScissorsPanicsCaught, "TestRunWithScissorsErrorReturned"))
+}
+
+func TestRunWithScissorsErrorDoesNotBlockWhenNoListener(t *testing.T) {
+	ctx := context.Background()
+	errC := make(chan error)
+
+	itRan := false
+	RunWithScissors(ctx, errC, "TestRunWithScissorsErrorDoesNotBlockWhenNoListener", func(ctx context.Context) error {
+		itRan = true
+		return fmt.Errorf("Some random error")
+	})
+
+	time.Sleep(100 * time.Millisecond)
+	require.Equal(t, true, itRan)
+	assert.Equal(t, 1.0, getCounterValue(ScissorsErrorsCaught, "TestRunWithScissorsErrorDoesNotBlockWhenNoListener"))
+	assert.Equal(t, 0.0, getCounterValue(ScissorsPanicsCaught, "TestRunWithScissorsErrorDoesNotBlockWhenNoListener"))
 }

--- a/node/pkg/common/scissors_test.go
+++ b/node/pkg/common/scissors_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/test-go/testify/require"
 
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
@@ -96,14 +96,15 @@ func TestRunWithScissorsCleanExit(t *testing.T) {
 	ctx := context.Background()
 	errC := make(chan error)
 
-	itRan := false
+	itRan := make(chan bool, 1)
 	RunWithScissors(ctx, errC, "TestRunWithScissorsCleanExit", func(ctx context.Context) error {
-		itRan = true
+		itRan <- true
 		return nil
 	})
 
+	shouldHaveRun := <-itRan
+	require.Equal(t, true, shouldHaveRun)
 	time.Sleep(100 * time.Millisecond)
-	require.Equal(t, true, itRan)
 	assert.Equal(t, 0.0, getCounterValue(ScissorsErrorsCaught, "TestRunWithScissorsCleanExit"))
 	assert.Equal(t, 0.0, getCounterValue(ScissorsPanicsCaught, "TestRunWithScissorsCleanExit"))
 }
@@ -112,9 +113,9 @@ func TestRunWithScissorsPanicReturned(t *testing.T) {
 	ctx := context.Background()
 	errC := make(chan error)
 
-	itRan := false
+	itRan := make(chan bool, 1)
 	RunWithScissors(ctx, errC, "TestRunWithScissorsPanicReturned", func(ctx context.Context) error {
-		itRan = true
+		itRan <- true
 		panic("Some random panic")
 	})
 
@@ -126,7 +127,8 @@ func TestRunWithScissorsPanicReturned(t *testing.T) {
 		break
 	}
 
-	require.Equal(t, true, itRan)
+	shouldHaveRun := <-itRan
+	require.Equal(t, true, shouldHaveRun)
 	assert.Error(t, err)
 	assert.Equal(t, "TestRunWithScissorsPanicReturned: Some random panic", err.Error())
 	assert.Equal(t, 0.0, getCounterValue(ScissorsErrorsCaught, "TestRunWithScissorsPanicReturned"))
@@ -137,14 +139,15 @@ func TestRunWithScissorsPanicDoesNotBlockWhenNoListener(t *testing.T) {
 	ctx := context.Background()
 	errC := make(chan error)
 
-	itRan := false
+	itRan := make(chan bool, 1)
 	RunWithScissors(ctx, errC, "TestRunWithScissorsPanicDoesNotBlockWhenNoListener", func(ctx context.Context) error {
-		itRan = true
+		itRan <- true
 		panic("Some random panic")
 	})
 
+	shouldHaveRun := <-itRan
+	require.Equal(t, true, shouldHaveRun)
 	time.Sleep(100 * time.Millisecond)
-	require.Equal(t, true, itRan)
 	assert.Equal(t, 0.0, getCounterValue(ScissorsErrorsCaught, "TestRunWithScissorsPanicDoesNotBlockWhenNoListener"))
 	assert.Equal(t, 1.0, getCounterValue(ScissorsPanicsCaught, "TestRunWithScissorsPanicDoesNotBlockWhenNoListener"))
 }
@@ -153,9 +156,9 @@ func TestRunWithScissorsErrorReturned(t *testing.T) {
 	ctx := context.Background()
 	errC := make(chan error)
 
-	itRan := false
+	itRan := make(chan bool, 1)
 	RunWithScissors(ctx, errC, "TestRunWithScissorsErrorReturned", func(ctx context.Context) error {
-		itRan = true
+		itRan <- true
 		return fmt.Errorf("Some random error")
 	})
 
@@ -167,7 +170,8 @@ func TestRunWithScissorsErrorReturned(t *testing.T) {
 		break
 	}
 
-	require.Equal(t, true, itRan)
+	shouldHaveRun := <-itRan
+	require.Equal(t, true, shouldHaveRun)
 	assert.Error(t, err)
 	assert.Equal(t, "Some random error", err.Error())
 	assert.Equal(t, 1.0, getCounterValue(ScissorsErrorsCaught, "TestRunWithScissorsErrorReturned"))
@@ -178,14 +182,15 @@ func TestRunWithScissorsErrorDoesNotBlockWhenNoListener(t *testing.T) {
 	ctx := context.Background()
 	errC := make(chan error)
 
-	itRan := false
+	itRan := make(chan bool, 1)
 	RunWithScissors(ctx, errC, "TestRunWithScissorsErrorDoesNotBlockWhenNoListener", func(ctx context.Context) error {
-		itRan = true
+		itRan <- true
 		return fmt.Errorf("Some random error")
 	})
 
+	shouldHaveRun := <-itRan
+	require.Equal(t, true, shouldHaveRun)
 	time.Sleep(100 * time.Millisecond)
-	require.Equal(t, true, itRan)
 	assert.Equal(t, 1.0, getCounterValue(ScissorsErrorsCaught, "TestRunWithScissorsErrorDoesNotBlockWhenNoListener"))
 	assert.Equal(t, 0.0, getCounterValue(ScissorsPanicsCaught, "TestRunWithScissorsErrorDoesNotBlockWhenNoListener"))
 }

--- a/node/pkg/common/scissors_test.go
+++ b/node/pkg/common/scissors_test.go
@@ -104,7 +104,10 @@ func TestRunWithScissorsCleanExit(t *testing.T) {
 
 	shouldHaveRun := <-itRan
 	require.Equal(t, true, shouldHaveRun)
+
+	// Need to wait a bit to make sure the scissors code completes without hanging.
 	time.Sleep(100 * time.Millisecond)
+
 	assert.Equal(t, 0.0, getCounterValue(ScissorsErrorsCaught, "TestRunWithScissorsCleanExit"))
 	assert.Equal(t, 0.0, getCounterValue(ScissorsPanicsCaught, "TestRunWithScissorsCleanExit"))
 }
@@ -147,7 +150,10 @@ func TestRunWithScissorsPanicDoesNotBlockWhenNoListener(t *testing.T) {
 
 	shouldHaveRun := <-itRan
 	require.Equal(t, true, shouldHaveRun)
+
+	// Need to wait a bit to make sure the scissors code completes without hanging.
 	time.Sleep(100 * time.Millisecond)
+
 	assert.Equal(t, 0.0, getCounterValue(ScissorsErrorsCaught, "TestRunWithScissorsPanicDoesNotBlockWhenNoListener"))
 	assert.Equal(t, 1.0, getCounterValue(ScissorsPanicsCaught, "TestRunWithScissorsPanicDoesNotBlockWhenNoListener"))
 }
@@ -190,7 +196,10 @@ func TestRunWithScissorsErrorDoesNotBlockWhenNoListener(t *testing.T) {
 
 	shouldHaveRun := <-itRan
 	require.Equal(t, true, shouldHaveRun)
+
+	// Need to wait a bit to make sure the scissors code completes without hanging.
 	time.Sleep(100 * time.Millisecond)
+
 	assert.Equal(t, 1.0, getCounterValue(ScissorsErrorsCaught, "TestRunWithScissorsErrorDoesNotBlockWhenNoListener"))
 	assert.Equal(t, 0.0, getCounterValue(ScissorsPanicsCaught, "TestRunWithScissorsErrorDoesNotBlockWhenNoListener"))
 }

--- a/node/pkg/common/scissors_test.go
+++ b/node/pkg/common/scissors_test.go
@@ -128,6 +128,7 @@ func TestRunWithScissorsPanicReturned(t *testing.T) {
 
 	require.Equal(t, true, itRan)
 	assert.Error(t, err)
+	assert.Equal(t, "TestRunWithScissorsPanicReturned: Some random panic", err.Error())
 	assert.Equal(t, 0.0, getCounterValue(ScissorsErrorsCaught, "TestRunWithScissorsPanicReturned"))
 	assert.Equal(t, 1.0, getCounterValue(ScissorsPanicsCaught, "TestRunWithScissorsPanicReturned"))
 }
@@ -168,6 +169,7 @@ func TestRunWithScissorsErrorReturned(t *testing.T) {
 
 	require.Equal(t, true, itRan)
 	assert.Error(t, err)
+	assert.Equal(t, "Some random error", err.Error())
 	assert.Equal(t, 1.0, getCounterValue(ScissorsErrorsCaught, "TestRunWithScissorsErrorReturned"))
 	assert.Equal(t, 0.0, getCounterValue(ScissorsPanicsCaught, "TestRunWithScissorsErrorReturned"))
 }


### PR DESCRIPTION
The existing RunWithScissors will hang if it tries to write to the error channel if there is no listener. This PR changes that. It also adds tests and metrics to allow us to verify the behavior.