### PR TITLE
sdk/js: fix `mock` bugs

### DIFF
--- a/sdk/js/src/mock/governance.ts
+++ b/sdk/js/src/mock/governance.ts
@@ -148,7 +148,7 @@ export class GovernanceEmitter extends MockEmitter {
   ) {
     const payload = Buffer.alloc(32);
     payload.write(
-      tryNativeToHexString(newContract, this.chain as ChainId),
+      tryNativeToHexString(newContract, chain as ChainId),
       0,
       "hex"
     );

--- a/sdk/js/src/mock/tokenBridge.ts
+++ b/sdk/js/src/mock/tokenBridge.ts
@@ -51,10 +51,10 @@ export class MockTokenBridge extends MockEmitter {
     serialized.writeUInt8(decimals, 35);
     // truncate to 32 characters
     symbol = symbol.substring(0, 32);
-    serialized.write(symbol, 68 - symbol.length);
+    serialized.write(symbol, 36);
     // truncate to 32 characters
     name = name.substring(0, 32);
-    serialized.write(name, 100 - name.length);
+    serialized.write(name, 68);
     return this.publishTokenBridgeMessage(
       serialized,
       nonce,


### PR DESCRIPTION
## Objective

Fixed a couple of bugs in the mock subdirectory of the Javascript SDK.
1. `MockTokenBridge` was not properly serializing the symbol and name in the Wormhole message payload.
2. `GovernanceEmitter` was using the wrong chain ID.

## How to Review PR
- Make sure CI tests run
- Review trivial changes