### PR TITLE
sui/wormhole: fix `init_package_info`

### DIFF
--- a/clients/js/consts.ts
+++ b/clients/js/consts.ts
@@ -32,9 +32,9 @@ const OVERRIDES = {
   },
   DEVNET: {
     sui: {
-      core: "0x130dc80b0686a2a25df775d2ddc8652762be33a270430395ffe2c63b1e57f205",
+      core: "0xb80e44b7c40b874f0162d2440d9f79468132e911c62591eba52fb65a1c9835bb",
       token_bridge:
-        "0xd0be0bd4ccd65461b6f750f334f774af09dc67bba0450986c7cfba689ecfd4d6",
+        "0x4510fff0657df153bb055d8dbb223aec9a4c291cacac79472999e8ffe82de8b8",
     },
     aptos: {
       token_bridge:

--- a/clients/js/sui/consts.ts
+++ b/clients/js/sui/consts.ts
@@ -15,9 +15,9 @@ export const SUI_OBJECT_IDS = {
   },
   DEVNET: {
     core_state:
-      "0x9ed35784102112cd126d762a314ae0dea22a2d40524d743e9b2c6ab66475be5d",
+      "0xc1867890b51a1fe873ce34fc4ebc6d87e1ebe30b340d9adccf77e38cf8f2453b",
     token_bridge_state:
-      "0xcdc4bcc4a8eca476cdc57770ab9564f5b88354dfad119222345a4f8ac8146184",
+      "0x1d8a273e7c7de53925aed3fc770466f40fbf2a1ce86dde4cf5434ba9084d45dd",
   },
 };
 

--- a/sdk/js/src/utils/consts.ts
+++ b/sdk/js/src/utils/consts.ts
@@ -514,9 +514,9 @@ const DEVNET = {
       "0x46da3d4c569388af61f951bdd1153f4c875f90c2991f6b2d0a38e2161a40852c",
   },
   sui: {
-    core: "0x130dc80b0686a2a25df775d2ddc8652762be33a270430395ffe2c63b1e57f205",
+    core: "0xb80e44b7c40b874f0162d2440d9f79468132e911c62591eba52fb65a1c9835bb",
     token_bridge:
-      "0xd0be0bd4ccd65461b6f750f334f774af09dc67bba0450986c7cfba689ecfd4d6",
+      "0x4510fff0657df153bb055d8dbb223aec9a4c291cacac79472999e8ffe82de8b8",
     nft_bridge: undefined,
   },
   moonbeam: {
@@ -844,9 +844,9 @@ export const SUI_OBJECT_IDS = {
   },
   DEVNET: {
     core_state:
-      "0x9ed35784102112cd126d762a314ae0dea22a2d40524d743e9b2c6ab66475be5d",
+      "0xc1867890b51a1fe873ce34fc4ebc6d87e1ebe30b340d9adccf77e38cf8f2453b",
     token_bridge_state:
-      "0xcdc4bcc4a8eca476cdc57770ab9564f5b88354dfad119222345a4f8ac8146184",
+      "0x1d8a273e7c7de53925aed3fc770466f40fbf2a1ce86dde4cf5434ba9084d45dd",
   },
 };
 export type SuiAddresses = typeof SUI_OBJECT_IDS;

--- a/sui/wormhole/Move.devnet.toml
+++ b/sui/wormhole/Move.devnet.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Wormhole"
-version = "0.1.1"
+version = "0.1.2"
 
 [dependencies.Sui]
 git = "https://github.com/MystenLabs/sui.git"

--- a/sui/wormhole/Move.toml
+++ b/sui/wormhole/Move.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Wormhole"
-version = "0.1.1"
+version = "0.1.2"
 
 [dependencies.Sui]
 git = "https://github.com/MystenLabs/sui.git"

--- a/sui/wormhole/sources/migrate.move
+++ b/sui/wormhole/sources/migrate.move
@@ -27,8 +27,8 @@ module wormhole::migrate {
         upgrade_vaa_buf: vector<u8>,
         the_clock: &Clock
     ) {
-        // This should be removed in an upgrade from 0.1.1.
-        state::migrate__v__0_1_1(wormhole_state);
+        // This should be removed in an upgrade from 0.1.2.
+        state::migrate__v__0_1_2(wormhole_state);
 
         // Perform standard migrate.
         handle_migrate(wormhole_state, upgrade_vaa_buf, the_clock);
@@ -99,7 +99,7 @@ module wormhole::migrate {
 
     #[test_only]
     public fun set_up_migrate(wormhole_state: &mut State) {
-        state::reverse_migrate__v__0_1_0(wormhole_state);
+        state::reverse_migrate__v__0_1_1(wormhole_state);
     }
 }
 
@@ -170,7 +170,7 @@ module wormhole::migrate_tests {
     }
 
     #[test]
-    #[expected_failure(abort_code = sui::dynamic_field::EFieldDoesNotExist)]
+    #[expected_failure(abort_code = wormhole::package_utils::E_INCORRECT_OLD_VERSION)]
     /// ^ This expected error may change depending on the migration. In most
     /// cases, this will abort with `wormhole::package_utils::E_INCORRECT_OLD_VERSION`.
     fun test_cannot_migrate_again() {

--- a/sui/wormhole/sources/state.move
+++ b/sui/wormhole/sources/state.move
@@ -449,37 +449,14 @@ module wormhole::state {
     //
     ////////////////////////////////////////////////////////////////////////////
 
-    public(friend) fun migrate__v__0_1_1(self: &mut State) {
-        // We need to add dynamic fields via the new package utils method. These
-        // fields do not exist in the previous build (0.1.0).
-        // See `state::new` above.
-
-        // Need to remove old dynamic field. This was set when performing the
-        // upgrade on previous version. We need to take this digest and then
-        // initialize package info with this as the pending digest.
-        let pending_digest =
-            sui::dynamic_field::remove(&mut self.id, CurrentDigest {});
-
-        // Initialize package info. This will be used for emitting information
-        // of successful migrations.
-        let upgrade_cap = &self.upgrade_cap;
-        package_utils::init_package_info(
-            &mut self.id,
-            upgrade_cap,
-            bytes32::default(),
-            pending_digest
-        );
+    public(friend) fun migrate__v__0_1_2(_self: &mut State) {
+        // Intentionally do nothing.
     }
 
     #[test_only]
     /// Bloody hack.
-    public fun reverse_migrate__v__0_1_0(self: &mut State) {
-        package_utils::remove_package_info(&mut self.id);
-
-        // Add back in old dynamic field(s)...
-
-        // Add dummy hash since this is the first time the package is published.
-        sui::dynamic_field::add(&mut self.id, CurrentDigest {}, bytes32::from_bytes(b"new build"));
+    public fun reverse_migrate__v__0_1_1(_self: &mut State) {
+        // Intentionally do nothing.
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/sui/wormhole/sources/utils/package_utils.move
+++ b/sui/wormhole/sources/utils/package_utils.move
@@ -155,7 +155,7 @@ module wormhole::package_utils {
             };
         field::add(id, CurrentPackage {}, info);
 
-        // Set placeholders for pending package and . We don't ever plan on removing
+        // Set placeholders for pending package. We don't ever plan on removing
         // this field.
         field::add(
             id,

--- a/sui/wormhole/sources/utils/package_utils.move
+++ b/sui/wormhole/sources/utils/package_utils.move
@@ -147,9 +147,10 @@ module wormhole::package_utils {
         current_digest: Bytes32,
         pending_digest: Bytes32
     ) {
+        let package = package::upgrade_package(upgrade_cap);
         let info =
             PackageInfo {
-                package: package::upgrade_package(upgrade_cap),
+                package,
                 digest: current_digest
             };
         field::add(id, CurrentPackage {}, info);
@@ -160,7 +161,7 @@ module wormhole::package_utils {
             id,
             PendingPackage {},
             PackageInfo {
-                package: object::id_from_address(@0x0),
+                package,
                 digest: pending_digest
             }
         );

--- a/sui/wormhole/sources/version_control.move
+++ b/sui/wormhole/sources/version_control.move
@@ -16,12 +16,12 @@ module wormhole::version_control {
     //
     ////////////////////////////////////////////////////////////////////////////
 
-    public(friend) fun current_version(): V__0_1_1 {
-       V__0_1_1 {}
+    public(friend) fun current_version(): V__0_1_2 {
+       V__0_1_2 {}
     }
 
-    public(friend) fun previous_version(): V__0_1_0 {
-        V__0_1_0 {}
+    public(friend) fun previous_version(): V__0_1_1 {
+        V__0_1_1 {}
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -35,6 +35,14 @@ module wormhole::version_control {
 
     /// RELEASE NOTES
     ///
+    /// - Fix `package_utils` to initialize pending package ID to be the same as
+    ///   the current package ID (both from the `UpgradeCap`).
+    ///
+    /// Also added `migrate__v__0_1_2 in `wormhole::state`, which is a no-op.
+    struct V__0_1_2 has store, drop, copy {}
+
+    /// RELEASE NOTES
+    ///
     /// - Add `PackageInfo` to `wormhole::package_utils`, which allows tracking
     ///   of the most relevant package ID.
     /// - Refactor package management into `wormhole::package_utils`.
@@ -42,13 +50,15 @@ module wormhole::version_control {
     ///
     /// Also added `migrate__v__0_1_1` in `wormhole::state`, which is
     /// meant to perform a one-time `State` modification via `migrate`.
+    ///
+    /// https://github.com/wormhole-foundation/wormhole/tree/5be93774da4c6d8062521933be29250aed97245d
     struct V__0_1_1 has store, drop, copy {}
 
     /// First published package.
     ///
     /// NOTE: This version is published on Sui testnet.
     ///
-    /// https://github.com/wormhole-foundation/wormhole/commit/03ff1b24cf913ed04ce59fe26b5d3abd53015f28
+    /// https://github.com/wormhole-foundation/wormhole/tree/03ff1b24cf913ed04ce59fe26b5d3abd53015f28
     struct V__0_1_0 has store, drop, copy {}
 
     // Dummy.
@@ -79,7 +89,7 @@ module wormhole::version_control {
     }
 
     #[test_only]
-    public fun previous_version_test_only(): V__0_1_0 {
+    public fun previous_version_test_only(): V__0_1_1 {
         previous_version()
     }
 }


### PR DESCRIPTION
## Objective

Fixed `package_utils::init_package_info` where the pending package ID was inadvertently set to the zero address.

## How to Review PR

- Make sure Move tests run via `make test`
- Make sure all migrate methods in Wormhole make sense