### PR TITLE
clients/js: set strict = true in tsconfig

### DIFF
--- a/clients/js/package-lock.json
+++ b/clients/js/package-lock.json
@@ -45,6 +45,7 @@
         "@truffle/hdwallet-provider": "^2.0.15",
         "@types/bn.js": "^5.1.0",
         "@types/bs58": "^4.0.1",
+        "@types/node-fetch": "^2.6.3",
         "@types/yargs": "^17.0.2",
         "copy-dir": "^1.3.0",
         "typescript": "^4.6"
@@ -3439,6 +3440,30 @@
       "version": "18.7.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.6.tgz",
       "integrity": "sha512-EdxgKRXgYsNITy5mjjXjVE/CS8YENSdhiagGrLqjG0pvA2owgJ6i4l7wy/PFZGC0B1/H20lWKN7ONVDNYDZm7A=="
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.3.tgz",
+      "integrity": "sha512-ETTL1mOEdq/sxUtgtOhKjyB2Irra4cjxksvcMUR5Zr4n+PxVhsCD9WS46oPbHL3et9Zde7CNRr+WUNlcHvsX+w==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      }
+    },
+    "node_modules/@types/node-fetch/node_modules/form-data": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/@types/pbkdf2": {
       "version": "3.1.0",
@@ -10752,6 +10777,29 @@
       "version": "18.7.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.6.tgz",
       "integrity": "sha512-EdxgKRXgYsNITy5mjjXjVE/CS8YENSdhiagGrLqjG0pvA2owgJ6i4l7wy/PFZGC0B1/H20lWKN7ONVDNYDZm7A=="
+    },
+    "@types/node-fetch": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.3.tgz",
+      "integrity": "sha512-ETTL1mOEdq/sxUtgtOhKjyB2Irra4cjxksvcMUR5Zr4n+PxVhsCD9WS46oPbHL3et9Zde7CNRr+WUNlcHvsX+w==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+          "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
     },
     "@types/pbkdf2": {
       "version": "3.1.0",

--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -59,6 +59,7 @@
     "@truffle/hdwallet-provider": "^2.0.15",
     "@types/bn.js": "^5.1.0",
     "@types/bs58": "^4.0.1",
+    "@types/node-fetch": "^2.6.3",
     "@types/yargs": "^17.0.2",
     "copy-dir": "^1.3.0",
     "typescript": "^4.6"

--- a/clients/js/src/cmds/aptos.ts
+++ b/clients/js/src/cmds/aptos.ts
@@ -1,3 +1,4 @@
+import { APTOS_DEPLOYER_ADDRESS_DEVNET } from "@certusone/wormhole-sdk";
 import {
   assertChain,
   CHAIN_ID_APTOS,
@@ -23,9 +24,11 @@ import {
   RPC_OPTIONS,
 } from "../consts";
 import { NETWORKS } from "../networks";
-import { runCommand, validator_args } from "../start-validator";
+import { runCommand, VALIDATOR_OPTIONS } from "../start-validator";
 import { assertNetwork, checkBinary, evm_address, hex } from "../utils";
 
+const APTOS_NODE_URL = "http://0.0.0.0:8080/v1";
+const APTOS_FAUCET_URL = "http://0.0.0.0:8081";
 const README_URL =
   "https://github.com/wormhole-foundation/wormhole/blob/main/aptos/README.md";
 
@@ -42,427 +45,410 @@ interface PackageBCS {
 
 export const command = "aptos";
 export const desc = "Aptos utilities";
-export const builder = function (y: typeof yargs) {
-  return (
-    y
-      // NOTE: there's no init-nft-bridge, because the native module initialiser
-      // functionality has stabilised on mainnet, so we just use that one (which
-      // gets called automatically)
-      .command(
-        "init-token-bridge",
-        "Init token bridge contract",
-        (yargs) => {
-          return yargs
-            .option("network", NETWORK_OPTIONS)
-            .option("rpc", RPC_OPTIONS);
-        },
-        async (argv) => {
-          const network = argv.network.toUpperCase();
-          assertNetwork(network);
-          const contract_address = evm_address(
-            CONTRACTS[network].aptos.token_bridge
-          );
-          const rpc = argv.rpc ?? NETWORKS[network]["aptos"].rpc;
-          await callEntryFunc(
-            network,
-            rpc,
-            `${contract_address}::token_bridge`,
-            "init",
-            [],
-            []
-          );
-        }
-      )
-      .command(
-        "init-wormhole",
-        "Init Wormhole core contract",
-        (yargs) => {
-          return yargs
-            .option("network", NETWORK_OPTIONS)
-            .option("rpc", RPC_OPTIONS)
-            .option("chain-id", {
-              describe: "Chain id",
-              type: "number",
-              default: CHAIN_ID_APTOS,
-              required: false,
-            })
-            .option("governance-chain-id", {
-              describe: "Governance chain id",
-              type: "number",
-              default: GOVERNANCE_CHAIN,
-              required: false,
-            })
-            .option("governance-address", {
-              describe: "Governance address",
-              type: "string",
-              default: GOVERNANCE_EMITTER,
-              required: false,
-            })
-            .option("guardian-address", {
-              alias: "g",
-              required: true,
-              describe: "Initial guardian's addresses (CSV)",
-              type: "string",
-            });
-        },
-        async (argv) => {
-          const network = argv.network.toUpperCase();
-          assertNetwork(network);
+export const builder = (y: typeof yargs) =>
+  y
+    // NOTE: there's no init-nft-bridge, because the native module initialiser
+    // functionality has stabilised on mainnet, so we just use that one (which
+    // gets called automatically)
+    .command(
+      "init-token-bridge",
+      "Init token bridge contract",
+      (yargs) =>
+        yargs.option("network", NETWORK_OPTIONS).option("rpc", RPC_OPTIONS),
+      async (argv) => {
+        const network = argv.network.toUpperCase();
+        assertNetwork(network);
+        const contract_address = evm_address(
+          CONTRACTS[network].aptos.token_bridge
+        );
+        const rpc = argv.rpc ?? NETWORKS[network]["aptos"].rpc;
+        await callEntryFunc(
+          network,
+          rpc,
+          `${contract_address}::token_bridge`,
+          "init",
+          [],
+          []
+        );
+      }
+    )
+    .command(
+      "init-wormhole",
+      "Init Wormhole core contract",
+      (yargs) =>
+        yargs
+          .option("network", NETWORK_OPTIONS)
+          .option("rpc", RPC_OPTIONS)
+          .option("chain-id", {
+            describe: "Chain id",
+            type: "number",
+            default: CHAIN_ID_APTOS,
+            demandOption: false,
+          })
+          .option("governance-chain-id", {
+            describe: "Governance chain id",
+            type: "number",
+            default: GOVERNANCE_CHAIN,
+            demandOption: false,
+          })
+          .option("governance-address", {
+            describe: "Governance address",
+            type: "string",
+            default: GOVERNANCE_EMITTER,
+            demandOption: false,
+          })
+          .option("guardian-address", {
+            alias: "g",
+            demandOption: true,
+            describe: "Initial guardian's addresses (CSV)",
+            type: "string",
+          }),
+      async (argv) => {
+        const network = argv.network.toUpperCase();
+        assertNetwork(network);
 
-          const contract_address = evm_address(CONTRACTS[network].aptos.core);
-          const guardian_addresses = argv["guardian-address"]
-            .split(",")
-            .map((address) => evm_address(address).substring(24));
-          const chain_id = argv["chain-id"];
-          const governance_address = evm_address(argv["governance-address"]);
-          const governance_chain_id = argv["governance-chain-id"];
+        const contract_address = evm_address(CONTRACTS[network].aptos.core);
+        const guardian_addresses = argv["guardian-address"]
+          .split(",")
+          .map((address) => evm_address(address).substring(24));
+        const chain_id = argv["chain-id"];
+        const governance_address = evm_address(argv["governance-address"]);
+        const governance_chain_id = argv["governance-chain-id"];
 
-          const guardians_serializer = new BCS.Serializer();
-          guardians_serializer.serializeU32AsUleb128(guardian_addresses.length);
-          guardian_addresses.forEach((address) =>
-            guardians_serializer.serializeBytes(Buffer.from(address, "hex"))
-          );
+        const guardians_serializer = new BCS.Serializer();
+        guardians_serializer.serializeU32AsUleb128(guardian_addresses.length);
+        guardian_addresses.forEach((address) =>
+          guardians_serializer.serializeBytes(Buffer.from(address, "hex"))
+        );
 
-          const args = [
-            BCS.bcsSerializeUint64(chain_id),
-            BCS.bcsSerializeUint64(governance_chain_id),
-            BCS.bcsSerializeBytes(Buffer.from(governance_address, "hex")),
-            guardians_serializer.getBytes(),
-          ];
-          const rpc = argv.rpc ?? NETWORKS[network]["aptos"].rpc;
-          await callEntryFunc(
-            network,
-            rpc,
-            `${contract_address}::wormhole`,
-            "init",
-            [],
-            args
-          );
-        }
-      )
-      .command(
-        "deploy <package-dir>",
-        "Deploy an Aptos package",
-        (yargs) => {
-          return yargs
-            .positional("package-dir", {
-              type: "string",
-            })
-            .option("network", NETWORK_OPTIONS)
-            .option("rpc", RPC_OPTIONS)
-            .option("named-addresses", NAMED_ADDRESSES_OPTIONS);
-        },
-        async (argv) => {
-          const network = argv.network.toUpperCase();
-          assertNetwork(network);
-          checkBinary("aptos", README_URL);
-          const p = buildPackage(argv["package-dir"], argv["named-addresses"]);
-          const b = serializePackage(p);
-          const rpc = argv.rpc ?? NETWORKS[network]["aptos"].rpc;
-          await callEntryFunc(
-            network,
-            rpc,
-            "0x1::code",
-            "publish_package_txn",
-            [],
-            [b.meta, b.bytecodes]
-          );
-          console.log("Deployed:", p.mv_files);
-        }
-      )
-      .command(
-        "deploy-resource <seed> <package-dir>",
-        "Deploy an Aptos package using a resource account",
-        (yargs) => {
-          return yargs
-            .positional("seed", {
-              type: "string",
-            })
-            .positional("package-dir", {
-              type: "string",
-            })
-            .option("network", NETWORK_OPTIONS)
-            .option("rpc", RPC_OPTIONS)
-            .option("named-addresses", NAMED_ADDRESSES_OPTIONS);
-        },
-        async (argv) => {
-          const network = argv.network.toUpperCase();
-          assertNetwork(network);
-          checkBinary("aptos", README_URL);
-          const p = buildPackage(argv["package-dir"], argv["named-addresses"]);
-          const b = serializePackage(p);
-          const seed = Buffer.from(argv["seed"], "ascii");
+        const args = [
+          BCS.bcsSerializeUint64(chain_id),
+          BCS.bcsSerializeUint64(governance_chain_id),
+          BCS.bcsSerializeBytes(Buffer.from(governance_address, "hex")),
+          guardians_serializer.getBytes(),
+        ];
+        const rpc = argv.rpc ?? NETWORKS[network]["aptos"].rpc;
+        await callEntryFunc(
+          network,
+          rpc,
+          `${contract_address}::wormhole`,
+          "init",
+          [],
+          args
+        );
+      }
+    )
+    .command(
+      "deploy <package-dir>",
+      "Deploy an Aptos package",
+      (yargs) =>
+        yargs
+          .positional("package-dir", {
+            type: "string",
+            describe: "Path to package directory",
+            demandOption: true,
+          })
+          .option("network", NETWORK_OPTIONS)
+          .option("rpc", RPC_OPTIONS)
+          .option("named-addresses", NAMED_ADDRESSES_OPTIONS),
+      async (argv) => {
+        const network = argv.network.toUpperCase();
+        assertNetwork(network);
+        checkBinary("aptos", README_URL);
+        const p = buildPackage(argv["package-dir"], argv["named-addresses"]);
+        const b = serializePackage(p);
+        const rpc = argv.rpc ?? NETWORKS[network]["aptos"].rpc;
+        await callEntryFunc(
+          network,
+          rpc,
+          "0x1::code",
+          "publish_package_txn",
+          [],
+          [b.meta, b.bytecodes]
+        );
+        console.log("Deployed:", p.mv_files);
+      }
+    )
+    .command(
+      "deploy-resource <seed> <package-dir>",
+      "Deploy an Aptos package using a resource account",
+      (yargs) =>
+        yargs
+          .positional("seed", {
+            type: "string",
+            describe: "Seed for resource account",
+            demandOption: true,
+          })
+          .positional("package-dir", {
+            type: "string",
+            describe: "Path to package directory",
+            demandOption: true,
+          })
+          .option("network", NETWORK_OPTIONS)
+          .option("rpc", RPC_OPTIONS)
+          .option("named-addresses", NAMED_ADDRESSES_OPTIONS),
+      async (argv) => {
+        const network = argv.network.toUpperCase();
+        assertNetwork(network);
+        checkBinary("aptos", README_URL);
+        const p = buildPackage(argv["package-dir"], argv["named-addresses"]);
+        const b = serializePackage(p);
+        const seed = Buffer.from(argv["seed"], "ascii");
 
-          // TODO(csongor): use deployer address from sdk (when it's there)
-          let module_name =
-            "0x277fa055b6a73c42c0662d5236c65c864ccbf2d4abd21f174a30c8b786eab84b::deployer";
-          if (network == "TESTNET" || network == "MAINNET") {
-            module_name =
-              "0x0108bc32f7de18a5f6e1e7d6ee7aff9f5fc858d0d87ac0da94dd8d2a5d267d6b::deployer";
-          }
-          const rpc = argv.rpc ?? NETWORKS[network]["aptos"].rpc;
-          await callEntryFunc(
-            network,
-            rpc,
-            module_name,
-            "deploy_derived",
-            [],
-            [b.meta, b.bytecodes, BCS.bcsSerializeBytes(seed)]
-          );
-          console.log("Deployed:", p.mv_files);
+        // TODO(csongor): use deployer address from sdk (when it's there)
+        let module_name =
+          "0x277fa055b6a73c42c0662d5236c65c864ccbf2d4abd21f174a30c8b786eab84b::deployer";
+        if (network == "TESTNET" || network == "MAINNET") {
+          module_name =
+            "0x0108bc32f7de18a5f6e1e7d6ee7aff9f5fc858d0d87ac0da94dd8d2a5d267d6b::deployer";
         }
-      )
-      .command(
-        "send-example-message <message>",
-        "Send example message",
-        (yargs) => {
-          return yargs
-            .positional("message", {
-              type: "string",
-            })
-            .option("network", NETWORK_OPTIONS);
-        },
-        async (argv) => {
-          const network = argv.network.toUpperCase();
-          assertNetwork(network);
-          const rpc = NETWORKS[network]["aptos"].rpc;
-          // TODO(csongor): use sdk address
-          let module_name =
-            "0x277fa055b6a73c42c0662d5236c65c864ccbf2d4abd21f174a30c8b786eab84b::sender";
-          if (network == "TESTNET" || network == "MAINNET") {
-            module_name =
-              "0x0108bc32f7de18a5f6e1e7d6ee7aff9f5fc858d0d87ac0da94dd8d2a5d267d6b::sender";
-          }
-          await callEntryFunc(
-            network,
-            rpc,
-            module_name,
-            "send_message",
-            [],
-            [BCS.bcsSerializeBytes(Buffer.from(argv["message"], "ascii"))]
-          );
+        const rpc = argv.rpc ?? NETWORKS[network]["aptos"].rpc;
+        await callEntryFunc(
+          network,
+          rpc,
+          module_name,
+          "deploy_derived",
+          [],
+          [b.meta, b.bytecodes, BCS.bcsSerializeBytes(seed)]
+        );
+        console.log("Deployed:", p.mv_files);
+      }
+    )
+    .command(
+      "send-example-message <message>",
+      "Send example message",
+      (yargs) =>
+        yargs
+          .positional("message", {
+            type: "string",
+            describe: "Message to send",
+            demandOption: true,
+          })
+          .option("network", NETWORK_OPTIONS),
+      async (argv) => {
+        const network = argv.network.toUpperCase();
+        assertNetwork(network);
+        const rpc = NETWORKS[network]["aptos"].rpc;
+        // TODO(csongor): use sdk address
+        let module_name =
+          "0x277fa055b6a73c42c0662d5236c65c864ccbf2d4abd21f174a30c8b786eab84b::sender";
+        if (network == "TESTNET" || network == "MAINNET") {
+          module_name =
+            "0x0108bc32f7de18a5f6e1e7d6ee7aff9f5fc858d0d87ac0da94dd8d2a5d267d6b::sender";
         }
-      )
-      .command(
-        "derive-resource-account <account> <seed>",
-        "Derive resource account address",
-        (yargs) => {
-          return yargs
-            .positional("account", {
-              type: "string",
-            })
-            .positional("seed", {
-              type: "string",
-            });
-        },
-        async (argv) => {
-          console.log(
-            deriveResourceAccount(
-              Buffer.from(hex(argv["account"]).substring(2), "hex"),
-              argv["seed"]
-            )
-          );
-        }
-      )
-      .command(
-        "derive-wrapped-address <chain> <origin-address>",
-        "Derive wrapped coin type",
-        (yargs) => {
-          return yargs
-            .positional("chain", {
-              type: "string",
-            })
-            .positional("origin-address", {
-              type: "string",
-            })
-            .option("network", NETWORK_OPTIONS);
-        },
-        async (argv) => {
-          const network = argv.network.toUpperCase();
-          assertNetwork(network);
-          let address = CONTRACTS[network].aptos.token_bridge;
-          if (address.startsWith("0x")) address = address.substring(2);
-          const token_bridge_address = Buffer.from(address, "hex");
-          assertChain(argv["chain"]);
-          const chain = coalesceChainId(argv["chain"]);
-          const origin_address = Buffer.from(
-            evm_address(argv["origin-address"]),
-            "hex"
-          );
-          console.log(
-            deriveWrappedAssetAddress(
-              token_bridge_address,
-              chain,
-              origin_address
-            )
-          );
-        }
-      )
-      .command(
-        "hash-contracts <package-dir>",
-        "Hash contract bytecodes for upgrade",
-        (yargs) => {
-          return yargs
-            .positional("seed", {
-              type: "string",
-            })
-            .positional("package-dir", {
-              type: "string",
-            })
-            .option("named-addresses", NAMED_ADDRESSES_OPTIONS);
-        },
-        (argv) => {
-          checkBinary("aptos", README_URL);
-          const p = buildPackage(argv["package-dir"], argv["named-addresses"]);
-          const b = serializePackage(p);
-          console.log(Buffer.from(b.codeHash).toString("hex"));
-        }
-      )
-      .command(
-        "upgrade <package-dir>",
-        "Perform upgrade after VAA has been submitted",
-        (_yargs) => {
-          return (
-            yargs
-              .positional("package-dir", {
-                type: "string",
-              })
-              // TODO(csongor): once the sdk has the addresses, just look that up
-              // based on the module
-              .option("contract-address", {
-                alias: "a",
-                required: true,
-                describe: "Address where the wormhole module is deployed",
-                type: "string",
-              })
-              .option("network", NETWORK_OPTIONS)
-              .option("rpc", RPC_OPTIONS)
-              .option("named-addresses", NAMED_ADDRESSES_OPTIONS)
-          );
-        },
-        async (argv) => {
-          const network = argv.network.toUpperCase();
-          assertNetwork(network);
-          checkBinary("aptos", README_URL);
-          const p = buildPackage(argv["package-dir"], argv["named-addresses"]);
-          const b = serializePackage(p);
-          const rpc = argv.rpc ?? NETWORKS[network]["aptos"].rpc;
-          // TODO(csongor): use deployer address from sdk (when it's there)
-          const hash = await callEntryFunc(
-            network,
-            rpc,
-            `${argv["contract-address"]}::contract_upgrade`,
-            "upgrade",
-            [],
-            [b.meta, b.bytecodes]
-          );
-          console.log("Deployed:", p.mv_files);
-          console.log(hash);
-        }
-      )
-      .command(
-        "migrate",
-        "Perform migration after contract upgrade",
-        (_yargs) => {
-          return (
-            yargs
-              // TODO(csongor): once the sdk has the addresses, just look that up
-              // based on the module
-              .option("contract-address", {
-                alias: "a",
-                required: true,
-                describe: "Address where the wormhole module is deployed",
-                type: "string",
-              })
-              .option("network", NETWORK_OPTIONS)
-              .option("rpc", RPC_OPTIONS)
-          );
-        },
-        async (argv) => {
-          const network = argv.network.toUpperCase();
-          assertNetwork(network);
-          checkBinary("aptos", README_URL);
-          const rpc = argv.rpc ?? NETWORKS[network]["aptos"].rpc;
-          // TODO(csongor): use deployer address from sdk (when it's there)
-          const hash = await callEntryFunc(
-            network,
-            rpc,
-            `${argv["contract-address"]}::contract_upgrade`,
-            "migrate",
-            [],
-            []
-          );
-          console.log(hash);
-        }
-      )
-      // TODO - make faucet support testnet in additional to localnet
-      .command(
-        "faucet",
-        "Request money from the faucet for a given account",
-        (yargs) => {
-          return yargs
-            .option("rpc", RPC_OPTIONS)
-            .option("faucet", {
-              alias: "f",
-              required: false,
-              describe: "Faucet url",
-              type: "string",
-            })
-            .option("amount", {
-              alias: "m",
-              required: false,
-              describe: "Amount to request",
-              type: "number",
-            })
-            .option("account", {
-              alias: "a",
-              required: false,
-              describe: "Account to fund",
-              type: "string",
-            });
-        },
-        async (argv) => {
-          let NODE_URL = "http://0.0.0.0:8080/v1";
-          let FAUCET_URL = "http://0.0.0.0:8081";
-          let account =
-            "0x277fa055b6a73c42c0662d5236c65c864ccbf2d4abd21f174a30c8b786eab84b";
-          let amount = 40000000;
+        await callEntryFunc(
+          network,
+          rpc,
+          module_name,
+          "send_message",
+          [],
+          [BCS.bcsSerializeBytes(Buffer.from(argv["message"], "ascii"))]
+        );
+      }
+    )
+    .command(
+      "derive-resource-account <account> <seed>",
+      "Derive resource account address",
+      (yargs) =>
+        yargs
+          .positional("account", {
+            type: "string",
+            describe: "Account address",
+            demandOption: true,
+          })
+          .positional("seed", {
+            type: "string",
+            describe: "Seed for resource account",
+            demandOption: true,
+          }),
+      async (argv) => {
+        console.log(
+          deriveResourceAccount(
+            Buffer.from(hex(argv["account"]).substring(2), "hex"),
+            argv["seed"]
+          )
+        );
+      }
+    )
+    .command(
+      "derive-wrapped-address <chain> <origin-address>",
+      "Derive wrapped coin type",
+      (yargs) =>
+        yargs
+          .positional("chain", {
+            type: "string",
+            describe: "Origin chain name",
+            demandOption: true,
+          })
+          .positional("origin-address", {
+            type: "string",
+            describe: "Address on origin chain",
+            demandOption: true,
+          })
+          .option("network", NETWORK_OPTIONS),
+      async (argv) => {
+        const network = argv.network.toUpperCase();
+        assertNetwork(network);
+        let address = CONTRACTS[network].aptos.token_bridge;
+        if (address.startsWith("0x")) address = address.substring(2);
+        const token_bridge_address = Buffer.from(address, "hex");
+        assertChain(argv["chain"]);
+        const chain = coalesceChainId(argv["chain"]);
+        const origin_address = Buffer.from(
+          evm_address(argv["origin-address"]),
+          "hex"
+        );
+        console.log(
+          deriveWrappedAssetAddress(token_bridge_address, chain, origin_address)
+        );
+      }
+    )
+    .command(
+      "hash-contracts <package-dir>",
+      "Hash contract bytecodes for upgrade",
+      (yargs) =>
+        yargs
+          .positional("package-dir", {
+            type: "string",
+            describe: "Path to package directory",
+            demandOption: true,
+          })
+          .option("named-addresses", NAMED_ADDRESSES_OPTIONS),
+      (argv) => {
+        checkBinary("aptos", README_URL);
+        const p = buildPackage(argv["package-dir"], argv["named-addresses"]);
+        const b = serializePackage(p);
+        console.log(Buffer.from(b.codeHash).toString("hex"));
+      }
+    )
+    .command(
+      "upgrade <package-dir>",
+      "Perform upgrade after VAA has been submitted",
+      (_yargs) =>
+        yargs
+          .positional("package-dir", {
+            type: "string",
+            describe: "Path to package directory",
+            demandOption: true,
+          })
+          // TODO(csongor): once the sdk has the addresses, just look that up
+          // based on the module
+          .option("contract-address", {
+            alias: "a",
+            demandOption: true,
+            describe: "Address where the wormhole module is deployed",
+            type: "string",
+          })
+          .option("network", NETWORK_OPTIONS)
+          .option("rpc", RPC_OPTIONS)
+          .option("named-addresses", NAMED_ADDRESSES_OPTIONS),
+      async (argv) => {
+        const network = argv.network.toUpperCase();
+        assertNetwork(network);
+        checkBinary("aptos", README_URL);
+        const p = buildPackage(argv["package-dir"], argv["named-addresses"]);
+        const b = serializePackage(p);
+        const rpc = argv.rpc ?? NETWORKS[network]["aptos"].rpc;
+        // TODO(csongor): use deployer address from sdk (when it's there)
+        const hash = await callEntryFunc(
+          network,
+          rpc,
+          `${argv["contract-address"]}::contract_upgrade`,
+          "upgrade",
+          [],
+          [b.meta, b.bytecodes]
+        );
+        console.log("Deployed:", p.mv_files);
+        console.log(hash);
+      }
+    )
+    .command(
+      "migrate",
+      "Perform migration after contract upgrade",
+      (_yargs) =>
+        yargs
+          // TODO(csongor): once the sdk has the addresses, just look that up
+          // based on the module
+          .option("contract-address", {
+            alias: "a",
+            demandOption: true,
+            describe: "Address where the wormhole module is deployed",
+            type: "string",
+          })
+          .option("network", NETWORK_OPTIONS)
+          .option("rpc", RPC_OPTIONS),
+      async (argv) => {
+        const network = argv.network.toUpperCase();
+        assertNetwork(network);
+        checkBinary("aptos", README_URL);
+        const rpc = argv.rpc ?? NETWORKS[network]["aptos"].rpc;
+        // TODO(csongor): use deployer address from sdk (when it's there)
+        const hash = await callEntryFunc(
+          network,
+          rpc,
+          `${argv["contract-address"]}::contract_upgrade`,
+          "migrate",
+          [],
+          []
+        );
+        console.log(hash);
+      }
+    )
+    // TODO - make faucet support testnet in additional to localnet
+    .command(
+      "faucet",
+      "Request money from the faucet for a given account",
+      (_yargs) =>
+        yargs
+          .option("rpc", {
+            alias: "r",
+            describe: "Override default rpc endpoint url",
+            type: "string",
+            demandOption: false,
+            default: APTOS_NODE_URL,
+          })
+          .option("faucet", {
+            alias: "f",
+            demandOption: false,
+            describe: "Faucet url",
+            type: "string",
+            default: APTOS_FAUCET_URL,
+          })
+          .option("amount", {
+            alias: "m",
+            demandOption: false,
+            describe: "Amount to request",
+            type: "number",
+            default: 40000000,
+          })
+          .option("account", {
+            alias: "a",
+            demandOption: false,
+            describe: "Account to fund",
+            type: "string",
+            default: APTOS_DEPLOYER_ADDRESS_DEVNET,
+          }),
+      async (argv) => {
+        const faucetClient = new FaucetClient(argv.rpc, argv.faucet);
+        await faucetClient.fundAccount(argv.account, argv.amount);
+        console.log(`Funded ${argv.account} with ${argv.amount} coins`);
+      }
+    )
+    .command(
+      "start-validator",
+      "Start a local aptos validator",
+      (yargs) => yargs.option("validator-args", VALIDATOR_OPTIONS),
+      (argv) => {
+        checkBinary("aptos", README_URL);
+        const cmd = `cd ${homedir()} && aptos node run-local-testnet --with-faucet --force-restart --assume-yes`;
+        runCommand(cmd, argv["validator-args"]);
+      }
+    )
+    .strict()
+    .demandCommand();
+export const handler = () => {};
 
-          if (argv.faucet != undefined) {
-            FAUCET_URL = argv.faucet as string;
-          }
-          if (argv.rpc != undefined) {
-            NODE_URL = argv.rpc as string;
-          }
-          if (argv.amount != undefined) {
-            amount = argv.amount as number;
-          }
-          if (argv.account != undefined) {
-            account = argv.account as string;
-          }
-          const faucetClient = new FaucetClient(NODE_URL, FAUCET_URL);
-          await faucetClient.fundAccount(account, amount);
-          console.log(`Funded ${account} with ${amount} coins`);
-        }
-      )
-      .command(
-        "start-validator",
-        "Start a local aptos validator",
-        (yargs) => {
-          return yargs.option("validator-args", validator_args);
-        },
-        (argv) => {
-          checkBinary("aptos", README_URL);
-          const cmd = `cd ${homedir()} && aptos node run-local-testnet --with-faucet --force-restart --assume-yes`;
-          runCommand(cmd, argv["validator-args"]);
-        }
-      )
-      .strict()
-      .demandCommand()
-  );
-};
-
-function buildPackage(dir: string, addrs?: string): Package {
+const buildPackage = (dir: string, addrs?: string): Package => {
   const named_addresses = addrs ? ["--named-addresses", addrs] : [];
   const aptos = spawnSync("aptos", [
     "move",
@@ -498,9 +484,9 @@ function buildPackage(dir: string, addrs?: string): Package {
       (mod: string) => `${buildDir}/bytecode_modules/${mod.split("::")[1]}.mv`
     ),
   };
-}
+};
 
-function serializePackage(p: Package): PackageBCS {
+const serializePackage = (p: Package): PackageBCS => {
   const metaBytes = fs.readFileSync(p.meta_file);
   const packageMetadataSerializer = new BCS.Serializer();
   packageMetadataSerializer.serializeBytes(metaBytes);
@@ -522,6 +508,4 @@ function serializePackage(p: Package): PackageBCS {
     bytecodes: serializedModules,
     codeHash,
   };
-}
-
-export const handler = (argv) => {};
+};

--- a/clients/js/src/cmds/chainId.ts
+++ b/clients/js/src/cmds/chainId.ts
@@ -13,9 +13,10 @@ export const builder = (y: typeof yargs) => {
     describe: "Chain to query",
     type: "string",
     choices: Object.keys(CHAINS),
-  });
+    demandOption: true,
+  } as const);
 };
-export const handler = (argv) => {
+export const handler = (argv: Awaited<ReturnType<typeof builder>["argv"]>) => {
   assertChain(argv["chain"]);
   console.log(coalesceChainId(argv["chain"]));
 };

--- a/clients/js/src/cmds/convert-to-emitter.ts
+++ b/clients/js/src/cmds/convert-to-emitter.ts
@@ -1,26 +1,30 @@
-import yargs from "yargs";
 import {
   CHAINS,
   assertChain,
 } from "@certusone/wormhole-sdk/lib/esm/utils/consts";
+import yargs from "yargs";
 import { getEmitterAddress } from "../emitter";
 
 export const command = "convert-to-emitter <chain> <address-to-convert>";
 export const desc = "Print address in emitter address format";
-export const builder = (y: typeof yargs) => {
-  return y
+export const builder = (y: typeof yargs) =>
+  y
     .positional("chain", {
       describe: "Chain to query",
       type: "string",
       choices: Object.keys(CHAINS),
-    })
+      demandOption: true,
+    } as const)
     .positional("address-to-convert", {
       describe: "Address to be converted to emitter address format",
       type: "string",
+      demandOption: true,
     });
-};
-export const handler = async (argv) => {
+export const handler = async (
+  argv: Awaited<ReturnType<typeof builder>["argv"]>
+) => {
   assertChain(argv["chain"]);
-  let chain = argv["chain"];
-  console.log(await getEmitterAddress(chain, argv["address-to-convert"]));
+  console.log(
+    await getEmitterAddress(argv["chain"], argv["address-to-convert"])
+  );
 };

--- a/clients/js/src/cmds/evm.ts
+++ b/clients/js/src/cmds/evm.ts
@@ -16,8 +16,8 @@ import {
   setStorageAt,
 } from "../evm";
 import { NETWORKS } from "../networks";
-import { runCommand, validator_args } from "../start-validator";
-import { evm_address } from "../utils";
+import { runCommand, VALIDATOR_OPTIONS } from "../start-validator";
+import { assertNetwork, evm_address } from "../utils";
 
 export const command = "evm";
 export const desc = "EVM utilities";
@@ -26,17 +26,17 @@ export const builder = function (y: typeof yargs) {
     .option("rpc", {
       describe: "RPC endpoint",
       type: "string",
-      required: false,
+      demandOption: false,
     })
     .command(
       "address-from-secret <secret>",
       "Compute a 20 byte eth address from a 32 byte private key",
-      (yargs) => {
-        return yargs.positional("secret", {
+      (yargs) =>
+        yargs.positional("secret", {
           type: "string",
           describe: "Secret key (32 bytes)",
-        });
-      },
+          demandOption: true,
+        } as const),
       (argv) => {
         console.log(ethers.utils.computeAddress(argv["secret"]));
       }
@@ -44,28 +44,31 @@ export const builder = function (y: typeof yargs) {
     .command(
       "storage-update",
       "Update a storage slot on an EVM fork during testing (anvil or hardhat)",
-      (yargs) => {
-        return yargs
+      (yargs) =>
+        yargs
           .option("contract-address", {
             alias: "a",
             describe: "Contract address",
             type: "string",
-            required: true,
+            demandOption: true,
           })
           .option("storage-slot", {
             alias: "k",
             describe: "Storage slot to modify",
             type: "string",
-            required: true,
+            demandOption: true,
           })
           .option("value", {
             alias: "v",
             describe: "Value to write into the slot (32 bytes)",
             type: "string",
-            required: true,
-          });
-      },
+            demandOption: true,
+          }),
       async (argv) => {
+        if (!argv["rpc"]) {
+          throw new Error("RPC required");
+        }
+
         const result = await setStorageAt(
           argv["rpc"],
           evm_address(argv["contract-address"]),
@@ -87,56 +90,49 @@ export const builder = function (y: typeof yargs) {
     .command(
       "info",
       "Query info about the on-chain state of the contract",
-      (yargs) => {
-        return yargs
+      (yargs) =>
+        yargs
           .option("chain", {
             alias: "c",
             describe: "Chain to query",
             type: "string",
             choices: Object.keys(CHAINS),
-            required: true,
+            demandOption: true,
           })
           .option("module", {
             alias: "m",
             describe: "Module to query",
             type: "string",
             choices: ["Core", "NFTBridge", "TokenBridge"],
-            required: true,
+            demandOption: true,
           })
           .option("network", {
             alias: "n",
             describe: "network",
             type: "string",
             choices: ["mainnet", "testnet", "devnet"],
-            required: true,
+            demandOption: true,
           })
           .option("contract-address", {
             alias: "a",
             describe: "Contract to query (override config)",
             type: "string",
-            required: false,
+            demandOption: false,
           })
           .option("implementation-only", {
             alias: "i",
             describe: "Only query implementation (faster)",
             type: "boolean",
             default: false,
-            required: false,
-          });
-      },
+            demandOption: false,
+          }),
       async (argv) => {
         assertChain(argv["chain"]);
         assertEVMChain(argv["chain"]);
         const network = argv.network.toUpperCase();
-        if (
-          network !== "MAINNET" &&
-          network !== "TESTNET" &&
-          network !== "DEVNET"
-        ) {
-          throw Error(`Unknown network: ${network}`);
-        }
-        let module = argv["module"] as "Core" | "NFTBridge" | "TokenBridge";
-        let rpc = argv["rpc"] ?? NETWORKS[network][argv["chain"]].rpc;
+        assertNetwork(network);
+        const module = argv["module"] as "Core" | "NFTBridge" | "TokenBridge";
+        const rpc = argv["rpc"] ?? NETWORKS[network][argv["chain"]].rpc;
         if (argv["implementation-only"]) {
           console.log(
             await getImplementation(
@@ -167,8 +163,8 @@ export const builder = function (y: typeof yargs) {
     .command(
       "hijack",
       "Override the guardian set of the core bridge contract during testing (anvil or hardhat)",
-      (yargs) => {
-        return yargs
+      (yargs) =>
+        yargs
           .option("core-contract-address", {
             alias: "a",
             describe: "Core contract address",
@@ -177,18 +173,17 @@ export const builder = function (y: typeof yargs) {
           })
           .option("guardian-address", {
             alias: "g",
-            required: true,
+            demandOption: true,
             describe: "Guardians' public addresses (CSV)",
             type: "string",
           })
           .option("guardian-set-index", {
             alias: "i",
-            required: false,
+            demandOption: false,
             describe:
               "New guardian set index (if unspecified, default to overriding the current index)",
             type: "number",
-          });
-      },
+          }),
       async (argv) => {
         const guardian_addresses = argv["guardian-address"].split(",");
         let rpc = argv["rpc"] ?? NETWORKS.DEVNET.ethereum.rpc;
@@ -203,9 +198,7 @@ export const builder = function (y: typeof yargs) {
     .command(
       "start-validator",
       "Start a local EVM validator",
-      (yargs) => {
-        return yargs.option("validator-args", validator_args);
-      },
+      (yargs) => yargs.option("validator-args", VALIDATOR_OPTIONS),
       (argv) => {
         const cmd = `cd ${homedir()} && npx ganache-cli -e 10000 --deterministic --time="1970-01-01T00:00:00+00:00"`;
         runCommand(cmd, argv["validator-args"]);
@@ -214,5 +207,4 @@ export const builder = function (y: typeof yargs) {
     .strict()
     .demandCommand();
 };
-
-export const handler = (argv) => {};
+export const handler = () => {};

--- a/clients/js/src/cmds/generate.ts
+++ b/clients/js/src/cmds/generate.ts
@@ -54,7 +54,7 @@ export const builder = function (y: typeof yargs) {
     y
       .option("guardian-secret", {
         alias: "g",
-        required: true,
+        demandOption: true,
         describe: "Guardians' secret keys (CSV)",
         type: "string",
       })
@@ -62,33 +62,30 @@ export const builder = function (y: typeof yargs) {
       .command(
         "registration",
         "Generate registration VAA",
-        (yargs) => {
-          return yargs
+        (yargs) =>
+          yargs
             .option("chain", {
               alias: "c",
               describe: "Chain to register",
-              type: "string",
               choices: Object.keys(CHAINS),
-              required: true,
-            })
+              demandOption: true,
+            } as const)
             .option("contract-address", {
               alias: "a",
               describe: "Contract to register",
               type: "string",
-              required: true,
+              demandOption: true,
             })
             .option("module", {
               alias: "m",
               describe: "Module to upgrade",
-              type: "string",
               choices: ["NFTBridge", "TokenBridge"],
-              required: true,
-            });
-        },
+              demandOption: true,
+            } as const),
         (argv) => {
-          let module = argv["module"] as "NFTBridge" | "TokenBridge";
+          const module = argv["module"];
           assertChain(argv["chain"]);
-          let payload: PortalRegisterChain<typeof module> = {
+          const payload: PortalRegisterChain<typeof module> = {
             module,
             type: "RegisterChain",
             chain: 0,
@@ -98,115 +95,110 @@ export const builder = function (y: typeof yargs) {
               argv["contract-address"]
             ),
           };
-          let v = makeVAA(
+          const vaa = makeVAA(
             GOVERNANCE_CHAIN,
             GOVERNANCE_EMITTER,
             argv["guardian-secret"].split(","),
             payload
           );
-          console.log(serialiseVAA(v));
+          console.log(serialiseVAA(vaa));
         }
       )
       // Upgrade
       .command(
         "upgrade",
         "Generate contract upgrade VAA",
-        (yargs) => {
-          return yargs
+        (yargs) =>
+          yargs
             .option("chain", {
               alias: "c",
               describe: "Chain to upgrade",
-              type: "string",
               choices: Object.keys(CHAINS),
-              required: true,
-            })
+              demandOption: true,
+            } as const)
             .option("contract-address", {
               alias: "a",
               describe: "Contract to upgrade to",
               type: "string",
-              required: true,
+              demandOption: true,
             })
             .option("module", {
               alias: "m",
               describe: "Module to upgrade",
-              type: "string",
               choices: ["Core", "NFTBridge", "TokenBridge"],
-              required: true,
-            });
-        },
+              demandOption: true,
+            } as const),
         (argv) => {
           assertChain(argv["chain"]);
-          let module = argv["module"] as "Core" | "NFTBridge" | "TokenBridge";
-          let payload: ContractUpgrade = {
+          const module = argv["module"];
+          const payload: ContractUpgrade = {
             module,
             type: "ContractUpgrade",
             chain: toChainId(argv["chain"]),
             address: parseCodeAddress(argv["chain"], argv["contract-address"]),
           };
-          let v = makeVAA(
+          const vaa = makeVAA(
             GOVERNANCE_CHAIN,
             GOVERNANCE_EMITTER,
             argv["guardian-secret"].split(","),
             payload
           );
-          console.log(serialiseVAA(v));
+          console.log(serialiseVAA(vaa));
         }
       )
       .command(
         "attestation",
         "Generate a token attestation VAA",
-        (yargs) => {
-          return yargs
+        (yargs) =>
+          yargs
             .option("emitter-chain", {
               alias: "e",
               describe: "Emitter chain of the VAA",
-              type: "string",
               choices: Object.keys(CHAINS),
-              required: true,
-            })
+              demandOption: true,
+            } as const)
             .option("emitter-address", {
               alias: "f",
               describe: "Emitter address of the VAA",
               type: "string",
-              required: true,
+              demandOption: true,
             })
             .option("chain", {
               alias: "c",
               describe: "Token's chain",
               type: "string",
               choices: Object.keys(CHAINS),
-              required: true,
+              demandOption: true,
             })
             .option("token-address", {
               alias: "a",
               describe: "Token's address",
               type: "string",
-              required: true,
+              demandOption: true,
             })
             .option("decimals", {
               alias: "d",
               describe: "Token's decimals",
               type: "number",
-              required: true,
+              demandOption: true,
             })
             .option("symbol", {
               alias: "s",
               describe: "Token's symbol",
               type: "string",
-              required: true,
+              demandOption: true,
             })
             .option("name", {
               alias: "n",
               describe: "Token's name",
               type: "string",
-              required: true,
-            });
-        },
+              demandOption: true,
+            }),
         (argv) => {
-          let emitter_chain = argv["emitter-chain"] as string;
+          const emitter_chain = argv["emitter-chain"];
           assertChain(argv["chain"]);
           assertChain(emitter_chain);
-          let payload: TokenBridgeAttestMeta = {
+          const payload: TokenBridgeAttestMeta = {
             module: "TokenBridge",
             type: "AttestMeta",
             chain: 0,
@@ -216,60 +208,59 @@ export const builder = function (y: typeof yargs) {
             symbol: argv["symbol"],
             name: argv["name"],
           };
-          let v = makeVAA(
+          const vaa = makeVAA(
             toChainId(emitter_chain),
-            parseAddress(emitter_chain, argv["emitter-address"] as string),
+            parseAddress(emitter_chain, argv["emitter-address"]),
             argv["guardian-secret"].split(","),
             payload
           );
-          console.log(serialiseVAA(v));
+          console.log(serialiseVAA(vaa));
         }
       )
       // RecoverChainId
       .command(
         "recover-chain-id",
         "Generate a recover chain ID VAA",
-        (yargs) => {
-          return yargs
+        (yargs) =>
+          yargs
             .option("module", {
               alias: "m",
               describe: "Module to upgrade",
-              type: "string",
               choices: ["Core", "NFTBridge", "TokenBridge"],
-              required: true,
-            })
+              demandOption: true,
+            } as const)
             .option("evm-chain-id", {
               alias: "e",
               describe: "EVM chain ID to set",
               type: "string",
-              required: true,
+              demandOption: true,
             })
             .option("new-chain-id", {
               alias: "c",
               describe: "New chain ID to set",
               type: "number",
-              required: true,
-            });
-        },
+              demandOption: true,
+            }),
         (argv) => {
-          let module = argv["module"] as "Core" | "NFTBridge" | "TokenBridge";
-          let payload: RecoverChainId = {
+          const module = argv["module"];
+          const payload: RecoverChainId = {
             module,
             type: "RecoverChainId",
             evmChainId: BigInt(argv["evm-chain-id"]),
             newChainId: argv["new-chain-id"],
           };
-          let v = makeVAA(
+          const vaa = makeVAA(
             GOVERNANCE_CHAIN,
             GOVERNANCE_EMITTER,
             argv["guardian-secret"].split(","),
             payload
           );
-          console.log(serialiseVAA(v));
+          console.log(serialiseVAA(vaa));
         }
       )
   );
 };
+export const handler = () => {};
 
 function parseAddress(chain: ChainName, address: string): string {
   if (chain === "unset") {
@@ -311,5 +302,3 @@ function parseCodeAddress(chain: ChainName, address: string): string {
     return parseAddress(chain, address);
   }
 }
-
-export const handler = (argv) => {};

--- a/clients/js/src/cmds/info.ts
+++ b/clients/js/src/cmds/info.ts
@@ -13,5 +13,4 @@ export const builder = (y: typeof yargs) =>
     .command(contractAddress)
     .command(convertToEmitter)
     .command(rpc);
-
-export const handler = (argv) => {};
+export const handler = () => {};

--- a/clients/js/src/cmds/parse.ts
+++ b/clients/js/src/cmds/parse.ts
@@ -7,9 +7,10 @@ export const builder = (y: typeof yargs) => {
   return y.positional("vaa", {
     describe: "vaa",
     type: "string",
+    demandOption: true,
   });
 };
-export const handler = (argv) => {
+export const handler = (argv: Awaited<ReturnType<typeof builder>["argv"]>) => {
   let buf: Buffer;
   try {
     buf = Buffer.from(String(argv.vaa), "hex");
@@ -22,8 +23,9 @@ export const handler = (argv) => {
       throw Error("Couldn't parse VAA as base64 or hex");
     }
   }
-  const parsed_vaa = parse(buf);
-  let parsed_vaa_with_digest = parsed_vaa;
-  parsed_vaa_with_digest["digest"] = vaaDigest(parsed_vaa);
-  console.log(JSON.stringify(parsed_vaa_with_digest, null, 2));
+
+  const parsedVaa = parse(buf);
+  console.log(
+    JSON.stringify({ ...parsedVaa, digest: vaaDigest(parsedVaa) }, null, 2)
+  );
 };

--- a/clients/js/src/cmds/recover.ts
+++ b/clients/js/src/cmds/recover.ts
@@ -4,18 +4,22 @@ import { hex } from "../utils";
 
 export const command = "recover <digest> <signature>";
 export const desc = "Recover an address from a signature";
-export const builder = (y: typeof yargs) => {
-  return y
+export const builder = (y: typeof yargs) =>
+  y
     .positional("digest", {
       describe: "digest",
       type: "string",
+      demandOption: true,
     })
     .positional("signature", {
       describe: "signature",
       type: "string",
+      demandOption: true,
     });
-};
-export const handler = async (argv) => {
+
+export const handler = async (
+  argv: Awaited<ReturnType<typeof builder>["argv"]>
+) => {
   console.log(
     ethers.utils.recoverAddress(hex(argv["digest"]), hex(argv["signature"]))
   );

--- a/clients/js/src/cmds/rpc.ts
+++ b/clients/js/src/cmds/rpc.ts
@@ -4,27 +4,27 @@ import {
 } from "@certusone/wormhole-sdk/lib/esm/utils/consts";
 import yargs from "yargs";
 import { NETWORKS } from "../networks";
+import { assertNetwork } from "../utils";
 
 export const command = "rpc <network> <chain>";
 export const desc = "Print RPC address";
-export const builder = (y: typeof yargs) => {
-  return y
+export const builder = (y: typeof yargs) =>
+  y
     .positional("network", {
       describe: "network",
-      type: "string",
       choices: ["mainnet", "testnet", "devnet"],
-    })
+      demandOption: true,
+    } as const)
     .positional("chain", {
       describe: "Chain to query",
-      type: "string",
       choices: Object.keys(CHAINS),
-    });
-};
-export const handler = async (argv) => {
+      demandOption: true,
+    } as const);
+export const handler = async (
+  argv: Awaited<ReturnType<typeof builder>["argv"]>
+) => {
   assertChain(argv["chain"]);
   const network = argv.network.toUpperCase();
-  if (network !== "MAINNET" && network !== "TESTNET" && network !== "DEVNET") {
-    throw Error(`Unknown network: ${network}`);
-  }
+  assertNetwork(network);
   console.log(NETWORKS[network][argv["chain"]].rpc);
 };

--- a/clients/js/src/cmds/sui/build.ts
+++ b/clients/js/src/cmds/sui/build.ts
@@ -21,33 +21,33 @@ export const addBuildCommands: YargsAddCommandsFn = (y: typeof yargs) =>
         .option("decimals", {
           alias: "d",
           describe: "Decimals of asset",
-          required: true,
+          demandOption: true,
           type: "number",
         })
         // Can't be called version because of a conflict with the native version option
         .option("version-struct", {
           alias: "v",
           describe: "Version control struct name (e.g. V__0_1_0)",
-          required: true,
+          demandOption: true,
           type: "string",
         })
         .option("network", NETWORK_OPTIONS)
         .option("package-path", {
           alias: "p",
           describe: "Path to coin module",
-          required: false,
+          demandOption: false,
           type: "string",
         })
         .option("wormhole-state", {
           alias: "w",
           describe: "Wormhole state object ID",
-          required: false,
+          demandOption: false,
           type: "string",
         })
         .option("token-bridge-state", {
           alias: "t",
           describe: "Token bridge state object ID",
-          required: false,
+          demandOption: false,
           type: "string",
         })
         .option("rpc", RPC_OPTIONS),
@@ -65,11 +65,23 @@ export const addBuildCommands: YargsAddCommandsFn = (y: typeof yargs) =>
         argv["wormhole-state"] ?? CONTRACTS[network].sui.core;
       const tokenBridgeStateObjectId =
         argv["token-bridge-state"] ?? CONTRACTS[network].sui.token_bridge;
+
+      if (!coreBridgeStateObjectId) {
+        throw new Error(
+          `Couldn't find core bridge state object ID for network ${network}`
+        );
+      }
+
+      if (!tokenBridgeStateObjectId) {
+        throw new Error(
+          `Couldn't find token bridge state object ID for network ${network}`
+        );
+      }
+
       const provider = getProvider(
         network,
         argv.rpc ?? NETWORKS[network].sui.rpc
       );
-
       const build = await buildCoin(
         provider,
         network,

--- a/clients/js/src/cmds/sui/deploy.ts
+++ b/clients/js/src/cmds/sui/deploy.ts
@@ -27,16 +27,17 @@ export const addDeployCommands: YargsAddCommandsFn = (y: typeof yargs) =>
   y.command(
     "deploy <package-dir>",
     "Deploy a Sui package",
-    (yargs) => {
-      return yargs
+    (yargs) =>
+      yargs
         .positional("package-dir", {
           type: "string",
+          describe: "Path to package directory",
+          demandOption: true,
         })
         .option("network", NETWORK_OPTIONS)
         .option("debug", DEBUG_OPTIONS)
         .option("private-key", PRIVATE_KEY_OPTIONS)
-        .option("rpc", RPC_OPTIONS);
-    },
+        .option("rpc", RPC_OPTIONS),
     async (argv) => {
       checkBinary("sui", README_URL);
 

--- a/clients/js/src/cmds/sui/index.ts
+++ b/clients/js/src/cmds/sui/index.ts
@@ -9,8 +9,8 @@ import { addUtilsCommands } from "./utils";
 
 export const command = "sui";
 export const desc = "Sui utilities";
-export const builder = function (y: typeof yargs) {
-  return new Yargs(y)
+export const builder = (y: typeof yargs) =>
+  new Yargs(y)
     .addCommands(addBuildCommands)
     .addCommands(addDeployCommands)
     .addCommands(addInitCommands)
@@ -20,5 +20,4 @@ export const builder = function (y: typeof yargs) {
     .y()
     .strict()
     .demandCommand();
-};
-export const handler = (argv) => {};
+export const handler = () => {};

--- a/clients/js/src/cmds/sui/setup.ts
+++ b/clients/js/src/cmds/sui/setup.ts
@@ -1,5 +1,6 @@
 import {
   ChainId,
+  ChainName,
   coalesceChainName,
 } from "@certusone/wormhole-sdk/lib/esm/utils/consts";
 import { parseTokenBridgeRegisterChainVaa } from "@certusone/wormhole-sdk/lib/esm/vaa/tokenBridge";
@@ -30,6 +31,7 @@ import {
   logPublishedPackageId,
   logTransactionDigest,
   registerChain,
+  setMaxGasBudgetDevnet,
 } from "../../sui";
 import { YargsAddCommandsFn } from "../Yargs";
 import { deploy } from "./deploy";
@@ -39,16 +41,15 @@ export const addSetupCommands: YargsAddCommandsFn = (y: typeof yargs) =>
   y.command(
     "setup-devnet",
     "Setup devnet by deploying and initializing core and token bridges and submitting chain registrations.",
-    (yargs) => {
-      return yargs
+    (yargs) =>
+      yargs
         .option("private-key", {
           alias: "k",
           describe: "Custom private key to sign txs",
-          required: false,
+          demandOption: false,
           type: "string",
         })
-        .option("rpc", RPC_OPTIONS);
-    },
+        .option("rpc", RPC_OPTIONS),
     async (argv) => {
       const network = "DEVNET";
       const privateKey = argv["private-key"];
@@ -62,8 +63,8 @@ export const addSetupCommands: YargsAddCommandsFn = (y: typeof yargs) =>
         rpc,
         privateKey
       );
-      assertSuccess(coreBridgeDeployRes, "Core bridge deployment failed.");
       logTransactionDigest(coreBridgeDeployRes);
+      assertSuccess(coreBridgeDeployRes, "Core bridge deployment failed.");
       logPublishedPackageId(coreBridgeDeployRes);
 
       // Init core bridge
@@ -79,11 +80,17 @@ export const addSetupCommands: YargsAddCommandsFn = (y: typeof yargs) =>
         rpc,
         privateKey
       );
+      logTransactionDigest(coreBridgeInitRes);
+      assertSuccess(coreBridgeInitRes, "Core bridge initialization failed.");
+
+      // Get core bridge state object ID
       const coreBridgeStateObjectId = getCreatedObjects(coreBridgeInitRes).find(
         (e) => isSameType(e.type, `${coreBridgePackageId}::state::State`)
-      ).objectId;
-      assertSuccess(coreBridgeInitRes, "Core bridge initialization failed.");
-      logTransactionDigest(coreBridgeInitRes);
+      )?.objectId;
+      if (!coreBridgeStateObjectId) {
+        throw new Error("Couldn't find core bridge state object ID.");
+      }
+
       console.log("Core bridge state object ID", coreBridgeStateObjectId);
 
       // Deploy token bridge
@@ -94,8 +101,8 @@ export const addSetupCommands: YargsAddCommandsFn = (y: typeof yargs) =>
         rpc,
         privateKey
       );
-      assertSuccess(tokenBridgeDeployRes, "Token bridge deployment failed.");
       logTransactionDigest(tokenBridgeDeployRes);
+      assertSuccess(tokenBridgeDeployRes, "Token bridge deployment failed.");
       logPublishedPackageId(tokenBridgeDeployRes);
 
       // Init token bridge
@@ -110,13 +117,19 @@ export const addSetupCommands: YargsAddCommandsFn = (y: typeof yargs) =>
         rpc,
         privateKey
       );
+      logTransactionDigest(tokenBridgeInitRes);
+      assertSuccess(tokenBridgeInitRes, "Token bridge initialization failed.");
+
+      // Get token bridge state object ID
       const tokenBridgeStateObjectId = getCreatedObjects(
         tokenBridgeInitRes
       ).find((e) =>
         isSameType(e.type, `${tokenBridgePackageId}::state::State`)
-      ).objectId;
-      assertSuccess(tokenBridgeInitRes, "Token bridge initialization failed.");
-      logTransactionDigest(tokenBridgeInitRes);
+      )?.objectId;
+      if (!tokenBridgeStateObjectId) {
+        throw new Error("Couldn't find token bridge state object ID.");
+      }
+
       console.log("Token bridge state object ID", tokenBridgeStateObjectId);
 
       // Deploy example app
@@ -142,7 +155,7 @@ export const addSetupCommands: YargsAddCommandsFn = (y: typeof yargs) =>
       );
       const exampleAppStateObjectId = getCreatedObjects(exampleAppInitRes).find(
         (e) => isSameType(e.type, `${exampleAppPackageId}::sender::State`)
-      ).objectId;
+      )?.objectId;
       logTransactionDigest(exampleAppInitRes);
       console.log("Example app state object ID", exampleAppStateObjectId);
 
@@ -185,10 +198,10 @@ export const addSetupCommands: YargsAddCommandsFn = (y: typeof yargs) =>
       }
 
       dotenv.config({ path: envPath });
-      const signer = getSigner(provider, network, privateKey);
+
       const tx = new TransactionBlock();
-      tx.setGasBudget(10000000000);
-      const registrations = [];
+      setMaxGasBudgetDevnet("DEVNET", tx);
+      const registrations: { chain: ChainName; module: string }[] = [];
       for (const key in process.env) {
         if (/^REGISTER_(.+)_TOKEN_BRIDGE_VAA$/.test(key)) {
           // Get VAA info
@@ -210,6 +223,7 @@ export const addSetupCommands: YargsAddCommandsFn = (y: typeof yargs) =>
         }
       }
 
+      const signer = getSigner(provider, network, privateKey);
       const registerRes = await executeTransactionBlock(signer, tx);
       assertSuccess(registerRes, "Chain registrations failed.");
 
@@ -228,13 +242,12 @@ export const addSetupCommands: YargsAddCommandsFn = (y: typeof yargs) =>
 const getEmitterCapObjectId = async (
   provider: JsonRpcProvider,
   tokenBridgeStateObjectId: string
-): Promise<string> => {
-  return getObjectFields(
+): Promise<string> =>
+  getObjectFields(
     await provider.getObject({
       id: tokenBridgeStateObjectId,
       options: {
         showContent: true,
       },
     })
-  ).emitter_cap.fields.id.id;
-};
+  )?.emitter_cap.fields.id.id;

--- a/clients/js/src/cmds/sui/utils.ts
+++ b/clients/js/src/cmds/sui/utils.ts
@@ -1,3 +1,4 @@
+import { PaginatedObjectsResponse } from "@mysten/sui.js";
 import yargs from "yargs";
 import { NETWORK_OPTIONS, RPC_OPTIONS } from "../../consts";
 import { NETWORKS } from "../../networks";
@@ -15,6 +16,7 @@ export const addUtilsCommands: YargsAddCommandsFn = (y: typeof yargs) =>
           .positional("owner", {
             describe: "Owner address",
             type: "string",
+            demandOption: true,
           })
           .option("network", NETWORK_OPTIONS)
           .option("rpc", RPC_OPTIONS),
@@ -25,11 +27,15 @@ export const addUtilsCommands: YargsAddCommandsFn = (y: typeof yargs) =>
         const owner = argv.owner;
 
         const provider = getProvider(network, rpc);
-        const objects = [];
+        const objects: PaginatedObjectsResponse["data"] = [];
 
-        let cursor = undefined;
+        let cursor: PaginatedObjectsResponse["nextCursor"] | undefined =
+          undefined;
         while (true) {
-          const res = await provider.getOwnedObjects({ owner, cursor });
+          const res: PaginatedObjectsResponse = await provider.getOwnedObjects({
+            owner,
+            cursor,
+          });
           objects.push(...res.data);
           if (res.hasNextPage) {
             cursor = res.nextCursor;
@@ -51,6 +57,7 @@ export const addUtilsCommands: YargsAddCommandsFn = (y: typeof yargs) =>
           .positional("state-object-id", {
             describe: "Object ID of State object",
             type: "string",
+            demandOption: true,
           })
           .option("network", NETWORK_OPTIONS)
           .option("rpc", RPC_OPTIONS),
@@ -72,6 +79,7 @@ export const addUtilsCommands: YargsAddCommandsFn = (y: typeof yargs) =>
           .positional("transaction-digest", {
             describe: "Digest of transaction to fetch",
             type: "string",
+            demandOption: true,
           })
           .option("network", {
             alias: "n",
@@ -79,7 +87,7 @@ export const addUtilsCommands: YargsAddCommandsFn = (y: typeof yargs) =>
             type: "string",
             choices: ["mainnet", "testnet", "devnet"],
             default: "devnet",
-            required: false,
+            demandOption: false,
           })
           .option("rpc", RPC_OPTIONS),
       async (argv) => {

--- a/clients/js/src/consts.ts
+++ b/clients/js/src/consts.ts
@@ -58,27 +58,26 @@ export const DEBUG_OPTIONS = {
   alias: "d",
   describe: "Log debug info",
   type: "boolean",
-  required: false,
+  demandOption: false,
 } as const;
 
 export const NAMED_ADDRESSES_OPTIONS = {
   describe: "Named addresses in the format addr1=0x0,addr2=0x1,...",
   type: "string",
-  require: false,
+  demandOption: false,
 } as const;
 
 export const NETWORK_OPTIONS = {
   alias: "n",
   describe: "Network",
-  type: "string",
   choices: ["mainnet", "testnet", "devnet"],
-  required: true,
+  demandOption: true,
 } as const;
 
 export const PRIVATE_KEY_OPTIONS = {
   alias: "k",
   describe: "Custom private key to sign transactions",
-  required: false,
+  demandOption: false,
   type: "string",
 } as const;
 
@@ -86,7 +85,7 @@ export const RPC_OPTIONS = {
   alias: "r",
   describe: "Override default rpc endpoint url",
   type: "string",
-  required: false,
+  demandOption: false,
 } as const;
 
 export const GOVERNANCE_CHAIN = CHAIN_ID_SOLANA;

--- a/clients/js/src/near-seed-phrase.d.ts
+++ b/clients/js/src/near-seed-phrase.d.ts
@@ -1,0 +1,10 @@
+declare module "near-seed-phrase" {
+  export function parseSeedPhrase(
+    seedPhrase: string,
+    derivationPath?: string
+  ): {
+    seedPhrase: string;
+    secretKey: string;
+    publicKey: string;
+  };
+}

--- a/clients/js/src/side-effects.ts
+++ b/clients/js/src/side-effects.ts
@@ -14,6 +14,7 @@ console.info = function (x: string) {
     info(x);
   }
 };
+
 const warn = console.warn;
 console.warn = function (x: string) {
   if (

--- a/clients/js/src/start-validator.ts
+++ b/clients/js/src/start-validator.ts
@@ -1,6 +1,6 @@
-import { spawnSync } from 'child_process';
+import { spawnSync } from "child_process";
 
-export const validator_args = {
+export const VALIDATOR_OPTIONS = {
   alias: "a",
   type: "string",
   array: true,
@@ -8,9 +8,9 @@ export const validator_args = {
   describe: "Additional args to validator",
 } as const;
 
-export function runCommand(baseCmd: string, args: readonly string[]) {
-  const args_string = args.map(a => `"${a}"`).join(" ");
+export const runCommand = (baseCmd: string, args: readonly string[]): void => {
+  const args_string = args.map((a) => `"${a}"`).join(" ");
   const cmd = `${baseCmd} ${args_string}`;
   console.log("\x1b[33m%s\x1b[0m", cmd);
   spawnSync(cmd, { shell: true, stdio: "inherit" });
-}
+};

--- a/clients/js/src/terra.ts
+++ b/clients/js/src/terra.ts
@@ -1,37 +1,38 @@
 import {
+  CONTRACTS,
+  TerraChainName,
+} from "@certusone/wormhole-sdk/lib/esm/utils/consts";
+import {
   Coin,
   Fee,
   LCDClient,
   MnemonicKey,
   MsgExecuteContract,
 } from "@terra-money/terra.js";
-import { fromUint8Array } from "js-base64";
-import { impossible, Payload } from "./vaa";
-import { NETWORKS } from "./networks";
 import axios from "axios";
-import {
-  CONTRACTS,
-  TerraChainName,
-} from "@certusone/wormhole-sdk/lib/esm/utils/consts";
+import { fromUint8Array } from "js-base64";
+import { NETWORKS } from "./networks";
+import { Network } from "./utils";
+import { Payload, impossible } from "./vaa";
 
 export async function execute_terra(
   payload: Payload,
   vaa: Buffer,
-  network: "MAINNET" | "TESTNET" | "DEVNET",
+  network: Network,
   chain: TerraChainName
-) {
-  let n = NETWORKS[network][chain];
-  let contracts = CONTRACTS[network][chain];
+): Promise<void> {
+  const { rpc, key, chain_id } = NETWORKS[network][chain];
+  const contracts = CONTRACTS[network][chain];
 
   const terra = new LCDClient({
-    URL: n.rpc,
-    chainID: n.chain_id,
+    URL: rpc,
+    chainID: chain_id,
     isClassic: chain === "terra",
   });
 
   const wallet = terra.wallet(
     new MnemonicKey({
-      mnemonic: n.key,
+      mnemonic: key,
     })
   );
 
@@ -39,7 +40,13 @@ export async function execute_terra(
   let execute_msg: object;
 
   switch (payload.module) {
-    case "Core":
+    case "Core": {
+      if (!contracts.core) {
+        throw new Error(
+          `Core bridge address not defined for ${chain} ${network}`
+        );
+      }
+
       target_contract = contracts.core;
       // sigh...
       execute_msg = {
@@ -59,14 +66,17 @@ export async function execute_terra(
         default:
           impossible(payload);
       }
+
       break;
-    case "NFTBridge":
-      if (contracts.nft_bridge === undefined) {
+    }
+    case "NFTBridge": {
+      if (!contracts.nft_bridge) {
         // NOTE: this code can safely be removed once the terra NFT bridge is
         // released, but it's fine for it to stay, as the condition will just be
         // skipped once 'contracts.nft_bridge' is defined
-        throw new Error("NFT bridge not supported yet for terra");
+        throw new Error(`NFT bridge not supported yet for ${chain}`);
       }
+
       target_contract = contracts.nft_bridge;
       execute_msg = {
         submit_vaa: {
@@ -88,8 +98,16 @@ export async function execute_terra(
         default:
           impossible(payload);
       }
+
       break;
-    case "TokenBridge":
+    }
+    case "TokenBridge": {
+      if (!contracts.token_bridge) {
+        throw new Error(
+          `Token bridge address not defined for ${chain} ${network}`
+        );
+      }
+
       target_contract = contracts.token_bridge;
       execute_msg = {
         submit_vaa: {
@@ -115,9 +133,10 @@ export async function execute_terra(
           throw Error("Can't complete payload 3 transfer from CLI");
         default:
           impossible(payload);
-          break;
       }
+
       break;
+    }
     default:
       target_contract = impossible(payload);
       execute_msg = impossible(payload);
@@ -131,11 +150,9 @@ export async function execute_terra(
   );
 
   const feeDenoms = ["uluna"];
-
   const gasPrices = await axios
     .get("https://terra-classic-fcd.publicnode.com/v1/txs/gas_prices")
     .then((result) => result.data);
-
   const feeEstimate = await terra.tx.estimateFee(
     [
       {
@@ -151,7 +168,7 @@ export async function execute_terra(
     }
   );
 
-  wallet
+  return wallet
     .createAndSignTx({
       msgs: [transaction],
       memo: "",

--- a/clients/js/src/vaa.ts
+++ b/clients/js/src/vaa.ts
@@ -1,7 +1,7 @@
 import { Parser } from "binary-parser"
+import * as elliptic from "elliptic"
 import { BigNumber, ethers } from "ethers"
 import { solidityKeccak256 } from "ethers/lib/utils"
-import * as elliptic from "elliptic"
 
 export interface Signature {
     guardianSetIndex: number
@@ -103,7 +103,7 @@ export function parse(buffer: Buffer): VAA<Payload | Other> {
     if (payload === null) {
         payload = {type: "Other", hex: Buffer.from(vaa.payload).toString("hex"), ascii: Buffer.from(vaa.payload).toString('utf8')}
     } else {
-        delete payload['tokenURILength']
+        delete (payload as any)['tokenURILength']
     }
     var myVAA = { ...vaa, payload }
 
@@ -829,7 +829,7 @@ function nftBridgeTransferParser(): P<NFTBridgeTransfer> {
         .array("tokenURI", {
             type: "uint8",
             lengthInBytes: function() {
-                return this.tokenURILength
+                return (this as any).tokenURILength
             },
             formatter: (arr: Uint8Array) => Buffer.from(arr).toString("utf8")
         })
@@ -868,7 +868,7 @@ function serialiseNFTBridgeTransfer(payload: NFTBridgeTransfer): string {
 // in, this function just throws. If the enum type is extended with new cases,
 // the call to this function will then fail to compile, drawing attention to an
 // unhandled case somewhere.
-export function impossible(a: never): any {
+export function impossible(a: never): never {
     throw new Error(`Impossible: ${a}`)
 }
 

--- a/clients/js/tsconfig.json
+++ b/clients/js/tsconfig.json
@@ -6,7 +6,8 @@
     "outDir": "./build",
     "moduleResolution": "node",
     "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "strict": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
This PR adds `strict: true` to `tsconfig.json` and takes care of any resulting errors. In general, most of this code doesn't touch logic, and instead focuses on null checks and legibility.

Things to review:
* NEAR CLI. Whatever code was previously in there was definitely broken, referencing multiple non-existent args, so this is probably strictly better even without testing. Still required some more involved changes, so would be good to look at.
* Type used in `yargs` handler (`Awaited<ReturnType<typeof builder>["argv"]>`). This type isn't perfect but should be good enough because it will always contain the types of the arguments (+ some extra fields). It doesn't seem possible to get the actual type that would appear if `handler` was passed into `yargs.command` along with `builder` since `yargs` throws the type away.