### PR TITLE
sui: fix typo in `authorize_governance`

### DIFF
--- a/sui/token_bridge/Move.lock
+++ b/sui/token_bridge/Move.lock
@@ -5,6 +5,9 @@ version = 0
 
 dependencies = [
   { name = "Sui" },
+]
+
+dev-dependencies = [
   { name = "Wormhole" },
 ]
 

--- a/sui/token_bridge/Move.lock
+++ b/sui/token_bridge/Move.lock
@@ -5,9 +5,6 @@ version = 0
 
 dependencies = [
   { name = "Sui" },
-]
-
-dev-dependencies = [
   { name = "Wormhole" },
 ]
 

--- a/sui/token_bridge/sources/governance/upgrade_contract.move
+++ b/sui/token_bridge/sources/governance/upgrade_contract.move
@@ -39,12 +39,12 @@ module token_bridge::upgrade_contract {
     }
 
     public fun authorize_governance(
-        wormhole_state: &State
+        token_bridge_state: &State
     ): DecreeTicket<GovernanceWitness> {
         governance_message::authorize_verify_local(
             GovernanceWitness {},
-            state::governance_chain(wormhole_state),
-            state::governance_contract(wormhole_state),
+            state::governance_chain(token_bridge_state),
+            state::governance_contract(token_bridge_state),
             state::governance_module(),
             ACTION_UPGRADE_CONTRACT
         )


### PR DESCRIPTION
## Summary
- `&State` is a ref to token bridge state and not worm state