### PR TITLE
scripts/scope checkers: reduce false negatives

### DIFF
--- a/scripts/check-docker-pin.sh
+++ b/scripts/check-docker-pin.sh
@@ -13,7 +13,7 @@
 #   - We ignore cosmwasm_artifacts AS artifacts because it's a local reference only, is built in tilt
 #   - We ignore base AS (ignite-go-build|ignite-vue-build) because the base image is already pinned in wormchain/Dockerfile.proto
 #
-git ls-files | grep "Dockerfile*" | xargs grep -s "FROM" | egrep -v 'sha256|scratch|solana|aptos|sui|base|cosmwasm_artifacts AS (application|base|builder|ci_tests|tests|artifacts|ignite-go-build|ignite-vue-build)'
+git ls-files -z | grep -z "Dockerfile*" | xargs -r -0 grep -s "FROM" | egrep -v 'sha256|scratch|solana|aptos|sui|base|cosmwasm_artifacts AS (application|base|builder|ci_tests|tests|artifacts|ignite-go-build|ignite-vue-build)'
 if [ $? -eq 0 ]; then
    echo "[!] Unpinned docker files" >&2
    exit 1

--- a/scripts/check-npm-package-scopes.sh
+++ b/scripts/check-npm-package-scopes.sh
@@ -2,7 +2,7 @@
 
 # This script checks to ensure that all our NPM packages have an appropriate scope.
 #
-git ls-files | grep "package.json" | xargs grep -s "\"name\":" | egrep -v '@certusone/|@wormhole-foundation/'
+git ls-files -z | grep -z "package.json" | xargs -n1 -r -0 /bin/bash -c 'printf "[$@]"; jq  ".name" "$@";' '' | egrep -v "^\[.*\]null$" | egrep -v '^\[.*\]"(@certusone/|@wormhole-foundation/)'
 if [ $? -eq 0 ]; then
    echo "[!] Unscoped npm packages" >&2
    exit 1


### PR DESCRIPTION
This change reduces false negatives in the scope checking scripts by
* supporting spaces and other special characters in file paths
* using jq instead of a simple grep to parse the json
* being more restrictive in the regexes on what to allow to pass through

This addresses all review comments in the previously abandoned PR https://github.com/wormhole-foundation/wormhole/pull/1774 