### PR TITLE
cosmwasm: remove terraswap dependency

### DIFF
--- a/cosmwasm/Cargo.lock
+++ b/cosmwasm/Cargo.lock
@@ -1232,15 +1232,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "protobuf"
-version = "2.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
-dependencies = [
- "bytes",
-]
-
-[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1681,20 +1672,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "terraswap"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9540f8489ec6e098de380c9fa8fa81fa95e502f87d63705aa6fba56817ad1a7"
-dependencies = [
- "cosmwasm-std",
- "cosmwasm-storage",
- "cw20",
- "protobuf",
- "schemars",
- "serde",
-]
-
-[[package]]
 name = "thiserror"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1743,7 +1720,6 @@ dependencies = [
  "schemars",
  "serde",
  "sha3 0.9.1",
- "terraswap",
  "thiserror",
  "wormhole-cosmwasm",
 ]

--- a/cosmwasm/Cargo.lock
+++ b/cosmwasm/Cargo.lock
@@ -1232,6 +1232,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+dependencies = [
+ "bytes",
+]
+
+[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1672,6 +1681,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "terraswap"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9540f8489ec6e098de380c9fa8fa81fa95e502f87d63705aa6fba56817ad1a7"
+dependencies = [
+ "cosmwasm-std",
+ "cosmwasm-storage",
+ "cw20",
+ "protobuf",
+ "schemars",
+ "serde",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1719,7 +1742,9 @@ dependencies = [
  "hex",
  "schemars",
  "serde",
+ "serde-json-wasm",
  "sha3 0.9.1",
+ "terraswap",
  "thiserror",
  "wormhole-cosmwasm",
 ]

--- a/cosmwasm/contracts/token-bridge/Cargo.toml
+++ b/cosmwasm/contracts/token-bridge/Cargo.toml
@@ -26,7 +26,6 @@ serde = { version = "1.0.137", default-features = false, features = ["derive"] }
 cw20 = "0.13.2"
 cw20-base = { version = "0.13.2", features = ["library"] }
 cw20-wrapped-2 = { version = "0.1.0", features = ["library"] }
-terraswap = "2.6.1"
 wormhole-cosmwasm = { version = "0.1.0", default-features = false, features = ["library"] }
 thiserror = { version = "1.0.31" }
 sha3 = { version = "0.9.1", default-features = false }

--- a/cosmwasm/contracts/token-bridge/Cargo.toml
+++ b/cosmwasm/contracts/token-bridge/Cargo.toml
@@ -30,3 +30,7 @@ wormhole-cosmwasm = { version = "0.1.0", default-features = false, features = ["
 thiserror = { version = "1.0.31" }
 sha3 = { version = "0.9.1", default-features = false }
 hex = "0.4.2"
+
+[dev-dependencies]
+terraswap = "2.6.1"
+serde-json-wasm = "0.4"

--- a/cosmwasm/contracts/token-bridge/src/contract.rs
+++ b/cosmwasm/contracts/token-bridge/src/contract.rs
@@ -8,7 +8,6 @@ use std::{
     cmp::{max, min},
     str::FromStr,
 };
-use terraswap::asset::{Asset, AssetInfo};
 
 use cw_wormhole::{
     byte_utils::{
@@ -31,9 +30,9 @@ use cosmwasm_std::{
 
 use crate::{
     msg::{
-        ChainRegistrationResponse, CompleteTransferResponse, ExecuteMsg, ExternalIdResponse,
-        InstantiateMsg, IsVaaRedeemedResponse, MigrateMsg, QueryMsg, TransferInfoResponse,
-        WrappedRegistryResponse,
+        Asset, AssetInfo, ChainRegistrationResponse, CompleteTransferResponse, ExecuteMsg,
+        ExternalIdResponse, InstantiateMsg, IsVaaRedeemedResponse, MigrateMsg, QueryMsg,
+        TransferInfoResponse, WrappedRegistryResponse,
     },
     state::{
         bridge_contracts, bridge_contracts_read, bridge_deposit, config, config_read,

--- a/cosmwasm/contracts/token-bridge/src/msg.rs
+++ b/cosmwasm/contracts/token-bridge/src/msg.rs
@@ -1,7 +1,6 @@
 use cosmwasm_std::{Binary, Uint128};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use terraswap::asset::{Asset, AssetInfo};
 
 use crate::token_address::{ExternalTokenId, TokenId};
 
@@ -131,4 +130,19 @@ pub struct CompleteTransferResponse {
     pub amount: Uint128,
     pub relayer: String,
     pub fee: Uint128,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct Asset {
+    pub info: AssetInfo,
+    pub amount: Uint128,
+}
+
+/// AssetInfo contract_addr is usually passed from the cw20 hook
+/// so we can trust the contract_addr is properly validated.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum AssetInfo {
+    Token { contract_addr: String },
+    NativeToken { denom: String },
 }


### PR DESCRIPTION
I think it makes sense to remove the `terraswap` dependency from the `cw_token_bridge` for a couple reasons:

1. It’s an extra dependency that cosmwasm integrators need to pull in to build token bridge `ExecuteMsg` types.
2. The type is very simple and the dependency has functionality specific to `terra`, so it shouldn't be included in the general cosmwasm contract.

These `Asset` and `AssetInfo` types are generally quite useful in cosmwasm, and should ideally be pulled out of terraswap and committed upstream to one of the cosmwasm std libs. However, that is a longer process, so defining them in the token bridge is a good solution for the interim.