### PR TITLE
sui: add outbound types and other things

### DIFF
--- a/clients/js/consts.ts
+++ b/clients/js/consts.ts
@@ -32,9 +32,9 @@ const OVERRIDES = {
   },
   DEVNET: {
     sui: {
-      core: "0xfc329a56b1c34688ca285aca200d3f14061ccfd23849e8178c345f50218a2448",
+      core: "0x237db734cabdcef4c0a8e97e7e4ef1c1f0c3e1ef8090f02aaf2c765bda8bc428",
       token_bridge:
-        "0x8c8dbbd61276b1fd9fa6b7f7cc966e556b86254d925aa39d28772250a9dc8db2",
+        "0xd70a026644c44c1ab8104856d6b6feff75ad8b2831c90a79eb264c4daadb2492",
     },
     aptos: {
       token_bridge:

--- a/clients/js/sui/consts.ts
+++ b/clients/js/sui/consts.ts
@@ -15,9 +15,9 @@ export const SUI_OBJECT_IDS = {
   },
   DEVNET: {
     core_state:
-      "0xb8d8fd9b805e4d1aea5c1edcc2e4097b99f3335ff673cfe01d2dbaa54aa564c2",
+      "0x59e9ce8f55cbd4f6b8fade7568e8ff7e594c1a37ec78eb126ebebe20d0722df2",
     token_bridge_state:
-      "0xcea50dafc22685e39b1469e12e4326788279d8e4108bfd2e2a59897199c65f50",
+      "0x7ffaddf3eda80ceafa0d958ff61a4f3532f165d6efa9ae4af2d3914db76c6a9d",
   },
 };
 

--- a/sdk/js/src/token_bridge/__tests__/sui-integration.ts
+++ b/sdk/js/src/token_bridge/__tests__/sui-integration.ts
@@ -1,6 +1,5 @@
 import {
   afterAll,
-  beforeAll,
   beforeEach,
   describe,
   expect,
@@ -10,20 +9,20 @@ import {
 import {
   Connection,
   Ed25519Keypair,
-  fromB64,
-  getMoveObjectType,
   JsonRpcProvider,
   RawSigner,
+  fromB64,
+  getMoveObjectType,
 } from "@mysten/sui.js";
 import {
   CONTRACTS,
+  SUI_OBJECT_IDS,
   executeTransactionBlock,
   getInnerType,
-  SUI_OBJECT_IDS,
 } from "../../utils";
 import { attestFromSui } from "../attest";
-import { assertIsNotNullOrUndefined } from "./utils/helpers";
 import { SUI_FAUCET_URL, SUI_NODE_URL } from "./utils/consts";
+import { assertIsNotNullOrUndefined } from "./utils/helpers";
 
 const JEST_TEST_TIMEOUT = 60000;
 jest.setTimeout(JEST_TEST_TIMEOUT);
@@ -62,7 +61,7 @@ afterAll(async () => {
 });
 
 describe("Sui SDK tests", () => {
-  test("Transfer native Sui token to Ethereum and back", async () => {
+  test.skip("Transfer native Sui token to Ethereum and back", async () => {
     // const SUI_COIN_TYPE = "0x2::sui::SUI";
 
     // Get COIN_8 coin type

--- a/sdk/js/src/utils/consts.ts
+++ b/sdk/js/src/utils/consts.ts
@@ -514,9 +514,9 @@ const DEVNET = {
       "0x46da3d4c569388af61f951bdd1153f4c875f90c2991f6b2d0a38e2161a40852c",
   },
   sui: {
-    core: "0xfc329a56b1c34688ca285aca200d3f14061ccfd23849e8178c345f50218a2448",
+    core: "0x237db734cabdcef4c0a8e97e7e4ef1c1f0c3e1ef8090f02aaf2c765bda8bc428",
     token_bridge:
-      "0x8c8dbbd61276b1fd9fa6b7f7cc966e556b86254d925aa39d28772250a9dc8db2",
+      "0xd70a026644c44c1ab8104856d6b6feff75ad8b2831c90a79eb264c4daadb2492",
     nft_bridge: undefined,
   },
   moonbeam: {
@@ -844,9 +844,9 @@ export const SUI_OBJECT_IDS = {
   },
   DEVNET: {
     core_state:
-      "0xb8d8fd9b805e4d1aea5c1edcc2e4097b99f3335ff673cfe01d2dbaa54aa564c2",
+      "0x59e9ce8f55cbd4f6b8fade7568e8ff7e594c1a37ec78eb126ebebe20d0722df2",
     token_bridge_state:
-      "0xcea50dafc22685e39b1469e12e4326788279d8e4108bfd2e2a59897199c65f50",
+      "0x7ffaddf3eda80ceafa0d958ff61a4f3532f165d6efa9ae4af2d3914db76c6a9d",
   },
 };
 export type SuiAddresses = typeof SUI_OBJECT_IDS;

--- a/sui/Makefile
+++ b/sui/Makefile
@@ -1,5 +1,9 @@
-BUILD_CONTRACT_DIRS := wormhole token_bridge
 TEST_CONTRACT_DIRS := wormhole token_bridge examples/coins examples/core_messages
+CLEAN_CONTRACT_DIRS := wormhole token_bridge examples/coins examples/core_messages
+
+.PHONY: clean
+clean:
+	$(foreach dir,$(TEST_CONTRACT_DIRS), make -C $(dir) $@ &&) true
 
 .PHONY: test
 test:

--- a/sui/examples/core_messages/sources/sender.move
+++ b/sui/examples/core_messages/sources/sender.move
@@ -44,6 +44,11 @@ module core_messages::sender {
         );
     }
 
+    /// NOTE: This is NOT the proper way of using the `prepare_message` and
+    /// `publish_message` workflow. This example app is meant for testing for
+    /// observing Wormhole messages via the guardian.
+    ///
+    /// See `publish_message` module for more info.
     public fun send_message(
         state: &mut State,
         wormhole_state: &mut WormholeState,
@@ -51,12 +56,17 @@ module core_messages::sender {
         the_clock: &Clock,
         ctx: &mut TxContext
     ): u64 {
-        wormhole::publish_message::publish_message(
+        use wormhole::publish_message::{prepare_message, publish_message};
+
+        // NOTE AGAIN: Integrators should NEVER call this within their contract.
+        publish_message(
             wormhole_state,
-            &mut state.emitter_cap,
-            0, // Set nonce to 0, intended for batch VAAs.
-            payload,
             coin::zero(ctx),
+            prepare_message(
+                &mut state.emitter_cap,
+                0, // Set nonce to 0, intended for batch VAAs.
+                payload
+            ),
             the_clock
         )
     }

--- a/sui/token_bridge/Makefile
+++ b/sui/token_bridge/Makefile
@@ -1,15 +1,15 @@
 -include ../../Makefile.help
 
-.PHONY: artifacts
-artifacts: build
+.PHONY: clean
+clean:
+	rm -rf build
 
-.PHONY: build
+.PHONY: check
 ## Build contract
-build:
-	sui move build
+check:
+	sui move build -d
 
 .PHONY: test
 ## Run tests
-test:
-	sui move build -d || exit $?
+test: check
 	sui move test -t 1

--- a/sui/token_bridge/sources/attest_token.move
+++ b/sui/token_bridge/sources/attest_token.move
@@ -12,7 +12,7 @@
 module token_bridge::attest_token {
     use std::option::{Self};
     use sui::coin::{CoinMetadata};
-    use wormhole::publish_message::{PreparedMessage};
+    use wormhole::publish_message::{MessageTicket};
 
     use token_bridge::asset_meta::{Self};
     use token_bridge::create_wrapped::{Self};
@@ -36,7 +36,7 @@ module token_bridge::attest_token {
         token_bridge_state: &mut State,
         coin_meta: &CoinMetadata<CoinType>,
         nonce: u32
-    ): PreparedMessage {
+    ): MessageTicket {
         state::check_minimum_requirement<AttestTokenControl>(
             token_bridge_state
         );

--- a/sui/token_bridge/sources/complete_transfer_with_payload.move
+++ b/sui/token_bridge/sources/complete_transfer_with_payload.move
@@ -20,7 +20,7 @@
 /// version of `complete_transfer_with_payload`.
 ///
 /// Instead, an integrator is encouraged to execute a transaction block, which
-/// executes `authorize_transfer` from the latest Token Bridge package ID and
+/// executes `authorize_transfer` using the latest Token Bridge package ID and
 /// to implement `redeem_coin` in his contract to consume this ticket. This is
 /// similar to how an integrator with Wormhole is not meant to use
 /// `vaa::parse_and_verify` in his contract in case the `vaa` module needs to
@@ -56,8 +56,11 @@ module token_bridge::complete_transfer_with_payload {
     /// `EmitterCap` generated from the `wormhole::emitter` module, whose ID is
     /// the expected redeemer for this token transfer.
     struct RedeemerTicket<phantom CoinType> {
+        /// Which chain ID this transfer originated from.
         source_chain: u16,
+        /// Deserialized transfer info.
         parsed: TransferWithPayload,
+        /// Coin of bridged asset.
         bridged_out: Coin<CoinType>
     }
 
@@ -69,12 +72,15 @@ module token_bridge::complete_transfer_with_payload {
     /// transfer amount along with the source chain and deserialized
     /// `TransferWithPayload`.
     ///
-    /// NOTE: It is important for integrators to refrain from calling this
-    /// method within their contracts. This method is meant to be called within
-    /// a transaction block, passing the `RedeemerTicket` to a method which
-    /// calls `redeem_coin` within a contract. If in a circumstance where this
-    /// module has a breaking change in an upgrade, `redeem_coin` will not be
-    /// affected by this change.
+    /// NOTE: This method is guarded by a minimum build version check. This
+    /// method could break backward compatibility on an upgrade.
+    ///
+    /// It is important for integrators to refrain from calling this method
+    /// within their contracts. This method is meant to be called in a
+    /// transaction block, passing the `RedeemerTicket` to a method which calls
+    /// `redeem_coin` within a contract. If in a circumstance where this module
+    /// has a breaking change in an upgrade, `redeem_coin` will not be affected
+    /// by this change.
     ///
     /// See `redeem_coin` for more details.
     public fun authorize_transfer<CoinType>(
@@ -110,7 +116,7 @@ module token_bridge::complete_transfer_with_payload {
     /// deserialized `TransferWithPayload` and source chain ID.
     ///
     /// NOTE: Integrators of Token Bridge redeeming these token transfers should
-    /// be calling only this method from their contracts. This method is  not
+    /// be calling only this method from their contracts. This method is not
     /// guarded by version control (thus not requiring a reference to the
     /// Token Bridge `State` object), so it is intended to work for any package
     /// version.

--- a/sui/token_bridge/sources/messages/transfer_with_payload.move
+++ b/sui/token_bridge/sources/messages/transfer_with_payload.move
@@ -14,7 +14,6 @@ module token_bridge::transfer_with_payload {
     use sui::object::{Self, ID};
     use wormhole::bytes::{Self};
     use wormhole::cursor::{Self};
-    use wormhole::emitter::{EmitterCap};
     use wormhole::external_address::{Self, ExternalAddress};
 
     use token_bridge::normalized_amount::{Self, NormalizedAmount};
@@ -49,10 +48,10 @@ module token_bridge::transfer_with_payload {
         payload: vector<u8>,
     }
 
-    /// Create new `TransferWithPayload` using Token Bridge's `EmitterCap` as
-    /// the sender.
-    public(friend) fun new_from_emitter(
-        emitter_cap: &EmitterCap,
+    /// Create new `TransferWithPayload` using a Token Bridge integrator's
+    /// emitter cap ID as the sender.
+    public(friend) fun new(
+        sender: ID,
         amount: NormalizedAmount,
         token_address: ExternalAddress,
         token_chain: u16,
@@ -66,14 +65,14 @@ module token_bridge::transfer_with_payload {
             token_chain,
             redeemer,
             redeemer_chain,
-            sender: external_address::from_id(object::id((emitter_cap))),
+            sender: external_address::from_id(sender),
             payload
         }
     }
 
     #[test_only]
-    public fun new_from_emitter_test_only(
-        emitter_cap: &EmitterCap,
+    public fun new_test_only(
+        sender: ID,
         amount: NormalizedAmount,
         token_address: ExternalAddress,
         token_chain: u16,
@@ -81,8 +80,8 @@ module token_bridge::transfer_with_payload {
         redeemer_chain: u16,
         payload: vector<u8>
     ): TransferWithPayload {
-        new_from_emitter(
-            emitter_cap,
+        new(
+            sender,
             amount,
             token_address,
             token_chain,
@@ -228,8 +227,8 @@ module token_bridge::transfer_with_payload_tests {
         let payload = b"All your base are belong to us.";
 
         let new_transfer =
-            transfer_with_payload::new_from_emitter_test_only(
-                &emitter_cap,
+            transfer_with_payload::new_test_only(
+                object::id(&emitter_cap),
                 amount,
                 token_address,
                 token_chain,

--- a/sui/token_bridge/sources/migrate.move
+++ b/sui/token_bridge/sources/migrate.move
@@ -50,7 +50,7 @@ module token_bridge::migrate {
         //
         // WARNING: The migration does *not* proceed atomically with the
         // upgrade (as they are done in separate transactions).
-        // If the nature of your migration absolutely requires the migration to
+        // If the nature of this migration absolutely requires the migration to
         // happen before certain other functionality is available, then guard
         // that functionality with the `assert!` from above.
         //

--- a/sui/token_bridge/sources/state.move
+++ b/sui/token_bridge/sources/state.move
@@ -7,19 +7,17 @@
 /// checking the emitter against its own registered emitters.
 module token_bridge::state {
     use std::option::{Self, Option};
-    use sui::clock::{Clock};
-    use sui::coin::{Coin};
     use sui::dynamic_field::{Self as field};
     use sui::event::{Self};
     use sui::object::{Self, ID, UID};
     use sui::package::{Self, UpgradeCap, UpgradeReceipt, UpgradeTicket};
-    use sui::sui::{SUI};
     use sui::table::{Self, Table};
     use sui::tx_context::{TxContext};
     use wormhole::bytes32::{Self, Bytes32};
     use wormhole::consumed_vaas::{Self, ConsumedVAAs};
     use wormhole::emitter::{Self, EmitterCap};
     use wormhole::external_address::{ExternalAddress};
+    use wormhole::publish_message::{PreparedMessage};
     use wormhole::required_version::{Self, RequiredVersion};
     use wormhole::state::{State as WormholeState};
     use wormhole::vaa::{Self, VAA};
@@ -252,23 +250,15 @@ module token_bridge::state {
     }
 
     /// Publish Wormhole message using Token Bridge's `EmitterCap`.
-    public(friend) fun publish_wormhole_message(
+    public(friend) fun prepare_wormhole_message(
         self: &mut State,
-        worm_state: &mut WormholeState,
         nonce: u32,
-        payload: vector<u8>,
-        message_fee: Coin<SUI>,
-        the_clock: &Clock
-    ): u64 {
-        use wormhole::publish_message::{publish_message};
-
-        publish_message(
-            worm_state,
+        payload: vector<u8>
+    ): PreparedMessage {
+        wormhole::publish_message::prepare_message(
             &mut self.emitter_cap,
             nonce,
             payload,
-            message_fee,
-            the_clock
         )
     }
 

--- a/sui/token_bridge/sources/state.move
+++ b/sui/token_bridge/sources/state.move
@@ -17,7 +17,7 @@ module token_bridge::state {
     use wormhole::consumed_vaas::{Self, ConsumedVAAs};
     use wormhole::emitter::{Self, EmitterCap};
     use wormhole::external_address::{ExternalAddress};
-    use wormhole::publish_message::{PreparedMessage};
+    use wormhole::publish_message::{MessageTicket};
     use wormhole::required_version::{Self, RequiredVersion};
     use wormhole::state::{State as WormholeState};
     use wormhole::vaa::{Self, VAA};
@@ -254,7 +254,7 @@ module token_bridge::state {
         self: &mut State,
         nonce: u32,
         payload: vector<u8>
-    ): PreparedMessage {
+    ): MessageTicket {
         wormhole::publish_message::prepare_message(
             &mut self.emitter_cap,
             nonce,

--- a/sui/token_bridge/sources/test/token_bridge_scenario.move
+++ b/sui/token_bridge/sources/test/token_bridge_scenario.move
@@ -4,11 +4,9 @@
 module token_bridge::token_bridge_scenario {
     use std::vector::{Self};
     use sui::balance::{Self};
-    use sui::clock::{Clock};
     use sui::package::{UpgradeCap};
     use sui::test_scenario::{Self, Scenario};
     use wormhole::external_address::{Self};
-    use wormhole::state::{State as WormholeState};
     use wormhole::wormhole_scenario::{
         deployer,
         return_state as return_wormhole_state,
@@ -107,28 +105,5 @@ module token_bridge::token_bridge_scenario {
 
     public fun return_state(token_bridge_state: State) {
         test_scenario::return_shared(token_bridge_state);
-    }
-
-    public fun take_states(scenario: &Scenario): (State, WormholeState) {
-        (
-            test_scenario::take_shared<State>(scenario),
-            test_scenario::take_shared<WormholeState>(scenario)
-        )
-    }
-
-    public fun return_states(
-        token_bridge_state: State,
-        worm_state: WormholeState
-    ) {
-        return_state(token_bridge_state);
-        wormhole::wormhole_scenario::return_state(worm_state);
-    }
-
-    public fun take_clock(scenario: &mut Scenario): Clock {
-        wormhole::wormhole_scenario::take_clock(scenario)
-    }
-
-    public fun return_clock(the_clock: Clock) {
-        wormhole::wormhole_scenario::return_clock(the_clock)
     }
 }

--- a/sui/token_bridge/sources/transfer_tokens.move
+++ b/sui/token_bridge/sources/transfer_tokens.move
@@ -12,12 +12,10 @@
 /// message payload.
 module token_bridge::transfer_tokens {
     use sui::balance::{Self};
-    use sui::clock::{Clock};
     use sui::coin::{Self, Coin};
-    use sui::sui::{SUI};
     use wormhole::bytes32::{Self};
     use wormhole::external_address::{Self, ExternalAddress};
-    use wormhole::state::{State as WormholeState};
+    use wormhole::publish_message::{PreparedMessage};
 
     use token_bridge::native_asset::{Self};
     use token_bridge::normalized_amount::{Self, NormalizedAmount};
@@ -45,15 +43,12 @@ module token_bridge::transfer_tokens {
     /// See `token_registry and `transfer_with_payload` module for more info.
     public fun transfer_tokens<CoinType>(
         token_bridge_state: &mut State,
-        worm_state: &mut WormholeState,
         bridged_in: Coin<CoinType>,
-        wormhole_fee: Coin<SUI>,
         recipient_chain: u16,
         recipient: vector<u8>,
         relayer_fee: u64,
-        nonce: u32,
-        the_clock: &Clock
-    ): (u64, Coin<CoinType>) {
+        nonce: u32
+    ): (PreparedMessage, Coin<CoinType>) {
         state::check_minimum_requirement<TransferTokensControl>(
             token_bridge_state
         );
@@ -67,21 +62,18 @@ module token_bridge::transfer_tokens {
                 relayer_fee
             );
 
-        // Publish with encoded `Transfer`.
-        let message_sequence =
-            state::publish_wormhole_message(
+        // Prepare Wormhole message with encoded `Transfer`.
+        let prepared_msg =
+            state::prepare_wormhole_message(
                 token_bridge_state,
-                worm_state,
                 nonce,
-                encoded_transfer,
-                wormhole_fee,
-                the_clock
+                encoded_transfer
             );
 
         // In addition to the Wormhole sequence number, return the `Coin` object
         // to the caller. This object have value if there was remaining dust
         // for a native Sui coin.
-        (message_sequence, bridged_in)
+        (prepared_msg, bridged_in)
     }
 
     /// For a given `CoinType`, prepare outbound transfer.
@@ -175,21 +167,18 @@ module token_bridge::transfer_tokens {
     #[test_only]
     public fun bridge_in_and_serialize_transfer_test_only<CoinType>(
         token_bridge_state: &mut State,
-        bridged_in: Coin<CoinType>,
+        bridged_in: &mut Coin<CoinType>,
         recipient_chain: u16,
         recipient: vector<u8>,
         relayer_fee: u64
-    ): (vector<u8>, Coin<CoinType>) {
-        let payload =
-            bridge_in_and_serialize_transfer(
-                token_bridge_state,
-                &mut bridged_in,
-                recipient_chain,
-                external_address::new(bytes32::from_bytes(recipient)),
-                relayer_fee
-            );
-
-        (payload, bridged_in)
+    ): vector<u8> {
+        bridge_in_and_serialize_transfer(
+            token_bridge_state,
+            bridged_in,
+            recipient_chain,
+            external_address::new(bytes32::from_bytes(recipient)),
+            relayer_fee
+        )
     }
 }
 
@@ -197,30 +186,27 @@ module token_bridge::transfer_tokens {
 module token_bridge::transfer_token_tests {
     use sui::coin::{Self};
     use sui::test_scenario::{Self};
-    use sui::transfer::{public_transfer};
-
-    use wormhole::external_address::{Self};
-    use wormhole::state::{chain_id};
     use wormhole::bytes32::{Self};
+    use wormhole::external_address::{Self};
+    use wormhole::publish_message::{Self};
+    use wormhole::state::{chain_id};
 
-    use token_bridge::coin_wrapped_7::{Self, COIN_WRAPPED_7};
     use token_bridge::coin_native_10::{Self, COIN_NATIVE_10};
-    use token_bridge::transfer_tokens::{Self};
+    use token_bridge::coin_wrapped_7::{Self, COIN_WRAPPED_7};
+    use token_bridge::native_asset::{Self};
+    use token_bridge::normalized_amount::{Self};
     use token_bridge::state::{Self};
     use token_bridge::token_bridge_scenario::{
         set_up_wormhole_and_token_bridge,
         register_dummy_emitter,
-        return_clock,
-        return_states,
-        take_clock,
-        take_states,
+        return_state,
+        take_state,
         person
     };
     use token_bridge::token_registry::{Self};
-    use token_bridge::wrapped_asset::{Self};
-    use token_bridge::native_asset::{Self};
     use token_bridge::transfer::{Self};
-    use token_bridge::normalized_amount::{Self};
+    use token_bridge::transfer_tokens::{Self};
+    use token_bridge::wrapped_asset::{Self};
 
     /// Test consts.
     const TEST_TARGET_RECIPIENT: vector<u8> = x"beef4269";
@@ -231,6 +217,8 @@ module token_bridge::transfer_token_tests {
 
     #[test]
     fun test_transfer_tokens_native_10() {
+        use token_bridge::transfer_tokens::{transfer_tokens};
+
         let sender = person();
         let my_scenario = test_scenario::begin(sender);
         let scenario = &mut my_scenario;
@@ -244,18 +232,18 @@ module token_bridge::transfer_token_tests {
 
         // Register and mint coins.
         let transfer_amount = 6942000;
-        let coin_10_balance = coin_native_10::init_register_and_mint(
-            scenario,
-            sender,
-            transfer_amount
-        );
+        let coin_10_balance =
+            coin_native_10::init_register_and_mint(
+                scenario,
+                sender,
+                transfer_amount
+            );
 
         // Ignore effects.
         test_scenario::next_tx(scenario, sender);
 
         // Fetch objects necessary for sending the transfer.
-        let (token_bridge_state, worm_state) = take_states(scenario);
-        let the_clock = take_clock(scenario);
+        let token_bridge_state = take_state(scenario);
 
         // Define the relayer fee.
         let relayer_fee = 100000;
@@ -272,19 +260,19 @@ module token_bridge::transfer_token_tests {
         let ctx = test_scenario::ctx(scenario);
 
         // Call `transfer_tokens`.
-        let (_, dust) =
-            transfer_tokens::transfer_tokens<COIN_NATIVE_10>(
+        let (
+            prepared_msg,
+            dust
+        ) =
+            transfer_tokens(
                 &mut token_bridge_state,
-                &mut worm_state,
                 coin::from_balance(coin_10_balance, ctx),
-                coin::mint_for_testing(wormhole_fee, ctx),
                 TEST_TARGET_CHAIN,
                 TEST_TARGET_RECIPIENT,
                 relayer_fee,
                 TEST_NONCE,
-                &the_clock
             );
-        assert!(coin::value(&dust) == 0, 0);
+        coin::destroy_zero(dust);
 
         // Balance check the Token Bridge after executing the transfer. The
         // balance should now reflect the `transfer_amount` defined in this
@@ -295,15 +283,18 @@ module token_bridge::transfer_token_tests {
             assert!(native_asset::custody(asset) == transfer_amount, 0);
         };
 
+        // Clean up.
+        publish_message::destroy(prepared_msg);
+        return_state(token_bridge_state);
+
         // Done.
-        return_states(token_bridge_state, worm_state);
-        coin::destroy_zero(dust);
-        return_clock(the_clock);
         test_scenario::end(my_scenario);
     }
 
     #[test]
     fun test_transfer_tokens_native_10_with_dust_refund() {
+        use token_bridge::transfer_tokens::{transfer_tokens};
+
         let sender = person();
         let my_scenario = test_scenario::begin(sender);
         let scenario = &mut my_scenario;
@@ -317,11 +308,12 @@ module token_bridge::transfer_token_tests {
 
         // Register and mint coins.
         let transfer_amount = 1000069;
-        let coin_10_balance = coin_native_10::init_register_and_mint(
-            scenario,
-            sender,
-            transfer_amount
-        );
+        let coin_10_balance =
+            coin_native_10::init_register_and_mint(
+                scenario,
+                sender,
+                transfer_amount
+            );
 
         // This value will be used later. The contract should return dust
         // to the caller since COIN_NATIVE_10 has 10 decimals.
@@ -331,8 +323,7 @@ module token_bridge::transfer_token_tests {
         test_scenario::next_tx(scenario, sender);
 
         // Fetch objects necessary for sending the transfer.
-        let (token_bridge_state, worm_state) = take_states(scenario);
-        let the_clock = take_clock(scenario);
+        let token_bridge_state = take_state(scenario);
 
         // Define the relayer fee.
         let relayer_fee = 100000;
@@ -345,21 +336,21 @@ module token_bridge::transfer_token_tests {
             assert!(native_asset::custody(asset) == 0, 0);
         };
 
-        // Cache context.
-        let ctx = test_scenario::ctx(scenario);
-
         // Call `transfer_tokens`.
-        let (_, dust) =
-            transfer_tokens::transfer_tokens<COIN_NATIVE_10>(
+        let (
+            prepared_msg,
+            dust
+        ) =
+            transfer_tokens(
                 &mut token_bridge_state,
-                &mut worm_state,
-                coin::from_balance(coin_10_balance, ctx),
-                coin::mint_for_testing(wormhole_fee, ctx),
+                coin::from_balance(
+                    coin_10_balance,
+                    test_scenario::ctx(scenario)
+                ),
                 TEST_TARGET_CHAIN,
                 TEST_TARGET_RECIPIENT,
                 relayer_fee,
-                TEST_NONCE,
-                &the_clock
+                TEST_NONCE
             );
         assert!(coin::value(&dust) == expected_dust, 0);
 
@@ -375,15 +366,21 @@ module token_bridge::transfer_token_tests {
             );
         };
 
+        // Clean up.
+        publish_message::destroy(prepared_msg);
+        coin::burn_for_testing(dust);
+        return_state(token_bridge_state);
+
         // Done.
-        return_states(token_bridge_state, worm_state);
-        return_clock(the_clock);
-        public_transfer(dust, @0x0);
         test_scenario::end(my_scenario);
     }
 
     #[test]
     fun test_serialize_transfer_tokens_native_10() {
+        use token_bridge::transfer_tokens::{
+            bridge_in_and_serialize_transfer_test_only
+        };
+
         let sender = person();
         let my_scenario = test_scenario::begin(sender);
         let scenario = &mut my_scenario;
@@ -397,35 +394,35 @@ module token_bridge::transfer_token_tests {
 
         // Register and mint coins.
         let transfer_amount = 6942000;
-        let coin_10_balance = coin_native_10::init_register_and_mint(
-            scenario,
-            sender,
-            transfer_amount
-        );
+        let bridged_coin_10 =
+            coin::from_balance(
+                coin_native_10::init_register_and_mint(
+                    scenario,
+                    sender,
+                    transfer_amount
+                ),
+                test_scenario::ctx(scenario)
+            );
 
         // Ignore effects.
         test_scenario::next_tx(scenario, sender);
 
         // Fetch objects necessary for sending the transfer.
-        let (token_bridge_state, worm_state) = take_states(scenario);
-        let the_clock = take_clock(scenario);
+        let token_bridge_state = take_state(scenario);
 
         // Define the relayer fee.
         let relayer_fee = 100000;
 
-        // Cache context.
-        let ctx = test_scenario::ctx(scenario);
-
         // Call `transfer_tokens`.
-        let (payload, dust) =
-            transfer_tokens::bridge_in_and_serialize_transfer_test_only(
+        let payload =
+            bridge_in_and_serialize_transfer_test_only(
                 &mut token_bridge_state,
-                coin::from_balance(coin_10_balance, ctx),
+                &mut bridged_coin_10,
                 TEST_TARGET_CHAIN,
                 TEST_TARGET_RECIPIENT,
                 relayer_fee
             );
-        assert!(coin::value(&dust) == 0, 0);
+        coin::destroy_zero(bridged_coin_10);
 
         // Construct expected payload from scratch and confirm that the
         // `transfer_tokens` call produces the same payload.
@@ -454,15 +451,17 @@ module token_bridge::transfer_token_tests {
             );
         assert!(transfer::serialize(expected_payload) == payload, 0);
 
+        // Clean up.
+        return_state(token_bridge_state);
+
         // Done.
-        coin::destroy_zero(dust);
-        return_states(token_bridge_state, worm_state);
-        return_clock(the_clock);
         test_scenario::end(my_scenario);
     }
 
     #[test]
     fun test_transfer_tokens_wrapped_7() {
+        use token_bridge::transfer_tokens::{transfer_tokens};
+
         let sender = person();
         let my_scenario = test_scenario::begin(sender);
         let scenario = &mut my_scenario;
@@ -476,18 +475,18 @@ module token_bridge::transfer_token_tests {
 
         // Register and mint coins.
         let transfer_amount = 42069000;
-        let coin_7_balance = coin_wrapped_7::init_register_and_mint(
-            scenario,
-            sender,
-            transfer_amount
-        );
+        let coin_7_balance =
+            coin_wrapped_7::init_register_and_mint(
+                scenario,
+                sender,
+                transfer_amount
+            );
 
         // Ignore effects.
         test_scenario::next_tx(scenario, sender);
 
         // Fetch objects necessary for sending the transfer.
-        let (token_bridge_state, worm_state) = take_states(scenario);
-        let the_clock = take_clock(scenario);
+        let token_bridge_state = take_state(scenario);
 
         // Define the relayer fee.
         let relayer_fee = 100000;
@@ -504,19 +503,19 @@ module token_bridge::transfer_token_tests {
         let ctx = test_scenario::ctx(scenario);
 
         // Call `transfer_tokens`.
-        let (_, dust) =
-            transfer_tokens::transfer_tokens<COIN_WRAPPED_7>(
+        let (
+            prepared_msg,
+            dust
+        ) =
+            transfer_tokens(
                 &mut token_bridge_state,
-                &mut worm_state,
                 coin::from_balance(coin_7_balance, ctx),
-                coin::mint_for_testing(wormhole_fee, ctx),
                 TEST_TARGET_CHAIN,
                 TEST_TARGET_RECIPIENT,
                 relayer_fee,
-                TEST_NONCE,
-                &the_clock
+                TEST_NONCE
             );
-        assert!(coin::value(&dust) == 0, 0);
+        coin::destroy_zero(dust);
 
         // Balance check the Token Bridge after executing the transfer. The
         // balance should be zero, since tokens are burned when an outbound
@@ -527,15 +526,20 @@ module token_bridge::transfer_token_tests {
             assert!(wrapped_asset::total_supply(asset) == 0, 0);
         };
 
+        // Clean up.
+        publish_message::destroy(prepared_msg);
+        return_state(token_bridge_state);
+
         // Done.
-        coin::destroy_zero(dust);
-        return_states(token_bridge_state, worm_state);
-        return_clock(the_clock);
         test_scenario::end(my_scenario);
     }
 
     #[test]
     fun test_serialize_transfer_tokens_wrapped_7() {
+        use token_bridge::transfer_tokens::{
+            bridge_in_and_serialize_transfer_test_only
+        };
+
         let sender = person();
         let my_scenario = test_scenario::begin(sender);
         let scenario = &mut my_scenario;
@@ -549,35 +553,35 @@ module token_bridge::transfer_token_tests {
 
         // Register and mint coins.
         let transfer_amount = 6942000;
-        let coin_7_balance = coin_wrapped_7::init_register_and_mint(
-            scenario,
-            sender,
-            transfer_amount
-        );
+        let bridged_coin_7 =
+            coin::from_balance(
+                coin_wrapped_7::init_register_and_mint(
+                    scenario,
+                    sender,
+                    transfer_amount
+                ),
+                test_scenario::ctx(scenario)
+            );
 
         // Ignore effects.
         test_scenario::next_tx(scenario, sender);
 
         // Fetch objects necessary for sending the transfer.
-        let (token_bridge_state, worm_state) = take_states(scenario);
-        let the_clock = take_clock(scenario);
+        let token_bridge_state = take_state(scenario);
 
         // Define the relayer fee.
         let relayer_fee = 100000;
 
-        // Cache context.
-        let ctx = test_scenario::ctx(scenario);
-
         // Call `transfer_tokens`.
-        let (payload, dust) =
-            transfer_tokens::bridge_in_and_serialize_transfer_test_only(
+        let payload =
+            bridge_in_and_serialize_transfer_test_only(
                 &mut token_bridge_state,
-                coin::from_balance(coin_7_balance, ctx),
+                &mut bridged_coin_7,
                 TEST_TARGET_CHAIN,
                 TEST_TARGET_RECIPIENT,
                 relayer_fee
             );
-        assert!(coin::value(&dust) == 0, 0);
+        coin::destroy_zero(bridged_coin_7);
 
         // Construct expected payload from scratch and confirm that the
         // `transfer_tokens` call produces the same payload.
@@ -611,16 +615,18 @@ module token_bridge::transfer_token_tests {
             );
         assert!(transfer::serialize(expected_payload) == payload, 0);
 
+        // Clean up.
+        return_state(token_bridge_state);
+
         // Done.
-        coin::destroy_zero(dust);
-        return_states(token_bridge_state, worm_state);
-        return_clock(the_clock);
         test_scenario::end(my_scenario);
     }
 
     #[test]
     #[expected_failure(abort_code = token_registry::E_UNREGISTERED)]
     fun test_cannot_transfer_tokens_native_not_registered() {
+        use token_bridge::transfer_tokens::{transfer_tokens};
+
         let sender = person();
         let my_scenario = test_scenario::begin(sender);
         let scenario = &mut my_scenario;
@@ -637,45 +643,49 @@ module token_bridge::transfer_token_tests {
 
         // NOTE: This test purposely doesn't `attest` COIN_NATIVE_10.
         let transfer_amount = 6942000;
-        let test_coins = coin::mint_for_testing<COIN_NATIVE_10>(
-            transfer_amount,
-            test_scenario::ctx(scenario)
-        );
+        let test_coins =
+            coin::mint_for_testing<COIN_NATIVE_10>(
+                transfer_amount,
+                test_scenario::ctx(scenario)
+            );
 
         // Ignore effects.
         test_scenario::next_tx(scenario, sender);
 
         // Fetch objects necessary for sending the transfer.
-        let (token_bridge_state, worm_state) = take_states(scenario);
-        let the_clock = take_clock(scenario);
+        let token_bridge_state = take_state(scenario);
 
         // Define the relayer fee.
         let relayer_fee = 100000;
 
         // Call `transfer_tokens`.
-        let (_, dust) = transfer_tokens::transfer_tokens<COIN_NATIVE_10>(
-            &mut token_bridge_state,
-            &mut worm_state,
-            test_coins,
-            coin::mint_for_testing(wormhole_fee, test_scenario::ctx(scenario)),
-            TEST_TARGET_CHAIN,
-            TEST_TARGET_RECIPIENT,
-            relayer_fee,
-            TEST_NONCE,
-            &the_clock
-        );
-        assert!(coin::value(&dust) == 0, 0);
+        let (
+            prepared_msg,
+            dust
+        ) =
+            transfer_tokens(
+                &mut token_bridge_state,
+                test_coins,
+                TEST_TARGET_CHAIN,
+                TEST_TARGET_RECIPIENT,
+                relayer_fee,
+                TEST_NONCE
+            );
+        coin::destroy_zero(dust);
+
+        // Clean up.
+        publish_message::destroy(prepared_msg);
+        return_state(token_bridge_state);
 
         // Done.
-        coin::destroy_zero(dust);
-        return_states(token_bridge_state, worm_state);
-        return_clock(the_clock);
         test_scenario::end(my_scenario);
     }
 
     #[test]
     #[expected_failure(abort_code = token_registry::E_UNREGISTERED)]
     fun test_cannot_transfer_tokens_wrapped_not_registered() {
+        use token_bridge::transfer_tokens::{transfer_tokens};
+
         let sender = person();
         let my_scenario = test_scenario::begin(sender);
         let scenario = &mut my_scenario;
@@ -695,46 +705,49 @@ module token_bridge::transfer_token_tests {
 
         // NOTE: This test purposely doesn't `attest` COIN_WRAPPED_7.
         let transfer_amount = 42069;
-        let test_coins = coin::mint_for_testing<COIN_WRAPPED_7>(
-            transfer_amount,
-            test_scenario::ctx(scenario)
-        );
+        let test_coins =
+            coin::mint_for_testing<COIN_WRAPPED_7>(
+                transfer_amount,
+                test_scenario::ctx(scenario)
+            );
 
         // Ignore effects.
         test_scenario::next_tx(scenario, sender);
 
         // Fetch objects necessary for sending the transfer.
-        let (token_bridge_state, worm_state) = take_states(scenario);
-        let the_clock = take_clock(scenario);
+        let token_bridge_state = take_state(scenario);
 
         // Define the relayer fee.
         let relayer_fee = 1000;
 
         // Call `transfer_tokens`.
-        let (_, dust) =
-            transfer_tokens::transfer_tokens<COIN_WRAPPED_7>(
+        let (
+            prepared_msg,
+            dust
+        ) =
+            transfer_tokens(
                 &mut token_bridge_state,
-                &mut worm_state,
                 test_coins,
-                coin::mint_for_testing(wormhole_fee, test_scenario::ctx(scenario)),
                 TEST_TARGET_CHAIN,
                 TEST_TARGET_RECIPIENT,
                 relayer_fee,
-                TEST_NONCE,
-                &the_clock
+                TEST_NONCE
             );
-        assert!(coin::value(&dust) == 0, 0);
+        coin::destroy_zero(dust);
+
+        // Clean up.
+        publish_message::destroy(prepared_msg);
+        return_state(token_bridge_state);
 
         // Done.
-        coin::destroy_zero(dust);
-        return_states(token_bridge_state, worm_state);
-        return_clock(the_clock);
         test_scenario::end(my_scenario);
     }
 
     #[test]
     #[expected_failure(abort_code = transfer_tokens::E_RELAYER_FEE_EXCEEDS_AMOUNT)]
     fun test_cannot_transfer_tokens_fee_exceeds_amount() {
+        use token_bridge::transfer_tokens::{transfer_tokens};
+
         let sender = person();
         let my_scenario = test_scenario::begin(sender);
         let scenario = &mut my_scenario;
@@ -750,41 +763,42 @@ module token_bridge::transfer_token_tests {
         // than the `transfer_amount`.
         let relayer_fee = 100001;
         let transfer_amount = 100000;
-        let coin_10_balance = coin_native_10::init_register_and_mint(
-            scenario,
-            sender,
-            transfer_amount
-        );
+        let coin_10_balance =
+            coin_native_10::init_register_and_mint(
+                scenario,
+                sender,
+                transfer_amount
+            );
 
         // Ignore effects.
         test_scenario::next_tx(scenario, sender);
 
         // Fetch objects necessary for sending the transfer.
-        let (token_bridge_state, worm_state) = take_states(scenario);
-        let the_clock = take_clock(scenario);
-
-        // Cache context.
-        let ctx = test_scenario::ctx(scenario);
+        let token_bridge_state = take_state(scenario);
 
         // The `transfer_tokens` call should revert.
-        let (_, dust) =
-            transfer_tokens::transfer_tokens<COIN_NATIVE_10>(
+        let (
+            prepared_msg,
+            dust
+        ) =
+            transfer_tokens(
                 &mut token_bridge_state,
-                &mut worm_state,
-                coin::from_balance(coin_10_balance, ctx),
-                coin::mint_for_testing(wormhole_fee, ctx),
+                coin::from_balance(
+                    coin_10_balance,
+                    test_scenario::ctx(scenario)
+                ),
                 TEST_TARGET_CHAIN,
                 TEST_TARGET_RECIPIENT,
                 relayer_fee,
-                TEST_NONCE,
-                &the_clock
+                TEST_NONCE
             );
-        assert!(coin::value(&dust) == 0, 0);
+        coin::destroy_zero(dust);
 
         // Done.
-        coin::destroy_zero(dust);
-        return_states(token_bridge_state, worm_state);
-        return_clock(the_clock);
+        publish_message::destroy(prepared_msg);
+        return_state(token_bridge_state);
+
+        // Clean up.
         test_scenario::end(my_scenario);
     }
 }

--- a/sui/token_bridge/sources/vaa.move
+++ b/sui/token_bridge/sources/vaa.move
@@ -23,6 +23,9 @@ module token_bridge::vaa {
     friend token_bridge::complete_transfer;
     friend token_bridge::complete_transfer_with_payload;
 
+    /// This type represents VAA data whose emitter is a registered Token Bridge
+    /// emitter. This message is also representative of a VAA that cannot be
+    /// replayed.
     struct TokenBridgeMessage {
         emitter_chain: u16,
         emitter_address: ExternalAddress,
@@ -39,9 +42,12 @@ module token_bridge::vaa {
     /// In its verification, this method checks whether the emitter is a
     /// registered Token Bridge contract on another network.
     ///
-    /// NOTE: This method has `friend` visibility so it is only callable by this
-    /// contract. Otherwise the replay protection could be abused to DoS the
-    /// Token Bridge.
+    /// NOTE: It is important for integrators to refrain from calling this
+    /// method within their contracts. This method is meant to be called within
+    /// a transaction block, passing the `TokenBridgeMessage` to one of the
+    /// Token Bridge methods that consumes this type. If in a circumstance where
+    /// this module has a breaking change in an upgrade, another method  (e.g.
+    /// `complete_transfer_with_payload`) will not be affected by this change.
     public fun verify_only_once(
         token_bridge_state: &mut State,
         verified_vaa: VAA

--- a/sui/token_bridge/sources/vaa.move
+++ b/sui/token_bridge/sources/vaa.move
@@ -27,10 +27,16 @@ module token_bridge::vaa {
     /// emitter. This message is also representative of a VAA that cannot be
     /// replayed.
     struct TokenBridgeMessage {
+        /// Wormhole chain ID from which network the message originated from.
         emitter_chain: u16,
+        /// Address of Token Bridge (standardized to 32 bytes) that produced
+        /// this message.
         emitter_address: ExternalAddress,
+        /// Sequence number of Token Bridge's Wormhole message.
         sequence: u64,
+        /// Token Bridge payload.
         payload: vector<u8>,
+        /// `VAA` digest.
         digest: Bytes32
     }
 

--- a/sui/wormhole/Makefile
+++ b/sui/wormhole/Makefile
@@ -1,15 +1,15 @@
 -include ../../Makefile.help
 
-.PHONY: artifacts
-artifacts: build
+.PHONY: clean
+clean:
+	rm -rf build
 
-.PHONY: build
+.PHONY: check
 ## Build contract
-build:
-	sui move build
+check:
+	sui move build -d
 
 .PHONY: test
 ## Run tests
-test:
-	sui move build -d || exit $?
+test: check
 	sui move test -d -t 1

--- a/sui/wormhole/sources/governance_message.move
+++ b/sui/wormhole/sources/governance_message.move
@@ -82,10 +82,10 @@ module wormhole::governance_message {
     /// checks to validate governance emitter before returning deserialized
     /// `GovernanceMessage`.
     ///
-    /// NOTE: This method is friendly with Wormhole contract governance methods
-    /// because these methods manage consuming VAA hashes themselves. Other
-    /// contracts that perform guardian governance should use
-    /// `parse_verify_and_consume_vaa`.
+    /// NOTE: It is expected that these VAAs are consumed only once using
+    /// `ConsumedVAAs`. Those contracts that use Guardian governance to perform
+    /// administrative functions are expected to have this container to protect
+    /// against replaying these governance actions.
     public fun verify_vaa(
         wormhole_state: &State,
         verified_vaa: VAA,
@@ -112,6 +112,12 @@ module wormhole::governance_message {
 
     /// Check module name, action and whether this action is intended for all
     /// chains before `take_payload` is called.
+    ///
+    /// NOTE: It is expected that these governance messages are consumed only
+    /// once using `ConsumedVAAs` to store the VAA digest. Those contracts that
+    /// use Guardian governance to perform administrative functions are expected
+    /// to have this container to protect against replaying these governance
+    /// actions.
     public fun take_global_action(
         msg: GovernanceMessage,
         expected_module_name: Bytes32,
@@ -127,6 +133,12 @@ module wormhole::governance_message {
 
     /// Check module name, action and whether this action is intended for Sui's
     /// chain ID before `take_payload` is called.
+    ///
+    /// NOTE: It is expected that these governance messages are consumed only
+    /// once using `ConsumedVAAs` to store the VAA digest. Those contracts that
+    /// use Guardian governance to perform administrative functions are expected
+    /// to have this container to protect against replaying these governance
+    /// actions.
     public fun take_local_action(
         msg: GovernanceMessage,
         expected_module_name: Bytes32,

--- a/sui/wormhole/sources/migrate.move
+++ b/sui/wormhole/sources/migrate.move
@@ -48,7 +48,7 @@ module wormhole::migrate {
         //
         // WARNING: The migration does *not* proceed atomically with the
         // upgrade (as they are done in separate transactions).
-        // If the nature of your migration absolutely requires the migration to
+        // If the nature of this migration absolutely requires the migration to
         // happen before certain other functionality is available, then guard
         // that functionality with the `assert!` from above.
         //

--- a/sui/wormhole/sources/publish_message.move
+++ b/sui/wormhole/sources/publish_message.move
@@ -1,10 +1,28 @@
 // SPDX-License-Identifier: Apache 2
 
-/// This module implements the method `publish_message` which emits a
-/// `WormholeMessage` event. This event is observed by the Guardian network and
-/// must have information relating to emitter (`sender`), message sequence
-/// relative to the emitter, nonce (i.e. batch ID), consistency level
-/// (i.e. finality) and arbitrary message payload.
+/// This module implements two methods: `prepare_message` and `publish_message`,
+/// which are to be executed in a transaction block in this order.
+///
+/// `prepare_message` allows a contract to pack Wormhole message info (payload
+/// that has meaning to an integrator plus nonce) in preparation to publish a
+/// `WormholeMessage` event via `publish_message`. Only the owner of an
+/// `EmitterCap` has the capability of creating this `PreparedMessage`.
+///
+/// `publish_message` unpacks the `PreparedMessage` and emits a
+/// `WormholeMessage` with this message info and timestamp. This event is
+/// observed by the Guardian network.
+///
+/// The purpose of splitting this message publishing into two steps is in case
+/// Wormhole needs to be upgraded and there is a breaking change for this
+/// module, an integrator would not be left broken. It is discouraged to put
+/// `publish_message` in an integrator's package logic. Otherwise, this
+/// integrator needs to be prepared to upgrade his contract to handle the latest
+/// version of `publish_message`.
+///
+/// Instead, an integtrator is encouraged to execute a transaction block, which
+/// executes `publish_message` using the latest Wormhole package ID and to
+/// implement `prepare_message` in his contract to produce `PreparedMessage`,
+/// which `publish_message` consumes.
 module wormhole::publish_message {
     use sui::coin::{Self, Coin};
     use sui::clock::{Self, Clock};
@@ -16,7 +34,8 @@ module wormhole::publish_message {
     use wormhole::state::{Self, State};
     use wormhole::version_control::{PublishMessage as PublishMessageControl};
 
-    /// `WormholeMessage` to be emitted via sui::event::emit.
+    /// This type is emitted via `sui::event` module. Guardians pick up this
+    /// observation and attest to its existence.
     struct WormholeMessage has drop, copy {
         /// `EmitterCap` object ID.
         sender: ID,
@@ -32,18 +51,65 @@ module wormhole::publish_message {
         timestamp: u64
     }
 
+    /// This type represents Wormhole message data. The sender is the object ID
+    /// of an `EmitterCap`, who acts as the capability of creating this type.
+    /// The only way to destroy this type is calling `publish_message` with
+    /// a fee to emit a `WormholeMessage` with the unpacked members of this
+    /// struct.
+    struct PreparedMessage {
+        /// `EmitterCap` object ID.
+        sender: ID,
+        /// From `EmitterCap`.
+        sequence: u64,
+        /// A.K.A. Batch ID.
+        nonce: u32,
+        /// Arbitrary message data relevant to integrator.
+        payload: vector<u8>
+    }
+
+    /// `prepare_message` constructs Wormhole message parameters. An
+    /// `EmitterCap` provides the capability to send an arbitrary payload.
+    ///
+    /// NOTE: Integrators of Wormhole should be calling only this method from
+    /// their contracts. This method is not guarded by version control (thus not
+    /// requiring a reference to the Wormhole `State` object), so it is intended
+    /// to work for any package version.
+    public fun prepare_message(
+        emitter_cap: &mut EmitterCap,
+        nonce: u32,
+        payload: vector<u8>
+    ): PreparedMessage {
+        // Produce sequence number for this message. This will also be the
+        // return value for this method.
+        let sequence = emitter::use_sequence(emitter_cap);
+
+        PreparedMessage {
+            sender: object::id(emitter_cap),
+            sequence,
+            nonce,
+            payload
+        }
+    }
+
     /// `publish_message` emits a message as a Sui event. This method uses the
     /// input `EmitterCap` as the registered sender of the
     /// `WormholeMessage`. It also produces a new sequence for this emitter.
     ///
     /// NOTE: This method is guarded by a minimum build version check. This
     /// method could break backward compatibility on an upgrade.
+    ///
+    /// It is important for integrators to refrain from calling this method
+    /// within their contracts. This method is meant to be called in a
+    /// tranasction block after receiving a `PreparedMessage` from calling
+    /// `prepare_message` within a contract. If in a circumstance where this
+    /// module has a breaking change in an upgrade, `prepare_message` will not
+    /// be affected by this change.
+    ///
+    /// See `prepare_message` for more details.
     public fun publish_message(
         wormhole_state: &mut State,
-        emitter_cap: &mut EmitterCap,
-        nonce: u32,
-        payload: vector<u8>,
         message_fee: Coin<SUI>,
+        prepared_msg: PreparedMessage,
         the_clock: &Clock
     ): u64 {
         state::check_minimum_requirement<PublishMessageControl>(wormhole_state);
@@ -53,21 +119,23 @@ module wormhole::publish_message {
         // expected fee amount.
         state::deposit_fee(wormhole_state, coin::into_balance(message_fee));
 
-        // Produce sequence number for this message. This will also be the
-        // return value for this method.
-        let sequence = emitter::use_sequence(emitter_cap);
+        let PreparedMessage {
+            sender,
+            sequence,
+            nonce,
+            payload
+        } = prepared_msg;
 
         // Truncate to seconds.
         let timestamp = clock::timestamp_ms(the_clock) / 1000;
 
-        // Sui is an instant finality chain, so we don't need
-        // confirmations.
+        // Sui is an instant finality chain, so we don't need confirmations.
         let consistency_level = 0;
 
         // Emit Sui event with `WormholeMessage`.
         event::emit(
             WormholeMessage {
-                sender: object::id(emitter_cap),
+                sender,
                 sequence,
                 nonce,
                 payload,
@@ -78,6 +146,16 @@ module wormhole::publish_message {
 
         // Done.
         sequence
+    }
+
+    #[test_only]
+    public fun destroy(prepared_msg: PreparedMessage) {
+        let PreparedMessage {
+            sender: _,
+            sequence: _,
+            nonce: _,
+            payload: _
+        } = prepared_msg;
     }
 }
 
@@ -90,7 +168,6 @@ module wormhole::publish_message_tests {
     use wormhole::fee_collector::{Self};
     use wormhole::required_version::{Self};
     use wormhole::state::{Self};
-    use wormhole::publish_message::{publish_message};
     use wormhole::version_control::{Self as control};
     use wormhole::wormhole_scenario::{
         person,
@@ -106,6 +183,8 @@ module wormhole::publish_message_tests {
     /// This test verifies that `publish_message` is successfully called when
     /// the specified message fee is used.
     public fun test_publish_message() {
+        use wormhole::publish_message::{prepare_message, publish_message};
+
         let user = person();
         let my_scenario = test_scenario::begin(user);
         let scenario = &mut my_scenario;
@@ -133,32 +212,44 @@ module wormhole::publish_message_tests {
             let effects = test_scenario::next_tx(scenario, user);
             assert!(test_scenario::num_user_events(&effects) == 1, 0);
 
+            // Prepare message.
+            let msg =
+                prepare_message(
+                    &mut emitter_cap,
+                    0, // nonce
+                    b"Hello World"
+                );
+
             // Finally publish Wormhole message.
             let sequence =
                 publish_message(
                     &mut worm_state,
-                    &mut emitter_cap,
-                    0, // nonce
-                    b"Hello World",
                     coin::mint_for_testing(
                         wormhole_message_fee,
                         test_scenario::ctx(scenario)
                     ),
+                    msg,
                     &the_clock
                 );
             assert!(sequence == 0, 0);
+
+            // Prepare another message.
+            let msg =
+                prepare_message(
+                    &mut emitter_cap,
+                    0, // nonce
+                    b"Hello World... again"
+                );
 
             // Publish again to check sequence uptick.
             let another_sequence =
                 publish_message(
                     &mut worm_state,
-                    &mut emitter_cap,
-                    0, // nonce
-                    b"Hello World... again",
                     coin::mint_for_testing(
                         wormhole_message_fee,
                         test_scenario::ctx(scenario)
                     ),
+                    msg,
                     &the_clock
                 );
             assert!(another_sequence == 1, 0);
@@ -190,16 +281,21 @@ module wormhole::publish_message_tests {
             let emitter_cap =
                 test_scenario::take_from_sender<EmitterCap>(scenario);
 
+            let msg =
+                prepare_message(
+                    &mut emitter_cap,
+                    0, // nonce
+                    b"Hello?"
+                );
+
             let sequence =
                 publish_message(
                     &mut worm_state,
-                    &mut emitter_cap,
-                    0, // nonce
-                    b"Hello?",
                     coin::mint_for_testing(
                         wormhole_message_fee,
                         test_scenario::ctx(scenario)
                     ),
+                    msg,
                     &the_clock
                 );
             assert!(sequence == 2, 0);
@@ -219,6 +315,8 @@ module wormhole::publish_message_tests {
     /// This test verifies that `publish_message` fails when the fee is not the
     /// correct amount. `FeeCollector` will be the reason for this abort.
     public fun test_cannot_publish_message_with_incorrect_fee() {
+        use wormhole::publish_message::{prepare_message, publish_message};
+
         let user = person();
         let my_scenario = test_scenario::begin(user);
         let scenario = &mut my_scenario;
@@ -239,16 +337,20 @@ module wormhole::publish_message_tests {
         let emitter_cap =
             emitter::new(&worm_state, test_scenario::ctx(scenario));
 
+        let msg =
+            prepare_message(
+                &mut emitter_cap,
+                0, // nonce
+                b"Hello World"
+            );
         // You shall not pass!
         publish_message(
             &mut worm_state,
-            &mut emitter_cap,
-            0, // nonce
-            b"Hello World",
             coin::mint_for_testing(
                 wrong_fee_amount,
                 test_scenario::ctx(scenario)
             ),
+            msg,
             &the_clock
         );
 
@@ -266,6 +368,8 @@ module wormhole::publish_message_tests {
     /// This test verifies that `publish_message` will fail if the minimum
     /// required version is greater than the current build's.
     public fun test_cannot_publish_message_outdated_build() {
+        use wormhole::publish_message::{prepare_message, publish_message};
+
         let user = person();
         let my_scenario = test_scenario::begin(user);
         let scenario = &mut my_scenario;
@@ -293,16 +397,21 @@ module wormhole::publish_message_tests {
         let emitter_cap =
             emitter::new(&worm_state, test_scenario::ctx(scenario));
 
+        let msg =
+            prepare_message(
+                &mut emitter_cap,
+                0, // nonce
+                b"Hello World",
+            );
+
         // You shall not pass!
         publish_message(
             &mut worm_state,
-            &mut emitter_cap,
-            0, // nonce
-            b"Hello World",
             coin::mint_for_testing(
                 wormhole_message_fee,
                 test_scenario::ctx(scenario)
             ),
+            msg,
             &the_clock
         );
 

--- a/sui/wormhole/sources/test/wormhole_scenario.move
+++ b/sui/wormhole/sources/test/wormhole_scenario.move
@@ -14,6 +14,7 @@ module wormhole::wormhole_scenario {
     use sui::test_scenario::{Self, Scenario};
 
     use wormhole::emitter::{EmitterCap};
+    use wormhole::governance_message::{Self, GovernanceMessage};
     use wormhole::setup::{Self, DeployerCap};
     use wormhole::state::{Self, State};
     use wormhole::vaa::{Self, VAA};
@@ -180,6 +181,31 @@ module wormhole::wormhole_scenario {
         return_clock(the_clock);
 
         out
+    }
+
+    public fun parse_and_verify_governance_vaa(
+        scenario: &mut Scenario,
+        vaa_buf: vector<u8>
+    ): GovernanceMessage {
+        test_scenario::next_tx(scenario, VAA_VERIFIER);
+
+        let the_clock = take_clock(scenario);
+        let worm_state = take_state(scenario);
+
+        let verified_vaa =
+            vaa::parse_and_verify(
+                &worm_state,
+                vaa_buf,
+                &the_clock
+            );
+
+        let msg = governance_message::verify_vaa(&worm_state, verified_vaa);
+
+        // Clean up.
+        return_state(worm_state);
+        return_clock(the_clock);
+
+        msg
     }
 
     public fun new_emitter(


### PR DESCRIPTION
## Objective
- Add outbound types meant to be passed around to avoid breaking integrators when either Wormhole or Token Bridge are upgraded (e.g. `PreparedMessage` is now passed into `publish_message`, and `prepare_message` is a simpler method that does not require a reference to the Wormhole `State`).
- Split `complete_transfer` into two methods (in case a relayer were to manage its payouts via contract).
- Add `_from_tx` methods to execute these new two-step methods in one call, meant to be executed directly from a transaction.
- Add ability to disable (and re-enable) methods via `wormhole::required_version`.
- Fix comments

## How to Review PR
- Make sure Move tests run via `make test`
- Either review each commit sequentially or review the code diff