### PR TITLE
Node: Update code owners for watchers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -60,20 +60,5 @@
 ## Supervisor Framework
 /node/pkg/supervisor/ @hendrikhofstadt @bruce-riley
 
-## Watcher - Algorand
-/node/pkg/watchers/algorand/ @evan-gray @jumpsiegel
-
-## Watcher - Aptos
-/node/pkg/watchers/aptos/ @evan-gray @jumpsiegel @panoel
-
-## Watcher - Cosmwasm
-/node/pkg/watchers/cosmwasm/ @evan-gray @hendrikhofstadt
-
-## Watcher - EVM
-/node/pkg/watchers/evm/ @evan-gray @bruce-riley @hendrikhofstadt
-
-## Watcher - NEAR
-/node/pkg/watchers/near/ @evan-gray @jumpsiegel @kev1n-peters
-
-## Watcher - Solana
-/node/pkg/watchers/solana/ @evan-gray @hendrikhofstadt @bruce-riley
+## Watchers
+/node/pkg/watchers @hendrikhofstadt @evan-gray @bruce-riley @panoel @kev1n-peters


### PR DESCRIPTION
Update the code owners for /node/pkg/watcher to be common across all the watchers. Removed people who are no longer active on WH. Added other developers from the prodOps team.