### PR TITLE
sui: update testnet Sui addresses

### DIFF
--- a/clients/js/src/consts.ts
+++ b/clients/js/src/consts.ts
@@ -19,9 +19,9 @@ const OVERRIDES = {
   },
   TESTNET: {
     sui: {
-      core: "0x69ae41bdef4770895eb4e7aaefee5e4673acc08f6917b4856cf55549c4573ca8",
+      core: "0x31358d198147da50db32eda2562951d53973a0c0ad5ed738e9b17d88b213d790",
       token_bridge:
-        "0x32422cb2f929b6a4e3f81b4791ea11ac2af896b310f3d9442aa1fe924ce0bab4",
+        "0x6fb10cdb7aa299e9a4308752dadecb049ff55a892de92992a1edbd7912b3d6da",
     },
     aptos: {
       token_bridge:

--- a/sdk/js/src/utils/consts.ts
+++ b/sdk/js/src/utils/consts.ts
@@ -359,9 +359,9 @@ const TESTNET = {
     nft_bridge: undefined,
   },
   sui: {
-    core: "0x69ae41bdef4770895eb4e7aaefee5e4673acc08f6917b4856cf55549c4573ca8",
+    core: "0x31358d198147da50db32eda2562951d53973a0c0ad5ed738e9b17d88b213d790",
     token_bridge:
-      "0x32422cb2f929b6a4e3f81b4791ea11ac2af896b310f3d9442aa1fe924ce0bab4",
+      "0x6fb10cdb7aa299e9a4308752dadecb049ff55a892de92992a1edbd7912b3d6da",
     nft_bridge: undefined,
   },
   moonbeam: {

--- a/sui/token_bridge/Move.testnet.toml
+++ b/sui/token_bridge/Move.testnet.toml
@@ -1,7 +1,7 @@
 [package]
 name = "TokenBridge"
-version = "0.1.1"
-published-at = "0x4eb7c5bca3759ab3064b46044edb5668c9066be8a543b28b58375f041f876a80"
+version = "0.2.0"
+published-at = "0x562760fc51d90d4ae1835bac3e91e0e6987d3497b06f066941d3e51f6e8d76d0"
 
 [dependencies.Sui]
 git = "https://github.com/MystenLabs/sui.git"
@@ -12,4 +12,4 @@ rev = "09b2081498366df936abae26eea4b2d5cafb2788"
 local = "../wormhole"
 
 [addresses]
-token_bridge = "0x92d81f28c167d90f84638c654b412fe7fa8e55bdfac7f638bdcf70306289be86"
+token_bridge = "0x562760fc51d90d4ae1835bac3e91e0e6987d3497b06f066941d3e51f6e8d76d0"

--- a/sui/wormhole/Move.testnet.toml
+++ b/sui/wormhole/Move.testnet.toml
@@ -1,7 +1,7 @@
 [package]
 name = "Wormhole"
-version = "0.1.2"
-published-at = "0x3542d705ec6a7e05045288ec99a6c4b4e3ded999b6feab720fab535b08fa51f8"
+version = "0.2.0"
+published-at = "0xf47329f4344f3bf0f8e436e2f7b485466cff300f12a166563995d3888c296a94"
 
 [dependencies.Sui]
 git = "https://github.com/MystenLabs/sui.git"
@@ -9,4 +9,4 @@ subdir = "crates/sui-framework/packages/sui-framework"
 rev = "09b2081498366df936abae26eea4b2d5cafb2788"
 
 [addresses]
-wormhole = "0x15e1e51cb59fe1f987b037da12745a278855c8ac73050f4f194466096a0ca05b"
+wormhole = "0xf47329f4344f3bf0f8e436e2f7b485466cff300f12a166563995d3888c296a94"


### PR DESCRIPTION
The purpose of this PR is to update the Sui testnet addresses in the `Move.testnet.toml` files, and the sdk. 