### PR TITLE
sui: replace ExternalAddress with type vector

### DIFF
--- a/clients/js/consts.ts
+++ b/clients/js/consts.ts
@@ -34,7 +34,7 @@ const OVERRIDES = {
     sui: {
       core: "0xe30c1b99ec028b93440a739bbbbca77d5eba502c916c3bec18f4c408ac49e7ac",
       token_bridge:
-        "0xaf230c5cc9da1c6234d819dc868baa591f22687ec727cdf8aa988df1a9915e62",
+        "0xcbd43526a6d3c50aa10f64d9ea0e378977c3dbfcccd57f0ce97e3e7f22ec6c2a",
     },
     aptos: {
       token_bridge:

--- a/clients/js/sui/consts.ts
+++ b/clients/js/sui/consts.ts
@@ -17,7 +17,7 @@ export const SUI_OBJECT_IDS = {
     core_state:
       "0x50d49cf0c8f0ab33b0c4ad1693a2617f6b4fe4dac3e6e2d0ce6e9fbe83795b51",
     token_bridge_state:
-      "0x546ee2833042967392ceeeca5a94a9070adad5331dcfa3584749f4aa8a285fe7",
+      "0x63406070af4b2ba9ba6a7c47b04ef0fb6d7529c8fa80fe2abe701d8b392cfd3f",
   },
 };
 

--- a/sdk/js/src/utils/consts.ts
+++ b/sdk/js/src/utils/consts.ts
@@ -516,7 +516,7 @@ const DEVNET = {
   sui: {
     core: "0xe30c1b99ec028b93440a739bbbbca77d5eba502c916c3bec18f4c408ac49e7ac",
     token_bridge:
-      "0xaf230c5cc9da1c6234d819dc868baa591f22687ec727cdf8aa988df1a9915e62",
+      "0xcbd43526a6d3c50aa10f64d9ea0e378977c3dbfcccd57f0ce97e3e7f22ec6c2a",
     nft_bridge: undefined,
   },
   moonbeam: {
@@ -846,7 +846,7 @@ export const SUI_OBJECT_IDS = {
     core_state:
       "0x50d49cf0c8f0ab33b0c4ad1693a2617f6b4fe4dac3e6e2d0ce6e9fbe83795b51",
     token_bridge_state:
-      "0x546ee2833042967392ceeeca5a94a9070adad5331dcfa3584749f4aa8a285fe7",
+      "0x63406070af4b2ba9ba6a7c47b04ef0fb6d7529c8fa80fe2abe701d8b392cfd3f",
   },
 };
 export type SuiAddresses = typeof SUI_OBJECT_IDS;

--- a/sui/token_bridge/sources/transfer_tokens.move
+++ b/sui/token_bridge/sources/transfer_tokens.move
@@ -16,7 +16,8 @@ module token_bridge::transfer_tokens {
     use sui::coin::{Self, Coin};
     use sui::sui::{SUI};
     use sui::tx_context::{Self, TxContext};
-    use wormhole::external_address::{ExternalAddress};
+    use wormhole::bytes32::{Self};
+    use wormhole::external_address::{Self, ExternalAddress};
     use wormhole::state::{State as WormholeState};
 
     use token_bridge::native_asset::{Self};
@@ -49,7 +50,7 @@ module token_bridge::transfer_tokens {
         bridged_in: Coin<CoinType>,
         wormhole_fee: Coin<SUI>,
         recipient_chain: u16,
-        recipient: ExternalAddress,
+        recipient: vector<u8>,
         relayer_fee: u64,
         nonce: u32,
         the_clock: &Clock
@@ -63,7 +64,7 @@ module token_bridge::transfer_tokens {
                 token_bridge_state,
                 &mut bridged_in,
                 recipient_chain,
-                recipient,
+                external_address::new(bytes32::from_bytes(recipient)),
                 relayer_fee
             );
 
@@ -191,14 +192,14 @@ module token_bridge::transfer_tokens {
         token_bridge_state: &mut State,
         bridged_in: Coin<CoinType>,
         recipient_chain: u16,
-        recipient: ExternalAddress,
+        recipient: vector<u8>,
         relayer_fee: u64
     ): (vector<u8>, Coin<CoinType>) {
         let payload = bridge_in_and_serialize_transfer(
             token_bridge_state,
             &mut bridged_in,
             recipient_chain,
-            recipient,
+            external_address::new(bytes32::from_bytes(recipient)),
             relayer_fee
         );
 
@@ -214,6 +215,7 @@ module token_bridge::transfer_token_tests {
 
     use wormhole::external_address::{Self};
     use wormhole::state::{chain_id};
+    use wormhole::bytes32::{Self};
 
     use token_bridge::coin_wrapped_7::{Self, COIN_WRAPPED_7};
     use token_bridge::coin_native_10::{Self, COIN_NATIVE_10};
@@ -235,7 +237,7 @@ module token_bridge::transfer_token_tests {
     use token_bridge::normalized_amount::{Self};
 
     /// Test consts.
-    const TEST_TARGET_RECIPIENT: address = @0xbeef4269;
+    const TEST_TARGET_RECIPIENT: vector<u8> = x"beef4269";
     const TEST_TARGET_CHAIN: u16 = 2;
     const TEST_NONCE: u32 = 0;
     const TEST_COIN_NATIVE_10_DECIMALS: u8 = 10;
@@ -290,7 +292,7 @@ module token_bridge::transfer_token_tests {
             coin::from_balance(coin_10_balance, ctx),
             coin::mint_for_testing(wormhole_fee, ctx),
             TEST_TARGET_CHAIN,
-            external_address::from_address(TEST_TARGET_RECIPIENT),
+            TEST_TARGET_RECIPIENT,
             relayer_fee,
             TEST_NONCE,
             &the_clock
@@ -366,7 +368,7 @@ module token_bridge::transfer_token_tests {
             coin::from_balance(coin_10_balance, ctx),
             coin::mint_for_testing(wormhole_fee, ctx),
             TEST_TARGET_CHAIN,
-            external_address::from_address(TEST_TARGET_RECIPIENT),
+            TEST_TARGET_RECIPIENT,
             relayer_fee,
             TEST_NONCE,
             &the_clock
@@ -431,7 +433,7 @@ module token_bridge::transfer_token_tests {
             &mut token_bridge_state,
             coin::from_balance(coin_10_balance, ctx),
             TEST_TARGET_CHAIN,
-            external_address::from_address(TEST_TARGET_RECIPIENT),
+            TEST_TARGET_RECIPIENT,
             relayer_fee
         );
         assert!(coin::value(&dust) == 0, 0);
@@ -457,7 +459,7 @@ module token_bridge::transfer_token_tests {
                 expected_amount,
                 expected_token_address,
                 chain_id(),
-                external_address::from_address(TEST_TARGET_RECIPIENT),
+                external_address::new(bytes32::from_bytes(TEST_TARGET_RECIPIENT)),
                 TEST_TARGET_CHAIN,
                 expected_relayer_fee
             );
@@ -519,7 +521,7 @@ module token_bridge::transfer_token_tests {
             coin::from_balance(coin_7_balance, ctx),
             coin::mint_for_testing(wormhole_fee, ctx),
             TEST_TARGET_CHAIN,
-            external_address::from_address(TEST_TARGET_RECIPIENT),
+            TEST_TARGET_RECIPIENT,
             relayer_fee,
             TEST_NONCE,
             &the_clock
@@ -581,7 +583,7 @@ module token_bridge::transfer_token_tests {
             &mut token_bridge_state,
             coin::from_balance(coin_7_balance, ctx),
             TEST_TARGET_CHAIN,
-            external_address::from_address(TEST_TARGET_RECIPIENT),
+            TEST_TARGET_RECIPIENT,
             relayer_fee
         );
         assert!(coin::value(&dust) == 0, 0);
@@ -612,7 +614,7 @@ module token_bridge::transfer_token_tests {
                 expected_amount,
                 expected_token_address,
                 expected_token_chain,
-                external_address::from_address(TEST_TARGET_RECIPIENT),
+                external_address::new(bytes32::from_bytes(TEST_TARGET_RECIPIENT)),
                 TEST_TARGET_CHAIN,
                 expected_relayer_fee
             );
@@ -666,7 +668,7 @@ module token_bridge::transfer_token_tests {
             test_coins,
             coin::mint_for_testing(wormhole_fee, test_scenario::ctx(scenario)),
             TEST_TARGET_CHAIN,
-            external_address::from_address(TEST_TARGET_RECIPIENT),
+            TEST_TARGET_RECIPIENT,
             relayer_fee,
             TEST_NONCE,
             &the_clock
@@ -721,7 +723,7 @@ module token_bridge::transfer_token_tests {
             test_coins,
             coin::mint_for_testing(wormhole_fee, test_scenario::ctx(scenario)),
             TEST_TARGET_CHAIN,
-            external_address::from_address(TEST_TARGET_RECIPIENT),
+            TEST_TARGET_RECIPIENT,
             relayer_fee,
             TEST_NONCE,
             &the_clock
@@ -776,7 +778,7 @@ module token_bridge::transfer_token_tests {
             coin::from_balance(coin_10_balance, ctx),
             coin::mint_for_testing(wormhole_fee, ctx),
             TEST_TARGET_CHAIN,
-            external_address::from_address(TEST_TARGET_RECIPIENT),
+            TEST_TARGET_RECIPIENT,
             relayer_fee,
             TEST_NONCE,
             &the_clock

--- a/sui/token_bridge/sources/transfer_tokens_with_payload.move
+++ b/sui/token_bridge/sources/transfer_tokens_with_payload.move
@@ -15,8 +15,9 @@ module token_bridge::transfer_tokens_with_payload {
     use sui::clock::{Clock};
     use sui::coin::{Coin};
     use sui::sui::{SUI};
+    use wormhole::bytes32::{Self};
     use wormhole::emitter::{EmitterCap};
-    use wormhole::external_address::{ExternalAddress};
+    use wormhole::external_address::{Self, ExternalAddress};
     use wormhole::state::{State as WormholeState};
 
     use token_bridge::state::{Self, State};
@@ -43,7 +44,7 @@ module token_bridge::transfer_tokens_with_payload {
         bridged_in: Coin<CoinType>,
         wormhole_fee: Coin<SUI>,
         redeemer_chain: u16,
-        redeemer: ExternalAddress,
+        redeemer: vector<u8>,
         payload: vector<u8>,
         nonce: u32,
         the_clock: &Clock
@@ -59,7 +60,7 @@ module token_bridge::transfer_tokens_with_payload {
                 emitter_cap,
                 &mut bridged_in,
                 redeemer_chain,
-                redeemer,
+                external_address::new(bytes32::from_bytes(redeemer)),
                 payload
             );
 
@@ -113,7 +114,7 @@ module token_bridge::transfer_tokens_with_payload {
         emitter_cap: &EmitterCap,
         bridged_in: Coin<CoinType>,
         redeemer_chain: u16,
-        redeemer: ExternalAddress,
+        redeemer: vector<u8>,
         payload: vector<u8>
     ): (vector<u8>, Coin<CoinType>) {
         let payload =
@@ -122,7 +123,7 @@ module token_bridge::transfer_tokens_with_payload {
                 emitter_cap,
                 &mut bridged_in,
                 redeemer_chain,
-                redeemer,
+                external_address::new(bytes32::from_bytes(redeemer)),
                 payload
             );
 
@@ -139,6 +140,7 @@ module token_bridge::transfer_tokens_with_payload_tests {
     use wormhole::external_address::{Self};
     use wormhole::state::{chain_id};
     use wormhole::emitter::{Self};
+    use wormhole::bytes32::{Self};
 
     use token_bridge::coin_wrapped_7::{Self, COIN_WRAPPED_7};
     use token_bridge::coin_native_10::{Self, COIN_NATIVE_10};
@@ -163,7 +165,7 @@ module token_bridge::transfer_tokens_with_payload_tests {
     use token_bridge::normalized_amount::{Self};
 
     /// Test consts.
-    const TEST_TARGET_RECIPIENT: address = @0xbeef4269;
+    const TEST_TARGET_RECIPIENT: vector<u8> = x"beef4269";
     const TEST_TARGET_CHAIN: u16 = 2;
     const TEST_NONCE: u32 = 0;
     const TEST_COIN_NATIVE_10_DECIMALS: u8 = 10;
@@ -221,7 +223,7 @@ module token_bridge::transfer_tokens_with_payload_tests {
                 coin::from_balance(coin_10_balance, ctx),
                 coin::mint_for_testing(wormhole_fee, ctx),
                 TEST_TARGET_CHAIN,
-                external_address::from_address(TEST_TARGET_RECIPIENT),
+                TEST_TARGET_RECIPIENT,
                 TEST_MESSAGE_PAYLOAD,
                 TEST_NONCE,
                 &the_clock,
@@ -300,7 +302,7 @@ module token_bridge::transfer_tokens_with_payload_tests {
             coin::from_balance(coin_10_balance, ctx),
             coin::mint_for_testing(wormhole_fee, ctx),
             TEST_TARGET_CHAIN,
-            external_address::from_address(TEST_TARGET_RECIPIENT),
+            TEST_TARGET_RECIPIENT,
             TEST_MESSAGE_PAYLOAD,
             TEST_NONCE,
             &the_clock
@@ -367,7 +369,7 @@ module token_bridge::transfer_tokens_with_payload_tests {
             &emitter_cap,
             coin::from_balance(coin_10_balance, ctx),
             TEST_TARGET_CHAIN,
-            external_address::from_address(TEST_TARGET_RECIPIENT),
+            TEST_TARGET_RECIPIENT,
             TEST_MESSAGE_PAYLOAD
         );
         assert!(coin::value(&dust) == 0, 0);
@@ -390,7 +392,7 @@ module token_bridge::transfer_tokens_with_payload_tests {
                 expected_amount,
                 expected_token_address,
                 chain_id(),
-                external_address::from_address(TEST_TARGET_RECIPIENT),
+                external_address::new(bytes32::from_bytes(TEST_TARGET_RECIPIENT)),
                 TEST_TARGET_CHAIN,
                 TEST_MESSAGE_PAYLOAD
             );
@@ -458,7 +460,7 @@ module token_bridge::transfer_tokens_with_payload_tests {
                 coin::from_balance(coin_7_balance, ctx),
                 coin::mint_for_testing(wormhole_fee, ctx),
                 TEST_TARGET_CHAIN,
-                external_address::from_address(TEST_TARGET_RECIPIENT),
+                TEST_TARGET_RECIPIENT,
                 TEST_MESSAGE_PAYLOAD,
                 TEST_NONCE,
                 &the_clock,
@@ -522,7 +524,7 @@ module token_bridge::transfer_tokens_with_payload_tests {
             &emitter_cap,
             coin::from_balance(coin_7_balance, ctx),
             TEST_TARGET_CHAIN,
-            external_address::from_address(TEST_TARGET_RECIPIENT),
+            TEST_TARGET_RECIPIENT,
             TEST_MESSAGE_PAYLOAD
         );
         assert!(coin::value(&dust) == 0, 0);
@@ -550,7 +552,7 @@ module token_bridge::transfer_tokens_with_payload_tests {
                 expected_amount,
                 expected_token_address,
                 expected_token_chain,
-                external_address::from_address(TEST_TARGET_RECIPIENT),
+                 external_address::new(bytes32::from_bytes(TEST_TARGET_RECIPIENT)),
                 TEST_TARGET_CHAIN,
                 TEST_MESSAGE_PAYLOAD
             );


### PR DESCRIPTION
The purpose of this PR is to replace the `ExternalAddress` type arguments with `vector<u8>` in both the `transfer_tokens` and `transfer_tokens_with_payload` functions. 