### PR TITLE
Node: Add logging around DB writes

### DIFF
--- a/node/pkg/accountant/accountant.go
+++ b/node/pkg/accountant/accountant.go
@@ -277,11 +277,12 @@ func (acct *Accountant) publishTransferAlreadyLocked(pe *pendingEntry) {
 
 // addPendingTransferAlreadyLocked adds a pending transfer to both the map and the database. It assumes the caller holds the lock.
 func (acct *Accountant) addPendingTransferAlreadyLocked(pe *pendingEntry) error {
-	acct.logger.Debug("addPendingTransferAlreadyLocked", zap.String("msgId", pe.msgId))
+	acct.logger.Info("writing transfer to database", zap.String("msgId", pe.msgId))
 	pe.setUpdTime()
 	if err := acct.db.AcctStorePendingTransfer(pe.msg); err != nil {
 		return err
 	}
+	acct.logger.Info("wrote message to database", zap.String("msgId", pe.msgId))
 
 	acct.pendingTransfers[pe.msgId] = pe
 	transfersOutstanding.Set(float64(len(acct.pendingTransfers)))

--- a/node/pkg/governor/governor.go
+++ b/node/pkg/governor/governor.go
@@ -398,6 +398,7 @@ func (gov *ChainGovernor) ProcessMsgForTime(msg *common.MessagePublication, now 
 
 	if enqueueIt {
 		dbData := db.PendingTransfer{ReleaseTime: releaseTime, Msg: *msg}
+		gov.logger.Info("writing pending transfer to database", zap.String("msgId", msg.MessageIDString()))
 		err = gov.db.StorePendingMsg(&dbData)
 		if err != nil {
 			gov.logger.Error("failed to store pending vaa",
@@ -408,6 +409,7 @@ func (gov *ChainGovernor) ProcessMsgForTime(msg *common.MessagePublication, now 
 			)
 			return false, err
 		}
+		gov.logger.Info("wrote pending transfer to database", zap.String("msgId", msg.MessageIDString()))
 
 		ce.pending = append(ce.pending, &pendingEntry{token: token, amount: payload.Amount, hash: hash, dbData: dbData})
 		gov.msgsSeen[hash] = transferEnqueued


### PR DESCRIPTION
Some of the guardians are noticing that after some length of time, their guardiand instance stops processing messages, which they report as the "RPCs stop working". Log analysis indicates that the issue is most likely that the main processor go routine is hanging up somewhere. Although we are not exactly sure what is happening, one possibility is that either the governor or the accountant is hanging while writing transfers to the database. Therefore, this PR adds logging around those writes. Since the governor and guardian only process token bridge messages, this should not cause an excessive amount of logging. Once this problem is resolved, the log messages will be removed.