### PR TITLE
sui: lower rpc processing latency

### DIFF
--- a/clients/js/sui/publish.ts
+++ b/clients/js/sui/publish.ts
@@ -10,7 +10,6 @@ import fs from "fs";
 import { resolve } from "path";
 import { Network } from "../utils";
 import { MoveToml } from "./MoveToml";
-import { pollTransactionForEffectsCert } from "./utils";
 
 export const publishPackage = async (
   signer: RawSigner,
@@ -52,15 +51,13 @@ export const publishPackage = async (
     );
 
     // Execute transactions
-    const { digest } = await signer.signAndExecuteTransactionBlock({
+    const res = await signer.signAndExecuteTransactionBlock({
       transactionBlock,
-      requestType: "WaitForEffectsCert",
       options: {
         showInput: true,
         showObjectChanges: true,
       },
     });
-    const res = await pollTransactionForEffectsCert(signer, digest);
 
     // Update network-specific Move.toml with package ID
     const publishEvents = getPublishedObjectChanges(res);

--- a/clients/js/sui/publish.ts
+++ b/clients/js/sui/publish.ts
@@ -10,6 +10,7 @@ import fs from "fs";
 import { resolve } from "path";
 import { Network } from "../utils";
 import { MoveToml } from "./MoveToml";
+import { pollTransactionForEffectsCert } from "./utils";
 
 export const publishPackage = async (
   signer: RawSigner,
@@ -51,13 +52,15 @@ export const publishPackage = async (
     );
 
     // Execute transactions
-    const res = await signer.signAndExecuteTransactionBlock({
+    const { digest } = await signer.signAndExecuteTransactionBlock({
       transactionBlock,
+      requestType: "WaitForEffectsCert",
       options: {
         showInput: true,
         showObjectChanges: true,
       },
     });
+    const res = await pollTransactionForEffectsCert(signer, digest);
 
     // Update network-specific Move.toml with package ID
     const publishEvents = getPublishedObjectChanges(res);

--- a/clients/js/sui/utils.ts
+++ b/clients/js/sui/utils.ts
@@ -193,7 +193,7 @@ export const pollTransactionForEffectsCert = async (
         });
         const completed = transaction.effects.status.status === "success";
         if (completed) return resolve(transaction);
-        setTimeout(poll, interval);
+        setTimeout(poll, interval, resolve, reject);
       } catch (error) {
         return reject(error);
       }

--- a/clients/js/sui/utils.ts
+++ b/clients/js/sui/utils.ts
@@ -197,6 +197,8 @@ export const pollTransactionForEffectsCert = async (
       } catch (error) {
         return reject(error);
       }
+    } else {
+      return reject(new Error("Retry attempts exceeded"));
     }
   };
 

--- a/clients/js/sui/utils.ts
+++ b/clients/js/sui/utils.ts
@@ -250,6 +250,8 @@ export const getOwnedObjectId = async (
     const is504HttpError = `${error}`.includes("504 Gateway Time-out");
     if (error && is504HttpError) {
       return findOwnedObjectByType(provider, owner, type);
+    } else {
+      throw error;
     }
   }
 };

--- a/clients/js/sui/utils.ts
+++ b/clients/js/sui/utils.ts
@@ -9,7 +9,6 @@ import {
   SUI_CLOCK_OBJECT_ID,
   SuiTransactionBlockResponse,
   TransactionBlock,
-  TransactionDigest,
   fromB64,
   normalizeSuiAddress,
 } from "@mysten/sui.js";
@@ -160,47 +159,6 @@ export const executeTransactionBlock = async (
       showObjectChanges: true,
     },
   });
-};
-
-export const pollTransactionForEffectsCert = async (
-  signer: RawSigner,
-  digest: TransactionDigest,
-  options?: {
-    retryAttempts?: number;
-    retryIntervalInMilliseconds?: number;
-  }
-): Promise<SuiTransactionBlockResponse> => {
-  const DEFAULT_ATTEMPTS_LIMIT = 10;
-  const DEFAULT_RETRY_MILLISECONDS_INTERVAL = 1000;
-
-  const limit = options?.retryAttempts || DEFAULT_ATTEMPTS_LIMIT;
-  const interval =
-    options?.retryIntervalInMilliseconds || DEFAULT_RETRY_MILLISECONDS_INTERVAL;
-
-  let attemptsCount = 0;
-
-  const poll = async (resolve, reject) => {
-    attemptsCount = attemptsCount + 1;
-    if (attemptsCount <= limit) {
-      try {
-        const transaction = await signer.provider.getTransactionBlock({
-          digest,
-          options: {
-            showEffects: true,
-          },
-        });
-        const completed = transaction.effects.status.status === "success";
-        if (completed) return resolve(transaction);
-        setTimeout(poll, interval, resolve, reject);
-      } catch (error) {
-        return reject(error);
-      }
-    } else {
-      return reject(new Error("Retry attempts exceeded"));
-    }
-  };
-
-  return new Promise(poll);
 };
 
 export const getCreatedObjects = (

--- a/clients/js/sui/utils.ts
+++ b/clients/js/sui/utils.ts
@@ -169,7 +169,7 @@ export const pollTransactionForEffectsCert = async (
   digest: TransactionDigest,
   options?: {
     retryAttempts?: number;
-    retryIntervalInMilliseconds: number;
+    retryIntervalInMilliseconds?: number;
   }
 ): Promise<SuiTransactionBlockResponse> => {
   const DEFAULT_ATTEMPTS_LIMIT = 10;

--- a/clients/js/sui/utils.ts
+++ b/clients/js/sui/utils.ts
@@ -56,8 +56,7 @@ export const execute_sui = async (
               tx.object(SUI_CLOCK_OBJECT_ID),
             ],
           });
-          const { digest } = await executeTransactionBlock(signer, tx);
-          await pollTransactionForEffectsCert(signer, digest);
+          await executeTransactionBlock(signer, tx);
           break;
         }
         case "ContractUpgrade":
@@ -126,8 +125,7 @@ export const execute_sui = async (
             ],
           });
 
-          const { digest } = await executeTransactionBlock(signer, tx);
-          await pollTransactionForEffectsCert(signer, digest);
+          await executeTransactionBlock(signer, tx);
           break;
         }
         case "AttestMeta":
@@ -155,7 +153,6 @@ export const executeTransactionBlock = async (
   // Let caller handle parsing and logging info
   return signer.signAndExecuteTransactionBlock({
     transactionBlock,
-    requestType: "WaitForEffectsCert",
     options: {
       showInput: true,
       showEffects: true,


### PR DESCRIPTION
Resolves #2670 

This PR solves 504 errors (Gateway Time-out) while using `filter` params on API method `suix_getOwnedObjects`

A new method `findOwnedObjectByType` has  been added to directly download all `OwnedObjects` and navigate them until finding our target. 

This implementation uses `cursor` to search in every response page. You can check the API docs [here](https://docs.sui.io/sui-jsonrpc#suix_getOwnedObjects).

Further context is available [here]( https://github.com/wormhole-foundation/wormhole/issues/2670#issuecomment-1518415668) 👀