### PR TITLE
sdk: assert no negative numGuardians in quorum calculation

### DIFF
--- a/sdk/vaa/quorum.go
+++ b/sdk/vaa/quorum.go
@@ -5,5 +5,8 @@ package vaa
 // The canonical source is the calculation in the contracts (solana/bridge/src/processor.rs and
 // ethereum/contracts/Wormhole.sol), and this needs to match the implementation in the contracts.
 func CalculateQuorum(numGuardians int) int {
+	if numGuardians < 0 {
+		panic("Invalid numGuardians is less than zero")
+	}
 	return ((numGuardians * 2) / 3) + 1
 }

--- a/sdk/vaa/quorum_test.go
+++ b/sdk/vaa/quorum_test.go
@@ -10,7 +10,7 @@ func TestCalculateQuorum(t *testing.T) {
 	type Test struct {
 		numGuardians int
 		quorumResult int
-		shouldPanic bool
+		shouldPanic  bool
 	}
 
 	tests := []Test{
@@ -42,7 +42,6 @@ func TestCalculateQuorum(t *testing.T) {
 		// Negative Test Cases
 		{numGuardians: -1, quorumResult: 1, shouldPanic: true},
 		{numGuardians: -1000, quorumResult: 1, shouldPanic: true},
-
 	}
 
 	for _, tc := range tests {

--- a/sdk/vaa/quorum_test.go
+++ b/sdk/vaa/quorum_test.go
@@ -10,9 +10,11 @@ func TestCalculateQuorum(t *testing.T) {
 	type Test struct {
 		numGuardians int
 		quorumResult int
+		shouldPanic bool
 	}
 
 	tests := []Test{
+		// Positive Test Cases
 		{numGuardians: 0, quorumResult: 1},
 		{numGuardians: 1, quorumResult: 1},
 		{numGuardians: 2, quorumResult: 2},
@@ -36,12 +38,21 @@ func TestCalculateQuorum(t *testing.T) {
 		{numGuardians: 50, quorumResult: 34},
 		{numGuardians: 100, quorumResult: 67},
 		{numGuardians: 1000, quorumResult: 667},
+
+		// Negative Test Cases
+		{numGuardians: -1, quorumResult: 1, shouldPanic: true},
+		{numGuardians: -1000, quorumResult: 1, shouldPanic: true},
+
 	}
 
 	for _, tc := range tests {
 		t.Run("", func(t *testing.T) {
-			num := CalculateQuorum(tc.numGuardians)
-			assert.Equal(t, tc.quorumResult, num)
+			if tc.shouldPanic {
+				assert.Panics(t, func() { CalculateQuorum(tc.numGuardians) }, "The code did not panic")
+			} else {
+				num := CalculateQuorum(tc.numGuardians)
+				assert.Equal(t, tc.quorumResult, num)
+			}
 		})
 	}
 }


### PR DESCRIPTION
This is a belt and suspenders addition to the Guardians computation of quorum to ensure that negative numbers will panic rather than returning a viable quorum expectation.