### PR TITLE
Node: Block height is always zero on Terra2

### DIFF
--- a/node/pkg/watchers/cosmwasm/watcher.go
+++ b/node/pkg/watchers/cosmwasm/watcher.go
@@ -116,7 +116,7 @@ func NewWatcher(
 	// Do not add a leading slash
 	latestBlockURL := "blocks/latest"
 
-	// Terra2 and Injective do things slightly differently than classic terra
+	// Terra2 and Injective do things slightly differently than terra classic
 	if chainID == vaa.ChainIDInjective || chainID == vaa.ChainIDTerra2 {
 		latestBlockURL = "cosmos/base/tendermint/v1beta1/blocks/latest"
 	}
@@ -276,7 +276,6 @@ func (e *Watcher) Run(ctx context.Context) error {
 
 				msgs := EventsToMessagePublications(e.contract, txHash, events.Array(), logger, e.chainID, e.contractAddressLogKey)
 				for _, msg := range msgs {
-					logger.Info("BOINK: publishing reobserved tx")
 					e.msgC <- msg
 					messagesConfirmed.WithLabelValues(networkName).Inc()
 				}

--- a/node/pkg/watchers/cosmwasm/watcher.go
+++ b/node/pkg/watchers/cosmwasm/watcher.go
@@ -116,8 +116,8 @@ func NewWatcher(
 	// Do not add a leading slash
 	latestBlockURL := "blocks/latest"
 
-	// Injective does things slightly differently than terra
-	if chainID == vaa.ChainIDInjective {
+	// Terra2 and Injective do things slightly differently than classic terra
+	if chainID == vaa.ChainIDInjective || chainID == vaa.ChainIDTerra2 {
 		latestBlockURL = "cosmos/base/tendermint/v1beta1/blocks/latest"
 	}
 
@@ -276,6 +276,7 @@ func (e *Watcher) Run(ctx context.Context) error {
 
 				msgs := EventsToMessagePublications(e.contract, txHash, events.Array(), logger, e.chainID, e.contractAddressLogKey)
 				for _, msg := range msgs {
+					logger.Info("BOINK: publishing reobserved tx")
 					e.msgC <- msg
 					messagesConfirmed.WithLabelValues(networkName).Inc()
 				}


### PR DESCRIPTION
The old block height query on Terra2 has stopped working.

See this doc for the API changes.
https://docs.terra.money/upgrade/