### PR TITLE
relayer: ensure addrs are checksum addrs in relayer engine

### DIFF
--- a/relayer/generic_relayer/relayer-engine-v2/src/env.ts
+++ b/relayer/generic_relayer/relayer-engine-v2/src/env.ts
@@ -13,6 +13,7 @@ import {
 } from "@certusone/wormhole-sdk";
 import { rootLogger } from "./log";
 import { dbg } from "../pkgs/sdk/src";
+import { ethers } from "ethers";
 
 const SCRIPTS_DIR = "../../../ethereum/ts-scripts/relayer";
 
@@ -130,11 +131,11 @@ export async function loadAppConfig(): Promise<{
   const wormholeRelayers = {} as Record<EVMChainId, string>;
   contracts.relayProviders.forEach(
     ({ chainId, address }: ContractConfigEntry) =>
-      (relayProviders[chainId] = address)
+      (relayProviders[chainId] = ethers.utils.getAddress(address))
   );
   contracts.coreRelayers.forEach(
     ({ chainId, address }: ContractConfigEntry) =>
-      (wormholeRelayers[chainId] = address)
+      (wormholeRelayers[chainId] = ethers.utils.getAddress(address))
   );
 
   return {

--- a/relayer/generic_relayer/relayer-engine-v2/src/processor.ts
+++ b/relayer/generic_relayer/relayer-engine-v2/src/processor.ts
@@ -40,8 +40,9 @@ export async function processGenericRelayerVaa(ctx: GRContext, next: Next) {
 
 async function processDelivery(ctx: GRContext) {
   const deliveryVaa = parseWormholeRelayerSend(ctx.vaa!.payload);
+  const sourceRelayProvider = ethers.utils.getAddress(wh.tryUint8ArrayToNative(deliveryVaa.sourceRelayProvider, "ethereum"));
   if (
-    wh.tryUint8ArrayToNative(deliveryVaa.sourceRelayProvider, "ethereum") !==
+    sourceRelayProvider !==
     ctx.relayProviders[ctx.vaa!.emitterChain as EVMChainId]
   ) {
     ctx.logger.info("Delivery vaa specifies different relay provider", {
@@ -54,8 +55,9 @@ async function processDelivery(ctx: GRContext) {
 
 async function processRedelivery(ctx: GRContext) {
   const redeliveryVaa = parseWormholeRelayerResend(ctx.vaa!.payload);
+  const sourceRelayProvider = ethers.utils.getAddress(wh.tryUint8ArrayToNative(redeliveryVaa.sourceRelayProvider, "ethereum"));
   if (
-    wh.tryUint8ArrayToNative(redeliveryVaa.sourceRelayProvider, "ethereum") !==
+    sourceRelayProvider !==
     ctx.relayProviders[ctx.vaa!.emitterChain as EVMChainId]
   ) {
     ctx.logger.info("Delivery vaa specifies different relay provider", {


### PR DESCRIPTION
Resolves post-merge review comment in https://github.com/wormhole-foundation/wormhole/pull/2844

>You should convert sourceRelayProvider to a checksum address before comparing it with the relayProviders .
