### PR TITLE
sui: add coin type mapping using token info as key

### DIFF
--- a/clients/js/consts.ts
+++ b/clients/js/consts.ts
@@ -34,7 +34,7 @@ const OVERRIDES = {
     sui: {
       core: "0xa26bb6f2c14d8921191aeb3e7b718a247e1b71c02e7598a0bfad5ad213d6f105",
       token_bridge:
-        "0x35457da8bf2ce514014bea4d66b7461f29e7185eff06097c2451065c06f691b2",
+        "0x6ec5e8a372cdc308917ccb28b5d24bed4fddb00451c1f7edc36feb36dbdfe190",
     },
     aptos: {
       token_bridge:

--- a/clients/js/sui/consts.ts
+++ b/clients/js/sui/consts.ts
@@ -17,7 +17,7 @@ export const SUI_OBJECT_IDS = {
     core_state:
       "0x6128b6adb677ac2da9ac5efb3003e5863825748f7a18786c5f612a4cb552fa50",
     token_bridge_state:
-      "0xff8d34100d23d54c48c662aa0def908b42048e1d84d1e9034fcb1cb91f5704aa",
+      "0xc9a5d6d04aec996e60efe6d675b3c9c8ecddd4544f20474916771b4f90b4b0dc",
   },
 };
 

--- a/sdk/js/src/utils/consts.ts
+++ b/sdk/js/src/utils/consts.ts
@@ -516,7 +516,7 @@ const DEVNET = {
   sui: {
     core: "0xa26bb6f2c14d8921191aeb3e7b718a247e1b71c02e7598a0bfad5ad213d6f105",
     token_bridge:
-      "0x35457da8bf2ce514014bea4d66b7461f29e7185eff06097c2451065c06f691b2",
+      "0x6ec5e8a372cdc308917ccb28b5d24bed4fddb00451c1f7edc36feb36dbdfe190",
     nft_bridge: undefined,
   },
   moonbeam: {
@@ -846,7 +846,7 @@ export const SUI_OBJECT_IDS = {
     core_state:
       "0x6128b6adb677ac2da9ac5efb3003e5863825748f7a18786c5f612a4cb552fa50",
     token_bridge_state:
-      "0xff8d34100d23d54c48c662aa0def908b42048e1d84d1e9034fcb1cb91f5704aa",
+      "0xc9a5d6d04aec996e60efe6d675b3c9c8ecddd4544f20474916771b4f90b4b0dc",
   },
 };
 export type SuiAddresses = typeof SUI_OBJECT_IDS;

--- a/sui/token_bridge/sources/resources/token_registry.move
+++ b/sui/token_bridge/sources/resources/token_registry.move
@@ -60,8 +60,8 @@ module token_bridge::token_registry {
     struct Key<phantom CoinType> has copy, drop, store {}
 
     /// This struct is not used for anything within the contract. It exists
-    /// purely for someone to be able to fetch the type name of coin type
-    /// as a string via `TokenRegistry`.
+    /// purely for someone with an RPC query to be able to fetch the type name
+    /// of coin type as a string via `TokenRegistry`.
     struct CoinTypeKey has drop, copy, store {
         chain: u16,
         addr: vector<u8>


### PR DESCRIPTION
## Objective

Add a convenient mapping in the `TokenRegistry` that maps chain ID and address to a specific coin type as string. This mapping is helpful for someone interacting with the contract via RPC where a coin type needs to be specified when interacting with the Token Bridge. It is especially helpful when completing a transfer, where the coin type is not encoded the token transfer VAA (only the canonical token info).

## How to Review

1. Make sure Move tests still run via `make test`.
2. Review the new member `coin_type` and how it is used when adding native and wrapped assets.
3. Review tests that validate `coin_type` entries.