### PR TITLE
sui: harden migrating to new build

### DIFF
--- a/clients/js/consts.ts
+++ b/clients/js/consts.ts
@@ -32,9 +32,9 @@ const OVERRIDES = {
   },
   DEVNET: {
     sui: {
-      core: "0x8b0811f5bb871ef8faccef3f0f84295f8ed56fe109fdfb0cc7bb271ff5b97581",
+      core: "0xb293dbf970046f0157ec881d46e3ff274ca73430b1ad597d8dbd98c0e54f904a",
       token_bridge:
-        "0x348b353a77d118d923efa7251b8144a8944b3e3f79eeffb4182564604efcf6d4",
+        "0x7e35f61f38e4f9fedb25cd40100a694f6174d49bd2bdf91d152118c02781aed1",
     },
     aptos: {
       token_bridge:

--- a/clients/js/consts.ts
+++ b/clients/js/consts.ts
@@ -32,9 +32,9 @@ const OVERRIDES = {
   },
   DEVNET: {
     sui: {
-      core: "0x237db734cabdcef4c0a8e97e7e4ef1c1f0c3e1ef8090f02aaf2c765bda8bc428",
+      core: "0x8b0811f5bb871ef8faccef3f0f84295f8ed56fe109fdfb0cc7bb271ff5b97581",
       token_bridge:
-        "0xd70a026644c44c1ab8104856d6b6feff75ad8b2831c90a79eb264c4daadb2492",
+        "0x348b353a77d118d923efa7251b8144a8944b3e3f79eeffb4182564604efcf6d4",
     },
     aptos: {
       token_bridge:

--- a/clients/js/sui/consts.ts
+++ b/clients/js/sui/consts.ts
@@ -15,9 +15,9 @@ export const SUI_OBJECT_IDS = {
   },
   DEVNET: {
     core_state:
-      "0xa136cdd2fbf6eeac52bcddf882c55daf8b0205b549a7b106a4704afcf9c85e6f",
+      "0x2647204bd89dbc9f9489e07cebc1e2e579b70c10963dd758b4c59de59ae966d7",
     token_bridge_state:
-      "0xf0d80ed63eb4758e8b38af9519af41e82823d703a81d323970163fcf44f552c8",
+      "0xf0c03c4492c61abd73b1cc139589fbd96e3b95c502d6f47cfa59637d320968b0",
   },
 };
 

--- a/clients/js/sui/consts.ts
+++ b/clients/js/sui/consts.ts
@@ -15,9 +15,9 @@ export const SUI_OBJECT_IDS = {
   },
   DEVNET: {
     core_state:
-      "0x59e9ce8f55cbd4f6b8fade7568e8ff7e594c1a37ec78eb126ebebe20d0722df2",
+      "0xa136cdd2fbf6eeac52bcddf882c55daf8b0205b549a7b106a4704afcf9c85e6f",
     token_bridge_state:
-      "0x7ffaddf3eda80ceafa0d958ff61a4f3532f165d6efa9ae4af2d3914db76c6a9d",
+      "0xf0d80ed63eb4758e8b38af9519af41e82823d703a81d323970163fcf44f552c8",
   },
 };
 

--- a/clients/js/sui/utils.ts
+++ b/clients/js/sui/utils.ts
@@ -4,6 +4,7 @@ import {
   Connection,
   Ed25519Keypair,
   JsonRpcProvider,
+  PaginatedObjectsResponse,
   RawSigner,
   SUI_CLOCK_OBJECT_ID,
   SuiTransactionBlockResponse,
@@ -122,6 +123,7 @@ export const execute_sui = async (
               decreeReceipt,
             ],
           });
+
           await executeTransactionBlock(signer, tx);
           break;
         }
@@ -169,6 +171,41 @@ export const getCreatedObjects = (
   }));
 };
 
+export const findOwnedObjectByType = async (
+  provider: JsonRpcProvider,
+  owner: string,
+  type: string,
+  cursor?: string
+): Promise<string | null> => {
+  const res: PaginatedObjectsResponse = await provider.getOwnedObjects({
+    owner,
+    filter: undefined, // Filter must be undefined to avoid 504 responses
+    cursor: cursor || undefined,
+    options: {
+      showType: true,
+    },
+  });
+
+  if (!res || !res.data) {
+    throw new SuiRpcValidationError(res);
+  }
+
+  const object = res.data.find((d) => d.data.type === type);
+
+  if (!object && res.hasNextPage) {
+    return findOwnedObjectByType(
+      provider,
+      owner,
+      type,
+      res.nextCursor as string
+    );
+  } else if (!object && !res.hasNextPage) {
+    return null;
+  } else {
+    return object.data.objectId;
+  }
+};
+
 export const getOwnedObjectId = async (
   provider: JsonRpcProvider,
   owner: string,
@@ -185,27 +222,37 @@ export const getOwnedObjectId = async (
     );
   }
 
-  const res = await provider.getOwnedObjects({
-    owner,
-    filter: { StructType: type },
-    options: {
-      showContent: true,
-    },
-  });
-  if (!res || !res.data) {
-    throw new SuiRpcValidationError(res);
-  }
+  try {
+    const res = await provider.getOwnedObjects({
+      owner,
+      filter: { StructType: type },
+      options: {
+        showContent: true,
+      },
+    });
+    if (!res || !res.data) {
+      throw new SuiRpcValidationError(res);
+    }
 
-  const objects = res.data.filter((o) => o.data?.objectId);
-  if (objects.length === 1) {
-    return objects[0].data?.objectId;
-  } else if (objects.length > 1) {
-    const objectsStr = JSON.stringify(objects, null, 2);
-    throw new Error(
-      `Found multiple objects owned by ${owner} of type ${type}. This may mean that we've received an unexpected response from the Sui RPC and \`worm\` logic needs to be updated to handle this. Objects: ${objectsStr}`
-    );
-  } else {
-    return null;
+    const objects = res.data.filter((o) => o.data?.objectId);
+    if (objects.length === 1) {
+      return objects[0].data?.objectId;
+    } else if (objects.length > 1) {
+      const objectsStr = JSON.stringify(objects, null, 2);
+      throw new Error(
+        `Found multiple objects owned by ${owner} of type ${type}. This may mean that we've received an unexpected response from the Sui RPC and \`worm\` logic needs to be updated to handle this. Objects: ${objectsStr}`
+      );
+    } else {
+      return null;
+    }
+  } catch (error) {
+    // Handle 504 error by using findOwnedObjectByType method
+    const is504HttpError = `${error}`.includes("504 Gateway Time-out");
+    if (error && is504HttpError) {
+      return findOwnedObjectByType(provider, owner, type);
+    } else {
+      throw error;
+    }
   }
 };
 

--- a/sdk/js/src/utils/consts.ts
+++ b/sdk/js/src/utils/consts.ts
@@ -514,9 +514,9 @@ const DEVNET = {
       "0x46da3d4c569388af61f951bdd1153f4c875f90c2991f6b2d0a38e2161a40852c",
   },
   sui: {
-    core: "0x8b0811f5bb871ef8faccef3f0f84295f8ed56fe109fdfb0cc7bb271ff5b97581",
+    core: "0xb293dbf970046f0157ec881d46e3ff274ca73430b1ad597d8dbd98c0e54f904a",
     token_bridge:
-      "0x348b353a77d118d923efa7251b8144a8944b3e3f79eeffb4182564604efcf6d4",
+      "0x7e35f61f38e4f9fedb25cd40100a694f6174d49bd2bdf91d152118c02781aed1",
     nft_bridge: undefined,
   },
   moonbeam: {
@@ -844,9 +844,9 @@ export const SUI_OBJECT_IDS = {
   },
   DEVNET: {
     core_state:
-      "0xa136cdd2fbf6eeac52bcddf882c55daf8b0205b549a7b106a4704afcf9c85e6f",
+      "0x2647204bd89dbc9f9489e07cebc1e2e579b70c10963dd758b4c59de59ae966d7",
     token_bridge_state:
-      "0xf0d80ed63eb4758e8b38af9519af41e82823d703a81d323970163fcf44f552c8",
+      "0xf0c03c4492c61abd73b1cc139589fbd96e3b95c502d6f47cfa59637d320968b0",
   },
 };
 export type SuiAddresses = typeof SUI_OBJECT_IDS;

--- a/sdk/js/src/utils/consts.ts
+++ b/sdk/js/src/utils/consts.ts
@@ -514,9 +514,9 @@ const DEVNET = {
       "0x46da3d4c569388af61f951bdd1153f4c875f90c2991f6b2d0a38e2161a40852c",
   },
   sui: {
-    core: "0x237db734cabdcef4c0a8e97e7e4ef1c1f0c3e1ef8090f02aaf2c765bda8bc428",
+    core: "0x8b0811f5bb871ef8faccef3f0f84295f8ed56fe109fdfb0cc7bb271ff5b97581",
     token_bridge:
-      "0xd70a026644c44c1ab8104856d6b6feff75ad8b2831c90a79eb264c4daadb2492",
+      "0x348b353a77d118d923efa7251b8144a8944b3e3f79eeffb4182564604efcf6d4",
     nft_bridge: undefined,
   },
   moonbeam: {
@@ -844,9 +844,9 @@ export const SUI_OBJECT_IDS = {
   },
   DEVNET: {
     core_state:
-      "0x59e9ce8f55cbd4f6b8fade7568e8ff7e594c1a37ec78eb126ebebe20d0722df2",
+      "0xa136cdd2fbf6eeac52bcddf882c55daf8b0205b549a7b106a4704afcf9c85e6f",
     token_bridge_state:
-      "0x7ffaddf3eda80ceafa0d958ff61a4f3532f165d6efa9ae4af2d3914db76c6a9d",
+      "0xf0d80ed63eb4758e8b38af9519af41e82823d703a81d323970163fcf44f552c8",
   },
 };
 export type SuiAddresses = typeof SUI_OBJECT_IDS;

--- a/sui/coin/Move.devnet.toml
+++ b/sui/coin/Move.devnet.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Coin"
-version = "0.0.1"
+version = "0.1.0"
 
 [dependencies.Sui]
 git = "https://github.com/MystenLabs/sui.git"

--- a/sui/coin/Move.toml
+++ b/sui/coin/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Coin"
-version = "0.0.1"
+version = "0.1.0"
 
 [dependencies.Sui]
 git = "https://github.com/MystenLabs/sui.git"

--- a/sui/examples/coins/Move.devnet.toml
+++ b/sui/examples/coins/Move.devnet.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Coins"
-version = "0.0.1"
+version = "0.1.0"
 
 [dependencies.Sui]
 git = "https://github.com/MystenLabs/sui.git"

--- a/sui/examples/coins/Move.toml
+++ b/sui/examples/coins/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Coins"
-version = "0.0.1"
+version = "0.1.0"
 
 [dependencies.Sui]
 git = "https://github.com/MystenLabs/sui.git"

--- a/sui/scripts/deploy.sh
+++ b/sui/scripts/deploy.sh
@@ -90,7 +90,7 @@ echo "$TOKEN_BRIDGE_PUBLISH_OUTPUT"
 
 echo -e "\n[4/4] Initializing token bridge..."
 TOKEN_BRIDGE_PACKAGE_ID=$(echo "$TOKEN_BRIDGE_PUBLISH_OUTPUT" | grep -oP 'Published to +\K.*')
-TOKEN_BRIDGE_INIT_OUTPUT=$($(echo worm sui init-token-bridge -n "$NETWORK" -p "$TOKEN_BRIDGE_PACKAGE_ID" --wormhole-package-id "$WORMHOLE_PACKAGE_ID" --wormhole-state "$WORMHOLE_STATE_OBJECT_ID" -"$PRIVATE_KEY_ARG"))
+TOKEN_BRIDGE_INIT_OUTPUT=$($(echo worm sui init-token-bridge -n "$NETWORK" -p "$TOKEN_BRIDGE_PACKAGE_ID" --wormhole-package-id "$WORMHOLE_PACKAGE_ID" --wormhole-state "$WORMHOLE_STATE_OBJECT_ID" "$PRIVATE_KEY_ARG"))
 TOKEN_BRIDGE_STATE_OBJECT_ID=$(echo "$TOKEN_BRIDGE_INIT_OUTPUT" | grep -oP 'Token bridge state object ID +\K.*')
 echo "$TOKEN_BRIDGE_INIT_OUTPUT"
 

--- a/sui/scripts/deploy.sh
+++ b/sui/scripts/deploy.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # Help message
 function usage() {
 cat <<EOF >&2
-Deploy and initialize Sui core bridge and token bridge contracts to the 
+Deploy and initialize Sui core bridge and token bridge contracts to the
 specified network. Additionally deploys an example messaging contract in
 devnet.
 
@@ -90,7 +90,7 @@ echo "$TOKEN_BRIDGE_PUBLISH_OUTPUT"
 
 echo -e "\n[4/4] Initializing token bridge..."
 TOKEN_BRIDGE_PACKAGE_ID=$(echo "$TOKEN_BRIDGE_PUBLISH_OUTPUT" | grep -oP 'Published to +\K.*')
-TOKEN_BRIDGE_INIT_OUTPUT=$($(echo worm sui init-token-bridge -n "$NETWORK" -p "$TOKEN_BRIDGE_PACKAGE_ID" --wormhole-state "$WORMHOLE_STATE_OBJECT_ID" "$PRIVATE_KEY_ARG"))
+TOKEN_BRIDGE_INIT_OUTPUT=$($(echo worm sui init-token-bridge -n "$NETWORK" -p "$TOKEN_BRIDGE_PACKAGE_ID" --wormhole-package-id "$WORMHOLE_PACKAGE_ID" --wormhole-state "$WORMHOLE_STATE_OBJECT_ID" -"$PRIVATE_KEY_ARG"))
 TOKEN_BRIDGE_STATE_OBJECT_ID=$(echo "$TOKEN_BRIDGE_INIT_OUTPUT" | grep -oP 'Token bridge state object ID +\K.*')
 echo "$TOKEN_BRIDGE_INIT_OUTPUT"
 
@@ -99,7 +99,7 @@ if [ "$NETWORK" = devnet ]; then
   EXAMPLE_APP_PUBLISH_OUTPUT=$($(echo worm sui deploy "$EXAMPLE_APP_PATH" -n "$NETWORK" "$PRIVATE_KEY_ARG"))
   EXAMPLE_APP_PACKAGE_ID=$(echo "$EXAMPLE_APP_PUBLISH_OUTPUT" | grep -oP 'Published to +\K.*')
   echo "$EXAMPLE_APP_PUBLISH_OUTPUT"
-  
+
   EXAMPLE_INIT_OUTPUT=$($(echo worm sui init-example-message-app -n "$NETWORK" -p "$EXAMPLE_APP_PACKAGE_ID" -w "$WORMHOLE_STATE_OBJECT_ID" "$PRIVATE_KEY_ARG"))
   EXAMPLE_APP_STATE_OBJECT_ID=$(echo "$EXAMPLE_INIT_OUTPUT" | grep -oP 'Example app state object ID +\K.*')
   echo "$EXAMPLE_INIT_OUTPUT"
@@ -108,7 +108,7 @@ if [ "$NETWORK" = devnet ]; then
   EXAMPLE_COIN_PUBLISH_OUTPUT=$($(echo worm sui deploy "$EXAMPLE_COIN_PATH" -n "$NETWORK" "$PRIVATE_KEY_ARG"))
   echo "$EXAMPLE_COIN_PUBLISH_OUTPUT"
 
-  echo -e "\nWormhole package ID: $WORMHOLE_PACKAGE_ID" 
+  echo -e "\nWormhole package ID: $WORMHOLE_PACKAGE_ID"
   echo "Token bridge package ID: $TOKEN_BRIDGE_PACKAGE_ID"
   echo "Wormhole state object ID: $WORMHOLE_STATE_OBJECT_ID"
   echo "Token bridge state object ID: $TOKEN_BRIDGE_STATE_OBJECT_ID"

--- a/sui/token_bridge/Makefile
+++ b/sui/token_bridge/Makefile
@@ -1,5 +1,7 @@
 -include ../../Makefile.help
 
+VERSION = $(shell grep -Po "version = \"\K[^\"]*" Move.toml | sed "s/\./_/g")
+
 .PHONY: clean
 clean:
 	rm -rf build
@@ -12,4 +14,5 @@ check:
 .PHONY: test
 ## Run tests
 test: check
+	grep "public(friend) fun current_version(): V__${VERSION} {" sources/version_control.move
 	sui move test -t 1

--- a/sui/token_bridge/Move.devnet.toml
+++ b/sui/token_bridge/Move.devnet.toml
@@ -1,6 +1,6 @@
 [package]
 name = "TokenBridge"
-version = "0.0.1"
+version = "0.1.0"
 
 [dependencies.Sui]
 git = "https://github.com/MystenLabs/sui.git"

--- a/sui/token_bridge/Move.toml
+++ b/sui/token_bridge/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "TokenBridge"
-version = "0.0.1"
+version = "0.1.0"
 
 [dependencies.Sui]
 git = "https://github.com/MystenLabs/sui.git"

--- a/sui/token_bridge/sources/attest_token.move
+++ b/sui/token_bridge/sources/attest_token.move
@@ -37,7 +37,7 @@ module token_bridge::attest_token {
         nonce: u32
     ): MessageTicket {
         // This capability ensures that the current build version is used.
-        let latest_only = state::cache_latest_only(token_bridge_state);
+        let latest_only = state::assert_latest_only(token_bridge_state);
 
         // Encode Wormhole message payload.
         let encoded_asset_meta =
@@ -101,7 +101,7 @@ module token_bridge::attest_token {
         coin_metadata: &CoinMetadata<CoinType>,
     ): vector<u8> {
         // This capability ensures that the current build version is used.
-        let latest_only = state::cache_latest_only(token_bridge_state);
+        let latest_only = state::assert_latest_only(token_bridge_state);
 
         serialize_asset_meta(&latest_only, token_bridge_state, coin_metadata)
     }

--- a/sui/token_bridge/sources/complete_transfer.move
+++ b/sui/token_bridge/sources/complete_transfer.move
@@ -88,7 +88,7 @@ module token_bridge::complete_transfer {
         ctx: &mut TxContext
     ): RelayerReceipt<CoinType> {
         // This capability ensures that the current build version is used.
-        let latest_only = state::cache_latest_only(token_bridge_state);
+        let latest_only = state::assert_latest_only(token_bridge_state);
 
         // Emitting the transfer being redeemed (and disregard return value).
         emit_transfer_redeemed(&msg);

--- a/sui/token_bridge/sources/complete_transfer_with_payload.move
+++ b/sui/token_bridge/sources/complete_transfer_with_payload.move
@@ -86,7 +86,7 @@ module token_bridge::complete_transfer_with_payload {
         ctx: &mut TxContext
     ): RedeemerReceipt<CoinType> {
         // This capability ensures that the current build version is used.
-        let latest_only = state::cache_latest_only(token_bridge_state);
+        let latest_only = state::assert_latest_only(token_bridge_state);
 
         // Emitting the transfer being redeemed.
         //

--- a/sui/token_bridge/sources/create_wrapped.move
+++ b/sui/token_bridge/sources/create_wrapped.move
@@ -155,7 +155,7 @@ module token_bridge::create_wrapped {
         // call performs an additional check of whether `WrappedAssetSetup` was
         // created using the current package.
         let latest_only =
-            state::cache_latest_only_specified<Version>(token_bridge_state);
+            state::assert_latest_only_specified<Version>(token_bridge_state);
 
         let WrappedAssetSetup {
             id,
@@ -191,7 +191,7 @@ module token_bridge::create_wrapped {
         msg: TokenBridgeMessage
     ) {
         // This capability ensures that the current build version is used.
-        let latest_only = state::cache_latest_only(token_bridge_state);
+        let latest_only = state::assert_latest_only(token_bridge_state);
 
         // Deserialize to `AssetMeta`.
         let token_meta = asset_meta::deserialize(vaa::take_payload(msg));

--- a/sui/token_bridge/sources/datatypes/normalized_amount.move
+++ b/sui/token_bridge/sources/datatypes/normalized_amount.move
@@ -111,7 +111,7 @@ module token_bridge::normalized_amount_test {
     use token_bridge::normalized_amount::{Self};
 
     #[test]
-    public fun test_from_and_to_raw() {
+    fun test_from_and_to_raw() {
         // Use decimals > 8 to check truncation.
         let decimals = 9;
         let raw_amount = 12345678910111;
@@ -127,7 +127,7 @@ module token_bridge::normalized_amount_test {
     }
 
     #[test]
-    public fun test_take_bytes() {
+    fun test_take_bytes() {
         let cur =
             cursor::new(
                 x"000000000000000000000000000000000000000000000000ffffffffffffffff"
@@ -145,7 +145,7 @@ module token_bridge::normalized_amount_test {
 
     #[test]
     #[expected_failure(abort_code = wormhole::bytes32::E_U64_OVERFLOW)]
-    public fun test_cannot_take_bytes_overflow() {
+    fun test_cannot_take_bytes_overflow() {
         let encoded_overflow =
             x"0000000000000000000000000000000000000000000000010000000000000000";
 

--- a/sui/token_bridge/sources/governance/register_chain.move
+++ b/sui/token_bridge/sources/governance/register_chain.move
@@ -47,7 +47,7 @@ module token_bridge::register_chain {
         ExternalAddress
     ) {
         // This capability ensures that the current build version is used.
-        let latest_only = state::cache_latest_only(token_bridge_state);
+        let latest_only = state::assert_latest_only(token_bridge_state);
 
         let payload =
             governance_message::take_payload(
@@ -125,7 +125,7 @@ module token_bridge::register_chain {
         contract_address: ExternalAddress
     ) {
         // This capability ensures that the current build version is used.
-        let latest_only = state::cache_latest_only(token_bridge_state);
+        let latest_only = state::assert_latest_only(token_bridge_state);
 
         register_new_emitter(
             &latest_only,

--- a/sui/token_bridge/sources/governance/register_chain.move
+++ b/sui/token_bridge/sources/governance/register_chain.move
@@ -20,6 +20,8 @@ module token_bridge::register_chain {
     /// Bridge contract address.
     const ACTION_REGISTER_CHAIN: u8 = 1;
 
+    struct GovernanceWitness has drop {}
+
     struct RegisterChain {
         chain: u16,
         contract_address: ExternalAddress,
@@ -27,8 +29,9 @@ module token_bridge::register_chain {
 
     public fun authorize_governance(
         token_bridge_state: &State
-    ): DecreeTicket {
+    ): DecreeTicket<GovernanceWitness> {
         governance_message::authorize_verify_global(
+            GovernanceWitness {},
             state::governance_chain(token_bridge_state),
             state::governance_contract(token_bridge_state),
             state::governance_module(),
@@ -38,7 +41,7 @@ module token_bridge::register_chain {
 
     public fun register_chain(
         token_bridge_state: &mut State,
-        receipt: DecreeReceipt
+        receipt: DecreeReceipt<GovernanceWitness>
     ): (
         u16,
         ExternalAddress

--- a/sui/token_bridge/sources/governance/upgrade_contract.move
+++ b/sui/token_bridge/sources/governance/upgrade_contract.move
@@ -26,6 +26,8 @@ module token_bridge::upgrade_contract {
     /// contract.
     const ACTION_UPGRADE_CONTRACT: u8 = 1;
 
+    struct GovernanceWitness has drop {}
+
     // Event reflecting package upgrade.
     struct ContractUpgraded has drop, copy {
         old_contract: ID,
@@ -38,8 +40,9 @@ module token_bridge::upgrade_contract {
 
     public fun authorize_governance(
         wormhole_state: &State
-    ): DecreeTicket {
+    ): DecreeTicket<GovernanceWitness> {
         governance_message::authorize_verify_local(
+            GovernanceWitness {},
             state::governance_chain(wormhole_state),
             state::governance_contract(wormhole_state),
             state::governance_module(),
@@ -53,7 +56,7 @@ module token_bridge::upgrade_contract {
     /// (in this case Sui), whose build digest is encoded in this message.
     public fun authorize_upgrade(
         token_bridge_state: &mut State,
-        receipt: DecreeReceipt
+        receipt: DecreeReceipt<GovernanceWitness>
     ): UpgradeTicket {
         // current package checking when consuming VAA hashes. This is because
         // upgrades are protected by the Sui VM, enforcing the latest package

--- a/sui/token_bridge/sources/messages/transfer.move
+++ b/sui/token_bridge/sources/messages/transfer.move
@@ -202,7 +202,7 @@ module token_bridge::transfer_tests {
     use token_bridge::normalized_amount::{Self};
 
     #[test]
-    public fun test_serialize_deserialize() {
+    fun test_serialize_deserialize() {
         let decimals = 8;
         let expected_amount = normalized_amount::from_raw(234567890, decimals);
         let expected_token_address = external_address::from_address(@0xbeef);
@@ -243,7 +243,7 @@ module token_bridge::transfer_tests {
 
     #[test]
     #[expected_failure(abort_code = transfer::E_INVALID_PAYLOAD)]
-    public fun test_cannot_deserialize_invalid_payload() {
+    fun test_cannot_deserialize_invalid_payload() {
         let invalid_payload = dummy_message::encoded_transfer_with_payload();
 
         // Show that the first byte is not the expected payload ID.

--- a/sui/token_bridge/sources/messages/transfer_with_payload.move
+++ b/sui/token_bridge/sources/messages/transfer_with_payload.move
@@ -275,11 +275,11 @@ module token_bridge::transfer_with_payload_tests {
         assert!(serialized == expected_serialized, 0);
 
         // Clean up.
-        emitter::destroy(emitter_cap);
+        emitter::destroy_test_only(emitter_cap);
     }
 
     #[test]
-    public fun test_deserialize() {
+    fun test_deserialize() {
         let expected_amount = normalized_amount::from_raw(234567890, 8);
         let expected_token_address = external_address::from_address(@0xbeef);
         let expected_token_chain = 1;
@@ -332,7 +332,7 @@ module token_bridge::transfer_with_payload_tests {
 
     #[test]
     #[expected_failure(abort_code = transfer_with_payload::E_INVALID_PAYLOAD)]
-    public fun test_cannot_deserialize_invalid_payload() {
+    fun test_cannot_deserialize_invalid_payload() {
         let invalid_payload = token_bridge::dummy_message::encoded_transfer();
 
         // Show that the first byte is not the expected payload ID.

--- a/sui/token_bridge/sources/migrate.move
+++ b/sui/token_bridge/sources/migrate.move
@@ -2,43 +2,41 @@
 
 /// This module implements a public method intended to be called after an
 /// upgrade has been commited. The purpose is to add one-off migration logic
-/// that would alter Token Bridge `State`.
+/// that would alter Wormhole `State`.
 ///
 /// Included in migration is the ability to ensure that breaking changes for
-/// any of Token Bridge's methods by enforcing the current build version as
-/// their required minimum version.
+/// any of Wormhole's methods by enforcing the current build version as their
+/// required minimum version.
 module token_bridge::migrate {
+    use wormhole::governance_message::{GovernanceMessage};
+    //use wormhole::vaa::{VAA};
+
     use token_bridge::state::{Self, State};
-    use token_bridge::version_control::{Migrate as MigrateControl};
+    use token_bridge::upgrade_contract::{Self};
 
-    // This import is only used when `state::require_current_version` is used.
-    //use token_bridge::version_control::{Self as control};
-
-    /// Execute migration logic. See `token_bridge::migrate` description for
-    /// more info.
-    public fun migrate(token_bridge_state: &mut State) {
-        state::check_minimum_requirement<MigrateControl>(token_bridge_state);
-
-        // Token Bridge `State` destroys the `MigrateTicket` as the final step.
-        state::consume_migrate_ticket(token_bridge_state);
-
-        ////////////////////////////////////////////////////////////////////////
+    /// Execute migration logic. See `wormhole::migrate` description for more
+    /// info.
+    public fun migrate(
+        wormhole_state: &mut State,
+        upgrade_msg: GovernanceMessage
+    ) {
+        // Update the version first.
         //
-        // If there are any methods that require the current build, we need to
-        // explicity require them here.
-        //
-        // Calls to `require_current_version` are commented out for convenience.
-        //
-        ////////////////////////////////////////////////////////////////////////
+        // See `version_control` module for hard-coded configuration.
+        state::migrate_version(wormhole_state);
 
-        // state::require_current_version<control::AttestToken>(token_bridge_state);
-        // state::require_current_version<control::CompleteTransfer>(token_bridge_state);
-        // state::require_current_version<control::CompleteTransferWithPayload>(token_bridge_state);
-        // state::require_current_version<control::CreateWrapped>(token_bridge_state);
-        // state::require_current_version<control::RegisterChain>(token_bridge_state);
-        // state::require_current_version<control::TransferTokens>(token_bridge_state);
-        // state::require_current_version<control::TransferTokensWithPayload>(token_bridge_state);
-        // state::require_current_version<control::Vaa>(token_bridge_state);
+        // This VAA needs to have been used for upgrading this package.
+        //
+        // NOTE: All of the following methods have protections to make sure that
+        // the current build is used. Given that we officially migrated the
+        // version as the first call of `migrate`, these should be successful.
+        let digest = upgrade_contract::take_digest(upgrade_msg);
+
+        // This state capability ensures that the current build version is used.
+        let cap = state::new_cap(wormhole_state);
+
+        // Check if build digest is the current one.
+        state::assert_current_digest(&cap, wormhole_state, digest);
 
         ////////////////////////////////////////////////////////////////////////
         //
@@ -57,9 +55,124 @@ module token_bridge::migrate {
         ////////////////////////////////////////////////////////////////////////
 
 
+        ////////////////////////////////////////////////////////////////////////
+    }
+}
 
-        ////////////////////////////////////////////////////////////////////////
+#[test_only]
+module token_bridge::migrate_tests {
+    use sui::test_scenario::{Self};
+    use wormhole::wormhole_scenario::{
+        parse_and_verify_governance_vaa
+    };
+
+    use token_bridge::state::{Self};
+    use token_bridge::version_control::{Self, V__DUMMY, V__0_1_0};
+    use token_bridge::token_bridge_scenario::{
+        person,
+        return_state,
+        set_up_wormhole_and_token_bridge,
+        take_state,
+        upgrade_token_bridge
+    };
+
+    const UPGRADE_VAA: vector<u8> =
+        x"0100000000010011f0d45907077bf2baf7da1872a48b8fdea161b14b9979d758c0f2bffa9f184d56f0c70fc8e2893d69861552bf074549969a155570313476f70d3ac4570b31860100bc614e0000000000010000000000000000000000000000000000000000000000000000000000000004000000000000000101000000000000000000000000000000000000000000546f6b656e42726964676501001500000000000000000000000000000000000000000000006e6577206275696c64";
+
+    #[test]
+    fun test_migrate() {
+        use token_bridge::migrate::{migrate};
+
+        let user = person();
+        let my_scenario = test_scenario::begin(user);
+        let scenario = &mut my_scenario;
+
+        // Initialize Wormhole.
+        let wormhole_message_fee = 350;
+        set_up_wormhole_and_token_bridge(scenario, wormhole_message_fee);
+
+        // Next transaction should be conducted as an ordinary user.
+        test_scenario::next_tx(scenario, user);
+
+        // Upgrade (digest is just b"new build") for testing purposes.
+        upgrade_token_bridge(scenario);
+
+        // Ignore effects.
+        test_scenario::next_tx(scenario, user);
+
+        let token_bridge_state = take_state(scenario);
+
+        // First migrate to V_DUMMY to simulate migrating from this to the
+        // existing build version.
+        state::migrate_version_test_only<V__0_1_0, V__DUMMY>(
+            &mut token_bridge_state,
+            version_control::dummy()
+        );
+
+        let msg =
+            parse_and_verify_governance_vaa(scenario, UPGRADE_VAA);
+        // Simulate executing with an outdated build by upticking the minimum
+        // required version for `publish_message` to something greater than
+        // this build.
+        migrate(&mut token_bridge_state, msg);
+
+        // Clean up.
+        return_state(token_bridge_state);
+
         // Done.
-        ////////////////////////////////////////////////////////////////////////
+        test_scenario::end(my_scenario);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = wormhole::package_utils::E_INCORRECT_OLD_VERSION)]
+    fun test_cannot_migrate_again() {
+        use token_bridge::migrate::{migrate};
+
+        let user = person();
+        let my_scenario = test_scenario::begin(user);
+        let scenario = &mut my_scenario;
+
+        // Initialize Wormhole.
+        let wormhole_message_fee = 350;
+        set_up_wormhole_and_token_bridge(scenario, wormhole_message_fee);
+
+        // Next transaction should be conducted as an ordinary user.
+        test_scenario::next_tx(scenario, user);
+
+        // Upgrade (digest is just b"new build") for testing purposes.
+        upgrade_token_bridge(scenario);
+
+        // Ignore effects.
+        test_scenario::next_tx(scenario, user);
+
+        let token_bridge_state = take_state(scenario);
+
+        // First migrate to V_DUMMY to simulate migrating from this to the
+        // existing build version.
+        state::migrate_version_test_only<V__0_1_0, V__DUMMY>(
+            &mut token_bridge_state,
+            version_control::dummy()
+        );
+
+        let msg =
+            parse_and_verify_governance_vaa(scenario, UPGRADE_VAA);
+        // Simulate executing with an outdated build by upticking the minimum
+        // required version for `publish_message` to something greater than
+        // this build.
+        migrate(&mut token_bridge_state, msg);
+
+        // Ignore effects.
+        test_scenario::next_tx(scenario, user);
+
+        let msg =
+            parse_and_verify_governance_vaa(scenario, UPGRADE_VAA);
+        // You shall not pass!
+        migrate(&mut token_bridge_state, msg);
+
+        // Clean up.
+        return_state(token_bridge_state);
+
+        // Done.
+        test_scenario::end(my_scenario);
     }
 }

--- a/sui/token_bridge/sources/migrate.move
+++ b/sui/token_bridge/sources/migrate.move
@@ -46,7 +46,7 @@ module token_bridge::migrate {
         state::migrate_version(token_bridge_state);
 
         // This capability ensures that the current build version is used.
-        let latest_only = state::cache_latest_only(token_bridge_state);
+        let latest_only = state::assert_latest_only(token_bridge_state);
 
         // Check if build digest is the current one.
         let digest =

--- a/sui/token_bridge/sources/migrate.move
+++ b/sui/token_bridge/sources/migrate.move
@@ -106,6 +106,7 @@ module token_bridge::migrate_tests {
         // existing build version.
         state::migrate_version_test_only<V__0_1_0, V__DUMMY>(
             &mut token_bridge_state,
+            version_control::first(),
             version_control::dummy()
         );
 
@@ -151,6 +152,7 @@ module token_bridge::migrate_tests {
         // existing build version.
         state::migrate_version_test_only<V__0_1_0, V__DUMMY>(
             &mut token_bridge_state,
+            version_control::first(),
             version_control::dummy()
         );
 

--- a/sui/token_bridge/sources/migrate.move
+++ b/sui/token_bridge/sources/migrate.move
@@ -16,7 +16,7 @@ module token_bridge::migrate {
 
     /// Execute migration logic. See `wormhole::migrate` description for more
     /// info.
-    public fun migrate(token_bridge_state: &mut State, receipt: DecreeReceipt) {
+    public fun migrate(token_bridge_state: &mut State, receipt: DecreeReceipt<upgrade_contract::GovernanceWitness>) {
         handle_migrate(token_bridge_state, receipt);
 
         ////////////////////////////////////////////////////////////////////////
@@ -39,7 +39,7 @@ module token_bridge::migrate {
         ////////////////////////////////////////////////////////////////////////
     }
 
-    fun handle_migrate(token_bridge_state: &mut State, receipt: DecreeReceipt) {
+    fun handle_migrate(token_bridge_state: &mut State, receipt: DecreeReceipt<upgrade_contract::GovernanceWitness>) {
         // Update the version first.
         //
         // See `version_control` module for hard-coded configuration.

--- a/sui/token_bridge/sources/resources/token_registry.move
+++ b/sui/token_bridge/sources/resources/token_registry.move
@@ -374,6 +374,7 @@ module token_bridge::token_registry_tests {
     use token_bridge::native_asset::{Self};
     use token_bridge::token_registry::{Self};
     use token_bridge::token_bridge_scenario::{person};
+    use token_bridge::version_control::{V__0_1_0};
     use token_bridge::wrapped_asset::{Self};
 
     struct SCAM_COIN has drop {}
@@ -491,7 +492,11 @@ module token_bridge::token_registry_tests {
         let scenario = &mut my_scenario;
 
         // Initialize new coin.
-        let treasury_cap = coin_wrapped_7::init_and_take_treasury_cap(scenario, caller);
+        let treasury_cap =
+            coin_wrapped_7::init_and_take_treasury_cap<V__0_1_0>(
+                scenario,
+                caller
+            );
 
         // Ignore effects.
         test_scenario::next_tx(scenario, caller);
@@ -657,7 +662,11 @@ module token_bridge::token_registry_tests {
         let my_scenario = test_scenario::begin(caller);
         let scenario = &mut my_scenario;
 
-        let treasury_cap = coin_wrapped_7::init_and_take_treasury_cap(scenario, caller);
+        let treasury_cap =
+            coin_wrapped_7::init_and_take_treasury_cap<V__0_1_0>(
+                scenario,
+                caller
+            );
 
         // Ignore effects.
         test_scenario::next_tx(scenario, caller);
@@ -766,7 +775,11 @@ module token_bridge::token_registry_tests {
         let scenario = &mut my_scenario;
 
         // Initialize new coin.
-        let treasury_cap = coin_wrapped_7::init_and_take_treasury_cap(scenario, caller);
+        let treasury_cap =
+            coin_wrapped_7::init_and_take_treasury_cap<V__0_1_0>(
+                scenario,
+                caller
+            );
 
         // Initialize other coin
         coin_native_10::init_test_only(test_scenario::ctx(scenario));

--- a/sui/token_bridge/sources/resources/wrapped_asset.move
+++ b/sui/token_bridge/sources/resources/wrapped_asset.move
@@ -288,10 +288,11 @@ module token_bridge::wrapped_asset_tests {
     use token_bridge::coin_wrapped_12::{COIN_WRAPPED_12, Self};
     use token_bridge::coin_wrapped_7::{COIN_WRAPPED_7, Self};
     use token_bridge::token_bridge_scenario::{person};
+    use token_bridge::version_control::{V__0_1_0};
     use token_bridge::wrapped_asset::{Self};
 
     #[test]
-    public fun test_wrapped_asset_7() {
+    fun test_wrapped_asset_7() {
         let caller = person();
         let my_scenario = test_scenario::begin(caller);
         let scenario = &mut my_scenario;
@@ -305,7 +306,11 @@ module token_bridge::wrapped_asset_tests {
         let expected_name = asset_meta::name(&parsed_meta);
 
         // Publish coin.
-        let treasury_cap = coin_wrapped_7::init_and_take_treasury_cap(scenario, caller);
+        let treasury_cap =
+            coin_wrapped_7::init_and_take_treasury_cap<V__0_1_0>(
+                scenario,
+                caller
+            );
 
         // Ignore effects.
         test_scenario::next_tx(scenario, caller);
@@ -423,7 +428,7 @@ module token_bridge::wrapped_asset_tests {
     }
 
     #[test]
-    public fun test_wrapped_asset_12() {
+    fun test_wrapped_asset_12() {
         let caller = person();
         let my_scenario = test_scenario::begin(caller);
         let scenario = &mut my_scenario;
@@ -437,7 +442,11 @@ module token_bridge::wrapped_asset_tests {
         let expected_name = asset_meta::name(&parsed_meta);
 
         // Publish coin.
-        let treasury_cap = coin_wrapped_12::init_and_take_treasury_cap(scenario, caller);
+        let treasury_cap =
+            coin_wrapped_12::init_and_take_treasury_cap<V__0_1_0>(
+                scenario,
+                caller
+            );
 
         // Ignore effects.
         test_scenario::next_tx(scenario, caller);
@@ -626,7 +635,11 @@ module token_bridge::wrapped_asset_tests {
             asset_meta::native_decimals(&parsed_meta);
 
         // Publish coin.
-        let treasury_cap = coin_wrapped_12::init_and_take_treasury_cap(scenario, caller);
+        let treasury_cap =
+            coin_wrapped_12::init_and_take_treasury_cap<V__0_1_0>(
+                scenario,
+                caller
+            );
 
         // Ignore effects.
         test_scenario::next_tx(scenario, caller);
@@ -697,7 +710,11 @@ module token_bridge::wrapped_asset_tests {
             asset_meta::native_decimals(&parsed_meta);
 
         // Publish coin.
-        let treasury_cap = coin_wrapped_12::init_and_take_treasury_cap(scenario, caller);
+        let treasury_cap =
+            coin_wrapped_12::init_and_take_treasury_cap<V__0_1_0>(
+                scenario,
+                caller
+            );
 
         // Ignore effects.
         test_scenario::next_tx(scenario, caller);
@@ -762,7 +779,11 @@ module token_bridge::wrapped_asset_tests {
         let scenario = &mut my_scenario;
 
         // Publish coin.
-        let treasury_cap = coin_wrapped_12::init_and_take_treasury_cap(scenario, caller);
+        let treasury_cap =
+            coin_wrapped_12::init_and_take_treasury_cap<V__0_1_0>(
+                scenario,
+                caller
+            );
 
         // Ignore effects.
         test_scenario::next_tx(scenario, caller);

--- a/sui/token_bridge/sources/setup.move
+++ b/sui/token_bridge/sources/setup.move
@@ -55,13 +55,10 @@ module token_bridge::setup {
         upgrade_cap: UpgradeCap,
         ctx: &mut TxContext
     ) {
-        let version = token_bridge::version_control::version();
-        assert!(version == 1, E_INVALID_BUILD_VERSION);
-
         wormhole::package_utils::assert_package_upgrade_cap<DeployerCap>(
             &upgrade_cap,
             package::compatible_policy(),
-            version
+            1
         );
 
         // Destroy deployer cap.

--- a/sui/token_bridge/sources/setup.move
+++ b/sui/token_bridge/sources/setup.move
@@ -7,7 +7,7 @@ module token_bridge::setup {
     use sui::package::{Self, UpgradeCap};
     use sui::transfer::{Self};
     use sui::tx_context::{Self, TxContext};
-    use wormhole::state::{State as WormholeState};
+    use wormhole::emitter::{EmitterCap};
 
     use token_bridge::state::{Self};
 
@@ -50,9 +50,11 @@ module token_bridge::setup {
     /// Only the owner of the `DeployerCap` can call this method. This
     /// method destroys the capability and shares the `State` object.
     public fun complete(
-        worm_state: &WormholeState,
         deployer: DeployerCap,
         upgrade_cap: UpgradeCap,
+        emitter_cap: EmitterCap,
+        governance_chain: u16,
+        governance_contract: vector<u8>,
         ctx: &mut TxContext
     ) {
         wormhole::package_utils::assert_package_upgrade_cap<DeployerCap>(
@@ -66,6 +68,15 @@ module token_bridge::setup {
         object::delete(id);
 
         // Share new state.
-        transfer::public_share_object(state::new(worm_state, upgrade_cap, ctx));
+        transfer::public_share_object(
+            state::new(
+                emitter_cap,
+                upgrade_cap,
+                governance_chain,
+                wormhole::external_address::new_nonzero(
+                    wormhole::bytes32::from_bytes(governance_contract)
+                ),
+                ctx
+            ));
     }
 }

--- a/sui/token_bridge/sources/state.move
+++ b/sui/token_bridge/sources/state.move
@@ -147,10 +147,12 @@ module token_bridge::state {
     #[test_only]
     public fun migrate_version_test_only<Old: store + drop, New: store + drop>(
         self: &mut State,
+        old_version: Old,
         new_version: New
     ) {
         wormhole::package_utils::update_version_type<Old, New>(
             &mut self.id,
+            old_version,
             new_version
         );
     }

--- a/sui/token_bridge/sources/state.move
+++ b/sui/token_bridge/sources/state.move
@@ -26,6 +26,8 @@ module token_bridge::state {
     const E_INVALID_BUILD_DIGEST: u64 = 0;
     /// Specified version does not match this build's version.
     const E_VERSION_MISMATCH: u64 = 1;
+    /// Emitter has already been used to emit Wormhole messages.
+    const E_USED_EMITTER: u64 = 2;
 
     friend token_bridge::attest_token;
     friend token_bridge::complete_transfer;
@@ -80,6 +82,8 @@ module token_bridge::state {
         governance_contract: ExternalAddress,
         ctx: &mut TxContext
     ): State {
+        assert!(wormhole::emitter::sequence(&emitter_cap) == 0, E_USED_EMITTER);
+
         let state = State {
             id: object::new(ctx),
             governance_chain,

--- a/sui/token_bridge/sources/state.move
+++ b/sui/token_bridge/sources/state.move
@@ -170,7 +170,7 @@ module token_bridge::state {
     public fun borrow_mut_token_registry_test_only(
         self: &mut State
     ): &mut TokenRegistry {
-        borrow_mut_token_registry(&cache_latest_only(self), self)
+        borrow_mut_token_registry(&assert_latest_only(self), self)
     }
 
     #[test_only]
@@ -214,7 +214,7 @@ module token_bridge::state {
     ///
     /// NOTE: This method allows caching the current version check so we avoid
     /// multiple checks to dynamic fields.
-    public(friend) fun cache_latest_only(self: &State): LatestOnly {
+    public(friend) fun assert_latest_only(self: &State): LatestOnly {
         package_utils::assert_version(
             &self.id,
             version_control::current_version()
@@ -231,7 +231,7 @@ module token_bridge::state {
     ///
     /// NOTE: This method allows caching the current version check so we avoid
     /// multiple checks to dynamic fields.
-    public(friend) fun cache_latest_only_specified<Version>(
+    public(friend) fun assert_latest_only_specified<Version>(
         self: &State
     ): LatestOnly {
         use std::type_name::{get};
@@ -241,13 +241,7 @@ module token_bridge::state {
             package_utils::type_of_version(version_control::current_version());
         assert!(current_type == get<Version>(), E_VERSION_MISMATCH);
 
-        cache_latest_only(self)
-    }
-
-    /// A more expressive method to enforce that the current build version is
-    /// used.
-    public(friend) fun assert_latest_only(self: &State) {
-        cache_latest_only(self);
+        assert_latest_only(self)
     }
 
     /// Store `VAA` hash as a way to claim a VAA. This method prevents a VAA

--- a/sui/token_bridge/sources/test/coin_wrapped_12.move
+++ b/sui/token_bridge/sources/test/coin_wrapped_12.move
@@ -24,11 +24,13 @@ module token_bridge::coin_wrapped_12 {
         x"0100000000010062f4dcd21bbbc4af8b8baaa2da3a0b168efc4c975de5b828c7a3c710b67a0a0d476d10a74aba7a7867866daf97d1372d8e6ee62ccc5ae522e3e603c67fa23787000000000000000045000200000000000000000000000000000000000000000000000000000000deadbeef00000000000000010f0200000000000000000000000000000000000000000000000000000000beefface00020c424545463f3f3f20616e642070726f666974000000000000000000000000000042656566206661636520546f6b656e3f3f3f20616e642070726f666974000000";
 
     fun init(witness: COIN_WRAPPED_12, ctx: &mut TxContext) {
+        use token_bridge::version_control::{V__0_1_0};
+
         let (
             setup,
             upgrade_cap
         ) =
-            create_wrapped::new_setup_test_only(
+            create_wrapped::new_setup_test_only<COIN_WRAPPED_12, V__0_1_0>(
                 witness,
                 8, // capped to 8
                 ctx
@@ -65,7 +67,7 @@ module token_bridge::coin_wrapped_12 {
 
     #[test_only]
     /// for a test scenario, simply deploy the coin and expose `Supply`.
-    public fun init_and_take_treasury_cap(
+    public fun init_and_take_treasury_cap<Version>(
         scenario: &mut Scenario,
         caller: address
     ): TreasuryCap<COIN_WRAPPED_12> {
@@ -80,7 +82,9 @@ module token_bridge::coin_wrapped_12 {
         // Ignore effects.
         test_scenario::next_tx(scenario, caller);
 
-        create_wrapped::take_treasury_cap(test_scenario::take_from_sender(scenario))
+        create_wrapped::take_treasury_cap<COIN_WRAPPED_12, Version>(
+            test_scenario::take_from_sender(scenario)
+        )
     }
 
     #[test_only]
@@ -89,7 +93,10 @@ module token_bridge::coin_wrapped_12 {
     /// NOTE: Even though this module is `#[test_only]`, this method is tagged
     /// with the same macro  as a trick to allow another method within this
     /// module to call `init` using OTW.
-    public fun init_and_register(scenario: &mut Scenario, caller: address) {
+    public fun init_and_register<Version>(
+        scenario: &mut Scenario,
+        caller: address
+    ) {
         use token_bridge::token_bridge_scenario::{return_state, take_state};
         use wormhole::wormhole_scenario::{parse_and_verify_vaa};
 
@@ -114,13 +121,16 @@ module token_bridge::coin_wrapped_12 {
         // Ignore effects.
         test_scenario::next_tx(scenario, caller);
 
-        let coin_meta = test_scenario::take_shared<CoinMetadata<COIN_WRAPPED_12>>(scenario);
+        let coin_meta =
+            test_scenario::take_shared<CoinMetadata<COIN_WRAPPED_12>>(scenario);
 
         // Register the attested asset.
         create_wrapped::complete_registration(
             &mut token_bridge_state,
             &mut coin_meta,
-            test_scenario::take_from_sender<WrappedAssetSetup<COIN_WRAPPED_12>>(
+            test_scenario::take_from_sender<
+                WrappedAssetSetup<COIN_WRAPPED_12, Version>
+            >(
                 scenario
             ),
             test_scenario::take_from_sender<UpgradeCap>(scenario),
@@ -137,7 +147,7 @@ module token_bridge::coin_wrapped_12 {
     /// NOTE: Even though this module is `#[test_only]`, this method is tagged
     /// with the same macro as a trick to allow another method within this
     /// module to call `init` using OTW.
-    public fun init_register_and_mint(
+    public fun init_register_and_mint<Version>(
         scenario: &mut Scenario,
         caller: address,
         amount: u64
@@ -145,7 +155,7 @@ module token_bridge::coin_wrapped_12 {
         use token_bridge::token_bridge_scenario::{return_state, take_state};
 
         // First publish and register.
-        init_and_register(scenario, caller);
+        init_and_register<Version>(scenario, caller);
 
         // Ignore effects.
         test_scenario::next_tx(scenario, caller);
@@ -173,7 +183,7 @@ module token_bridge::coin_wrapped_12_tests {
     use token_bridge::coin_wrapped_12::{token_meta};
 
     #[test]
-    public fun test_native_decimals() {
+    fun test_native_decimals() {
         let meta = token_meta();
         assert!(asset_meta::native_decimals(&meta) == 12, 0);
         asset_meta::destroy(meta);

--- a/sui/token_bridge/sources/test/token_bridge_scenario.move
+++ b/sui/token_bridge/sources/test/token_bridge_scenario.move
@@ -48,13 +48,26 @@ module token_bridge::token_bridge_scenario {
         return_wormhole_state(wormhole_state);
     }
 
+    /// Perform an upgrade (which just upticks the current version of what the
+    /// `State` believes is true).
+    public fun upgrade_token_bridge(scenario: &mut Scenario) {
+        // Clean up from activity prior.
+        test_scenario::next_tx(scenario, person());
+
+        let token_bridge_state = take_state(scenario);
+        state::test_upgrade(&mut token_bridge_state);
+
+        // Clean up.
+        return_state(token_bridge_state);
+    }
+
     /// Register arbitrary chain ID with the same emitter address (0xdeadbeef).
     public fun register_dummy_emitter(scenario: &mut Scenario, chain: u16) {
         // Ignore effects.
         test_scenario::next_tx(scenario, person());
 
         let token_bridge_state = take_state(scenario);
-        state::register_new_emitter_test_only(
+        token_bridge::register_chain::register_new_emitter_test_only(
             &mut token_bridge_state,
             chain,
             external_address::from_address(@0xdeadbeef)

--- a/sui/token_bridge/sources/test/token_bridge_scenario.move
+++ b/sui/token_bridge/sources/test/token_bridge_scenario.move
@@ -35,12 +35,26 @@ module token_bridge::token_bridge_scenario {
         // Ignore effects.
         test_scenario::next_tx(scenario, deployer());
 
-        // Finally share `State`.
         let wormhole_state = take_wormhole_state(scenario);
+
+        let upgrade_cap =
+            test_scenario::take_from_sender<UpgradeCap>(scenario);
+        let emitter_cap =
+            wormhole::emitter::new(
+                &wormhole_state,
+                test_scenario::ctx(scenario)
+            );
+        let governance_chain = 1;
+        let governance_contract =
+            x"0000000000000000000000000000000000000000000000000000000000000004";
+
+        // Finally share `State`.
         setup::complete(
-            &mut wormhole_state,
             test_scenario::take_from_sender<DeployerCap>(scenario),
-            test_scenario::take_from_sender<UpgradeCap>(scenario),
+            upgrade_cap,
+            emitter_cap,
+            governance_chain,
+            governance_contract,
             test_scenario::ctx(scenario)
         );
 

--- a/sui/token_bridge/sources/transfer_tokens.move
+++ b/sui/token_bridge/sources/transfer_tokens.move
@@ -134,7 +134,7 @@ module token_bridge::transfer_tokens {
         ticket: TransferTicket<CoinType>
     ): MessageTicket {
         // This capability ensures that the current build version is used.
-        let latest_only = state::cache_latest_only(token_bridge_state);
+        let latest_only = state::assert_latest_only(token_bridge_state);
 
         let (
             nonce,
@@ -292,7 +292,7 @@ module token_bridge::transfer_tokens {
         vector<u8>
     ) {
         // This capability ensures that the current build version is used.
-        let latest_only = state::cache_latest_only(token_bridge_state);
+        let latest_only = state::assert_latest_only(token_bridge_state);
 
         bridge_in_and_serialize_transfer(
             &latest_only,

--- a/sui/token_bridge/sources/transfer_tokens_with_payload.move
+++ b/sui/token_bridge/sources/transfer_tokens_with_payload.move
@@ -135,7 +135,7 @@ module token_bridge::transfer_tokens_with_payload {
         prepared_transfer: TransferTicket<CoinType>
     ): MessageTicket {
         // This capability ensures that the current build version is used.
-        let latest_only = state::cache_latest_only(token_bridge_state);
+        let latest_only = state::assert_latest_only(token_bridge_state);
 
         // Encode Wormhole message payload.
         let (
@@ -216,7 +216,7 @@ module token_bridge::transfer_tokens_with_payload {
         vector<u8>
     ) {
         // This capability ensures that the current build version is used.
-        let latest_only = state::cache_latest_only(token_bridge_state);
+        let latest_only = state::assert_latest_only(token_bridge_state);
 
         bridge_in_and_serialize_transfer(
             &latest_only,

--- a/sui/token_bridge/sources/transfer_tokens_with_payload.move
+++ b/sui/token_bridge/sources/transfer_tokens_with_payload.move
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: Apache 2
 
-/// This module implements three methods: `prepare_transfer`,
-/// `transfer_tokens_with_payload` and `transfer_tokens_with_payload_from_tx`.
-/// `prepare_transfer` and `transfer_tokens_with_payload` are meant to work
-/// together while `transfer_tokens_with_payload_from_tx` executes both in one
-/// call.
+/// This module implements three methods: `prepare_transfer` and
+/// `transfer_tokens_with_payload`, which are meant to work together.
 ///
 /// `prepare_transfer` allows a contract to pack token transfer parameters with
 /// an arbitrary payload in preparation to bridge these assets to another
@@ -28,11 +25,6 @@
 /// package ID and to implement `prepare_transfer` in his contract to produce
 /// `PrepareTransferWithPayload`.
 ///
-/// Alternatively, `transfer_tokens_with_payload_from_tx` is meant to be
-/// executed directly from a transaction, which provides the convenience of
-/// sending dust back to the transaction sender and constructing
-/// `MessageTicket` in one call.
-///
 /// NOTE: Only assets that exist in the `TokenRegistry` can be bridged out,
 /// which are native Sui assets that have been attested for via `attest_token`
 /// and wrapped foreign assets that have been created using foreign asset
@@ -44,14 +36,13 @@ module token_bridge::transfer_tokens_with_payload {
     use sui::balance::{Balance};
     use sui::coin::{Coin};
     use sui::object::{Self, ID};
-    use sui::tx_context::{TxContext};
     use wormhole::bytes32::{Self};
     use wormhole::emitter::{EmitterCap};
     use wormhole::external_address::{Self};
     use wormhole::publish_message::{MessageTicket};
 
     use token_bridge::normalized_amount::{NormalizedAmount};
-    use token_bridge::state::{Self, State, StateCap};
+    use token_bridge::state::{Self, State, LatestOnly};
     use token_bridge::token_registry::{VerifiedAsset};
     use token_bridge::transfer_with_payload::{Self};
 
@@ -143,8 +134,8 @@ module token_bridge::transfer_tokens_with_payload {
         token_bridge_state: &mut State,
         prepared_transfer: TransferTicket<CoinType>
     ): MessageTicket {
-        // This state capability ensures that the current build version is used.
-        let cap = state::new_cap(token_bridge_state);
+        // This capability ensures that the current build version is used.
+        let latest_only = state::cache_latest_only(token_bridge_state);
 
         // Encode Wormhole message payload.
         let (
@@ -152,67 +143,22 @@ module token_bridge::transfer_tokens_with_payload {
             encoded_transfer_with_payload
          ) =
             bridge_in_and_serialize_transfer(
-                &cap,
+                &latest_only,
                 token_bridge_state,
                 prepared_transfer
             );
 
         // Prepare Wormhole message with encoded `TransferWithPayload`.
         state::prepare_wormhole_message(
-            &cap,
+            &latest_only,
             token_bridge_state,
             nonce,
             encoded_transfer_with_payload
         )
     }
 
-    /// `transfer_tokens_with_payload_from_tx` constructs token transfer
-    /// parameters like in `prepare_transfer` and executes
-    /// `transfer_tokens_with_payload`. This method is meant to provide a
-    /// convenient way to bridge assets in one action, returning the prepared
-    /// Wormhole message (which should be consumed by calling `publish_message`
-    /// in a transaction block). Any remaining amount (A.K.A. dust) from the
-    /// funds provided will be sent back to the transaction sender. The
-    /// returned coin object is the same object moved into this method.
-    ///
-    /// NOTE: This method is guarded by a minimum build version check via
-    /// `transfer_tokens_with_payload`. This method could break backward
-    /// compatibility on an upgrade. It is important for integrators to refrain
-    /// from calling this method within their contracts.
-    public fun transfer_tokens_with_payload_from_tx<CoinType>(
-        token_bridge_state: &mut State,
-        emitter_cap: &EmitterCap,
-        funded: Coin<CoinType>,
-        redeemer_chain: u16,
-        redeemer: vector<u8>,
-        payload: vector<u8>,
-        nonce: u32,
-        ctx: &TxContext
-    ): MessageTicket {
-        let (
-            prepared_transfer,
-            dust
-        ) =
-            prepare_transfer(
-                emitter_cap,
-                state::verified_asset(token_bridge_state),
-                funded,
-                redeemer_chain,
-                redeemer,
-                payload,
-                nonce
-            );
-
-        // Either destroy dust if it has zero value or send it back to the
-        // transaction sender.
-        token_bridge::coin_utils::return_nonzero(dust, ctx);
-
-        // Finally bridge assets out.
-        transfer_tokens_with_payload(token_bridge_state, prepared_transfer)
-    }
-
     fun bridge_in_and_serialize_transfer<CoinType>(
-        cap: &StateCap,
+        latest_only: &LatestOnly,
         token_bridge_state: &mut State,
         prepared_transfer: TransferTicket<CoinType>
     ): (
@@ -237,7 +183,7 @@ module token_bridge::transfer_tokens_with_payload {
             token_address
         ) =
             burn_or_deposit_funds(
-                cap,
+                latest_only,
                 token_bridge_state,
                 &asset_info,
                 bridged_in
@@ -269,11 +215,11 @@ module token_bridge::transfer_tokens_with_payload {
         u32,
         vector<u8>
     ) {
-        // This state capability ensures that the current build version is used.
-        let cap = state::new_cap(token_bridge_state);
+        // This capability ensures that the current build version is used.
+        let latest_only = state::cache_latest_only(token_bridge_state);
 
         bridge_in_and_serialize_transfer(
-            &cap,
+            &latest_only,
             token_bridge_state,
             prepared_transfer
         )
@@ -779,6 +725,90 @@ module token_bridge::transfer_tokens_with_payload_tests {
         // Clean up.
         emitter::destroy_test_only(emitter_cap);
         return_state(token_bridge_state);
+
+        // Done.
+        test_scenario::end(my_scenario);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = wormhole::package_utils::E_OUTDATED_VERSION)]
+    fun test_cannot_transfer_tokens_with_payload_outdated_version() {
+        use token_bridge::transfer_tokens_with_payload::{
+            prepare_transfer,
+            transfer_tokens_with_payload
+        };
+
+        let sender = person();
+        let my_scenario = test_scenario::begin(sender);
+        let scenario = &mut my_scenario;
+
+        // Set up contracts.
+        let wormhole_fee = 350;
+        set_up_wormhole_and_token_bridge(scenario, wormhole_fee);
+
+        // Register foreign emitter on chain ID == 2.
+        register_dummy_emitter(scenario, TEST_TARGET_CHAIN);
+
+        // Register and mint coins.
+        let transfer_amount = 6942000;
+        let coin_10_balance =
+            coin_native_10::init_register_and_mint(
+                scenario,
+                sender,
+                transfer_amount
+            );
+
+        // Ignore effects.
+        test_scenario::next_tx(scenario, sender);
+
+        // Fetch objects necessary for sending the transfer.
+        let token_bridge_state = take_state(scenario);
+
+        // Register and obtain a new wormhole emitter cap.
+        let emitter_cap = emitter::dummy();
+
+        let asset_info = state::verified_asset(&token_bridge_state);
+        let (
+            prepared_transfer,
+            dust
+        ) =
+            prepare_transfer(
+                &emitter_cap,
+                asset_info,
+                coin::from_balance(
+                    coin_10_balance,
+                    test_scenario::ctx(scenario)
+                ),
+                TEST_TARGET_CHAIN,
+                TEST_TARGET_RECIPIENT,
+                TEST_MESSAGE_PAYLOAD,
+                TEST_NONCE,
+            );
+        coin::destroy_zero(dust);
+
+        // Conveniently roll version back.
+        state::reverse_migrate_version(&mut token_bridge_state);
+
+        // Simulate executing with an outdated build by upticking the minimum
+        // required version for `publish_message` to something greater than
+        // this build.
+        state::migrate_version_test_only(
+            &mut token_bridge_state,
+            token_bridge::version_control::dummy(),
+            token_bridge::version_control::next_version()
+        );
+
+        // You shall not pass!
+        let prepared_msg =
+            transfer_tokens_with_payload(
+                &mut token_bridge_state,
+                prepared_transfer
+            );
+
+        // Clean up.
+        publish_message::destroy(prepared_msg);
+        return_state(token_bridge_state);
+        emitter::destroy_test_only(emitter_cap);
 
         // Done.
         test_scenario::end(my_scenario);

--- a/sui/token_bridge/sources/vaa.move
+++ b/sui/token_bridge/sources/vaa.move
@@ -61,7 +61,7 @@ module token_bridge::vaa {
         verified_vaa: VAA
     ): TokenBridgeMessage {
         // This capability ensures that the current build version is used.
-        let latest_only = state::cache_latest_only(token_bridge_state);
+        let latest_only = state::assert_latest_only(token_bridge_state);
 
         // First parse and verify VAA using Wormhole. This also consumes the VAA
         // hash to prevent replay.

--- a/sui/token_bridge/sources/version_control.move
+++ b/sui/token_bridge/sources/version_control.move
@@ -1,61 +1,27 @@
 // SPDX-License-Identifier: Apache 2
 
-/// This module implements dynamic field keys as empty structs. These keys with
-/// `RequiredVersion` are used to determine minimum build requirements for
-/// particular Wormhole methods and breaking backward compatibility for these
-/// methods if an upgrade requires the latest upgrade version for its
-/// functionality.
+/// This module implements dynamic field keys as empty structs. These keys are
+/// used to determine the latest version for this build. If the current version
+/// is not this build's, then paths through the `state` module will abort.
 ///
-/// See `token_bridge::state` for more info.
+/// See `token_bridge::state` and `wormhole::package_utils` for more info.
 module token_bridge::version_control {
-    use std::type_name::{Self, TypeName};
-
-    use wormhole::package_utils::{Self};
-
-    #[test_only]
-    friend token_bridge::version_control_tests;
-
     ////////////////////////////////////////////////////////////////////////////
     //
     //  Hard-coded Version Control
     //
-    //  Before upgrading, please set the types to match the latest version.
-    //  `assert_current` is intended to be used for most paths through the
-    //  `State` object.
+    //  Before upgrading, please set the types for `current_version` and
+    //  `previous_version` to match the correct types (current being the latest
+    //  version reflecting this build).
     //
     ////////////////////////////////////////////////////////////////////////////
 
-    public(friend) fun latest_version(): V__0_1_0 {
+    public(friend) fun current_version(): V__0_1_0 {
        V__0_1_0 {}
     }
 
     public(friend) fun previous_version(): V__DUMMY {
         V__DUMMY {}
-    }
-
-    public(friend) fun type_of_version<Version: drop>(_version: Version): TypeName {
-        type_name::get<Version>()
-    }
-
-    /// Assert that the version hard-coded in this check is the current one.
-    public(friend) fun assert_current(id: &UID) {
-        // NOTE: This version should be the current build version. Please use
-        // the struct at the top of this list of structs (where `V__DUMMY`
-        // should be at the bottom).
-        package_utils::assert_version(id, latest_version());
-    }
-
-    public(friend) fun assert_current_specified<Version>(id: &UID) {
-        use std::type_name::{get};
-
-        assert_current(id);
-        assert!(type_of_version(latest_version()) == get<Version>(), E_VERSION_MISMATCH);
-    }
-
-    /// Perform the official migration of one hard-coded version type to
-    /// another.
-    public(friend) fun update_to_current(id: &mut UID) {
-        package_utils::update_version_type(id, previous_version(), latest_version());
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -79,39 +45,11 @@ module token_bridge::version_control {
     //
     ////////////////////////////////////////////////////////////////////////////
 
-    use sui::object::{UID};
-
     friend token_bridge::state;
-
-    const E_VERSION_MISMATCH: u64 = 0;
-
-    /// Only called once when `State` is created.
-    public(friend) fun initialize(id: &mut UID) {
-        package_utils::init_version(id, V__0_1_0 {});
-    }
-
-    #[test_only]
-    public fun initialize_test_only(id: &mut UID) {
-        initialize(id);
-    }
-
-    #[test_only]
-    public fun update_test_only<Old: store + drop, New: store + drop>(
-        id: &mut UID,
-        old_version: Old,
-        new_version: New
-    ) {
-        package_utils::update_version_type<Old, New>(id, old_version, new_version);
-    }
 
     #[test_only]
     public fun dummy(): V__DUMMY {
         V__DUMMY {}
-    }
-
-    #[test_only]
-    public fun first(): V__0_1_0 {
-        V__0_1_0 {}
     }
 
     #[test_only]
@@ -120,130 +58,5 @@ module token_bridge::version_control {
     #[test_only]
     public fun next_version(): V__MIGRATED {
         V__MIGRATED {}
-    }
-
-    #[test_only]
-    public fun assert_current_test_only(id: &UID) {
-        assert_current(id);
-    }
-}
-
-#[test_only]
-module token_bridge::version_control_tests {
-    use sui::object::{Self, UID};
-    use sui::tx_context::{Self};
-    use token_bridge::version_control::{Self, V__0_1_0, V__MIGRATED};
-
-    struct State has key {
-        id: UID
-    }
-
-    struct V_DUMMY has store, drop, copy {}
-
-    #[test]
-    fun test_assert_current() {
-        // Create dummy state.
-        let state = State { id: object::new(&mut tx_context::dummy()) };
-        version_control::initialize_test_only(&mut state.id);
-
-        version_control::assert_current_test_only(&state.id);
-
-        // Clean up.
-        let State { id } = state;
-        object::delete(id);
-    }
-
-    #[test]
-    #[expected_failure(abort_code = wormhole::package_utils::E_INCORRECT_OLD_VERSION)]
-    fun test_cannot_update_incorrect_old_version() {
-        // Create dummy state.
-        let state = State { id: object::new(&mut tx_context::dummy()) };
-        version_control::initialize_test_only(&mut state.id);
-
-        version_control::assert_current_test_only(&state.id);
-
-        // You shall not pass!
-        version_control::update_test_only<V__MIGRATED, V__MIGRATED>(
-            &mut state.id,
-            version_control::next_version(),
-            version_control::next_version()
-        );
-
-        // Clean up.
-        let State { id } = state;
-        object::delete(id);
-    }
-
-    #[test]
-    #[expected_failure(abort_code = wormhole::package_utils::E_SAME_VERSION)]
-    fun test_cannot_update_same_version() {
-        // Create dummy state.
-        let state = State { id: object::new(&mut tx_context::dummy()) };
-        version_control::initialize_test_only(&mut state.id);
-
-        version_control::assert_current_test_only(&state.id);
-
-        // You shall not pass!
-        version_control::update_test_only<V__0_1_0, V__0_1_0>(
-            &mut state.id,
-            version_control::first(),
-            version_control::first()
-        );
-
-        // Clean up.
-        let State { id } = state;
-        object::delete(id);
-    }
-
-    #[test]
-    #[expected_failure(abort_code = wormhole::package_utils::E_OUTDATED_VERSION)]
-    fun test_cannot_assert_current_outdated_version() {
-        // Create dummy state.
-        let state = State { id: object::new(&mut tx_context::dummy()) };
-        version_control::initialize_test_only(&mut state.id);
-
-        version_control::assert_current_test_only(&state.id);
-
-        // Valid update.
-        version_control::update_test_only<V__0_1_0, V__MIGRATED>(
-            &mut state.id,
-            version_control::first(),
-            version_control::next_version()
-        );
-
-        // You shall not pass!
-        version_control::assert_current_test_only(&state.id);
-
-        // Clean up.
-        let State { id } = state;
-        object::delete(id);
-    }
-
-    #[test]
-    #[expected_failure(abort_code = wormhole::package_utils::E_TYPE_NOT_ALLOWED)]
-    fun test_cannot_update_type_not_allowed() {
-        // Create dummy state.
-        let state = State { id: object::new(&mut tx_context::dummy()) };
-        version_control::initialize_test_only(&mut state.id);
-
-        version_control::assert_current_test_only(&state.id);
-
-        // You shall not pass!
-        version_control::update_test_only<V__0_1_0, V_DUMMY>(
-            &mut state.id,
-            version_control::first(),
-            V_DUMMY {}
-        );
-
-        // Clean up.
-        let State { id } = state;
-        object::delete(id);
-    }
-
-    #[test]
-    fun test_latest_version_different_from_previous() {
-        let prev = version_control::previous_version();
-        let curr = version_control::latest_version();
-        assert!(version_control::type_of_version(prev) != version_control::type_of_version(curr), 0);
     }
 }

--- a/sui/token_bridge/sources/version_control.move
+++ b/sui/token_bridge/sources/version_control.move
@@ -2,55 +2,219 @@
 
 /// This module implements dynamic field keys as empty structs. These keys with
 /// `RequiredVersion` are used to determine minimum build requirements for
-/// particular Token Bridge methods and breaking backward compatibility for
-/// these methods if an upgrade requires the latest upgrade version for its
+/// particular Wormhole methods and breaking backward compatibility for these
+/// methods if an upgrade requires the latest upgrade version for its
 /// functionality.
 ///
-/// See `wormhole::required_version` and `token_bridge::state` for more info.
+/// See `token_bridge::state` for more info.
 module token_bridge::version_control {
-    /// This value tracks the current version of the Token Bridge version. We
-    /// are placing this constant value at the top, which goes against Move
-    /// style guides so that we bring special attention to changing this value
-    /// when a new implementation is built for a contract upgrade.
-    const CURRENT_BUILD_VERSION: u64 = 1;
+    use wormhole::package_utils::{Self};
 
-    /// Key used to check minimum version requirement for `attest_token` module.
-    struct AttestToken {}
+    ////////////////////////////////////////////////////////////////////////////
+    //
+    //  Hard-coded Version Control
+    //
+    //  Before upgrading, please set the types to match the latest version.
+    //  `assert_current` is intended to be used for most paths through the
+    //  `State` object.
+    //
+    ////////////////////////////////////////////////////////////////////////////
 
-    /// Key used to check minimum version requirement for `complete_transfer`
-    /// module.
-    struct CompleteTransfer {}
+    /// Assert that the version hard-coded in this check is the current one.
+    public(friend) fun assert_current(id: &UID) {
+        // NOTE: This version should be the current build version. Please use
+        // the struct at the top of this list of structs (where `V__DUMMY`
+        // should be at the bottom).
+        package_utils::assert_version<V__0_1_0>(id);
+    }
 
-    /// Key used to check minimum version requirement for
-    /// `complete_transfer_with_payload` module.
-    struct CompleteTransferWithPayload {}
+    public(friend) fun assert_current_specified<Version>(id: &UID) {
+        use std::type_name::{get};
 
-    /// Key used to check minimum version requirement for `create_wrapped`
-    /// module.
-    struct CreateWrapped {}
+        assert_current(id);
+        assert!(get<V__0_1_0>() == get<Version>(), E_VERSION_MISMATCH);
+    }
 
-    /// Key used to check minimum version requirement for `migrate` module.
-    struct Migrate {}
+    /// Perform the official migration of one hard-coded version type to
+    /// another.
+    public(friend) fun update_to_current(id: &mut UID) {
+        package_utils::update_version_type<V__DUMMY, V__0_1_0>(id, V__0_1_0 {});
+    }
 
-    /// Key used to check minimum version requirement for `register_chain`
-    /// module.
-    struct RegisterChain {}
+    ////////////////////////////////////////////////////////////////////////////
+    //
+    //  Change Log
+    //
+    //  Please write release notes as doc strings for each version struct. These
+    //  notes will be our attempt at tracking upgrades. Wish us luck.
+    //
+    ////////////////////////////////////////////////////////////////////////////
 
-    /// Key used to check minimum version requirement for `transfer_tokens`
-    /// module.
-    struct TransferTokens {}
+    /// First published package.
+    struct V__0_1_0 has store, drop, copy {}
 
-    /// Key used to check minimum version requirement for
-    /// `transfer_tokens_with_payload` module.
-    struct TransferTokensWithPayload {}
+    // Dummy.
+    struct V__DUMMY has store, drop, copy {}
 
-    /// Key used to check minimum version requirement for `vaa` module.
-    struct Vaa {}
+    ////////////////////////////////////////////////////////////////////////////
+    //
+    //  Implementation and Test-Only Methods
+    //
+    ////////////////////////////////////////////////////////////////////////////
 
-    /// Return const value `CURRENT_BUILD_VERSION` for this particular build.
-    /// This value is used to determine whether this implementation meets
-    /// minimum requirements for various Wormhole methods required by `State`.
-    public fun version(): u64 {
-        CURRENT_BUILD_VERSION
+    use sui::object::{UID};
+
+    friend token_bridge::state;
+
+    const E_VERSION_MISMATCH: u64 = 0;
+
+    /// Only called once when `State` is created.
+    public(friend) fun initialize(id: &mut UID) {
+        package_utils::init_version(id, V__0_1_0 {});
+    }
+
+    #[test_only]
+    public fun initialize_test_only(id: &mut UID) {
+        initialize(id);
+    }
+
+    #[test_only]
+    public fun update_test_only<Old: store + drop, New: store + drop>(
+        id: &mut UID,
+        new_version: New
+    ) {
+        package_utils::update_version_type<Old, New>(id, new_version);
+    }
+
+    #[test_only]
+    public fun dummy(): V__DUMMY {
+        V__DUMMY {}
+    }
+
+    #[test_only]
+    public fun first(): V__0_1_0 {
+        V__0_1_0 {}
+    }
+
+    #[test_only]
+    struct V__MIGRATED has store, drop, copy {}
+
+    #[test_only]
+    public fun next_version(): V__MIGRATED {
+        V__MIGRATED {}
+    }
+
+    #[test_only]
+    public fun assert_current_test_only(id: &UID) {
+        assert_current(id);
+    }
+}
+
+#[test_only]
+module token_bridge::version_control_tests {
+    use sui::object::{Self, UID};
+    use sui::tx_context::{Self};
+    use token_bridge::version_control::{Self, V__0_1_0, V__MIGRATED};
+
+    struct State has key {
+        id: UID
+    }
+
+    struct V_DUMMY has store, drop, copy {}
+
+    #[test]
+    fun test_assert_current() {
+        // Create dummy state.
+        let state = State { id: object::new(&mut tx_context::dummy()) };
+        version_control::initialize_test_only(&mut state.id);
+
+        version_control::assert_current_test_only(&state.id);
+
+        // Clean up.
+        let State { id } = state;
+        object::delete(id);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = wormhole::package_utils::E_INCORRECT_OLD_VERSION)]
+    fun test_cannot_update_incorrect_old_version() {
+        // Create dummy state.
+        let state = State { id: object::new(&mut tx_context::dummy()) };
+        version_control::initialize_test_only(&mut state.id);
+
+        version_control::assert_current_test_only(&state.id);
+
+        // You shall not pass!
+        version_control::update_test_only<V__MIGRATED, V__MIGRATED>(
+            &mut state.id,
+            version_control::next_version()
+        );
+
+        // Clean up.
+        let State { id } = state;
+        object::delete(id);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = wormhole::package_utils::E_SAME_VERSION)]
+    fun test_cannot_update_same_version() {
+        // Create dummy state.
+        let state = State { id: object::new(&mut tx_context::dummy()) };
+        version_control::initialize_test_only(&mut state.id);
+
+        version_control::assert_current_test_only(&state.id);
+
+        // You shall not pass!
+        version_control::update_test_only<V__0_1_0, V__0_1_0>(
+            &mut state.id,
+            version_control::first()
+        );
+
+        // Clean up.
+        let State { id } = state;
+        object::delete(id);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = wormhole::package_utils::E_OUTDATED_VERSION)]
+    fun test_cannot_assert_current_outdated_version() {
+        // Create dummy state.
+        let state = State { id: object::new(&mut tx_context::dummy()) };
+        version_control::initialize_test_only(&mut state.id);
+
+        version_control::assert_current_test_only(&state.id);
+
+        // Valid update.
+        version_control::update_test_only<V__0_1_0, V__MIGRATED>(
+            &mut state.id,
+            version_control::next_version()
+        );
+
+        // You shall not pass!
+        version_control::assert_current_test_only(&state.id);
+
+        // Clean up.
+        let State { id } = state;
+        object::delete(id);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = wormhole::package_utils::E_TYPE_NOT_ALLOWED)]
+    fun test_cannot_update_type_not_allowed() {
+        // Create dummy state.
+        let state = State { id: object::new(&mut tx_context::dummy()) };
+        version_control::initialize_test_only(&mut state.id);
+
+        version_control::assert_current_test_only(&state.id);
+
+        // You shall not pass!
+        version_control::update_test_only<V__0_1_0, V_DUMMY>(
+            &mut state.id,
+            V_DUMMY {}
+        );
+
+        // Clean up.
+        let State { id } = state;
+        object::delete(id);
     }
 }

--- a/sui/wormhole/Makefile
+++ b/sui/wormhole/Makefile
@@ -1,5 +1,7 @@
 -include ../../Makefile.help
 
+VERSION = $(shell grep -Po "version = \"\K[^\"]*" Move.toml | sed "s/\./_/g")
+
 .PHONY: clean
 clean:
 	rm -rf build
@@ -12,4 +14,5 @@ check:
 .PHONY: test
 ## Run tests
 test: check
+	grep "public(friend) fun current_version(): V__${VERSION} {" sources/version_control.move
 	sui move test -d -t 1

--- a/sui/wormhole/Move.devnet.toml
+++ b/sui/wormhole/Move.devnet.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Wormhole"
-version = "0.0.1"
+version = "0.1.0"
 
 [dependencies.Sui]
 git = "https://github.com/MystenLabs/sui.git"

--- a/sui/wormhole/Move.toml
+++ b/sui/wormhole/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Wormhole"
-version = "0.0.1"
+version = "0.1.0"
 
 [dependencies.Sui]
 git = "https://github.com/MystenLabs/sui.git"

--- a/sui/wormhole/sources/emitter.move
+++ b/sui/wormhole/sources/emitter.move
@@ -163,6 +163,7 @@ module wormhole::emitter_tests {
         // this build.
         state::migrate_version_test_only<V__0_1_0, V__MIGRATED>(
             &mut worm_state,
+            version_control::first(),
             version_control::next_version()
         );
 

--- a/sui/wormhole/sources/emitter.move
+++ b/sui/wormhole/sources/emitter.move
@@ -97,7 +97,7 @@ module wormhole::emitter_tests {
 
     use wormhole::emitter::{Self};
     use wormhole::state::{Self};
-    use wormhole::version_control::{Self, V__0_1_0, V__MIGRATED};
+    use wormhole::version_control::{Self};
     use wormhole::wormhole_scenario::{
         person,
         return_state,
@@ -161,7 +161,7 @@ module wormhole::emitter_tests {
         // Simulate executing with an outdated build by upticking the minimum
         // required version for `publish_message` to something greater than
         // this build.
-        state::migrate_version_test_only<V__0_1_0, V__MIGRATED>(
+        state::migrate_version_test_only(
             &mut worm_state,
             version_control::first(),
             version_control::next_version()

--- a/sui/wormhole/sources/governance/set_fee.move
+++ b/sui/wormhole/sources/governance/set_fee.move
@@ -4,16 +4,26 @@
 /// Wormhole message fee to another amount.
 module wormhole::set_fee {
     use wormhole::bytes32::{Self};
-    use wormhole::consumed_vaas::{Self};
     use wormhole::cursor::{Self};
-    use wormhole::governance_message::{Self, GovernanceMessage};
-    use wormhole::state::{Self, State, StateCap};
+    use wormhole::governance_message::{Self, DecreeTicket, DecreeReceipt};
+    use wormhole::state::{Self, State};
 
     /// Specific governance payload ID (action) for setting Wormhole fee.
     const ACTION_SET_FEE: u8 = 3;
 
     struct SetFee {
         amount: u64
+    }
+
+    public fun authorize_governance(
+        wormhole_state: &State
+    ): DecreeTicket {
+        governance_message::authorize_verify_local(
+            state::governance_chain(wormhole_state),
+            state::governance_contract(wormhole_state),
+            state::governance_module(),
+            ACTION_SET_FEE
+        )
     }
 
     /// Redeem governance VAA to configure Wormhole message fee amount in SUI
@@ -25,38 +35,21 @@ module wormhole::set_fee {
     /// method could break backward compatibility on an upgrade.
     public fun set_fee(
         wormhole_state: &mut State,
-        msg: GovernanceMessage
+        receipt: DecreeReceipt
     ): u64 {
         // This state capability ensures that the current build version is used.
         let cap = state::new_cap(wormhole_state);
 
-        // Do not allow this VAA to be replayed.
-        consumed_vaas::consume(
-            state::borrow_mut_consumed_vaas(&cap, wormhole_state),
-            governance_message::vaa_hash(&msg)
-        );
-
-        // Proceed with setting the new message fee.
-        handle_set_fee(&cap, wormhole_state, msg)
-    }
-
-    fun handle_set_fee(
-        cap: &StateCap,
-        wormhole_state: &mut State,
-        msg: GovernanceMessage
-    ): u64 {
-        // Verify that this governance message is to update the Wormhole fee.
-        let governance_payload =
-            governance_message::take_local_action(
-                msg,
-                state::governance_module(),
-                ACTION_SET_FEE
+        let payload =
+            governance_message::take_payload(
+                state::borrow_mut_consumed_vaas(&cap, wormhole_state),
+                receipt
             );
 
         // Deserialize the payload as amount to change the Wormhole fee.
-        let SetFee { amount } = deserialize(governance_payload);
+        let SetFee { amount } = deserialize(payload);
 
-        state::set_message_fee(cap, wormhole_state, amount);
+        state::set_message_fee(&cap, wormhole_state, amount);
 
         amount
     }
@@ -89,7 +82,7 @@ module wormhole::set_fee_tests {
     use wormhole::set_fee::{Self};
     use wormhole::state::{Self};
     use wormhole::vaa::{Self};
-    use wormhole::version_control::{Self, V__0_1_0, V__MIGRATED};
+    use wormhole::version_control::{Self};
     use wormhole::wormhole_scenario::{
         person,
         return_clock,
@@ -104,10 +97,6 @@ module wormhole::set_fee_tests {
         x"01000000000100181aa27fd44f3060fad0ae72895d42f97c45f7a5d34aa294102911370695e91e17ae82caa59f779edde2356d95cd46c2c381cdeba7a8165901a562374f212d750000bc614e000000000001000000000000000000000000000000000000000000000000000000000000000400000000000000010100000000000000000000000000000000000000000000000000000000436f7265030015000000000000000000000000000000000000000000000000000000000000015e";
     const VAA_SET_FEE_MAX: vector<u8> =
         x"01000000000100b0697fd31572e11b2256cf46d5934f38fbb90e6265e999bee50950846bf9f94d5b86f247cce20e3cc158163be7b5ae21ebaaf67e20d597229ca04d505fd4bc1c0000bc614e000000000001000000000000000000000000000000000000000000000000000000000000000400000000000000010100000000000000000000000000000000000000000000000000000000436f7265030015000000000000000000000000000000000000000000000000ffffffffffffffff";
-    const VAA_BOGUS_TARGET_CHAIN: vector<u8> =
-        x"010000000001000d34e2f56f1558252796b631f12b4f85b991d3ef52de57df6d45c8ad998c58202655d5cab2d6613688c0fcd7ae1504fc474eb96ec0591598339c133cbf8b68240000bc614e000000000001000000000000000000000000000000000000000000000000000000000000000400000000000000010100000000000000000000000000000000000000000000000000000000436f7265030002000000000000000000000000000000000000000000000000000000000000015e";
-    const VAA_BOGUS_ACTION: vector<u8> =
-        x"01000000000100bd79122fe306c2edd56ac5938acabfdadaae7906dfbfc140bd2f76f3996b20210fcda38caee5901d19d7f8b70169a46cf605f3f234d387c72a03accaf96f01ef0100bc614e000000000001000000000000000000000000000000000000000000000000000000000000000400000000000000010100000000000000000000000000000000000000000000000000000000436f7265010015000000000000000000000000000000000000000000000000000000000000015e";
     const VAA_SET_FEE_OVERFLOW: vector<u8> =
         x"01000000000100950a509a797c9b40a678a5d6297f5b74e1ce1794b3c012dad5774c395e65e8b0773cf160113f571f1452ee98d10aa61273b6bc8aefa74a3c8f7e2c9c89fb25fa0000bc614e000000000001000000000000000000000000000000000000000000000000000000000000000400000000000000010100000000000000000000000000000000000000000000000000000000436f72650300150000000000000000000000000000000000000000000000010000000000000000";
 
@@ -133,10 +122,12 @@ module wormhole::set_fee_tests {
         // Double-check current fee (from setup).
         assert!(state::message_fee(&worm_state) == wormhole_fee, 0);
 
-        let parsed =
+        let verified_vaa =
             vaa::parse_and_verify(&worm_state, VAA_SET_FEE_1, &the_clock);
-        let msg = governance_message::verify_vaa(&worm_state, parsed);
-        let fee_amount = set_fee(&mut worm_state, msg);
+        let ticket = set_fee::authorize_governance(&worm_state);
+        let receipt =
+            governance_message::verify_vaa(&worm_state, verified_vaa, ticket);
+        let fee_amount = set_fee(&mut worm_state, receipt);
         assert!(wormhole_fee != fee_amount, 0);
 
         // Confirm the fee changed.
@@ -151,10 +142,12 @@ module wormhole::set_fee_tests {
         // Finally set the fee again to max u64 (this will effectively pause
         // Wormhole message publishing until the fee gets adjusted back to a
         // reasonable level again).
-        let parsed =
+        let verified_vaa =
             vaa::parse_and_verify(&worm_state, VAA_SET_FEE_MAX, &the_clock);
-        let msg = governance_message::verify_vaa(&worm_state, parsed);
-        let fee_amount = set_fee(&mut worm_state, msg);
+        let ticket = set_fee::authorize_governance(&worm_state);
+        let receipt =
+            governance_message::verify_vaa(&worm_state, verified_vaa, ticket);
+        let fee_amount = set_fee(&mut worm_state, receipt);
 
         // Confirm.
         assert!(state::message_fee(&worm_state) == fee_amount, 0);
@@ -192,10 +185,12 @@ module wormhole::set_fee_tests {
         // Double-check current fee (from setup).
         assert!(state::message_fee(&worm_state) == wormhole_fee, 0);
 
-        let parsed =
+        let verified_vaa =
             vaa::parse_and_verify(&worm_state, VAA_SET_FEE_1, &the_clock);
-        let msg = governance_message::verify_vaa(&worm_state, parsed);
-        let fee_amount = set_fee(&mut worm_state, msg);
+        let ticket = set_fee::authorize_governance(&worm_state);
+        let receipt =
+            governance_message::verify_vaa(&worm_state, verified_vaa, ticket);
+        let fee_amount = set_fee(&mut worm_state, receipt);
 
         // Confirm the fee changed.
         assert!(state::message_fee(&worm_state) == fee_amount, 0);
@@ -229,105 +224,21 @@ module wormhole::set_fee_tests {
         let the_clock = take_clock(scenario);
 
         // Set once.
-        let parsed =
+        let verified_vaa =
             vaa::parse_and_verify(&worm_state, VAA_SET_FEE_1, &the_clock);
-        let msg = governance_message::verify_vaa(&worm_state, parsed);
-        set_fee(&mut worm_state, msg);
+        let ticket = set_fee::authorize_governance(&worm_state);
+        let receipt =
+            governance_message::verify_vaa(&worm_state, verified_vaa, ticket);
+        set_fee(&mut worm_state, receipt);
 
-        let parsed =
+        let verified_vaa =
             vaa::parse_and_verify(&worm_state, VAA_SET_FEE_1, &the_clock);
-        let msg = governance_message::verify_vaa(&worm_state, parsed);
+        let ticket = set_fee::authorize_governance(&worm_state);
+        let receipt =
+            governance_message::verify_vaa(&worm_state, verified_vaa, ticket);
 
         // You shall not pass!
-        set_fee(&mut worm_state, msg);
-
-        // Clean up.
-        return_state(worm_state);
-        return_clock(the_clock);
-
-        // Done.
-        test_scenario::end(my_scenario);
-    }
-
-    #[test]
-    #[expected_failure(
-        abort_code = governance_message::E_GOVERNANCE_TARGET_CHAIN_NOT_SUI
-    )]
-    fun test_cannot_set_fee_invalid_target_chain() {
-        // Testing this method.
-        use wormhole::set_fee::{set_fee};
-
-        // Set up.
-        let caller = person();
-        let my_scenario = test_scenario::begin(caller);
-        let scenario = &mut my_scenario;
-
-        let wormhole_fee = 420;
-        set_up_wormhole(scenario, wormhole_fee);
-
-        // Prepare test to execute `set_fee`.
-        test_scenario::next_tx(scenario, caller);
-
-        let worm_state = take_state(scenario);
-        let the_clock = take_clock(scenario);
-
-        // Setting a new fee only applies to this chain since the denomination
-        // is SUI.
-        let parsed =
-            vaa::parse_and_verify(
-                &worm_state,
-                VAA_BOGUS_TARGET_CHAIN,
-                &the_clock
-            );
-        let msg = governance_message::verify_vaa(&worm_state, parsed);
-        assert!(!governance_message::is_local_action(&msg), 0);
-
-        // You shall not pass!
-        set_fee(&mut worm_state, msg);
-
-        // Clean up.
-        return_state(worm_state);
-        return_clock(the_clock);
-
-        // Done.
-        test_scenario::end(my_scenario);
-    }
-
-    #[test]
-    #[expected_failure(
-        abort_code = governance_message::E_INVALID_GOVERNANCE_ACTION
-    )]
-    fun test_cannot_set_fee_invalid_action() {
-        // Testing this method.
-        use wormhole::set_fee::{set_fee};
-
-        // Set up.
-        let caller = person();
-        let my_scenario = test_scenario::begin(caller);
-        let scenario = &mut my_scenario;
-
-        let wormhole_fee = 420;
-        set_up_wormhole(scenario, wormhole_fee);
-
-        // Prepare test to execute `set_fee`.
-        test_scenario::next_tx(scenario, caller);
-
-        let worm_state = take_state(scenario);
-        let the_clock = take_clock(scenario);
-
-        // Setting a new fee only applies to this chain since the denomination
-        // is SUI.
-        let parsed =
-            vaa::parse_and_verify(
-                &worm_state,
-                VAA_BOGUS_ACTION,
-                &the_clock
-            );
-        let msg = governance_message::verify_vaa(&worm_state, parsed);
-        assert!(governance_message::action(&msg) != set_fee::action(), 0);
-
-        // You shall not pass!
-        set_fee(&mut worm_state, msg);
+        set_fee(&mut worm_state, receipt);
 
         // Clean up.
         return_state(worm_state);
@@ -358,14 +269,14 @@ module wormhole::set_fee_tests {
         let the_clock = take_clock(scenario);
 
         // Show that the encoded fee is greater than u64 max.
-        let parsed =
+        let verified_vaa =
             vaa::parse_and_verify(
                 &worm_state,
                 VAA_SET_FEE_OVERFLOW,
                 &the_clock
             );
-        let msg = governance_message::verify_vaa(&worm_state, parsed);
-        let payload = governance_message::payload(&msg);
+        let payload =
+            governance_message::take_decree(vaa::payload(&verified_vaa));
         let cur = cursor::new(payload);
 
         let fee_amount = bytes::take_u256_be(&mut cur);
@@ -373,8 +284,12 @@ module wormhole::set_fee_tests {
 
         cursor::destroy_empty(cur);
 
+        let ticket = set_fee::authorize_governance(&worm_state);
+        let receipt =
+            governance_message::verify_vaa(&worm_state, verified_vaa, ticket);
+
         // You shall not pass!
-        set_fee(&mut worm_state, msg);
+        set_fee(&mut worm_state, receipt);
 
         // Clean up.
         return_state(worm_state);
@@ -407,21 +322,25 @@ module wormhole::set_fee_tests {
         // Simulate executing with an outdated build by upticking the minimum
         // required version for `publish_message` to something greater than
         // this build.
-        state::migrate_version_test_only<V__0_1_0, V__MIGRATED>(
+        state::migrate_version_test_only(
             &mut worm_state,
             version_control::first(),
             version_control::next_version()
         );
 
-        let parsed =
+        let verified_vaa =
             vaa::parse_and_verify(
                 &worm_state,
                 VAA_SET_FEE_1,
                 &the_clock
             );
-        let msg = governance_message::verify_vaa(&worm_state, parsed);
+
+        let ticket = set_fee::authorize_governance(&worm_state);
+        let receipt =
+            governance_message::verify_vaa(&worm_state, verified_vaa, ticket);
+
         // You shall not pass!
-        set_fee(&mut worm_state, msg);
+        set_fee(&mut worm_state, receipt);
 
         // Clean up.
         return_state(worm_state);

--- a/sui/wormhole/sources/governance/set_fee.move
+++ b/sui/wormhole/sources/governance/set_fee.move
@@ -11,14 +11,17 @@ module wormhole::set_fee {
     /// Specific governance payload ID (action) for setting Wormhole fee.
     const ACTION_SET_FEE: u8 = 3;
 
+    struct GovernanceWitness has drop {}
+
     struct SetFee {
         amount: u64
     }
 
     public fun authorize_governance(
         wormhole_state: &State
-    ): DecreeTicket {
+    ): DecreeTicket<GovernanceWitness> {
         governance_message::authorize_verify_local(
+            GovernanceWitness {},
             state::governance_chain(wormhole_state),
             state::governance_contract(wormhole_state),
             state::governance_module(),
@@ -35,7 +38,7 @@ module wormhole::set_fee {
     /// method could break backward compatibility on an upgrade.
     public fun set_fee(
         wormhole_state: &mut State,
-        receipt: DecreeReceipt
+        receipt: DecreeReceipt<GovernanceWitness>
     ): u64 {
         // This capability ensures that the current build version is used.
         let latest_only = state::cache_latest_only(wormhole_state);

--- a/sui/wormhole/sources/governance/set_fee.move
+++ b/sui/wormhole/sources/governance/set_fee.move
@@ -409,6 +409,7 @@ module wormhole::set_fee_tests {
         // this build.
         state::migrate_version_test_only<V__0_1_0, V__MIGRATED>(
             &mut worm_state,
+            version_control::first(),
             version_control::next_version()
         );
 

--- a/sui/wormhole/sources/governance/set_fee.move
+++ b/sui/wormhole/sources/governance/set_fee.move
@@ -41,7 +41,7 @@ module wormhole::set_fee {
         receipt: DecreeReceipt<GovernanceWitness>
     ): u64 {
         // This capability ensures that the current build version is used.
-        let latest_only = state::cache_latest_only(wormhole_state);
+        let latest_only = state::assert_latest_only(wormhole_state);
 
         let payload =
             governance_message::take_payload(

--- a/sui/wormhole/sources/governance/transfer_fee.move
+++ b/sui/wormhole/sources/governance/transfer_fee.move
@@ -584,6 +584,7 @@ module wormhole::transfer_fee_tests {
         // this build.
         state::migrate_version_test_only<V__0_1_0, V__MIGRATED>(
             &mut worm_state,
+            version_control::first(),
             version_control::next_version()
         );
 

--- a/sui/wormhole/sources/governance/transfer_fee.move
+++ b/sui/wormhole/sources/governance/transfer_fee.move
@@ -16,6 +16,8 @@ module wormhole::transfer_fee {
     /// Specific governance payload ID (action) for setting Wormhole fee.
     const ACTION_TRANSFER_FEE: u8 = 4;
 
+    struct GovernanceWitness has drop {}
+
     struct TransferFee {
         amount: u64,
         recipient: address
@@ -23,8 +25,9 @@ module wormhole::transfer_fee {
 
     public fun authorize_governance(
         wormhole_state: &State
-    ): DecreeTicket {
+    ): DecreeTicket<GovernanceWitness> {
         governance_message::authorize_verify_local(
+            GovernanceWitness {},
             state::governance_chain(wormhole_state),
             state::governance_contract(wormhole_state),
             state::governance_module(),
@@ -41,7 +44,7 @@ module wormhole::transfer_fee {
     /// method could break backward compatibility on an upgrade.
     public fun transfer_fee(
         wormhole_state: &mut State,
-        receipt: DecreeReceipt,
+        receipt: DecreeReceipt<GovernanceWitness>,
         ctx: &mut TxContext
     ): u64 {
         // This capability ensures that the current build version is used.

--- a/sui/wormhole/sources/governance/transfer_fee.move
+++ b/sui/wormhole/sources/governance/transfer_fee.move
@@ -48,7 +48,7 @@ module wormhole::transfer_fee {
         ctx: &mut TxContext
     ): u64 {
         // This capability ensures that the current build version is used.
-        let latest_only = state::cache_latest_only(wormhole_state);
+        let latest_only = state::assert_latest_only(wormhole_state);
 
         let payload =
             governance_message::take_payload(

--- a/sui/wormhole/sources/governance/update_guardian_set.move
+++ b/sui/wormhole/sources/governance/update_guardian_set.move
@@ -24,6 +24,8 @@ module wormhole::update_guardian_set {
     /// Specific governance payload ID (action) for updating the guardian set.
     const ACTION_UPDATE_GUARDIAN_SET: u8 = 2;
 
+    struct GovernanceWitness has drop {}
+
     /// Event reflecting a Guardian Set update.
     struct GuardianSetAdded has drop, copy {
         new_index: u32
@@ -36,8 +38,9 @@ module wormhole::update_guardian_set {
 
     public fun authorize_governance(
         wormhole_state: &State
-    ): DecreeTicket {
+    ): DecreeTicket<GovernanceWitness> {
         governance_message::authorize_verify_global(
+            GovernanceWitness {},
             state::governance_chain(wormhole_state),
             state::governance_contract(wormhole_state),
             state::governance_module(),
@@ -53,7 +56,7 @@ module wormhole::update_guardian_set {
     /// method could break backward compatibility on an upgrade.
     public fun update_guardian_set(
         wormhole_state: &mut State,
-        receipt: DecreeReceipt,
+        receipt: DecreeReceipt<GovernanceWitness>,
         the_clock: &Clock
     ): u32 {
         // This capability ensures that the current build version is used.

--- a/sui/wormhole/sources/governance/update_guardian_set.move
+++ b/sui/wormhole/sources/governance/update_guardian_set.move
@@ -532,6 +532,7 @@ module wormhole::update_guardian_set_tests {
         // this build.
         state::migrate_version_test_only<V__0_1_0, V__MIGRATED>(
             &mut worm_state,
+            version_control::first(),
             version_control::next_version()
         );
 

--- a/sui/wormhole/sources/governance/update_guardian_set.move
+++ b/sui/wormhole/sources/governance/update_guardian_set.move
@@ -60,7 +60,7 @@ module wormhole::update_guardian_set {
         the_clock: &Clock
     ): u32 {
         // This capability ensures that the current build version is used.
-        let latest_only = state::cache_latest_only(wormhole_state);
+        let latest_only = state::assert_latest_only(wormhole_state);
 
         // Even though this disallows the VAA to be replayed, it may be
         // impossible to redeem the same VAA again because `governance_message`

--- a/sui/wormhole/sources/governance/upgrade_contract.move
+++ b/sui/wormhole/sources/governance/upgrade_contract.move
@@ -25,6 +25,8 @@ module wormhole::upgrade_contract {
     /// contract.
     const ACTION_UPGRADE_CONTRACT: u8 = 1;
 
+    struct GovernanceWitness has drop {}
+
     // Event reflecting package upgrade.
     struct ContractUpgraded has drop, copy {
         old_contract: ID,
@@ -37,8 +39,9 @@ module wormhole::upgrade_contract {
 
     public fun authorize_governance(
         wormhole_state: &State
-    ): DecreeTicket {
+    ): DecreeTicket<GovernanceWitness> {
         governance_message::authorize_verify_local(
+            GovernanceWitness {},
             state::governance_chain(wormhole_state),
             state::governance_contract(wormhole_state),
             state::governance_module(),
@@ -52,7 +55,7 @@ module wormhole::upgrade_contract {
     /// (in this case Sui), whose build digest is encoded in this message.
     public fun authorize_upgrade(
         wormhole_state: &mut State,
-        receipt: DecreeReceipt
+        receipt: DecreeReceipt<GovernanceWitness>
     ): UpgradeTicket {
         // NOTE: This is the only governance method that does not enforce
         // current package checking when consuming VAA hashes. This is because

--- a/sui/wormhole/sources/governance_message.move
+++ b/sui/wormhole/sources/governance_message.move
@@ -563,6 +563,7 @@ module wormhole::governance_message_tests {
 
         state::migrate_version_test_only<V__0_1_0, V__MIGRATED>(
             &mut worm_state,
+            version_control::first(),
             version_control::next_version()
         );
 

--- a/sui/wormhole/sources/governance_message.move
+++ b/sui/wormhole/sources/governance_message.move
@@ -97,7 +97,7 @@ module wormhole::governance_message {
         verified_vaa: VAA,
         ticket: DecreeTicket
     ): DecreeReceipt {
-        state::assert_current(wormhole_state);
+        state::assert_latest_only(wormhole_state);
 
         let DecreeTicket {
             governance_chain,
@@ -654,12 +654,15 @@ module wormhole::governance_message_tests {
                 3 // set fee
             );
 
+        // Conveniently roll version back.
+        state::reverse_migrate_version(&mut worm_state);
+
         // Simulate executing with an outdated build by upticking the minimum
         // required version for `publish_message` to something greater than
         // this build.
         state::migrate_version_test_only(
             &mut worm_state,
-            version_control::first(),
+            version_control::dummy(),
             version_control::next_version()
         );
 

--- a/sui/wormhole/sources/governance_message.move
+++ b/sui/wormhole/sources/governance_message.move
@@ -32,7 +32,8 @@ module wormhole::governance_message {
 
     /// The public constructors for `DecreeTicket` (`authorize_verify_global`
     /// and `authorize_verify_local`) require a witness of type `T`. This is to
-    /// ensure that `DecreeTicket`s cannot be mixed up between modules maliciously.
+    /// ensure that `DecreeTicket`s cannot be mixed up between modules
+    /// maliciously.
     struct DecreeTicket<phantom T> {
         governance_chain: u16,
         governance_contract: ExternalAddress,
@@ -46,6 +47,8 @@ module wormhole::governance_message {
         digest: Bytes32
     }
 
+    /// This method prepares `DecreeTicket` for global governance action. This
+    /// means the VAA encodes target chain ID == 0.
     public fun authorize_verify_global<T: drop>(
         _witness: T,
         governance_chain: u16,
@@ -62,6 +65,8 @@ module wormhole::governance_message {
         }
     }
 
+    /// This method prepares `DecreeTicket` for local governance action. This
+    /// means the VAA encodes target chain ID == 21 (Sui's).
     public fun authorize_verify_local<T: drop>(
         _witness: T,
         governance_chain: u16,
@@ -78,6 +83,8 @@ module wormhole::governance_message {
         }
     }
 
+    /// This method unpacks `DecreeReceipt` and puts the VAA digest into a
+    /// `ConsumedVAAs` container. Then it returns the governance payload.
     public fun take_payload<T>(
         consumed: &mut ConsumedVAAs,
         receipt: DecreeReceipt<T>
@@ -89,14 +96,18 @@ module wormhole::governance_message {
         payload
     }
 
+    /// Method to peek into the payload in `DecreeReceipt`.
     public fun payload<T>(receipt: &DecreeReceipt<T>): vector<u8> {
         receipt.payload
     }
 
+    /// Destroy the receipt.
     public fun destroy<T>(receipt: DecreeReceipt<T>) {
         let DecreeReceipt { payload: _, digest: _ } = receipt;
     }
 
+    /// This method unpacks a `DecreeTicket` to validate its members to make
+    /// sure that the parameters match what was encoded in the VAA.
     public fun verify_vaa<T>(
         wormhole_state: &State,
         verified_vaa: VAA,

--- a/sui/wormhole/sources/migrate.move
+++ b/sui/wormhole/sources/migrate.move
@@ -110,6 +110,7 @@ module wormhole::migrate_tests {
         // existing build version.
         state::migrate_version_test_only<V__0_1_0, V__DUMMY>(
             &mut worm_state,
+            version_control::first(),
             version_control::dummy()
         );
 
@@ -155,6 +156,7 @@ module wormhole::migrate_tests {
         // existing build version.
         state::migrate_version_test_only<V__0_1_0, V__DUMMY>(
             &mut worm_state,
+            version_control::first(),
             version_control::dummy()
         );
 

--- a/sui/wormhole/sources/migrate.move
+++ b/sui/wormhole/sources/migrate.move
@@ -8,35 +8,39 @@
 /// any of Wormhole's methods by enforcing the current build version as their
 /// required minimum version.
 module wormhole::migrate {
+    use sui::clock::{Clock};
+    use wormhole::governance_message::{Self};
     use wormhole::state::{Self, State};
-    use wormhole::version_control::{Migrate as MigrateControl};
-
-    // This import is only used when `state::require_current_version` is used.
-    //use wormhole::version_control::{Self as control};
+    use wormhole::upgrade_contract::{Self};
+    use wormhole::vaa::{Self};
 
     /// Execute migration logic. See `wormhole::migrate` description for more
     /// info.
-    public fun migrate(wormhole_state: &mut State) {
-        state::check_minimum_requirement<MigrateControl>(wormhole_state);
-
-        // Wormhole `State` destroys the `MigrateTicket` as the final step.
-        state::consume_migrate_ticket(wormhole_state);
-
-        ////////////////////////////////////////////////////////////////////////
+    public fun migrate(
+        wormhole_state: &mut State,
+        upgrade_vaa_buf: vector<u8>,
+        the_clock: &Clock
+    ) {
+        // Update the version first.
         //
-        // If there are any methods that require the current build, we need to
-        // explicity require them here.
-        //
-        // Calls to `require_current_version` are commented out for convenience.
-        //
-        ////////////////////////////////////////////////////////////////////////
+        // See `version_control` module for hard-coded configuration.
+        state::migrate_version(wormhole_state);
 
-        // state::require_current_version<control::NewEmitter>(wormhole_state);
-        // state::require_current_version<control::ParseAndVerify>(wormhole_state);
-        // state::require_current_version<control::PublishMessage>(wormhole_state);
-        // state::require_current_version<control::SetFee>(wormhole_state);
-        // state::require_current_version<control::TransferFee>(wormhole_state);
-        // state::require_current_version<control::UpdateGuardianSet>(wormhole_state);
+        // This VAA needs to have been used for upgrading this package.
+        //
+        // NOTE: All of the following methods have protections to make sure that
+        // the current build is used. Given that we officially migrated the
+        // version as the first call of `migrate`, these should be successful.
+        let verified_vaa =
+            vaa::parse_and_verify(wormhole_state, upgrade_vaa_buf, the_clock);
+        let msg = governance_message::verify_vaa(wormhole_state, verified_vaa);
+        let digest = upgrade_contract::take_digest(msg);
+
+        // This state capability ensures that the current build version is used.
+        let cap = state::new_cap(wormhole_state);
+
+        // Check if build digest is the current one.
+        state::assert_current_digest(&cap, wormhole_state, digest);
 
         ////////////////////////////////////////////////////////////////////////
         //
@@ -55,9 +59,118 @@ module wormhole::migrate {
         ////////////////////////////////////////////////////////////////////////
 
 
+        ////////////////////////////////////////////////////////////////////////
+    }
+}
 
-        ////////////////////////////////////////////////////////////////////////
+#[test_only]
+module wormhole::migrate_tests {
+    use sui::test_scenario::{Self};
+
+    use wormhole::state::{Self};
+    use wormhole::version_control::{Self, V__DUMMY, V__0_1_0};
+    use wormhole::wormhole_scenario::{
+        person,
+        return_clock,
+        return_state,
+        set_up_wormhole,
+        take_clock,
+        take_state,
+        upgrade_wormhole
+    };
+
+    const UPGRADE_VAA: vector<u8> =
+        x"01000000000100db695668c0c91f4df6e4106dcb912d9062898fd976d631ff1c1b4109ccd203b43cd2419c7d9a191f8d42a780419e63307aacc93080d8629c6c03061c52becf1d0100bc614e000000000001000000000000000000000000000000000000000000000000000000000000000400000000000000010100000000000000000000000000000000000000000000000000000000436f726501001500000000000000000000000000000000000000000000006e6577206275696c64";
+
+    #[test]
+    fun test_migrate() {
+        use wormhole::migrate::{migrate};
+
+        let user = person();
+        let my_scenario = test_scenario::begin(user);
+        let scenario = &mut my_scenario;
+
+        // Initialize Wormhole.
+        let wormhole_message_fee = 350;
+        set_up_wormhole(scenario, wormhole_message_fee);
+
+        // Next transaction should be conducted as an ordinary user.
+        test_scenario::next_tx(scenario, user);
+
+        // Upgrade (digest is just b"new build") for testing purposes.
+        upgrade_wormhole(scenario);
+
+        // Ignore effects.
+        test_scenario::next_tx(scenario, user);
+
+        let worm_state = take_state(scenario);
+        let the_clock = take_clock(scenario);
+
+        // First migrate to V_DUMMY to simulate migrating from this to the
+        // existing build version.
+        state::migrate_version_test_only<V__0_1_0, V__DUMMY>(
+            &mut worm_state,
+            version_control::dummy()
+        );
+
+        // Simulate executing with an outdated build by upticking the minimum
+        // required version for `publish_message` to something greater than
+        // this build.
+        migrate(&mut worm_state, UPGRADE_VAA, &the_clock);
+
+        // Clean up.
+        return_state(worm_state);
+        return_clock(the_clock);
+
         // Done.
-        ////////////////////////////////////////////////////////////////////////
+        test_scenario::end(my_scenario);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = wormhole::package_utils::E_INCORRECT_OLD_VERSION)]
+    fun test_cannot_migrate_again() {
+        use wormhole::migrate::{migrate};
+
+        let user = person();
+        let my_scenario = test_scenario::begin(user);
+        let scenario = &mut my_scenario;
+
+        // Initialize Wormhole.
+        let wormhole_message_fee = 350;
+        set_up_wormhole(scenario, wormhole_message_fee);
+
+        // Next transaction should be conducted as an ordinary user.
+        test_scenario::next_tx(scenario, user);
+
+        // Upgrade (digest is just b"new build") for testing purposes.
+        upgrade_wormhole(scenario);
+
+        // Ignore effects.
+        test_scenario::next_tx(scenario, user);
+
+        let worm_state = take_state(scenario);
+        let the_clock = take_clock(scenario);
+
+        // First migrate to V_DUMMY to simulate migrating from this to the
+        // existing build version.
+        state::migrate_version_test_only<V__0_1_0, V__DUMMY>(
+            &mut worm_state,
+            version_control::dummy()
+        );
+
+        // Simulate executing with an outdated build by upticking the minimum
+        // required version for `publish_message` to something greater than
+        // this build.
+        migrate(&mut worm_state, UPGRADE_VAA, &the_clock);
+
+        // You shall not pass!
+        migrate(&mut worm_state, UPGRADE_VAA, &the_clock);
+
+        // Clean up.
+        return_state(worm_state);
+        return_clock(the_clock);
+
+        // Done.
+        test_scenario::end(my_scenario);
     }
 }

--- a/sui/wormhole/sources/migrate.move
+++ b/sui/wormhole/sources/migrate.move
@@ -74,7 +74,7 @@ module wormhole::migrate {
             );
 
         // This capability ensures that the current build version is used.
-        let latest_only = state::cache_latest_only(wormhole_state);
+        let latest_only = state::assert_latest_only(wormhole_state);
 
         // Check if build digest is the current one.
         let digest =

--- a/sui/wormhole/sources/publish_message.move
+++ b/sui/wormhole/sources/publish_message.move
@@ -396,6 +396,7 @@ module wormhole::publish_message_tests {
         // this build.
         state::migrate_version_test_only<V__0_1_0, V__MIGRATED>(
             &mut worm_state,
+            version_control::first(),
             version_control::next_version()
         );
 

--- a/sui/wormhole/sources/publish_message.move
+++ b/sui/wormhole/sources/publish_message.move
@@ -170,7 +170,7 @@ module wormhole::publish_message_tests {
     use wormhole::emitter::{Self, EmitterCap};
     use wormhole::fee_collector::{Self};
     use wormhole::state::{Self};
-    use wormhole::version_control::{Self, V__0_1_0, V__MIGRATED};
+    use wormhole::version_control::{Self};
     use wormhole::wormhole_scenario::{
         person,
         return_clock,
@@ -394,7 +394,7 @@ module wormhole::publish_message_tests {
         // Simulate executing with an outdated build by upticking the minimum
         // required version for `publish_message` to something greater than
         // this build.
-        state::migrate_version_test_only<V__0_1_0, V__MIGRATED>(
+        state::migrate_version_test_only(
             &mut worm_state,
             version_control::first(),
             version_control::next_version()

--- a/sui/wormhole/sources/publish_message.move
+++ b/sui/wormhole/sources/publish_message.move
@@ -111,7 +111,7 @@ module wormhole::publish_message {
         the_clock: &Clock
     ): u64 {
         // This capability ensures that the current build version is used.
-        let latest_only = state::cache_latest_only(wormhole_state);
+        let latest_only = state::assert_latest_only(wormhole_state);
 
         // Deposit `message_fee`. This method interacts with the `FeeCollector`,
         // which will abort if `message_fee` does not equal the collector's

--- a/sui/wormhole/sources/resources/consumed_vaas.move
+++ b/sui/wormhole/sources/resources/consumed_vaas.move
@@ -20,4 +20,10 @@ module wormhole::consumed_vaas {
     public fun consume(self: &mut ConsumedVAAs, digest: Bytes32) {
         set::add(&mut self.hashes, digest);
     }
+
+    #[test_only]
+    public fun destroy(consumed: ConsumedVAAs) {
+        let ConsumedVAAs { hashes } = consumed;
+        set::destroy(hashes);
+    }
 }

--- a/sui/wormhole/sources/setup.move
+++ b/sui/wormhole/sources/setup.move
@@ -53,13 +53,10 @@ module wormhole::setup {
         message_fee: u64,
         ctx: &mut TxContext
     ) {
-        let version = wormhole::version_control::version();
-        assert!(version == 1, E_INVALID_BUILD_VERSION);
-
         wormhole::package_utils::assert_package_upgrade_cap<DeployerCap>(
             &upgrade_cap,
             package::compatible_policy(),
-            version
+            1
         );
 
         // Destroy deployer cap.
@@ -99,7 +96,7 @@ module wormhole::setup_tests {
     use wormhole::wormhole_scenario::{person};
 
     #[test]
-    public fun test_init() {
+    fun test_init() {
         let deployer = person();
         let my_scenario = test_scenario::begin(deployer);
         let scenario = &mut my_scenario;
@@ -129,7 +126,7 @@ module wormhole::setup_tests {
     }
 
     #[test]
-    public fun test_complete() {
+    fun test_complete() {
         let deployer = person();
         let my_scenario = test_scenario::begin(deployer);
         let scenario = &mut my_scenario;
@@ -215,7 +212,9 @@ module wormhole::setup_tests {
         );
 
         let guardians =
-            guardian_set::guardians(state::guardian_set_at(&worm_state, 0));
+            guardian_set::guardians(
+                state::guardian_set_at(&worm_state, 0)
+            );
         let num_guardians = vector::length(guardians);
         assert!(num_guardians == vector::length(&initial_guardians), 0);
 
@@ -256,7 +255,7 @@ module wormhole::setup_tests {
     #[expected_failure(
         abort_code = wormhole::package_utils::E_INVALID_UPGRADE_CAP
     )]
-    public fun test_cannot_complete_invalid_upgrade_cap() {
+    fun test_cannot_complete_invalid_upgrade_cap() {
         let deployer = person();
         let my_scenario = test_scenario::begin(deployer);
         let scenario = &mut my_scenario;

--- a/sui/wormhole/sources/state.move
+++ b/sui/wormhole/sources/state.move
@@ -125,7 +125,7 @@ module wormhole::state {
 
         // Store the initial guardian set.
         add_new_guardian_set(
-            &cache_latest_only(&state),
+            &assert_latest_only(&state),
             &mut state,
             guardian_set::new(guardian_set_index, initial_guardians)
         );
@@ -204,12 +204,12 @@ module wormhole::state {
 
     #[test_only]
     public fun cache_latest_only_test_only(self: &State): LatestOnly {
-        cache_latest_only(self)
+        assert_latest_only(self)
     }
 
     #[test_only]
     public fun deposit_fee_test_only(self: &mut State, fee: Balance<SUI>) {
-        deposit_fee(&cache_latest_only(self), self, fee)
+        deposit_fee(&assert_latest_only(self), self, fee)
     }
 
     #[test_only]
@@ -252,19 +252,13 @@ module wormhole::state {
     ///
     /// NOTE: This method allows caching the current version check so we avoid
     /// multiple checks to dynamic fields.
-    public(friend) fun cache_latest_only(self: &State): LatestOnly {
+    public(friend) fun assert_latest_only(self: &State): LatestOnly {
         package_utils::assert_version(
             &self.id,
             version_control::current_version()
         );
 
         LatestOnly {}
-    }
-
-    /// A more expressive method to enforce that the current build version is
-    /// used.
-    public(friend) fun assert_latest_only(self: &State) {
-        cache_latest_only(self);
     }
 
     /// Deposit fee when sending Wormhole message. This method does not

--- a/sui/wormhole/sources/state.move
+++ b/sui/wormhole/sources/state.move
@@ -229,10 +229,12 @@ module wormhole::state {
     #[test_only]
     public fun migrate_version_test_only<Old: store + drop, New: store + drop>(
         self: &mut State,
+        old_version: Old,
         new_version: New
     ) {
         wormhole::package_utils::update_version_type<Old, New>(
             &mut self.id,
+            old_version,
             new_version
         );
     }

--- a/sui/wormhole/sources/test/wormhole_scenario.move
+++ b/sui/wormhole/sources/test/wormhole_scenario.move
@@ -14,7 +14,7 @@ module wormhole::wormhole_scenario {
     use sui::test_scenario::{Self, Scenario};
 
     use wormhole::emitter::{EmitterCap};
-    use wormhole::governance_message::{Self, GovernanceMessage};
+    use wormhole::governance_message::{Self, DecreeTicket, DecreeReceipt};
     use wormhole::setup::{Self, DeployerCap};
     use wormhole::state::{Self, State};
     use wormhole::vaa::{Self, VAA};
@@ -178,29 +178,22 @@ module wormhole::wormhole_scenario {
         out
     }
 
-    public fun parse_and_verify_governance_vaa(
+    public fun verify_governance_vaa(
         scenario: &mut Scenario,
-        vaa_buf: vector<u8>
-    ): GovernanceMessage {
+        verified_vaa: VAA,
+        ticket: DecreeTicket
+    ): DecreeReceipt {
         test_scenario::next_tx(scenario, VAA_VERIFIER);
 
-        let the_clock = take_clock(scenario);
         let worm_state = take_state(scenario);
 
-        let verified_vaa =
-            vaa::parse_and_verify(
-                &worm_state,
-                vaa_buf,
-                &the_clock
-            );
-
-        let msg = governance_message::verify_vaa(&worm_state, verified_vaa);
+        let receipt =
+            governance_message::verify_vaa(&worm_state, verified_vaa, ticket);
 
         // Clean up.
         return_state(worm_state);
-        return_clock(the_clock);
 
-        msg
+        receipt
     }
 
     public fun new_emitter(

--- a/sui/wormhole/sources/test/wormhole_scenario.move
+++ b/sui/wormhole/sources/test/wormhole_scenario.move
@@ -18,7 +18,6 @@ module wormhole::wormhole_scenario {
     use wormhole::setup::{Self, DeployerCap};
     use wormhole::state::{Self, State};
     use wormhole::vaa::{Self, VAA};
-    use wormhole::version_control::{Self as control};
 
     const DEPLOYER: address = @0xDEADBEEF;
     const WALLET_1: address = @0xB0B1;
@@ -99,15 +98,11 @@ module wormhole::wormhole_scenario {
         // Clean up from activity prior.
         test_scenario::next_tx(scenario, person());
 
-        let worm_state = test_scenario::take_shared<State>(scenario);
+        let worm_state = take_state(scenario);
         state::test_upgrade(&mut worm_state);
-        assert!(
-            state::current_version(&worm_state) > control::version(),
-            0
-        );
 
         // Clean up.
-        test_scenario::return_shared(worm_state);
+        return_state(worm_state);
     }
 
     /// Address of wallet that published Wormhole contract.

--- a/sui/wormhole/sources/test/wormhole_scenario.move
+++ b/sui/wormhole/sources/test/wormhole_scenario.move
@@ -178,11 +178,11 @@ module wormhole::wormhole_scenario {
         out
     }
 
-    public fun verify_governance_vaa(
+    public fun verify_governance_vaa<T>(
         scenario: &mut Scenario,
         verified_vaa: VAA,
-        ticket: DecreeTicket
-    ): DecreeReceipt {
+        ticket: DecreeTicket<T>
+    ): DecreeReceipt<T> {
         test_scenario::next_tx(scenario, VAA_VERIFIER);
 
         let worm_state = take_state(scenario);

--- a/sui/wormhole/sources/utils/package_utils.move
+++ b/sui/wormhole/sources/utils/package_utils.move
@@ -3,11 +3,26 @@
 /// This module implements utilities that supplement those methods implemented
 /// in `sui::package`.
 module wormhole::package_utils {
-    use sui::object::{Self};
+    use std::type_name::{Self};
+    use sui::dynamic_field::{Self as field};
+    use sui::object::{Self, UID};
     use sui::package::{Self, UpgradeCap};
 
     /// `UpgradeCap` is not from the same package as `T`.
     const E_INVALID_UPGRADE_CAP: u64 = 0;
+    /// Build is not current.
+    const E_OUTDATED_VERSION: u64 = 1;
+    /// Old version to update from is wrong.
+    const E_INCORRECT_OLD_VERSION: u64 = 2;
+    /// Old and new are the same version.
+    const E_SAME_VERSION: u64 = 3;
+    /// Current version is misconfigured.
+    const E_INVALID_VERSION: u64 = 4;
+    /// Version types must come from this module.
+    const E_TYPE_NOT_ALLOWED: u64 = 5;
+
+    /// Key for version dynamic fields.
+    struct CurrentVersion has store, drop, copy {}
 
     /// Convenience method that can be used with any package that requires
     /// `UpgradeCap` to have certain preconditions before it is considered
@@ -37,5 +52,46 @@ module wormhole::package_utils {
             ),
             E_INVALID_UPGRADE_CAP
         );
+    }
+
+    /// Update from version n to n+1. We enforce that the versions be kept in
+    /// a module called "version_control".
+    public fun update_version_type<
+        Old: store + drop,
+        New: store + drop
+    >(
+        id: &mut UID,
+        new_version: New
+    ) {
+        use std::ascii::{into_bytes};
+
+        assert!(
+            field::exists_with_type<CurrentVersion, Old>(id, CurrentVersion {}),
+            E_INCORRECT_OLD_VERSION
+        );
+        let _: Old = field::remove(id, CurrentVersion {});
+
+        let new_type = type_name::get<New>();
+        // Make sure the new type does not equal the old type, which means there
+        // is no protection against either build.
+        assert!(new_type != type_name::get<Old>(), E_SAME_VERSION);
+
+        // Also make sure `New` originates from this module.
+        let module_name = into_bytes(type_name::get_module(&new_type));
+        assert!(module_name == b"version_control", E_TYPE_NOT_ALLOWED);
+
+        // Finally add the new version.
+        field::add(id, CurrentVersion {}, new_version);
+    }
+
+    public fun assert_version<Version: store>(id: &UID) {
+        assert!(
+            field::exists_with_type<CurrentVersion, Version>(id, CurrentVersion {}),
+            E_OUTDATED_VERSION
+        )
+    }
+
+    public fun init_version<Version: store>(id: &mut UID, version: Version) {
+        field::add(id, CurrentVersion {}, version);
     }
 }

--- a/sui/wormhole/sources/utils/package_utils.move
+++ b/sui/wormhole/sources/utils/package_utils.move
@@ -61,6 +61,7 @@ module wormhole::package_utils {
         New: store + drop
     >(
         id: &mut UID,
+        _old_version: Old,
         new_version: New
     ) {
         use std::ascii::{into_bytes};
@@ -84,7 +85,7 @@ module wormhole::package_utils {
         field::add(id, CurrentVersion {}, new_version);
     }
 
-    public fun assert_version<Version: store>(id: &UID) {
+    public fun assert_version<Version: store + drop>(id: &UID, _version: Version) {
         assert!(
             field::exists_with_type<CurrentVersion, Version>(id, CurrentVersion {}),
             E_OUTDATED_VERSION

--- a/sui/wormhole/sources/vaa.move
+++ b/sui/wormhole/sources/vaa.move
@@ -380,7 +380,7 @@ module wormhole::vaa_tests {
     use wormhole::guardian_signature::{Self};
     use wormhole::state::{Self};
     use wormhole::vaa::{Self};
-    use wormhole::version_control::{Self, V__0_1_0, V__MIGRATED};
+    use wormhole::version_control::{Self};
     use wormhole::wormhole_scenario::{
         guardians,
         person,
@@ -771,7 +771,7 @@ module wormhole::vaa_tests {
         let worm_state = take_state(scenario);
         let the_clock = take_clock(scenario);
 
-        state::migrate_version_test_only<V__0_1_0, V__MIGRATED>(
+        state::migrate_version_test_only(
             &mut worm_state,
             version_control::first(),
             version_control::next_version()

--- a/sui/wormhole/sources/vaa.move
+++ b/sui/wormhole/sources/vaa.move
@@ -773,6 +773,7 @@ module wormhole::vaa_tests {
 
         state::migrate_version_test_only<V__0_1_0, V__MIGRATED>(
             &mut worm_state,
+            version_control::first(),
             version_control::next_version()
         );
 

--- a/sui/wormhole/sources/vaa.move
+++ b/sui/wormhole/sources/vaa.move
@@ -158,7 +158,7 @@ module wormhole::vaa {
         buf: vector<u8>,
         the_clock: &Clock
     ): VAA {
-        state::assert_current(wormhole_state);
+        state::assert_latest_only(wormhole_state);
 
         // Deserialize VAA buffer (and return `VAA` after verifying signatures).
         let (signatures, vaa) = parse(buf);
@@ -771,9 +771,15 @@ module wormhole::vaa_tests {
         let worm_state = take_state(scenario);
         let the_clock = take_clock(scenario);
 
+        // Conveniently roll version back.
+        state::reverse_migrate_version(&mut worm_state);
+
+        // Simulate executing with an outdated build by upticking the minimum
+        // required version for `publish_message` to something greater than
+        // this build.
         state::migrate_version_test_only(
             &mut worm_state,
-            version_control::first(),
+            version_control::dummy(),
             version_control::next_version()
         );
 

--- a/sui/wormhole/sources/version_control.move
+++ b/sui/wormhole/sources/version_control.move
@@ -6,45 +6,206 @@
 /// methods if an upgrade requires the latest upgrade version for its
 /// functionality.
 ///
-/// See `wormhole::required_version` and `wormhole::state` for more info.
+/// See `wormhole::state` for more info.
 module wormhole::version_control {
-    /// This value tracks the current version of the Wormhole version. We are
-    /// placing this constant value at the top, which goes against Move style
-    /// guides so that we bring special attention to changing this value when
-    /// a new implementation is built for a contract upgrade.
-    const CURRENT_BUILD_VERSION: u64 = 1;
+    use wormhole::package_utils::{Self};
 
-    /// Key used to check minimum version requirement for `emitter` module.
-    struct Emitter {}
+    ////////////////////////////////////////////////////////////////////////////
+    //
+    //  Hard-coded Version Control
+    //
+    //  Before upgrading, please set the types to match the latest version.
+    //  `assert_current` is intended to be used for most paths through the
+    //  `State` object.
+    //
+    ////////////////////////////////////////////////////////////////////////////
 
-    /// Key used to check minimum version requirement for `governance_message`
-    /// module.
-    struct GovernanceMessage {}
+    /// Assert that the version hard-coded in this check is the current one.
+    public(friend) fun assert_current(id: &UID) {
+        // NOTE: This version should be the current build version. Please use
+        // the struct at the top of this list of structs (where `V__DUMMY`
+        // should be at the bottom).
+        package_utils::assert_version<V__0_1_0>(id);
+    }
 
-    /// Key used to check minimum version requirement for `migrate` module.
-    struct Migrate {}
+    /// Perform the official migration of one hard-coded version type to
+    /// another.
+    public(friend) fun update_to_current(id: &mut UID) {
+        package_utils::update_version_type<V__DUMMY, V__0_1_0>(id, V__0_1_0 {});
+    }
 
-    /// Key used to check minimum version requirement for `publish_module`
-    /// module.
-    struct PublishMessage {}
+    ////////////////////////////////////////////////////////////////////////////
+    //
+    //  Change Log
+    //
+    //  Please write release notes as doc strings for each version struct. These
+    //  notes will be our attempt at tracking upgrades. Wish us luck.
+    //
+    ////////////////////////////////////////////////////////////////////////////
 
-    /// Key used to check minimum version requirement for `set_fee` module.
-    struct SetFee {}
+    /// First published package.
+    struct V__0_1_0 has store, drop, copy {}
 
-    /// Key used to check minimum version requirement for `transfer_fee` module.
-    struct TransferFee {}
+    // Dummy.
+    struct V__DUMMY has store, drop, copy {}
 
-    /// Key used to check minimum version requirement for `update_guardian_set`
-    /// module.
-    struct UpdateGuardianSet {}
+    ////////////////////////////////////////////////////////////////////////////
+    //
+    //  Implementation and Test-Only Methods
+    //
+    ////////////////////////////////////////////////////////////////////////////
 
-    /// Key used to check minimum version requirement for `vaa` module.
-    struct Vaa {}
+    use sui::object::{UID};
 
-    /// Return const value `CURRENT_BUILD_VERSION` for this particular build.
-    /// This value is used to determine whether this implementation meets
-    /// minimum requirements for various Wormhole methods required by `State`.
-    public fun version(): u64 {
-        CURRENT_BUILD_VERSION
+    friend wormhole::state;
+
+    /// Only called once when `State` is created.
+    public(friend) fun initialize(id: &mut UID) {
+        package_utils::init_version(id, V__0_1_0 {});
+    }
+
+    #[test_only]
+    public fun initialize_test_only(id: &mut UID) {
+        initialize(id);
+    }
+
+    #[test_only]
+    public fun update_test_only<Old: store + drop, New: store + drop>(
+        id: &mut UID,
+        new_version: New
+    ) {
+        package_utils::update_version_type<Old, New>(id, new_version);
+    }
+
+    #[test_only]
+    public fun dummy(): V__DUMMY {
+        V__DUMMY {}
+    }
+
+    #[test_only]
+    public fun first(): V__0_1_0 {
+        V__0_1_0 {}
+    }
+
+    #[test_only]
+    struct V__MIGRATED has store, drop, copy {}
+
+    #[test_only]
+    public fun next_version(): V__MIGRATED {
+        V__MIGRATED {}
+    }
+
+    #[test_only]
+    public fun assert_current_test_only(id: &UID) {
+        assert_current(id);
+    }
+}
+
+#[test_only]
+module wormhole::version_control_tests {
+    use sui::object::{Self, UID};
+    use sui::tx_context::{Self};
+    use wormhole::version_control::{Self, V__0_1_0, V__MIGRATED};
+
+    struct State has key {
+        id: UID
+    }
+
+    struct V_DUMMY has store, drop, copy {}
+
+    #[test]
+    fun test_assert_current() {
+        // Create dummy state.
+        let state = State { id: object::new(&mut tx_context::dummy()) };
+        version_control::initialize_test_only(&mut state.id);
+
+        version_control::assert_current_test_only(&state.id);
+
+        // Clean up.
+        let State { id } = state;
+        object::delete(id);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = wormhole::package_utils::E_INCORRECT_OLD_VERSION)]
+    fun test_cannot_update_incorrect_old_version() {
+        // Create dummy state.
+        let state = State { id: object::new(&mut tx_context::dummy()) };
+        version_control::initialize_test_only(&mut state.id);
+
+        version_control::assert_current_test_only(&state.id);
+
+        // You shall not pass!
+        version_control::update_test_only<V__MIGRATED, V__MIGRATED>(
+            &mut state.id,
+            version_control::next_version()
+        );
+
+        // Clean up.
+        let State { id } = state;
+        object::delete(id);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = wormhole::package_utils::E_SAME_VERSION)]
+    fun test_cannot_update_same_version() {
+        // Create dummy state.
+        let state = State { id: object::new(&mut tx_context::dummy()) };
+        version_control::initialize_test_only(&mut state.id);
+
+        version_control::assert_current_test_only(&state.id);
+
+        // You shall not pass!
+        version_control::update_test_only<V__0_1_0, V__0_1_0>(
+            &mut state.id,
+            version_control::first()
+        );
+
+        // Clean up.
+        let State { id } = state;
+        object::delete(id);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = wormhole::package_utils::E_OUTDATED_VERSION)]
+    fun test_cannot_assert_current_outdated_version() {
+        // Create dummy state.
+        let state = State { id: object::new(&mut tx_context::dummy()) };
+        version_control::initialize_test_only(&mut state.id);
+
+        version_control::assert_current_test_only(&state.id);
+
+        // Valid update.
+        version_control::update_test_only<V__0_1_0, V__MIGRATED>(
+            &mut state.id,
+            version_control::next_version()
+        );
+
+        // You shall not pass!
+        version_control::assert_current_test_only(&state.id);
+
+        // Clean up.
+        let State { id } = state;
+        object::delete(id);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = wormhole::package_utils::E_TYPE_NOT_ALLOWED)]
+    fun test_cannot_update_type_not_allowed() {
+        // Create dummy state.
+        let state = State { id: object::new(&mut tx_context::dummy()) };
+        version_control::initialize_test_only(&mut state.id);
+
+        version_control::assert_current_test_only(&state.id);
+
+        // You shall not pass!
+        version_control::update_test_only<V__0_1_0, V_DUMMY>(
+            &mut state.id,
+            V_DUMMY {}
+        );
+
+        // Clean up.
+        let State { id } = state;
+        object::delete(id);
     }
 }

--- a/sui/wormhole/sources/version_control.move
+++ b/sui/wormhole/sources/version_control.move
@@ -8,7 +8,12 @@
 ///
 /// See `wormhole::state` for more info.
 module wormhole::version_control {
+    use std::type_name::{Self, TypeName};
+
     use wormhole::package_utils::{Self};
+
+    #[test_only]
+    friend wormhole::version_control_tests;
 
     ////////////////////////////////////////////////////////////////////////////
     //
@@ -20,18 +25,30 @@ module wormhole::version_control {
     //
     ////////////////////////////////////////////////////////////////////////////
 
+    public(friend) fun latest_version(): V__0_1_0 {
+       V__0_1_0 {}
+    }
+
+    public(friend) fun previous_version(): V__DUMMY {
+        V__DUMMY {}
+    }
+
+    public(friend) fun type_of_version<Version: drop>(_version: Version): TypeName {
+        type_name::get<Version>()
+    }
+
     /// Assert that the version hard-coded in this check is the current one.
     public(friend) fun assert_current(id: &UID) {
         // NOTE: This version should be the current build version. Please use
         // the struct at the top of this list of structs (where `V__DUMMY`
         // should be at the bottom).
-        package_utils::assert_version<V__0_1_0>(id);
+        package_utils::assert_version(id, latest_version());
     }
 
     /// Perform the official migration of one hard-coded version type to
     /// another.
     public(friend) fun update_to_current(id: &mut UID) {
-        package_utils::update_version_type<V__DUMMY, V__0_1_0>(id, V__0_1_0 {});
+        package_utils::update_version_type(id, previous_version(), latest_version());
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -72,9 +89,10 @@ module wormhole::version_control {
     #[test_only]
     public fun update_test_only<Old: store + drop, New: store + drop>(
         id: &mut UID,
+        old_version: Old,
         new_version: New
     ) {
-        package_utils::update_version_type<Old, New>(id, new_version);
+        package_utils::update_version_type<Old, New>(id, old_version, new_version);
     }
 
     #[test_only]
@@ -138,6 +156,7 @@ module wormhole::version_control_tests {
         // You shall not pass!
         version_control::update_test_only<V__MIGRATED, V__MIGRATED>(
             &mut state.id,
+            version_control::next_version(),
             version_control::next_version()
         );
 
@@ -158,6 +177,7 @@ module wormhole::version_control_tests {
         // You shall not pass!
         version_control::update_test_only<V__0_1_0, V__0_1_0>(
             &mut state.id,
+            version_control::first(),
             version_control::first()
         );
 
@@ -178,6 +198,7 @@ module wormhole::version_control_tests {
         // Valid update.
         version_control::update_test_only<V__0_1_0, V__MIGRATED>(
             &mut state.id,
+            version_control::first(),
             version_control::next_version()
         );
 
@@ -201,11 +222,19 @@ module wormhole::version_control_tests {
         // You shall not pass!
         version_control::update_test_only<V__0_1_0, V_DUMMY>(
             &mut state.id,
+            version_control::first(),
             V_DUMMY {}
         );
 
         // Clean up.
         let State { id } = state;
         object::delete(id);
+    }
+
+    #[test]
+    fun test_latest_version_different_from_previous() {
+        let prev = version_control::previous_version();
+        let curr = version_control::latest_version();
+        assert!(version_control::type_of_version(prev) != version_control::type_of_version(curr), 0);
     }
 }

--- a/sui/wormhole/sources/version_control.move
+++ b/sui/wormhole/sources/version_control.move
@@ -1,54 +1,27 @@
 // SPDX-License-Identifier: Apache 2
 
-/// This module implements dynamic field keys as empty structs. These keys with
-/// `RequiredVersion` are used to determine minimum build requirements for
-/// particular Wormhole methods and breaking backward compatibility for these
-/// methods if an upgrade requires the latest upgrade version for its
-/// functionality.
+/// This module implements dynamic field keys as empty structs. These keys are
+/// used to determine the latest version for this build. If the current version
+/// is not this build's, then paths through the `state` module will abort.
 ///
-/// See `wormhole::state` for more info.
+/// See `wormhole::state` and `wormhole::package_utils` for more info.
 module wormhole::version_control {
-    use std::type_name::{Self, TypeName};
-
-    use wormhole::package_utils::{Self};
-
-    #[test_only]
-    friend wormhole::version_control_tests;
-
     ////////////////////////////////////////////////////////////////////////////
     //
     //  Hard-coded Version Control
     //
-    //  Before upgrading, please set the types to match the latest version.
-    //  `assert_current` is intended to be used for most paths through the
-    //  `State` object.
+    //  Before upgrading, please set the types for `current_version` and
+    //  `previous_version` to match the correct types (current being the latest
+    //  version reflecting this build).
     //
     ////////////////////////////////////////////////////////////////////////////
 
-    public(friend) fun latest_version(): V__0_1_0 {
+    public(friend) fun current_version(): V__0_1_0 {
        V__0_1_0 {}
     }
 
     public(friend) fun previous_version(): V__DUMMY {
         V__DUMMY {}
-    }
-
-    public(friend) fun type_of_version<Version: drop>(_version: Version): TypeName {
-        type_name::get<Version>()
-    }
-
-    /// Assert that the version hard-coded in this check is the current one.
-    public(friend) fun assert_current(id: &UID) {
-        // NOTE: This version should be the current build version. Please use
-        // the struct at the top of this list of structs (where `V__DUMMY`
-        // should be at the bottom).
-        package_utils::assert_version(id, latest_version());
-    }
-
-    /// Perform the official migration of one hard-coded version type to
-    /// another.
-    public(friend) fun update_to_current(id: &mut UID) {
-        package_utils::update_version_type(id, previous_version(), latest_version());
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -72,37 +45,14 @@ module wormhole::version_control {
     //
     ////////////////////////////////////////////////////////////////////////////
 
-    use sui::object::{UID};
-
     friend wormhole::state;
 
-    /// Only called once when `State` is created.
-    public(friend) fun initialize(id: &mut UID) {
-        package_utils::init_version(id, V__0_1_0 {});
-    }
-
     #[test_only]
-    public fun initialize_test_only(id: &mut UID) {
-        initialize(id);
-    }
-
-    #[test_only]
-    public fun update_test_only<Old: store + drop, New: store + drop>(
-        id: &mut UID,
-        old_version: Old,
-        new_version: New
-    ) {
-        package_utils::update_version_type<Old, New>(id, old_version, new_version);
-    }
+    friend wormhole::package_utils_tests;
 
     #[test_only]
     public fun dummy(): V__DUMMY {
         V__DUMMY {}
-    }
-
-    #[test_only]
-    public fun first(): V__0_1_0 {
-        V__0_1_0 {}
     }
 
     #[test_only]
@@ -111,130 +61,5 @@ module wormhole::version_control {
     #[test_only]
     public fun next_version(): V__MIGRATED {
         V__MIGRATED {}
-    }
-
-    #[test_only]
-    public fun assert_current_test_only(id: &UID) {
-        assert_current(id);
-    }
-}
-
-#[test_only]
-module wormhole::version_control_tests {
-    use sui::object::{Self, UID};
-    use sui::tx_context::{Self};
-    use wormhole::version_control::{Self, V__0_1_0, V__MIGRATED};
-
-    struct State has key {
-        id: UID
-    }
-
-    struct V_DUMMY has store, drop, copy {}
-
-    #[test]
-    fun test_assert_current() {
-        // Create dummy state.
-        let state = State { id: object::new(&mut tx_context::dummy()) };
-        version_control::initialize_test_only(&mut state.id);
-
-        version_control::assert_current_test_only(&state.id);
-
-        // Clean up.
-        let State { id } = state;
-        object::delete(id);
-    }
-
-    #[test]
-    #[expected_failure(abort_code = wormhole::package_utils::E_INCORRECT_OLD_VERSION)]
-    fun test_cannot_update_incorrect_old_version() {
-        // Create dummy state.
-        let state = State { id: object::new(&mut tx_context::dummy()) };
-        version_control::initialize_test_only(&mut state.id);
-
-        version_control::assert_current_test_only(&state.id);
-
-        // You shall not pass!
-        version_control::update_test_only<V__MIGRATED, V__MIGRATED>(
-            &mut state.id,
-            version_control::next_version(),
-            version_control::next_version()
-        );
-
-        // Clean up.
-        let State { id } = state;
-        object::delete(id);
-    }
-
-    #[test]
-    #[expected_failure(abort_code = wormhole::package_utils::E_SAME_VERSION)]
-    fun test_cannot_update_same_version() {
-        // Create dummy state.
-        let state = State { id: object::new(&mut tx_context::dummy()) };
-        version_control::initialize_test_only(&mut state.id);
-
-        version_control::assert_current_test_only(&state.id);
-
-        // You shall not pass!
-        version_control::update_test_only<V__0_1_0, V__0_1_0>(
-            &mut state.id,
-            version_control::first(),
-            version_control::first()
-        );
-
-        // Clean up.
-        let State { id } = state;
-        object::delete(id);
-    }
-
-    #[test]
-    #[expected_failure(abort_code = wormhole::package_utils::E_OUTDATED_VERSION)]
-    fun test_cannot_assert_current_outdated_version() {
-        // Create dummy state.
-        let state = State { id: object::new(&mut tx_context::dummy()) };
-        version_control::initialize_test_only(&mut state.id);
-
-        version_control::assert_current_test_only(&state.id);
-
-        // Valid update.
-        version_control::update_test_only<V__0_1_0, V__MIGRATED>(
-            &mut state.id,
-            version_control::first(),
-            version_control::next_version()
-        );
-
-        // You shall not pass!
-        version_control::assert_current_test_only(&state.id);
-
-        // Clean up.
-        let State { id } = state;
-        object::delete(id);
-    }
-
-    #[test]
-    #[expected_failure(abort_code = wormhole::package_utils::E_TYPE_NOT_ALLOWED)]
-    fun test_cannot_update_type_not_allowed() {
-        // Create dummy state.
-        let state = State { id: object::new(&mut tx_context::dummy()) };
-        version_control::initialize_test_only(&mut state.id);
-
-        version_control::assert_current_test_only(&state.id);
-
-        // You shall not pass!
-        version_control::update_test_only<V__0_1_0, V_DUMMY>(
-            &mut state.id,
-            version_control::first(),
-            V_DUMMY {}
-        );
-
-        // Clean up.
-        let State { id } = state;
-        object::delete(id);
-    }
-
-    #[test]
-    fun test_latest_version_different_from_previous() {
-        let prev = version_control::previous_version();
-        let curr = version_control::latest_version();
-        assert!(version_control::type_of_version(prev) != version_control::type_of_version(curr), 0);
     }
 }


### PR DESCRIPTION
## Objective

Here we are again. As we have been reviewing the consequences of upgrading contracts, we have been valuating the execution of version control. The existing upgradability design allowed for too much room for error when configuring hard-coded versions via `u64` (to be in line with the `UpgradeCap`).

This change aims to dissociate version control from how `UpgradeCap` tracks its package versions by establishing specific types that denote build versions. When a package is upgraded, we enforce the implementor to add a new version struct in _version_control.move_ (with release notes justifying the new struct).

Calling `migrate` is now a requirement to establish the upgraded build as the only functioning build for both Wormhole and Token Bridge.

Given the new paradigm of passing package types to limit the blast radius of upgrading contracts, we can now enforce that the package called on via transaction block is the latest package (as opposed to tracking minimum required versions).

### How to Review PR

_Carefully..._

- Make sure Move tests run via `make test`.
- Review _version_control.move_ in both Wormhole and Token Bridge **EXTREMELY CAREFULLY**.
- Review _version_control.move_ tests.
- Review `migrate` modules (plus tests).
- Review tests that enforce breaking changes when version control updates its version.