### PR TITLE
Sui: Replace ExternalAddress type with vector. 

### DIFF
--- a/sui/README.md
+++ b/sui/README.md
@@ -24,7 +24,7 @@ Make sure your Cargo version is at least 1.65.0 and then follow the steps below:
 Install the `Sui` CLI. This tool is used to compile the contracts and run the tests.
 
 ```sh
-cargo install --locked --git https://github.com/MystenLabs/sui.git --rev a63f425b9999c7fdfe483598720a9effc0acdc9e sui sui-faucet
+cargo install --locked --git https://github.com/MystenLabs/sui.git --rev 3a70c4374090b020b95465787f3220a95d8ab0ba sui sui-faucet
 ```
 
 Some useful Sui CLI commands are

--- a/sui/coin/Move.devnet.toml
+++ b/sui/coin/Move.devnet.toml
@@ -5,7 +5,7 @@ version = "0.0.1"
 [dependencies.Sui]
 git = "https://github.com/MystenLabs/sui.git"
 subdir = "crates/sui-framework/packages/sui-framework"
-rev = "a63f425b9999c7fdfe483598720a9effc0acdc9e"
+rev = "3a70c4374090b020b95465787f3220a95d8ab0ba"
 
 [dependencies.TokenBridge]
 local = "../token_bridge"

--- a/sui/coin/Move.toml
+++ b/sui/coin/Move.toml
@@ -5,7 +5,7 @@ version = "0.0.1"
 [dependencies.Sui]
 git = "https://github.com/MystenLabs/sui.git"
 subdir = "crates/sui-framework/packages/sui-framework"
-rev = "a63f425b9999c7fdfe483598720a9effc0acdc9e"
+rev = "3a70c4374090b020b95465787f3220a95d8ab0ba"
 
 [dependencies.TokenBridge]
 local = "../token_bridge"

--- a/sui/examples/coins/Move.devnet.toml
+++ b/sui/examples/coins/Move.devnet.toml
@@ -5,7 +5,7 @@ version = "0.0.1"
 [dependencies.Sui]
 git = "https://github.com/MystenLabs/sui.git"
 subdir = "crates/sui-framework/packages/sui-framework"
-rev = "a63f425b9999c7fdfe483598720a9effc0acdc9e"
+rev = "3a70c4374090b020b95465787f3220a95d8ab0ba"
 
 [dependencies.Wormhole]
 local = "../../wormhole"

--- a/sui/examples/coins/Move.toml
+++ b/sui/examples/coins/Move.toml
@@ -5,7 +5,7 @@ version = "0.0.1"
 [dependencies.Sui]
 git = "https://github.com/MystenLabs/sui.git"
 subdir = "crates/sui-framework/packages/sui-framework"
-rev = "a63f425b9999c7fdfe483598720a9effc0acdc9e"
+rev = "3a70c4374090b020b95465787f3220a95d8ab0ba"
 
 [dependencies.Wormhole]
 local = "../../wormhole"

--- a/sui/examples/core_messages/Move.devnet.toml
+++ b/sui/examples/core_messages/Move.devnet.toml
@@ -5,7 +5,7 @@ version = "1.0.0"
 [dependencies.Sui]
 git = "https://github.com/MystenLabs/sui.git"
 subdir = "crates/sui-framework/packages/sui-framework"
-rev = "a63f425b9999c7fdfe483598720a9effc0acdc9e"
+rev = "3a70c4374090b020b95465787f3220a95d8ab0ba"
 
 [dependencies.Wormhole]
 local = "../../wormhole"

--- a/sui/examples/core_messages/Move.lock
+++ b/sui/examples/core_messages/Move.lock
@@ -5,16 +5,19 @@ version = 0
 
 dependencies = [
   { name = "Sui" },
+]
+
+dev-dependencies = [
   { name = "Wormhole" },
 ]
 
 [[move.package]]
 name = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "a63f425b9999c7fdfe483598720a9effc0acdc9e", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "3a70c4374090b020b95465787f3220a95d8ab0ba", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 name = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "a63f425b9999c7fdfe483598720a9effc0acdc9e", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "3a70c4374090b020b95465787f3220a95d8ab0ba", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { name = "MoveStdlib" },

--- a/sui/examples/core_messages/Move.toml
+++ b/sui/examples/core_messages/Move.toml
@@ -5,7 +5,7 @@ version = "1.0.0"
 [dependencies.Sui]
 git = "https://github.com/MystenLabs/sui.git"
 subdir = "crates/sui-framework/packages/sui-framework"
-rev = "a63f425b9999c7fdfe483598720a9effc0acdc9e"
+rev = "3a70c4374090b020b95465787f3220a95d8ab0ba"
 
 [dependencies.Wormhole]
 local = "../../wormhole"

--- a/sui/token_bridge/Move.devnet.toml
+++ b/sui/token_bridge/Move.devnet.toml
@@ -5,7 +5,7 @@ version = "0.0.1"
 [dependencies.Sui]
 git = "https://github.com/MystenLabs/sui.git"
 subdir = "crates/sui-framework/packages/sui-framework"
-rev = "a63f425b9999c7fdfe483598720a9effc0acdc9e"
+rev = "3a70c4374090b020b95465787f3220a95d8ab0ba"
 
 [dependencies.Wormhole]
 local = "../wormhole"

--- a/sui/token_bridge/Move.lock
+++ b/sui/token_bridge/Move.lock
@@ -5,16 +5,19 @@ version = 0
 
 dependencies = [
   { name = "Sui" },
+]
+
+dev-dependencies = [
   { name = "Wormhole" },
 ]
 
 [[move.package]]
 name = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "a63f425b9999c7fdfe483598720a9effc0acdc9e", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "3a70c4374090b020b95465787f3220a95d8ab0ba", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 name = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "a63f425b9999c7fdfe483598720a9effc0acdc9e", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "3a70c4374090b020b95465787f3220a95d8ab0ba", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { name = "MoveStdlib" },

--- a/sui/token_bridge/Move.toml
+++ b/sui/token_bridge/Move.toml
@@ -5,7 +5,7 @@ version = "0.0.1"
 [dependencies.Sui]
 git = "https://github.com/MystenLabs/sui.git"
 subdir = "crates/sui-framework/packages/sui-framework"
-rev = "a63f425b9999c7fdfe483598720a9effc0acdc9e"
+rev = "3a70c4374090b020b95465787f3220a95d8ab0ba"
 
 [dependencies.Wormhole]
 local = "../wormhole"

--- a/sui/token_bridge/sources/transfer_tokens.move
+++ b/sui/token_bridge/sources/transfer_tokens.move
@@ -16,8 +16,9 @@ module token_bridge::transfer_tokens {
     use sui::coin::{Self, Coin};
     use sui::sui::{SUI};
     use sui::tx_context::{Self, TxContext};
-    use wormhole::external_address::{ExternalAddress};
+    use wormhole::external_address::{Self, ExternalAddress};
     use wormhole::state::{State as WormholeState};
+    use wormhole::bytes32::{Self};
 
     use token_bridge::native_asset::{Self};
     use token_bridge::normalized_amount::{Self, NormalizedAmount};
@@ -49,7 +50,7 @@ module token_bridge::transfer_tokens {
         bridged_in: Coin<CoinType>,
         wormhole_fee: Coin<SUI>,
         recipient_chain: u16,
-        recipient: ExternalAddress,
+        recipient: vector<u8>,
         relayer_fee: u64,
         nonce: u32,
         the_clock: &Clock
@@ -63,7 +64,7 @@ module token_bridge::transfer_tokens {
                 token_bridge_state,
                 &mut bridged_in,
                 recipient_chain,
-                recipient,
+                external_address::new(bytes32::from_bytes(recipient)),
                 relayer_fee
             );
 
@@ -191,14 +192,14 @@ module token_bridge::transfer_tokens {
         token_bridge_state: &mut State,
         bridged_in: Coin<CoinType>,
         recipient_chain: u16,
-        recipient: ExternalAddress,
+        recipient: vector<u8>,
         relayer_fee: u64
     ): (vector<u8>, Coin<CoinType>) {
         let payload = bridge_in_and_serialize_transfer(
             token_bridge_state,
             &mut bridged_in,
             recipient_chain,
-            recipient,
+            external_address::new(bytes32::from_bytes(recipient)),
             relayer_fee
         );
 
@@ -214,6 +215,7 @@ module token_bridge::transfer_token_tests {
 
     use wormhole::external_address::{Self};
     use wormhole::state::{chain_id};
+    use wormhole::bytes32::{Self};
 
     use token_bridge::coin_wrapped_7::{Self, COIN_WRAPPED_7};
     use token_bridge::coin_native_10::{Self, COIN_NATIVE_10};
@@ -235,7 +237,7 @@ module token_bridge::transfer_token_tests {
     use token_bridge::normalized_amount::{Self};
 
     /// Test consts.
-    const TEST_TARGET_RECIPIENT: address = @0xbeef4269;
+    const TEST_TARGET_RECIPIENT: vector<u8> = x"beef4269";
     const TEST_TARGET_CHAIN: u16 = 2;
     const TEST_NONCE: u32 = 0;
     const TEST_COIN_NATIVE_10_DECIMALS: u8 = 10;
@@ -290,7 +292,7 @@ module token_bridge::transfer_token_tests {
             coin::from_balance(coin_10_balance, ctx),
             coin::mint_for_testing(wormhole_fee, ctx),
             TEST_TARGET_CHAIN,
-            external_address::from_address(TEST_TARGET_RECIPIENT),
+            TEST_TARGET_RECIPIENT,
             relayer_fee,
             TEST_NONCE,
             &the_clock
@@ -366,7 +368,7 @@ module token_bridge::transfer_token_tests {
             coin::from_balance(coin_10_balance, ctx),
             coin::mint_for_testing(wormhole_fee, ctx),
             TEST_TARGET_CHAIN,
-            external_address::from_address(TEST_TARGET_RECIPIENT),
+            TEST_TARGET_RECIPIENT,
             relayer_fee,
             TEST_NONCE,
             &the_clock
@@ -431,7 +433,7 @@ module token_bridge::transfer_token_tests {
             &mut token_bridge_state,
             coin::from_balance(coin_10_balance, ctx),
             TEST_TARGET_CHAIN,
-            external_address::from_address(TEST_TARGET_RECIPIENT),
+            TEST_TARGET_RECIPIENT,
             relayer_fee
         );
         assert!(coin::value(&dust) == 0, 0);
@@ -457,7 +459,7 @@ module token_bridge::transfer_token_tests {
                 expected_amount,
                 expected_token_address,
                 chain_id(),
-                external_address::from_address(TEST_TARGET_RECIPIENT),
+                external_address::new(bytes32::from_bytes(TEST_TARGET_RECIPIENT)),
                 TEST_TARGET_CHAIN,
                 expected_relayer_fee
             );
@@ -519,7 +521,7 @@ module token_bridge::transfer_token_tests {
             coin::from_balance(coin_7_balance, ctx),
             coin::mint_for_testing(wormhole_fee, ctx),
             TEST_TARGET_CHAIN,
-            external_address::from_address(TEST_TARGET_RECIPIENT),
+            TEST_TARGET_RECIPIENT,
             relayer_fee,
             TEST_NONCE,
             &the_clock
@@ -581,7 +583,7 @@ module token_bridge::transfer_token_tests {
             &mut token_bridge_state,
             coin::from_balance(coin_7_balance, ctx),
             TEST_TARGET_CHAIN,
-            external_address::from_address(TEST_TARGET_RECIPIENT),
+            TEST_TARGET_RECIPIENT,
             relayer_fee
         );
         assert!(coin::value(&dust) == 0, 0);
@@ -612,7 +614,7 @@ module token_bridge::transfer_token_tests {
                 expected_amount,
                 expected_token_address,
                 expected_token_chain,
-                external_address::from_address(TEST_TARGET_RECIPIENT),
+                external_address::new(bytes32::from_bytes(TEST_TARGET_RECIPIENT)),
                 TEST_TARGET_CHAIN,
                 expected_relayer_fee
             );
@@ -666,7 +668,7 @@ module token_bridge::transfer_token_tests {
             test_coins,
             coin::mint_for_testing(wormhole_fee, test_scenario::ctx(scenario)),
             TEST_TARGET_CHAIN,
-            external_address::from_address(TEST_TARGET_RECIPIENT),
+            TEST_TARGET_RECIPIENT,
             relayer_fee,
             TEST_NONCE,
             &the_clock
@@ -721,7 +723,7 @@ module token_bridge::transfer_token_tests {
             test_coins,
             coin::mint_for_testing(wormhole_fee, test_scenario::ctx(scenario)),
             TEST_TARGET_CHAIN,
-            external_address::from_address(TEST_TARGET_RECIPIENT),
+            TEST_TARGET_RECIPIENT,
             relayer_fee,
             TEST_NONCE,
             &the_clock
@@ -776,7 +778,7 @@ module token_bridge::transfer_token_tests {
             coin::from_balance(coin_10_balance, ctx),
             coin::mint_for_testing(wormhole_fee, ctx),
             TEST_TARGET_CHAIN,
-            external_address::from_address(TEST_TARGET_RECIPIENT),
+            TEST_TARGET_RECIPIENT,
             relayer_fee,
             TEST_NONCE,
             &the_clock

--- a/sui/token_bridge/sources/transfer_tokens_with_payload.move
+++ b/sui/token_bridge/sources/transfer_tokens_with_payload.move
@@ -16,7 +16,8 @@ module token_bridge::transfer_tokens_with_payload {
     use sui::coin::{Coin};
     use sui::sui::{SUI};
     use wormhole::emitter::{EmitterCap};
-    use wormhole::external_address::{ExternalAddress};
+    use wormhole::external_address::{Self, ExternalAddress};
+    use wormhole::bytes32::{Self};
     use wormhole::state::{State as WormholeState};
 
     use token_bridge::state::{Self, State};
@@ -43,7 +44,7 @@ module token_bridge::transfer_tokens_with_payload {
         bridged_in: Coin<CoinType>,
         wormhole_fee: Coin<SUI>,
         redeemer_chain: u16,
-        redeemer: ExternalAddress,
+        redeemer: vector<u8>,
         payload: vector<u8>,
         nonce: u32,
         the_clock: &Clock
@@ -59,7 +60,7 @@ module token_bridge::transfer_tokens_with_payload {
                 emitter_cap,
                 &mut bridged_in,
                 redeemer_chain,
-                redeemer,
+                external_address::new(bytes32::from_bytes(redeemer)),
                 payload
             );
 
@@ -113,7 +114,7 @@ module token_bridge::transfer_tokens_with_payload {
         emitter_cap: &EmitterCap,
         bridged_in: Coin<CoinType>,
         redeemer_chain: u16,
-        redeemer: ExternalAddress,
+        redeemer: vector<u8>,
         payload: vector<u8>
     ): (vector<u8>, Coin<CoinType>) {
         let payload =
@@ -122,7 +123,7 @@ module token_bridge::transfer_tokens_with_payload {
                 emitter_cap,
                 &mut bridged_in,
                 redeemer_chain,
-                redeemer,
+                external_address::new(bytes32::from_bytes(redeemer)),
                 payload
             );
 
@@ -139,6 +140,7 @@ module token_bridge::transfer_tokens_with_payload_tests {
     use wormhole::external_address::{Self};
     use wormhole::state::{chain_id};
     use wormhole::emitter::{Self};
+    use wormhole::bytes32::{Self};
 
     use token_bridge::coin_wrapped_7::{Self, COIN_WRAPPED_7};
     use token_bridge::coin_native_10::{Self, COIN_NATIVE_10};
@@ -163,7 +165,7 @@ module token_bridge::transfer_tokens_with_payload_tests {
     use token_bridge::normalized_amount::{Self};
 
     /// Test consts.
-    const TEST_TARGET_RECIPIENT: address = @0xbeef4269;
+    const TEST_TARGET_RECIPIENT: vector<u8> = x"beef4269";
     const TEST_TARGET_CHAIN: u16 = 2;
     const TEST_NONCE: u32 = 0;
     const TEST_COIN_NATIVE_10_DECIMALS: u8 = 10;
@@ -221,7 +223,7 @@ module token_bridge::transfer_tokens_with_payload_tests {
                 coin::from_balance(coin_10_balance, ctx),
                 coin::mint_for_testing(wormhole_fee, ctx),
                 TEST_TARGET_CHAIN,
-                external_address::from_address(TEST_TARGET_RECIPIENT),
+                TEST_TARGET_RECIPIENT,
                 TEST_MESSAGE_PAYLOAD,
                 TEST_NONCE,
                 &the_clock,
@@ -300,7 +302,7 @@ module token_bridge::transfer_tokens_with_payload_tests {
             coin::from_balance(coin_10_balance, ctx),
             coin::mint_for_testing(wormhole_fee, ctx),
             TEST_TARGET_CHAIN,
-            external_address::from_address(TEST_TARGET_RECIPIENT),
+            TEST_TARGET_RECIPIENT,
             TEST_MESSAGE_PAYLOAD,
             TEST_NONCE,
             &the_clock
@@ -367,7 +369,7 @@ module token_bridge::transfer_tokens_with_payload_tests {
             &emitter_cap,
             coin::from_balance(coin_10_balance, ctx),
             TEST_TARGET_CHAIN,
-            external_address::from_address(TEST_TARGET_RECIPIENT),
+            TEST_TARGET_RECIPIENT,
             TEST_MESSAGE_PAYLOAD
         );
         assert!(coin::value(&dust) == 0, 0);
@@ -390,7 +392,7 @@ module token_bridge::transfer_tokens_with_payload_tests {
                 expected_amount,
                 expected_token_address,
                 chain_id(),
-                external_address::from_address(TEST_TARGET_RECIPIENT),
+                external_address::new(bytes32::from_bytes(TEST_TARGET_RECIPIENT)),
                 TEST_TARGET_CHAIN,
                 TEST_MESSAGE_PAYLOAD
             );
@@ -458,7 +460,7 @@ module token_bridge::transfer_tokens_with_payload_tests {
                 coin::from_balance(coin_7_balance, ctx),
                 coin::mint_for_testing(wormhole_fee, ctx),
                 TEST_TARGET_CHAIN,
-                external_address::from_address(TEST_TARGET_RECIPIENT),
+                TEST_TARGET_RECIPIENT,
                 TEST_MESSAGE_PAYLOAD,
                 TEST_NONCE,
                 &the_clock,
@@ -522,7 +524,7 @@ module token_bridge::transfer_tokens_with_payload_tests {
             &emitter_cap,
             coin::from_balance(coin_7_balance, ctx),
             TEST_TARGET_CHAIN,
-            external_address::from_address(TEST_TARGET_RECIPIENT),
+            TEST_TARGET_RECIPIENT,
             TEST_MESSAGE_PAYLOAD
         );
         assert!(coin::value(&dust) == 0, 0);
@@ -550,7 +552,7 @@ module token_bridge::transfer_tokens_with_payload_tests {
                 expected_amount,
                 expected_token_address,
                 expected_token_chain,
-                external_address::from_address(TEST_TARGET_RECIPIENT),
+                 external_address::new(bytes32::from_bytes(TEST_TARGET_RECIPIENT)),
                 TEST_TARGET_CHAIN,
                 TEST_MESSAGE_PAYLOAD
             );

--- a/sui/wormhole/Move.devnet.toml
+++ b/sui/wormhole/Move.devnet.toml
@@ -5,7 +5,7 @@ version = "0.0.1"
 [dependencies.Sui]
 git = "https://github.com/MystenLabs/sui.git"
 subdir = "crates/sui-framework/packages/sui-framework"
-rev = "a63f425b9999c7fdfe483598720a9effc0acdc9e"
+rev = "3a70c4374090b020b95465787f3220a95d8ab0ba"
 
 [addresses]
 wormhole = "_"

--- a/sui/wormhole/Move.lock
+++ b/sui/wormhole/Move.lock
@@ -9,11 +9,11 @@ dependencies = [
 
 [[move.package]]
 name = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "a63f425b9999c7fdfe483598720a9effc0acdc9e", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "3a70c4374090b020b95465787f3220a95d8ab0ba", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 name = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "a63f425b9999c7fdfe483598720a9effc0acdc9e", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "3a70c4374090b020b95465787f3220a95d8ab0ba", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { name = "MoveStdlib" },

--- a/sui/wormhole/Move.toml
+++ b/sui/wormhole/Move.toml
@@ -5,7 +5,7 @@ version = "0.0.1"
 [dependencies.Sui]
 git = "https://github.com/MystenLabs/sui.git"
 subdir = "crates/sui-framework/packages/sui-framework"
-rev = "a63f425b9999c7fdfe483598720a9effc0acdc9e"
+rev = "3a70c4374090b020b95465787f3220a95d8ab0ba"
 
 [addresses]
 wormhole = "_"


### PR DESCRIPTION
The purpose of this PR is to convert the `recipient` argument from type `ExternalAddress` to type `vector<u8>` in `transfer_tokens`. This PR also converts the `redeemer` argument from type `ExternalAddress` to type `vector<u8>` in `transfer_tokens_with_payload`. Both of these changes will reduce the number of network calls when invoking either function from the client side.