### PR TITLE
Update docker push workflow

### DIFF
--- a/.github/workflows/generic-relayer-docker.yml
+++ b/.github/workflows/generic-relayer-docker.yml
@@ -3,7 +3,7 @@ name: Publish generic relayer container image
 on:
   workflow_dispatch:
   push:
-    branches: ["generic-relayer-merge"]
+    branches: ["generic-relayer-merge", "gr/re-app-docker-push"]
   release:
     types: [published]
 

--- a/relayer/generic_relayer/relayer-engine-v2/Dockerfile
+++ b/relayer/generic_relayer/relayer-engine-v2/Dockerfile
@@ -64,7 +64,9 @@ COPY --chown=node:node ./ethereum .
 USER root
 RUN npm i --save-dev --global typechain
 RUN forge install --no-git --no-commit
-RUN forge build -o build
+RUN apt-get install tree
+RUN make dependencies
+RUN tree -L 1; forge build -o build
 RUN typechain --target=ethers-v5 --out-dir=./ethers-contracts ./build/**/*.json
 
 


### PR DESCRIPTION
Allow pushing the relayer engine docker image to ghcr so that relay providers can pull it automatically 