### PR TITLE
G relayer redelivery tests

### DIFF
--- a/ethereum/contracts/interfaces/relayer/IDelivery.sol
+++ b/ethereum/contracts/interfaces/relayer/IDelivery.sol
@@ -70,5 +70,7 @@ interface IDelivery {
     error VaaKeysDoNotMatchVaas(uint8 index); // The VAA at index 'index' does not match the 'index'-th description given on the source chain in the 'messages' field
     error VaaKeysLengthDoesNotMatchVaasLength(); // The VAA array has a different length than the original array of VaaKey descriptions from the source chain
     error ForwardNotSufficientlyFunded(uint256 amountOfFunds, uint256 amountOfFundsNeeded); // Should never happen as this should have already been checked for
-    error InvalidOverride(); // Invalid overrides were passed in to the delivery
+    error InvalidOverrideGasLimit(); // Invalid gas limit override was passed in to the delivery
+    error InvalidOverrideReceiverValue(); // Invalid receiver value override was passed in to the delivery
+    error InvalidOverrideMaximumRefund(); // Invalid maximum refund override was passed in to the delivery
 }

--- a/ethereum/contracts/interfaces/relayer/IWormholeRelayerInstructionParser.sol
+++ b/ethereum/contracts/interfaces/relayer/IWormholeRelayerInstructionParser.sol
@@ -21,15 +21,39 @@ interface IWormholeRelayerInstructionParser {
         bytes payload;
     }
 
+    struct RedeliveryInstruction {
+        IWormholeRelayer.VaaKey key;
+        uint256 newMaximumRefundTarget;
+        uint256 newReceiverValueTarget;
+        bytes32 sourceRelayProvider;
+        ExecutionParameters executionParameters;
+    }
+
     struct ExecutionParameters {
         uint8 version;
         uint32 gasLimit;
+    }
+
+    struct DeliveryOverride {
+        uint32 gasLimit;
+        uint256 maximumRefund;
+        uint256 receiverValue;
+        bytes32 redeliveryHash;
     }
 
     function decodeDeliveryInstruction(bytes memory encoded)
         external
         pure
         returns (DeliveryInstruction memory);
+
+    function decodeRedeliveryInstruction(bytes memory encoded) 
+        external
+        pure
+        returns (RedeliveryInstruction memory);
+
+    function encodeDeliveryOverride(DeliveryOverride memory request) external pure returns (bytes memory encoded);
+
+    function decodeDeliveryOverride(bytes memory encoded) external pure returns (DeliveryOverride memory output);
 
     function toWormholeFormat(address addr) external pure returns (bytes32 whFormat);
 

--- a/ethereum/contracts/relayer/coreRelayer/CoreRelayerDelivery.sol
+++ b/ethereum/contracts/relayer/coreRelayer/CoreRelayerDelivery.sol
@@ -425,10 +425,12 @@ abstract contract CoreRelayerDelivery is CoreRelayerGovernance {
             return (deliveryInstruction, 0x0);
         } else {
             IDelivery.DeliveryOverride memory overrides = decodeDeliveryOverride(encoded);
-            if(overrides.gasLimit < deliveryInstruction.executionParameters.gasLimit 
-                || overrides.receiverValue < deliveryInstruction.receiverValueTarget 
-                || overrides.maximumRefund < deliveryInstruction.maximumRefundTarget){
-                revert IDelivery.InvalidOverride();
+            if(overrides.gasLimit < deliveryInstruction.executionParameters.gasLimit) {
+                revert IDelivery.InvalidOverrideGasLimit();
+            } else if(overrides.receiverValue < deliveryInstruction.receiverValueTarget) {
+                revert IDelivery.InvalidOverrideReceiverValue();
+            } else if(overrides.maximumRefund < deliveryInstruction.maximumRefundTarget) {
+                revert IDelivery.InvalidOverrideMaximumRefund();
             }
 
             deliveryInstruction.executionParameters.gasLimit = overrides.gasLimit;


### PR DESCRIPTION
Closes #2702  and #2699, and upgrades the forge mock generic relayer to allow Redeliveries