### PR TITLE
additional improvements / clean-up

### DIFF
--- a/ethereum/contracts/interfaces/relayer/IWormholeReceiver.sol
+++ b/ethereum/contracts/interfaces/relayer/IWormholeReceiver.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.0;
 
 /**
- * @notice DeliveryData is the struct that the relay provider passes into 'deliver' containing an
+ * @notice DeliveryData is the struct that the relay provider passes into `deliver()` containing an
  *     array of the signed wormhole messages that are to be relayed
  *
  * @custom:member sourceAddress - the (wormhole format) address on the sending chain which requested
@@ -25,25 +25,34 @@ struct DeliveryData {
 
 interface IWormholeReceiver {
    /**
-     * @notice When a 'send' is performed with this contract as the target, this function will be invoked.
-     * To get the address that will invoke this contract, call the 'getDeliveryAddress()' function on this chain (the target chain)'s WormholeRelayer contract
+     * @notice When a `send` is performed with this contract as the target, this function will be
+     *     invoked.
+     *   To get the address that will invoke this contract, call the `getDeliveryAddress()` function
+     *     on this chain (the target chain)'s WormholeRelayer contract
      *
-     * NOTE: This function should be restricted such that only getDeliveryAddress() can call it.
+     * NOTE: This function should be restricted such that only `getDeliveryAddress()` can call it.
      *
      * We also recommend that this function:
-     *      - Stores all received 'deliveryData.deliveryHash's in a mapping (bytes32 => bool), and on every call, checks that deliveryData.deliveryHash has not already been stored in the map
-     *        (This is to prevent other users maliciously trying to relay the same message)
-     *      - Checks that 'deliveryData.sourceChain' and 'deliveryData.sourceAddress' are indeed who you expect to have requested the calling of 'send' or 'forward' on the source chain
+     *   - Stores all received `deliveryData.deliveryHash`s in a mapping `(bytes32 => bool)`, and
+     *       on every call, checks that deliveryData.deliveryHash has not already been stored in the
+     *       map (This is to prevent other users maliciously trying to relay the same message)
+     *   - Checks that `deliveryData.sourceChain` and `deliveryData.sourceAddress` are indeed who
+     *       you expect to have requested the calling of `send` or `forward` on the source chain
      *
-     * The invocation of this function corresponding to the 'send' request will have msg.value equal to the receiverValue specified in the send request.
+     * The invocation of this function corresponding to the `send` request will have msg.value equal
+     *   to the receiverValue specified in the send request.
      *
-     * If the invocation of this function reverts or exceeds the gasLimit (maxTransactionFee) specified by the send requester, this delivery will result in a ReceiverFailure.
+     * If the invocation of this function reverts or exceeds the gas limit (`maxTransactionFee`)
+     *   specified by the send requester, this delivery will result in a `ReceiverFailure`.
      *
-     * @param deliveryData - This struct contains information about the delivery which is being performed
-     * @param signedVaas - Additional VAAs which were requested to be included in this delivery. They are guaranteed to all be included and in the same order as was specified in the delivery request.
-     * NOTE: These signedVaas are NOT verified by the Wormhole core contract prior to being provided to this call.
-     * Always make sure parseAndVerify is called on the Wormhole core contract before trusting the content of a raw VAA,
-     * otherwise the VAA may be invalid or malicious.
+     * @param deliveryData - This struct contains information about the delivery which is being
+     *     performed
+     * @param signedVaas - Additional VAAs which were requested to be included in this delivery.
+     *   They are guaranteed to all be included and in the same order as was specified in the
+     *     delivery request.
+     * NOTE: These signedVaas are NOT verified by the Wormhole core contract prior to being provided
+     *     to this call. Always make sure `parseAndVerify()` is called on the Wormhole core contract
+     *     before trusting the content of a raw VAA, otherwise the VAA may be invalid or malicious.
      */
   function receiveWormholeMessages(
     DeliveryData memory deliveryData,

--- a/ethereum/contracts/interfaces/relayer/IWormholeRelayer.sol
+++ b/ethereum/contracts/interfaces/relayer/IWormholeRelayer.sol
@@ -20,6 +20,7 @@ error ExceedsMaximumBudget(
 
 //Currently only 0 is deemed a bogus price
 error RelayProviderQuotedBogusAssetPrice(address relayProvider, uint16 chainId, uint256 price);
+error RelayProviderQuotedBogusGasPrice(address relayProvider, uint16 chainId, uint256 gasPrice);
 error RelayProviderDoesNotSupportTargetChain(address relayer, uint16 chainId);
 
 //When calling `forward()` on the CoreRelayer if no delivery is in progress

--- a/ethereum/contracts/interfaces/relayer/IWormholeRelayer.sol
+++ b/ethereum/contracts/interfaces/relayer/IWormholeRelayer.sol
@@ -2,18 +2,15 @@
 
 pragma solidity ^0.8.0;
 
-//TODO AMO: Decide on use regarding '' vs `` quotation of variables/function names in comments
-//            and then make it uniform.
-
 //132 is chosen because 132 = 4 (function selector) + 4*32 (4 32-byte words)
 uint256 constant RETURNDATA_TRUNCATION_THRESHOLD = 132;
 
-// msg.value was not equal to (one wormhole message fee) + maxTransactionFee + receiverValue
+//When msg.value was not equal to (one wormhole message fee) + `maxTransactionFee` + `receiverValue`
 error InvalidMsgValue(uint256 msgValue, uint256 totalFee);
-// Max transaction fee is not enough to pay for 1 unit of gas
+//When max transaction fee is not enough to pay for 1 unit of gas
 error InsufficientMaxTransactionFee(); 
-//(maxTransactionFee, converted to target chain currency) + (receiverValue, converted to target
-//  chain currency) is greater than what your chosen relay provider allows as a maximum budget
+//When (`maxTransactionFee`, converted to target chain currency) + (`receiverValue`, converted to
+//  target chain currency) is greater than what the chosen relay provider allows as a maximum budget
 error ExceedsMaximumBudget(
   uint256 requested,
   uint256 maximum,
@@ -21,15 +18,16 @@ error ExceedsMaximumBudget(
   uint16 chainId
 );
 
+//Currently only 0 is deemed a bogus price
 error RelayProviderQuotedBogusAssetPrice(address relayProvider, uint16 chainId, uint256 price);
 error RelayProviderDoesNotSupportTargetChain(address relayer, uint16 chainId);
 
-//Forwards can only be requested within execution of 'receiveWormholeMessages', or when a delivery
-//  is in progress
+//When calling `forward()` on the CoreRelayer if no delivery is in progress
 error NoDeliveryInProgress(); 
-// A delivery cannot occur during another delivery
+//When calling `delivery()` a second time even though a delivery is already in progress
 error ReentrantDelivery(address msgSender, address lockedBy);
-//A forward was requested from an address that is not the 'targetAddress' of the original delivery.
+//When any other contract but the delivery target calls `forward()` on the CoreRelayer while a
+//  delivery is in progress
 error ForwardRequestFromWrongAddress(address msgSender, address deliveryTarget);
 
 error InvalidPayloadId(uint8 parsed, uint8 expected);
@@ -37,24 +35,32 @@ error InvalidPayloadLength(uint256 received, uint256 expected);
 error InvalidVaaKeyType(uint8 parsed);
 
 error InvalidDeliveryVaa(string reason);
-// The delivery VAA (signed wormhole message with delivery instructions) was not emitted by the registered CoreRelayer contract
+//When the delivery VAA (signed wormhole message with delivery instructions) was not emitted by the
+//  registered CoreRelayer contract
 error InvalidEmitter(bytes32 emitter, bytes32 registered, uint16 chainId);
-error VaaKeysLengthDoesNotMatchVaasLength(uint256 keys, uint256 vaas); // The VAA array has a different length than the original array of VaaKey descriptions from the source chain
-error VaaKeysDoNotMatchVaas(uint8 index); // The VAA at index 'index' does not match the 'index'-th description given on the source chain in the 'messages' field
+error VaaKeysLengthDoesNotMatchVaasLength(uint256 keys, uint256 vaas);
+error VaaKeysDoNotMatchVaas(uint8 index);
+//When someone tries to call an external function of the CoreRelayer that is only intended to be
+//  called by the CoreRelayer itself (to allow retroactive reverts for atomicity)
 error RequesterNotCoreRelayer();
 
-error SendNotSufficientlyFunded(); // The container of delivery instructions (for which this current delivery was in) was not fully funded on the source chain
-error TargetChainIsNotThisChain(uint16 targetChainId); // The specified target chain is not the current chain
-error ForwardNotSufficientlyFunded(uint256 amountOfFunds, uint256 amountOfFundsNeeded); // Should never happen as this should have already been checked for
-error InvalidOverrideGasLimit(); // Invalid gas limit override was passed in to the delivery
-error InvalidOverrideReceiverValue(); // Invalid receiver value override was passed in to the delivery
-error InvalidOverrideMaximumRefund(); // Invalid maximum refund override was passed in to the delivery
+//When trying to relay a `DeliveryInstruction` to any other chain but the one it was specified for
+error TargetChainIsNotThisChain(uint16 targetChainId);
+error ForwardNotSufficientlyFunded(uint256 amountOfFunds, uint256 amountOfFundsNeeded);
+//When a `DeliveryOverride` contains a gas limit that's less than the original
+error InvalidOverrideGasLimit();
+//When a `DeliveryOverride` contains a receiver value that's less than the original
+error InvalidOverrideReceiverValue();
+//When a `DeliveryOverride` contains a maximum refund that's less than the original
+error InvalidOverrideMaximumRefund();
 
-error InsufficientRelayerFunds(uint256 msgValue, uint256 minimum); // The relay provider didn't pass in sufficient funds (msg.value does not cover the necessary budget fees)
+//When the relay provider doesn't pass in sufficient funds (i.e. msg.value does not cover the
+//  necessary budget fees)
+error InsufficientRelayerFunds(uint256 msgValue, uint256 minimum);
 
-//duplicated from utils.sol:
+//When a bytes32 field can't be converted into a 20 byte EVM address, because the 12 padding bytes
+//  are non-zero (duplicated from Utils.sol)
 error NotAnEvmAddress(bytes32);
-error OutOfBounds(uint256 offset, uint256 length);
 
 enum VaaKeyType {
   EMITTER_SEQUENCE,
@@ -62,15 +68,15 @@ enum VaaKeyType {
 }
 
 /**
- * @notice This 'VaaKey' struct identifies a wormhole message
- * VaaKeyType.EMITTER_SEQUENCE is the only infoType currently supported
+ * @notice This `VaaKey` struct identifies a wormhole message
+ *   `VaaKeyType.EMITTER_SEQUENCE` is the only `infoType` that's currently supported
  *
  * @custom:member infoType - determines which of the remaining fields are actually specified.
- *                           Currently must be VaaKeyType.EMITTER_SEQUENCE
- * @custom:member chainId - only specified if infoType == VaaKeyType.EMITTER_SEQUENCE
- * @custom:member emitterAddress - only specified if infoType = VaaKeyType.EMITTER_SEQUENCE
- * @custom:member sequence - only specified if infoType = VaaKeyType.EMITTER_SEQUENCE
- * @custom:member vaaHash - only specified if infoType = VaaKeyType.VAAHASH
+ *                           Currently must be `VaaKeyType.EMITTER_SEQUENCE`
+ * @custom:member chainId - only specified if `infoType == VaaKeyType.EMITTER_SEQUENCE`
+ * @custom:member emitterAddress - only specified if `infoType = VaaKeyType.EMITTER_SEQUENCE`
+ * @custom:member sequence - only specified if `infoType = VaaKeyType.EMITTER_SEQUENCE`
+ * @custom:member vaaHash - only specified if `infoType = VaaKeyType.VAAHASH`
  */
 struct VaaKey {
   VaaKeyType infoType;
@@ -110,12 +116,18 @@ struct RedeliveryInstruction {
 }
 
 /**
- * @notice DeliveryOverride is a struct which can alter several aspects of a delivery.
+ * @notice When a user requests a `resend()`, a `RedeliveryInstruction` is emitted by the
+ *     CoreRelayer and in turn converted by the relay provider into an encoded (=serialized)
+ *     `DeliveryOverride` struct which is then passed to `delivery()` to override the parameters of
+ *     a previously failed delivery attempt.
  *
- * @custom:member gaslimit override, must be greater than the gasLimit specified in the delivery instruction.
- * @custom:member maximumRefund override, must be greater than or equal to the maximumRefund specified in the delivery instruction.
- * @custom:member receiverValue override, must be greater than or equal to the receiverValue specified in the delivery instruction.
- * @custom:member the hash of the redelivery which is being performed, or 0 if none.
+ * @custom:member gasLimit - must be >= than the `gasLimit` specified in the `executionParameters`
+ *     of the original `DeliveryInstruction`
+ * @custom:member maximumRefund - must >= than the `maximumRefund` specified in the original
+ *     `DeliveryInstruction`
+ * @custom:member receiverValue - must >= than the `receiverValue` specified in the original
+ *     `DeliveryInstruction`
+ * @custom:member redeliveryHash - the hash of the redelivery which is being performed
  */
 struct DeliveryOverride {
   uint32 gasLimit;
@@ -125,27 +137,27 @@ struct DeliveryOverride {
 }
 
 /**
- * @notice This 'Send' struct represents a request to relay to a contract at address 'targetAddress' on chain 'targetChainId'
+ * @notice This `Send` struct represents a request to relay to a contract at address `targetAddress` on chain `targetChainId`
  *
  * @custom:member targetChainId The chain that the encoded+signed Wormhole messages (VAAs) are delivered to, in Wormhole Chain ID format
- * @custom:member targetAddress The address (in Wormhole 32-byte format) on chain 'targetChainId' of the contract to which the vaas are delivered.
- * This contract must implement the IWormholeReceiver interface, which simply requires a 'receiveWormholeMessage(bytes[] memory vaas, bytes[] memory additionalData)' endpoint
- * @custom:member refundAddress The address (in Wormhole 32-byte format) on chain 'targetChainId' to which any leftover funds (that weren't used for target chain gas or passed into targetAddress as value) should be sent
+ * @custom:member targetAddress The address (in Wormhole 32-byte format) on chain `targetChainId` of the contract to which the vaas are delivered.
+ * This contract must implement the IWormholeReceiver interface, which simply requires a `receiveWormholeMessage(bytes[] memory vaas, bytes[] memory additionalData)` endpoint
+ * @custom:member refundAddress The address (in Wormhole 32-byte format) on chain `targetChainId` to which any leftover funds (that weren't used for target chain gas or passed into targetAddress as value) should be sent
  * @custom:member maxTransactionFee The maximum amount (denominated in source chain (this chain) currency) that you wish to spend on funding gas for the target chain.
  * If more gas is needed on the target chain than is paid for, there will be a Receiver Failure.
- * Any unused value out of this fee will be refunded to 'refundAddress'
+ * Any unused value out of this fee will be refunded to `refundAddress`
  * @custom:member receiverValue The amount (denominated in source chain currency) that will be converted to target chain currency and passed into the receiveWormholeMessage endpoint as value.
  * @custom:member relayProviderAddress The address of (the relay provider you wish to deliver the messages)'s contract on this source chain. This must be a contract that implements IRelayProvider.
  * If request.maxTransactionFee >= quoteGas(request.targetChainId, gasLimit, relayProvider),
- * then as long as 'request.targetAddress''s receiveWormholeMessage function uses at most 'gasLimit' units of gas (and doesn't revert), the delivery will succeed
- * If request.receiverValue >= quoteReceiverValue(request.targetChainId, targetAmount, relayProvider), then at least 'targetAmount' of targetChainId currency will be passed into the 'receiveWormholeFunction' as value.
+ * then as long as `request.targetAddress`'s receiveWormholeMessage function uses at most `gasLimit` units of gas (and doesn`t revert), the delivery will succeed
+ * If request.receiverValue >= quoteReceiverValue(request.targetChainId, targetAmount, relayProvider), then at least `targetAmount` of targetChainId currency will be passed into the `receiveWormholeFunction` as value.
  * To use the default relay provider, set this field to be getDefaultRelayProvider()
  * @custom:member vaaKeys Array of VaaKey structs identifying each message to be relayed. Each VaaKey struct specifies a wormhole message, either by the VAA hash, or by the (chain id, emitter address, sequence number) triple.
  * The relay provider will set the second parameter in the call to receiveWormholeMessages to be an array of signed VAAs specified by this vaaKeys array.
- * Specifically, the 'signedVaas' array will have the same length as 'vaaKeys', and additionally for each 0 <= i < vaaKeys.length, signedVaas[i] will match the description in vaaKeys[i]
- * @custom:member consistencyLevel The level of finality to reach before emitting the Wormhole VAA corresponding to this 'send' request. See https://book.wormhole.com/wormhole/3_coreLayerContracts.html#consistency-levels
+ * Specifically, the `signedVaas` array will have the same length as `vaaKeys`, and additionally for each 0 <= i < vaaKeys.length, signedVaas[i] will match the description in vaaKeys[i]
+ * @custom:member consistencyLevel The level of finality to reach before emitting the Wormhole VAA corresponding to this `send` request. See https://book.wormhole.com/wormhole/3_coreLayerContracts.html#consistency-levels
  * @custom:member payload an optional payload which will be delivered to the receiving contract.
- * @custom:member relayParameters This should be 'getDefaultRelayParameters()'
+ * @custom:member relayParameters This should be `getDefaultRelayParameters()`
  */
   //TODO AMO: Why does this struct exist as an externally visible struct?
   //TODO AMO: Reconsider order of parameters to be consistent with function parameter
@@ -178,38 +190,39 @@ interface IWormholeRelayerSend is IWormholeRelayerBase {
    */
 
   /**
-   * @notice This 'send' function emits a wormhole message (VAA) that alerts the default wormhole
-   * relay provider to call the receiveWormholeMessage(DeliveryData memory deliveryData, bytes[]
-   * memory signedVaas) endpoint of the contract on chain 'targetChainId' and address
-   * 'targetAddress' with the first argument being a DeliveryData struct  
-   * and with the second argument (signedVaas) empty. This endpoint can be found in IWormholeReceiver.sol
+   * @notice This `send` function emits a wormhole message (VAA) that alerts the default wormhole
+   *     relay provider to call the `receiveWormholeMessage(DeliveryData memory deliveryData,
+   *     bytes[] memory signedVaas)` endpoint of the contract on chain `targetChainId` and address
+   *     `targetAddress` with the first argument being a `DeliveryData` struct and with the second
+   *     argument (`signedVaas`) empty.
+   *   This endpoint can be found in IWormholeReceiver.sol
    *
    *
    * @param targetChainId The chain that the vaas are delivered to, in Wormhole Chain ID format
-   * @param targetAddress The address (in Wormhole 32-byte format) on chain 'targetChainId' of the
+   * @param targetAddress The address (in Wormhole 32-byte format) on chain `targetChainId` of the
    *     contract to which the vaas are delivered.
    *   This contract must implement the IWormholeReceiver interface, which simply requires a
-   *     'receiveWormholeMessage(DeliveryData memory deliveryData, bytes[] memory signedVaas)'
+   *     `receiveWormholeMessage(DeliveryData memory deliveryData, bytes[] memory signedVaas)`
    *     endpoint.
    * @param refundChainId The chain where the refund should be sent. If the refundChainId is not the
    *     targetChainId, a new empty delivery will be initiated in order to perform the refund,
    *     which is subject to the provider's rates on the target chain.
-   * @param refundAddress The address (in Wormhole 32-byte format) on chain 'refundChainId' to
+   * @param refundAddress The address (in Wormhole 32-byte format) on chain `refundChainId` to
    *     which any leftover funds (that weren't used for target chain gas or passed into
    *     targetAddress as value) should be sent.
    * @param maxTransactionFee The maximum amount (denominated in source chain (this chain)
    *     currency) that you wish to spend on funding gas for the target chain.
    *   If more gas is needed on the target chain than is paid for, there will be a Receiver
    *     Failure and the call to targetAddress will revert.
-   *   Any unused value out of this fee will be refunded to refundAddress'.
+   *   Any unused value out of this fee will be refunded to `refundAddress`.
    *   If maxTransactionFee >= quoteGas(targetChainId, gasLimit, getDefaultRelayProvider()), then
-   *     as long as targetAddress's receiveWormholeMessage function uses at most 'gasLimit'
+   *     as long as targetAddress's receiveWormholeMessage function uses at most `gasLimit`
    *     units of gas (and doesn't revert), the delivery will succeed.
    * @param receiverValue The amount (denominated in source chain currency) that will be converted
    *     to target chain currency and passed into the receiveWormholeMessage endpoint as value.
    *   If receiverValue >= quoteReceiverValue(targetChainId, targetAmount,
-   *     getDefaultRelayProvider()), then at least 'targetAmount' of targetChainId currency will be
-   *     passed into the 'receiveWormholeFunction' as value.
+   *     getDefaultRelayProvider()), then at least `targetAmount` of targetChainId currency will be
+   *     passed into the `receiveWormholeFunction` as value.
    * @param payload An arbitrary payload which will be sent to the receiver contract.
    *
    * This function must be called with a payment of exactly:
@@ -231,28 +244,27 @@ interface IWormholeRelayerSend is IWormholeRelayerBase {
   ) external payable returns (uint64 sequence);
 
   /**
-   *  @notice This 'send' function emits a wormhole message (VAA) that alerts the default wormhole relay provider to
-   *  call the receiveWormholeMessage(DeliveryData memory deliveryData, bytes[] memory signedVaas) endpoint of the contract on chain 'targetChainId' and address 'targetAddress'
-   *  with the first argument being a DeliveryData struct 
-   *  and with the second argument being wormhole messages (VAAs) from the current transaction that match the descriptions in the 'vaaKeys' array (which have additionally been encoded and signed by the Guardian set to form 'signed VAAs')
+   *  @notice This `send` function emits a wormhole message (VAA) that alerts the default wormhole relay provider to
+   *  call the receiveWormholeMessage(DeliveryData memory deliveryData, bytes[] memory signedVaas) endpoint of the contract on chain `targetChainId` and address `targetAddress`
+   *  with the first argument being a DeliveryData struct and with the second argument being wormhole messages (VAAs) from the current transaction that match the descriptions in the `vaaKeys` array (which have additionally been encoded and signed by the Guardian set to form `signed VAAs`)
    *
    *
    *  @param targetChainId The chain that the vaas are delivered to, in Wormhole Chain ID format
-   *  @param targetAddress The address (in Wormhole 32-byte format) on chain 'targetChainId' of the contract to which the vaas are delivered.
-   *  This contract must implement the IWormholeReceiver interface, which simply requires a 'receiveWormholeMessage(DeliveryData memory deliveryData, bytes[] memory signedVaas)' endpoint
+   *  @param targetAddress The address (in Wormhole 32-byte format) on chain `targetChainId` of the contract to which the vaas are delivered.
+   *  This contract must implement the IWormholeReceiver interface, which simply requires a `receiveWormholeMessage(DeliveryData memory deliveryData, bytes[] memory signedVaas)` endpoint
    *  @param refundChainId The chain where the refund should be sent. If the refundChainId is not the targetChainId, a new empty delivery will be initiated in order to perform the refund, which is subject to the provider's rates on the target chain.
-   *  @param refundAddress The address (in Wormhole 32-byte format) on chain 'refundChainId' to which any leftover funds (that weren't used for target chain gas or passed into targetAddress as value) should be sent
+   *  @param refundAddress The address (in Wormhole 32-byte format) on chain `refundChainId` to which any leftover funds (that weren't used for target chain gas or passed into targetAddress as value) should be sent
    *  @param maxTransactionFee The maximum amount (denominated in source chain (this chain) currency) that you wish to spend on funding gas for the target chain.
    *  If more gas is needed on the target chain than is paid for, there will be a Receiver Failure.
-   *  Any unused value out of this fee will be refunded to 'refundAddress'
-   *  If maxTransactionFee >= quoteGas(targetChainId, gasLimit, getDefaultRelayProvider()), then as long as 'targetAddress''s receiveWormholeMessage function uses at most 'gasLimit' units of gas (and doesn't revert), the delivery will succeed
+   *  Any unused value out of this fee will be refunded to `refundAddress`
+   *  If maxTransactionFee >= quoteGas(targetChainId, gasLimit, getDefaultRelayProvider()), then as long as `targetAddress`'s receiveWormholeMessage function uses at most `gasLimit` units of gas (and doesn't revert), the delivery will succeed
    *  @param receiverValue The amount (denominated in source chain currency) that will be converted to target chain currency and passed into the receiveWormholeMessage endpoint as value.
-   *  If receiverValue >= quoteReceiverValue(targetChainId, targetAmount, getDefaultRelayProvider()), then at least 'targetAmount' of targetChainId currency will be passed into the 'receiveWormholeFunction' as value.
+   *  If receiverValue >= quoteReceiverValue(targetChainId, targetAmount, getDefaultRelayProvider()), then at least `targetAmount` of targetChainId currency will be passed into the `receiveWormholeFunction` as value.
    *  @param payload an arbitrary payload which will be sent to the receiver contract.
    *  @param vaaKeys Array of VaaKey structs identifying each message to be relayed. Each VaaKey struct specifies a wormhole message, either by the VAA hash, or by the (chain id, emitter address, sequence number) triple.
    *  The relay provider will call receiveWormholeMessages with an array of signed VAAs specified by this vaaKeys array.
-   *  Specifically, the 'signedVaas' array will have the same length as 'vaaKeys', and additionally for each 0 <= i < vaaKeys.length, signedVaas[i] will match the description in vaaKeys[i]
-   *  @param consistencyLevel  The level of finality to reach before emitting the Wormhole VAA corresponding to this 'send' request. See https://book.wormhole.com/wormhole/3_coreLayerContracts.html#consistency-levels
+   *  Specifically, the `signedVaas` array will have the same length as `vaaKeys`, and additionally for each 0 <= i < vaaKeys.length, signedVaas[i] will match the description in vaaKeys[i]
+   *  @param consistencyLevel  The level of finality to reach before emitting the Wormhole VAA corresponding to this `send` request. See https://book.wormhole.com/wormhole/3_coreLayerContracts.html#consistency-levels
    *
    * This function must be called with a payment of exactly:
    *   maxTransactionFee + receiverValue + one wormhole message fee
@@ -273,10 +285,10 @@ interface IWormholeRelayerSend is IWormholeRelayerBase {
   ) external payable returns (uint64 sequence);
 
   /**
-   *  @notice This 'send' function emits a wormhole message (VAA) that alerts the relay provider specified by sendParams.relayProviderAddress to
-   *  call the receiveWormholeMessage(DeliveryData memory deliveryData, bytes[] memory signedVaas) endpoint of the contract on chain 'sendParams.targetChainId' and address 'sendParams.targetAddress'
+   *  @notice This `send` function emits a wormhole message (VAA) that alerts the relay provider specified by sendParams.relayProviderAddress to
+   *  call the receiveWormholeMessage(DeliveryData memory deliveryData, bytes[] memory signedVaas) endpoint of the contract on chain `sendParams.targetChainId` and address `sendParams.targetAddress`
    *  with the first argument being a DeliveryData struct 
-   *  and with the second argument being wormhole messages (VAAs) from the current transaction that match the descriptions in the 'sendParams.vaaKeys' array (which have additionally been encoded and signed by the Guardian set to form 'signed VAAs')
+   *  and with the second argument being wormhole messages (VAAs) from the current transaction that match the descriptions in the `sendParams.vaaKeys` array (which have additionally been encoded and signed by the Guardian set to form `signed VAAs`)
    *
    *
    *  @param sendParams The Send request containing info about the targetChainId, targetAddress, refundAddress, maxTransactionFee, receiverValue, relayProviderAddress, vaaKeys, consistencyLevel, payload, and relayParameters
@@ -290,39 +302,39 @@ interface IWormholeRelayerSend is IWormholeRelayerBase {
   function send(Send memory sendParams) external payable returns (uint64 sequence);
 
   /**
-   * @notice This 'forward' function can only be called in a IWormholeReceiver within the 'receiveWormholeMessages' function
-   * It's purpose is to use any leftover fee from the 'maxTransactionFee' of the current delivery to fund another delivery
+   * @notice This `forward` function can only be called in a IWormholeReceiver within the `receiveWormholeMessages` function
+   * It's purpose is to use any leftover fee from the `maxTransactionFee` of the current delivery to fund another delivery
    *
    * Specifically, suppose an integrator requested a Send (with parameters oldTargetChain, oldTargetAddress, etc)
-   * and sets quoteGas(oldTargetChain, gasLimit, oldRelayProvider) as 'maxTransactionFee' in a Send,
+   * and sets quoteGas(oldTargetChain, gasLimit, oldRelayProvider) as `maxTransactionFee` in a Send,
    * but during the delivery on oldTargetChain, the call to oldTargetAddress's receiveWormholeMessages endpoint uses only x units of gas (where x < gasLimit).
    *
-   * Normally, (gasLimit - x)/gasLimit * oldMaxTransactionFee, converted to target chain currency, would be refunded to 'oldRefundAddress'.
+   * Normally, (gasLimit - x)/gasLimit * oldMaxTransactionFee, converted to target chain currency, would be refunded to `oldRefundAddress`.
    * However, if during execution of receiveWormholeMessage the integrator made a call to forward,
    *
    * We instead would use [(gasLimit - x)/gasLimit * oldMaxTransactionFee, converted to target chain currency] + (any additional funds passed into forward)
-   * to fund a new delivery (of wormhole messages emitted during execution of oldTargetAddress's receiveWormholeMessages) that is requested in the call to 'forward'.
+   * to fund a new delivery (of wormhole messages emitted during execution of oldTargetAddress's receiveWormholeMessages) that is requested in the call to `forward`.
    *
-   * Specifically, this 'forward' function is only callable within a delivery (during receiveWormholeMessages) and indicates the in-progress delivery to use any leftover funds from the current delivery to fund a new delivery
-   * or equivalently, indicates the in-progress delivery to call the receiveWormholeMessage(DeliveryData memory deliveryData, bytes[] memory signedVaas) endpoint of the contract on chain 'targetChainId' and address 'targetAddress'
-   * with the first argument being wormhole messages (VAAs) from the current transaction that match the descriptions in the 'vaaKeys' array (which have additionally been encoded and signed by the Guardian set to form 'signed VAAs'),
+   * Specifically, this `forward` function is only callable within a delivery (during receiveWormholeMessages) and indicates the in-progress delivery to use any leftover funds from the current delivery to fund a new delivery
+   * or equivalently, indicates the in-progress delivery to call the receiveWormholeMessage(DeliveryData memory deliveryData, bytes[] memory signedVaas) endpoint of the contract on chain `targetChainId` and address `targetAddress`
+   * with the first argument being wormhole messages (VAAs) from the current transaction that match the descriptions in the `vaaKeys` array (which have additionally been encoded and signed by the Guardian set to form `signed VAAs`),
    * and with the second argument empty
    *
    * @param targetChainId The chain that the vaas are delivered to, in Wormhole Chain ID format
-   * @param targetAddress The address (in Wormhole 32-byte format) on chain 'targetChainId' of the contract to which the vaas are delivered.
-   * This contract must implement the IWormholeReceiver interface, which simply requires a 'receiveWormholeMessage(DeliveryData memory deliveryData, bytes[] memory signedVaas)' endpoint
-   * @param refundAddress The address (in Wormhole 32-byte format) on chain 'refundChainId' to which any leftover funds (that weren't used for target chain gas or passed into targetAddress as value) should be sent
+   * @param targetAddress The address (in Wormhole 32-byte format) on chain `targetChainId` of the contract to which the vaas are delivered.
+   * This contract must implement the IWormholeReceiver interface, which simply requires a `receiveWormholeMessage(DeliveryData memory deliveryData, bytes[] memory signedVaas)` endpoint
+   * @param refundAddress The address (in Wormhole 32-byte format) on chain `refundChainId` to which any leftover funds (that weren't used for target chain gas or passed into targetAddress as value) should be sent
    * @param refundChainId The chain where the refund should be sent. If the refundChainId is not the targetChainId, a new empty delivery will be initiated in order to perform the refund, which is subject to the provider's rates on the target chain.
    * @param maxTransactionFee The maximum amount (denominated in source chain (this chain) currency) that you wish to spend on funding gas for the target chain.
    * If more gas is needed on the target chain than is paid for, there will be a Receiver Failure.
-   * Any unused value out of this fee will be refunded to 'refundAddress'
-   * If maxTransactionFee >= quoteGas(targetChainId, gasLimit, getDefaultRelayProvider()), then as long as 'targetAddress''s receiveWormholeMessage function uses at most 'gasLimit' units of gas (and doesn't revert), the delivery will succeed
+   * Any unused value out of this fee will be refunded to `refundAddress`
+   * If maxTransactionFee >= quoteGas(targetChainId, gasLimit, getDefaultRelayProvider()), then as long as `targetAddress`'s receiveWormholeMessage function uses at most `gasLimit` units of gas (and doesn't revert), the delivery will succeed
    * @param receiverValue The amount (denominated in source chain currency) that will be converted to target chain currency and passed into the receiveWormholeMessage endpoint as value.
-   * If receiverValue >= quoteReceiverValue(targetChainId, targetAmount, getDefaultRelayProvider()), then at least 'targetAmount' of targetChainId currency will be passed into the 'receiveWormholeFunction' as value.
+   * If receiverValue >= quoteReceiverValue(targetChainId, targetAmount, getDefaultRelayProvider()), then at least `targetAmount` of targetChainId currency will be passed into the `receiveWormholeFunction` as value.
    * @param vaaKeys Array of VaaKey structs identifying each message to be relayed. Each VaaKey struct specifies a wormhole message in the current transaction, either by the VAA hash, or by the (emitter address, sequence number) pair.
    * The relay provider will call receiveWormholeMessages with an array of signed VAAs specified by this vaaKeys array.
-   * Specifically, the 'signedVaas' array will have the same length as 'vaaKeys', and additionally for each 0 <= i < vaaKeys.length, signedVaas[i] will match the description in vaaKeys[i]
-   * @param consistencyLevel The level of finality to reach before emitting the Wormhole VAA corresponding to this 'forward' request. See https://book.wormhole.com/wormhole/3_coreLayerContracts.html#consistency-levels
+   * Specifically, the `signedVaas` array will have the same length as `vaaKeys`, and additionally for each 0 <= i < vaaKeys.length, signedVaas[i] will match the description in vaaKeys[i]
+   * @param consistencyLevel The level of finality to reach before emitting the Wormhole VAA corresponding to this `forward` request. See https://book.wormhole.com/wormhole/3_coreLayerContracts.html#consistency-levels
    *
    * This forward will succeed if (leftover funds from the current delivery that would have been refunded) + (any extra msg.value passed into forward) is at least maxTransactionFee + receiverValue + one wormhole message fee.
    */
@@ -339,22 +351,22 @@ interface IWormholeRelayerSend is IWormholeRelayerBase {
   ) external payable;
 
   /**
-   * @notice This 'forward' function can only be called in a IWormholeReceiver within the 'receiveWormholeMessages' function
-   * It's purpose is to use any leftover fee from the 'maxTransactionFee' of the current delivery to fund another delivery
+   * @notice This `forward` function can only be called in a IWormholeReceiver within the `receiveWormholeMessages` function
+   * It's purpose is to use any leftover fee from the `maxTransactionFee` of the current delivery to fund another delivery
    *
    * Specifically, suppose an integrator requested a Send (with parameters oldTargetChain, oldTargetAddress, etc)
-   * and sets quoteGas(oldTargetChain, gasLimit, oldRelayProvider) as 'maxTransactionFee' in a Send,
+   * and sets quoteGas(oldTargetChain, gasLimit, oldRelayProvider) as `maxTransactionFee` in a Send,
    * but during the delivery on oldTargetChain, the call to oldTargetAddress's receiveWormholeMessages endpoint uses only x units of gas (where x < gasLimit).
    *
-   * Normally, (gasLimit - x)/gasLimit * oldMaxTransactionFee, converted to target chain currency, would be refunded to 'oldRefundAddress'.
+   * Normally, (gasLimit - x)/gasLimit * oldMaxTransactionFee, converted to target chain currency, would be refunded to `oldRefundAddress`.
    * However, if during execution of receiveWormholeMessage the integrator made a call to forward,
    *
    * We instead would use [(gasLimit - x)/gasLimit * oldMaxTransactionFee, converted to target chain currency] + (any additional funds passed into forward)
-   * to fund a new delivery (of wormhole messages emitted during execution of oldTargetAddress's receiveWormholeMessages) that is requested in the call to 'forward'.
+   * to fund a new delivery (of wormhole messages emitted during execution of oldTargetAddress's receiveWormholeMessages) that is requested in the call to `forward`.
    *
-   * Specifically, this 'forward' function is only callable within a delivery (during receiveWormholeMessages) and indicates the in-progress delivery to use any leftover funds from the current delivery to fund a new delivery
-   * or equivalently, indicates the in-progress delivery to call the receiveWormholeMessage(bytes[] memory vaas, bytes[] memory additionalData) endpoint of the contract on chain 'targetChainId' and address 'targetAddress'
-   * with the first argument being wormhole messages (VAAs) from the current transaction that match the descriptions in the 'vaaKeys' array (which have additionally been encoded and signed by the Guardian set to form 'signed VAAs'),
+   * Specifically, this `forward` function is only callable within a delivery (during receiveWormholeMessages) and indicates the in-progress delivery to use any leftover funds from the current delivery to fund a new delivery
+   * or equivalently, indicates the in-progress delivery to call the receiveWormholeMessage(bytes[] memory vaas, bytes[] memory additionalData) endpoint of the contract on chain `targetChainId` and address `targetAddress`
+   * with the first argument being wormhole messages (VAAs) from the current transaction that match the descriptions in the `vaaKeys` array (which have additionally been encoded and signed by the Guardian set to form `signed VAAs`),
    * and with the second argument empty
    *
    * @param sendParams The Send request containing info about the targetChainId, targetAddress, refundAddress, maxTransactionFee, receiverValue, and relayParameters
@@ -362,11 +374,11 @@ interface IWormholeRelayerSend is IWormholeRelayerBase {
    * This forward will succeed if (leftover funds from the current delivery that would have been refunded) + (any extra msg.value passed into forward) is at least maxTransactionFee + receiverValue + one wormhole message fee.
    * notparam vaaKeys Array of VaaKey structs identifying each message to be relayed. Each VaaKey struct specifies a wormhole message in the current transaction, either by the VAA hash, or by the (emitter address, sequence number) pair.
    * The relay provider will call receiveWormholeMessages with an array of signed VAAs specified by this vaaKeys array.
-   * Specifically, the 'signedVaas' array will have the same length as 'vaaKeys', and additionally for each 0 <= i < vaaKeys.length, signedVaas[i] will match the description in vaaKeys[i]
+   * Specifically, the `signedVaas` array will have the same length as `vaaKeys`, and additionally for each 0 <= i < vaaKeys.length, signedVaas[i] will match the description in vaaKeys[i]
    * notparam relayProvider The address of (the relay provider you wish to deliver the messages)'s contract on this source chain. This must be a contract that implements IRelayProvider.
    * If sendParams.maxTransactionFee >= quoteGas(sendParams.targetChainId, gasLimit, relayProvider),
-   * then as long as 'sendParams.targetAddress''s receiveWormholeMessage function uses at most 'gasLimit' units of gas (and doesn't revert), the delivery will succeed
-   * If sendParams.receiverValue >= quoteReceiverValue(sendParams.targetChainId, targetAmount, relayProvider), then at least 'targetAmount' of targetChainId currency will be passed into the 'receiveWormholeFunction' as value.
+   * then as long as `sendParams.targetAddress`'s receiveWormholeMessage function uses at most `gasLimit` units of gas (and doesn't revert), the delivery will succeed
+   * If sendParams.receiverValue >= quoteReceiverValue(sendParams.targetChainId, targetAmount, relayProvider), then at least `targetAmount` of targetChainId currency will be passed into the `receiveWormholeFunction` as value.
    * To use the default relay provider, set this field to be getDefaultRelayProvider()
    *
    * This function must be called with a payment of exactly sendParams.maxTransactionFee + sendParams.receiverValue + one wormhole message fee.
@@ -374,26 +386,42 @@ interface IWormholeRelayerSend is IWormholeRelayerBase {
   function forward(Send memory sendParams) external payable;
 
   /**
-   * @notice This 'resend' function allows a caller to request an additional delivery of a specified `send` VAA, with an updated provider, maxTransactionFee, and receiveValue.
-   * This function is intended to help integrators more eaily resolve ReceiverFailure cases, or other scenarios where an delivery was not able to be correctly performed.
+   * @notice This `resend` function allows a caller to request an additional delivery of a specified
+   *   `send` VAA, with an updated provider, maxTransactionFee, and receiveValue.
+   * This function is intended to help integrators more eaily resolve ReceiverFailure cases, or
+   *   other scenarios where an delivery was not able to be correctly performed.
    *
-   * No checks about the original delivery VAA are performed prior to the emission of the redelivery instruction. Therefore, caller should be careful not to request
-   * redeliveries in the following cases, as they will result in an undeliverable, invalid redelivery instruction that the provider will not be able to perform:
+   * No checks about the original delivery VAA are performed prior to the emission of the redelivery
+   *   instruction. Therefore, caller should be careful not to request redeliveries in the following
+   *   cases, as they will result in an undeliverable, invalid redelivery instruction that the
+   *   provider will not be able to perform:
    *
    * - If the specified VaaKey does not correspond to a valid delivery VAA.
    * - If the targetChainId does not equal the targetChainId of the original delivery.
-   * - If the gasLimit calculated from 'newMaxTransactionFee' is less than the original delivery's gas limit.
-   * - If the receiverValueTarget (amount of receiver value to pass into the target contract) calculated from newReceiverValue is lower than the original delivery's receiverValueTarget.
-   * - If the new calculated maximumRefundTarget (maximum possible refund amount) calculated from 'newMaxTransactionFee' is lower than the original delivery's maximumRefundTarget.
+   * - If the gasLimit calculated from `newMaxTransactionFee` is less than the original delivery's
+   *     gas limit.
+   * - If the receiverValueTarget (amount of receiver value to pass into the target contract)
+   *     calculated from newReceiverValue is lower than the original delivery's receiverValueTarget.
+   * - If the new calculated maximumRefundTarget (maximum possible refund amount) calculated from
+   *     `newMaxTransactionFee` is lower than the original delivery's maximumRefundTarget.
    *
-   * Similar to send, you must call this function with msg.value = nexMaxTransactionFee + newReceiverValue + wormhole.messageFee() in order to pay for the delivery.
+   * Similar to send, you must call this function with `msg.value = nexMaxTransactionFee +
+   *  newReceiverValue + wormhole.messageFee()` in order to pay for the delivery.
    *
-   * @param key a VAA Key corresponding to the delivery which should be performed again. This must correspond to a valid delivery instruction VAA.
-   * @param newMaxTransactionFee - the maxTransactionFee (in this chain's wei) that should be used for the redelivery. Must be greater than or equal to the new relayProvider's quoted price for the original gas amount (i.e. must not result in a lower gas limit)
-   * AND must result in a maximum transaction fee refund equal to or greater than the original delivery
-   * @param newReceiverValue - the receiverValue (in this chain's wei) that should be used for the redelivery. Must result in receiverValue on the target chain which is equal to or greater than the original delivery.
+   * @param key a VAA Key corresponding to the delivery which should be performed again. This must
+   *     correspond to a valid delivery instruction VAA.
+   * @param newMaxTransactionFee - the maxTransactionFee (in this chain's wei) that should be used
+   *     for the redelivery.
+   *   Must be greater than or equal to the new relayProvider's quoted price for the original gas
+   *     amount (i.e. must not result in a lower gas limit) AND must result in a maximum transaction
+   *     fee refund equal to or greater than the original
+   * delivery
+   * @param newReceiverValue - the receiverValue (in this chain's wei) that should be used for the
+   *     redelivery. Must result in receiverValue on the target chain which is equal to or greater
+   *     than the original delivery.
    * @param targetChainId - the chain which the original delivery targetted.
-   * @param relayProviderAddress - the address of the relayProvider (on this chain) which should be used for this redelivery.
+   * @param relayProviderAddress - the address of the relayProvider (on this chain) which should be
+   *     used for this redelivery.
    */
   function resend(
     VaaKey memory key,
@@ -404,18 +432,21 @@ interface IWormholeRelayerSend is IWormholeRelayerBase {
   ) external payable returns (uint64 sequence);
 
   /**
-   * @notice quoteGas tells you how much maxTransactionFee (denominated in current (source) chain currency) must be in order to fund a call to
-   * receiveWormholeMessages on a contract on chain 'targetChainId' that uses 'gasLimit' units of gas
+   * @notice quoteGas tells you how much maxTransactionFee (denominated in current (source) chain
+   *     currency) must be in order to fund a call to receiveWormholeMessages on a contract on chain
+   *     `targetChainId` that uses `gasLimit` units of gas
    *
-   * Specifically, for a Send 'request',
-   * If 'request.targetAddress''s receiveWormholeMessage function uses 'gasLimit' units of gas,
-   * then we must have request.maxTransactionFee >= quoteGas(request.targetChainId, gasLimit, relayProvider)
+   *   Specifically, for a Send `request`, if `request.targetAddress`'s `receiveWormholeMessage()`
+   *     uses `gasLimit` units of gas, then we must have
+   *     `request.maxTransactionFee >= quoteGas(request.targetChainId, gasLimit, relayProvider)`
    *
    * @param targetChainId the target chain that you wish to use gas on
    * @param gasLimit the amount of gas you wish to use
-   * @param relayProvider The address of (the relay provider you wish to deliver the messages)'s contract on this source chain. This must be a contract that implements IRelayProvider.
+   * @param relayProvider The address of (the relay provider you wish to deliver the messages)'s
+   *     contract on this source chain. This must be a contract that implements IRelayProvider.
    *
-   * @return maxTransactionFee The 'maxTransactionFee' you pass into your request (to relay messages to 'targetChainId' and use 'gasLimit' units of gas) must be at least this amount
+   * @return maxTransactionFee The `maxTransactionFee` you pass into your request (to relay messages
+   *     to `targetChainId` and use `gasLimit` units of gas) must be at least this amount
    */
   function quoteGas(
     uint16 targetChainId,
@@ -425,12 +456,12 @@ interface IWormholeRelayerSend is IWormholeRelayerBase {
 
   /**
    * @notice quoteReceiverValue tells you how much receiverValue (denominated in current (source)
-   *   chain currency) must be in order for the relay provider to pass in 'targetAmount' as msg
+   *   chain currency) must be in order for the relay provider to pass in `targetAmount` as msg
    *   value when calling receiveWormholeMessages.
    *
-   * Specifically, for a send 'request',
-   * In order for 'request.targetAddress''s receiveWormholeMessage function to be called with
-   *   'targetAmount' of value, then we must have request.receiverValue >=
+   * Specifically, for a send `request`,
+   * In order for `request.targetAddress`'s receiveWormholeMessage function to be called with
+   *   `targetAmount` of value, then we must have request.receiverValue >=
    *   quoteReceiverValue(request.targetChainId, targetAmount, relayProvider)
    *
    * @param targetChainId the target chain that you wish to receive value on
@@ -438,8 +469,8 @@ interface IWormholeRelayerSend is IWormholeRelayerBase {
    * @param relayProvider The address of (the relay provider you wish to deliver the messages)'s
    *   contract on this source chain. This must be a contract that implements IRelayProvider.
    *
-   * @return receiverValue The 'receiverValue' you pass into your send request (to relay messages
-   *   to 'targetChainId' with 'targetAmount' of value) must be at least this amount
+   * @return receiverValue The `receiverValue` you pass into your send request (to relay messages
+   *   to `targetChainId` with `targetAmount` of value) must be at least this amount
    */
   function quoteReceiverValue(
     uint16 targetChainId,
@@ -462,20 +493,24 @@ interface IWormholeRelayerSend is IWormholeRelayerBase {
 }
 
 /**
- * @notice TargetDeliveryParameters is the struct that the relay provider passes into 'deliver'
- * containing an array of the signed wormhole messages that are to be relayed
+ * @notice TargetDeliveryParameters is the struct that the relay provider passes into `deliver`
+ *     containing an array of the signed wormhole messages that are to be relayed
  *
- * @custom:member encodedVMs An array of signed wormhole messages (all from the same source chain transaction)
- * @custom:member encodedDeliveryVAA signed wormhole message from the source chain's CoreRelayer contract with payload being the encoded delivery instruction container
- * @custom:member relayerRefundAddress The address to which any refunds to the relay provider should be sent
- * @custom:member overrides. Optional overrides field which must be an empty bytes or parse to a DeliveryOverride struct
+ * @custom:member encodedVMs - An array of signed wormhole messages (all from the same source chain
+ *     transaction)
+ * @custom:member encodedDeliveryVAA - Signed wormhole message from the source chain's CoreRelayer
+ *     contract with payload being the encoded delivery instruction container
+ * @custom:member relayerRefundAddress - The address to which any refunds to the relay provider
+ *     should be sent
+ * @custom:member overrides - Optional overrides field which must be either an empty bytes array or
+ *     it must be an encoded DeliveryOverride struct
  */
 //TODO AMO: Why does this struct exist in the first place?
 struct TargetDeliveryParameters {
   bytes[] encodedVMs;
   bytes encodedDeliveryVAA;
   address payable relayerRefundAddress;
-  bytes overrides; //optional, encoded DeliveryOverride struct
+  bytes overrides;
 }
 
 interface IWormholeRelayerDelivery is IWormholeRelayerBase {
@@ -496,20 +531,33 @@ interface IWormholeRelayerDelivery is IWormholeRelayerBase {
   }
 
   /**
-   * @custom:member recipientContract The target contract address
-   * @custom:member sourceChainId The chain which this delivery was requested from (in wormhole ChainID format)
-   * @custom:member sequence The wormhole sequence number of the delivery VAA on the source chain corresponding to this delivery request
-   * @custom:member deliveryVaaHash The hash of the delivery VAA corresponding to this delivery request
-   * @custom:member gasUsed The amount of gas that was used to call your target contract (and, if there was a forward, to ensure that there were enough funds to complete the forward)
-   * @custom:member status either RECEIVER_FAILURE (if target contract reverts), SUCCESS (target contract doesn't revert, and no forwards requested),
-   * FORWARD_REQUEST_FAILURE (target contract doesn't revert, at least one forward requested, not enough funds to cover all forwards), or FORWARD_REQUEST_SUCCESS (target contract doesn't revert, enough funds for all forwards).
-   * @custom:member additionalStatusInfo empty if status is SUCCESS.
-   * If status is RECEIVER_FAILURE, this is 132 bytes of the return data (with revert reason information).
-   * If status is FORWARD_REQUEST_FAILURE, this is also the return data,
-   * which is specifically an error ForwardNotSufficientlyFunded(uint256 amountOfFunds, uint256 amountOfFundsNeeded)
-   * @custom:member refundStatus Result of the refund. REFUND_SUCCESS or REFUND_FAIL are for refunds where targetChainId=refundChainId; the others are for targetChainId!=refundChainId,
-   * where a cross chain refund is necessary
-   * @custom:member overridesInfo // empty if not a override, else is the encoded DeliveryOverride struct
+   * @custom:member recipientContract - The target contract address
+   * @custom:member sourceChainId - The chain which this delivery was requested from (in wormhole
+   *     ChainID format)
+   * @custom:member sequence - The wormhole sequence number of the delivery VAA on the source chain
+   *     corresponding to this delivery request
+   * @custom:member deliveryVaaHash - The hash of the delivery VAA corresponding to this delivery
+   *     request
+   * @custom:member gasUsed - The amount of gas that was used to call your target contract (and, if
+   *     there was a forward, to ensure that there were enough funds to complete the forward)
+   * @custom:member status:
+   *   - RECEIVER_FAILURE, if the target contract reverts
+   *   - SUCCESS, if the target contract doesn't revert and no forwards were requested
+   *   - FORWARD_REQUEST_FAILURE, if the target contract doesn't revert, forwards were requested,
+   *       but provided/leftover funds were not sufficient to cover them all
+   *   - FORWARD_REQUEST_SUCCESS, if the target contract doesn't revert and all forwards are covered
+   * @custom:member additionalStatusInfo:
+   *   - If status is SUCCESS or FORWARD_REQUEST_SUCCESS, then this is empty.
+   *   - If status is RECEIVER_FAILURE, this is `RETURNDATA_TRUNCATION_THRESHOLD` bytes of the
+   *       return data (i.e. potentially truncated revert reason information).
+   *   - If status is FORWARD_REQUEST_FAILURE, this is also the return data, which is specifically
+   *       an error ForwardNotSufficientlyFunded(uint256 amountOfFunds, uint256 amountOfFundsNeeded)
+   * @custom:member refundStatus - Result of the refund. REFUND_SUCCESS or REFUND_FAIL are for
+   *     refunds where targetChainId=refundChainId; the others are for targetChainId!=refundChainId,
+   *     where a cross chain refund is necessary
+   * @custom:member overridesInfo:
+   *   - If not an override: empty bytes array
+   *   - Otherwise: An encoded `DeliveryOverride`
    */
   event Delivery(
     address indexed recipientContract,
@@ -524,7 +572,7 @@ interface IWormholeRelayerDelivery is IWormholeRelayerBase {
   );
 
   /**
-   * @notice The relay provider calls 'deliver' to relay messages as described by one delivery instruction
+   * @notice The relay provider calls `deliver` to relay messages as described by one delivery instruction
    *
    * The instruction specifies the target chain (must be this chain), target address, refund address, maximum refund (in this chain's currency),
    * receiver value (in this chain's currency), upper bound on gas, and the permissioned address allowed to execute this instruction

--- a/ethereum/contracts/relayer/coreRelayer/CoreRelayerBase.sol
+++ b/ethereum/contracts/relayer/coreRelayer/CoreRelayerBase.sol
@@ -127,7 +127,7 @@ abstract contract CoreRelayerBase is IWormholeRelayerBase {
                                         send.targetChainId, send.maxTransactionFee, relayProvider
                                       );
     instruction.receiverValueTarget = convertReceiverValueAmountToTarget(
-                                        send.receiverValue, send.targetChainId, relayProvider
+                                        send.targetChainId, send.receiverValue, relayProvider
                                       );
     instruction.senderAddress       = toWormholeFormat(msg.sender);
     instruction.sourceRelayProvider = toWormholeFormat(send.relayProviderAddress);
@@ -179,8 +179,8 @@ abstract contract CoreRelayerBase is IWormholeRelayerBase {
    *   by the relay provider `provider`.
    */
   function convertReceiverValueAmountToTarget(
-    uint256 sourceAmount,
     uint16 targetChainId,
+    uint256 sourceAmount,
     IRelayProvider provider
   ) internal view returns (uint256 targetAmount) { unchecked {
     (uint16 buffer, uint16 denominator) = provider.getAssetConversionBuffer(targetChainId);

--- a/ethereum/contracts/relayer/coreRelayer/CoreRelayerBase.sol
+++ b/ethereum/contracts/relayer/coreRelayer/CoreRelayerBase.sol
@@ -24,8 +24,8 @@ import {
 } from "./CoreRelayerStorage.sol";
 
 abstract contract CoreRelayerBase is IWormholeRelayerBase {
-  //TODO AMO: see https://book.wormhole.com/wormhole/3_coreLayerContracts.html#consistency-levels
-  //  15 is valid choice perhaps, but it feels messy... (seems like it should be 201?)
+  //see https://book.wormhole.com/wormhole/3_coreLayerContracts.html#consistency-levels
+  //  15 is valid choice for now but ultimately we want something more canonical (202?)
   //  Also, these values should definitely not be defined here but should be provided by IWormhole!
   uint8 internal constant CONSISTENCY_LEVEL_FINALIZED = 15;
   uint8 internal constant CONSISTENCY_LEVEL_INSTANT = 200;
@@ -61,8 +61,8 @@ abstract contract CoreRelayerBase is IWormholeRelayerBase {
     uint8 consistencyLevel,
     IRelayProvider relayProvider
   ) internal returns (uint64 sequence) { 
-    sequence =
-      getWormhole().publishMessage{value: wormholeMessageFee}(0, encodedInstruction, consistencyLevel);
+    sequence = getWormhole()
+      .publishMessage{value: wormholeMessageFee}(0, encodedInstruction, consistencyLevel);
 
     emit SendEvent(sequence, maxTransactionFee, receiverValue);
 
@@ -110,9 +110,9 @@ abstract contract CoreRelayerBase is IWormholeRelayerBase {
   // ----------------------------------------- Conversion ------------------------------------------
 
   /** 
-   * Calculate how much gas the relay provider can pay for on 'sendParams.targetChain' using
-   *   'sendParams.newTransactionFee', and calculate how much value the relay provider will pass
-   *   into 'sendParams.targetAddress'.
+   * Calculate how much gas the relay provider can pay for on `sendParams.targetChain` using
+   *   `sendParams.newTransactionFee`, and calculate how much value the relay provider will pass
+   *   into `sendParams.targetAddress`.
    */
   function convertSendToDeliveryInstruction(
     Send memory send
@@ -147,10 +147,10 @@ abstract contract CoreRelayerBase is IWormholeRelayerBase {
    *   maximum refund of the delivery transaction should be, in terms of target chain currency
    *
    * The maximum refund is the amount that would be refunded to refundAddress if the call to
-   *   'receiveWormholeMessages' were to counterfactually take 0 gas.
+   *   `receiveWormholeMessages` were to counterfactually take 0 gas.
    *
    * It does this by calculating (maxTransactionFee - deliveryOverhead) and converting (using the
-   *   relay provider's prices) to target chain currency (where 'deliveryOverhead' is the
+   *   relay provider's prices) to target chain currency (where `deliveryOverhead` is the
    *   relayProvider's base fee for delivering to targetChainId [in units of source chain currency])
    */
   function calculateTargetDeliveryMaximumRefund(
@@ -170,13 +170,13 @@ abstract contract CoreRelayerBase is IWormholeRelayerBase {
   }}
 
   /**
-   * If the user specifies (for 'receiverValue) 'sourceAmount' of source chain currency, with relay
-   *   provider 'provider', then this function calculates how much the relayer will pass into
+   * If the user specifies (for `receiverValue`) `sourceAmount` of source chain currency, with relay
+   *   provider `provider`, then this function calculates how much the relayer will pass into
    *   receiveWormholeMessages on the target chain (in target chain currency).
    *
    * The calculation simply converts this amount to target chain's currency, but also applies a
-   *   multiplier of 'denominator/(denominator + buffer)' where these values are also specified
-   *   by the relay provider 'provider'.
+   *   multiplier of `denominator/(denominator + buffer)` where these values are also specified
+   *   by the relay provider `provider`.
    */
   function convertReceiverValueAmountToTarget(
     uint256 sourceAmount,
@@ -195,8 +195,8 @@ abstract contract CoreRelayerBase is IWormholeRelayerBase {
    * Given a targetChainId, maxTransactionFee, and a relay provider, this function calculates what
    *   the gas limit of the delivery transaction should be.
    * It does this by calculating (maxTransactionFee - deliveryOverhead)/gasPrice where
-   *  'deliveryOverhead' is the relayProvider's base fee for delivering to targetChain and
-   *  'gasPrice' is the relayProvider's fee per unit of target chain gas.
+   *  `deliveryOverhead` is the relayProvider's base fee for delivering to targetChain and
+   *  `gasPrice` is the relayProvider's fee per unit of target chain gas.
    * Provider fees are quoted in units of the source chain currency.
    */
   function calculateTargetGasDeliveryAmount(
@@ -215,9 +215,9 @@ abstract contract CoreRelayerBase is IWormholeRelayerBase {
   }}
 
   /**
-   * Converts 'sourceAmount' of source chain currency to units of target chain currency using the
-   *   prices of 'provider' and also multiplying by a specified fraction
-   *   'multiplierNumerator/multiplierDenominator', rounding up or down specified by 'roundUp', and
+   * Converts `sourceAmount` of source chain currency to units of target chain currency using the
+   *   prices of `provider` and also multiplying by a specified fraction
+   *   `multiplierNumerator/multiplierDenominator`, rounding up or down specified by `roundUp`, and
    *   without performing intermediate rounding, i.e. the result should be as if float arithmetic
    *   was done and the rounding performed at the end
    */

--- a/ethereum/contracts/relayer/coreRelayer/CoreRelayerBase.sol
+++ b/ethereum/contracts/relayer/coreRelayer/CoreRelayerBase.sol
@@ -11,6 +11,7 @@ import {
   ForwardRequestFromWrongAddress,
   RelayProviderDoesNotSupportTargetChain,
   RelayProviderQuotedBogusAssetPrice,
+  RelayProviderQuotedBogusGasPrice,
   Send,
   DeliveryInstruction,
   ExecutionParameters,
@@ -116,149 +117,108 @@ abstract contract CoreRelayerBase is IWormholeRelayerBase {
    */
   function convertSendToDeliveryInstruction(
     Send memory send
-  ) internal view returns (DeliveryInstruction memory instruction) {
-    IRelayProvider relayProvider = IRelayProvider(send.relayProviderAddress);
+  ) internal view returns (DeliveryInstruction memory instruction, IRelayProvider relayProvider) {
+    relayProvider = IRelayProvider(send.relayProviderAddress);
 
-    instruction.targetChainId       = send.targetChainId;
-    instruction.targetAddress       = send.targetAddress;
-    instruction.refundChainId       = send.refundChainId;
-    instruction.refundAddress       = send.refundAddress;
-    instruction.maximumRefundTarget = calculateTargetDeliveryMaximumRefund(
-                                        send.targetChainId, send.maxTransactionFee, relayProvider
-                                      );
-    instruction.receiverValueTarget = convertReceiverValueAmountToTarget(
-                                        send.targetChainId, send.receiverValue, relayProvider
-                                      );
-    instruction.senderAddress       = toWormholeFormat(msg.sender);
-    instruction.sourceRelayProvider = toWormholeFormat(send.relayProviderAddress);
-    instruction.targetRelayProvider = relayProvider.getTargetChainAddress(send.targetChainId);
-    instruction.vaaKeys             = send.vaaKeys;
-    instruction.consistencyLevel    = send.consistencyLevel;
-    instruction.payload             = send.payload;
-    instruction.executionParameters = ExecutionParameters({
-                                        gasLimit: calculateTargetGasDeliveryAmount(
-                                          send.targetChainId, send.maxTransactionFee, relayProvider
-                                        )
-                                      });
+    (uint256 maximumRefundTarget, uint256 receiverValueTarget, uint32 gasLimit) =
+      calculateTargetParams(
+        send.targetChainId, send.maxTransactionFee, send.receiverValue, relayProvider
+      );
+
+    instruction = DeliveryInstruction({
+      targetChainId: send.targetChainId,
+      targetAddress: send.targetAddress,
+      refundChainId: send.refundChainId,
+      refundAddress: send.refundAddress,
+      maximumRefundTarget: maximumRefundTarget,
+      receiverValueTarget: receiverValueTarget,
+      senderAddress: toWormholeFormat(msg.sender),
+      sourceRelayProvider: toWormholeFormat(send.relayProviderAddress),
+      targetRelayProvider: relayProvider.getTargetChainAddress(send.targetChainId),
+      vaaKeys: send.vaaKeys,
+      consistencyLevel: send.consistencyLevel,
+      payload: send.payload,
+      executionParameters: ExecutionParameters({
+        gasLimit: gasLimit
+      })
+    });
   }
 
-  /**
-   * Given a targetChain, maxTransactionFee, and a relay provider, this function calculates what the
-   *   maximum refund of the delivery transaction should be, in terms of target chain currency
-   *
-   * The maximum refund is the amount that would be refunded to refundAddress if the call to
-   *   `receiveWormholeMessages` were to counterfactually take 0 gas.
-   *
-   * It does this by calculating (maxTransactionFee - deliveryOverhead) and converting (using the
-   *   relay provider's prices) to target chain currency (where `deliveryOverhead` is the
-   *   relayProvider's base fee for delivering to targetChainId [in units of source chain currency])
-   */
-  function calculateTargetDeliveryMaximumRefund(
+  function calculateTargetParams(
     uint16 targetChainId,
     uint256 maxTransactionFee,
+    uint256 receiverValue,
     IRelayProvider provider
-  ) internal view returns (uint256 maximumRefund) { unchecked {
+  ) internal view returns (
+    uint256 maximumRefundTarget,
+    uint256 receiverValueTarget,
+    uint32 gasLimit
+  ) {
+    if (!provider.isChainSupported(targetChainId))
+      revert RelayProviderDoesNotSupportTargetChain(address(provider), targetChainId);
+
+    (uint256 sourcePrice, uint256 targetPrice) =
+      getAssetPricesWithBuffer(getChainId(), targetChainId, provider);
+
+    receiverValueTarget = convertAmount(receiverValue, sourcePrice, targetPrice, false);
+
     uint256 overhead = provider.quoteDeliveryOverhead(targetChainId);
-    if (maxTransactionFee > overhead) { 
-      (uint16 buffer, uint16 denominator) = provider.getAssetConversionBuffer(targetChainId);
-      uint256 remainder = maxTransactionFee - overhead;
-      uint256 numerator = uint256(denominator) + buffer;
-      maximumRefund = assetConversionHelper(
-        getChainId(), remainder, targetChainId, denominator, numerator, false, provider
-      );
-    }
-  }}
+    if (maxTransactionFee > overhead) { unchecked {
+      uint256 maxFeeSubOverhead = maxTransactionFee - overhead;
 
-  /**
-   * If the user specifies (for `receiverValue`) `sourceAmount` of source chain currency, with relay
-   *   provider `provider`, then this function calculates how much the relayer will pass into
-   *   receiveWormholeMessages on the target chain (in target chain currency).
-   *
-   * The calculation simply converts this amount to target chain's currency, but also applies a
-   *   multiplier of `denominator/(denominator + buffer)` where these values are also specified
-   *   by the relay provider `provider`.
-   */
-  function convertReceiverValueAmountToTarget(
-    uint16 targetChainId,
-    uint256 sourceAmount,
-    IRelayProvider provider
-  ) internal view returns (uint256 targetAmount) { unchecked {
-    (uint16 buffer, uint16 denominator) = provider.getAssetConversionBuffer(targetChainId);
-    uint256 numerator = uint256(denominator) + buffer;
-    //multiplying with inverse of numerator/denominator, i.e. they are used flipped
-    targetAmount = assetConversionHelper(
-      getChainId(), sourceAmount, targetChainId, denominator, numerator, false, provider
-    );
-  }}
+      maximumRefundTarget = convertAmount(maxFeeSubOverhead, sourcePrice, targetPrice, false);
 
-  /**
-   * Given a targetChainId, maxTransactionFee, and a relay provider, this function calculates what
-   *   the gas limit of the delivery transaction should be.
-   * It does this by calculating (maxTransactionFee - deliveryOverhead)/gasPrice where
-   *  `deliveryOverhead` is the relayProvider's base fee for delivering to targetChain and
-   *  `gasPrice` is the relayProvider's fee per unit of target chain gas.
-   * Provider fees are quoted in units of the source chain currency.
-   */
-  function calculateTargetGasDeliveryAmount(
-    uint16 targetChainId,
-    uint256 maxTransactionFee,
-    IRelayProvider provider
-  ) internal view returns (uint32 gasAmount) { unchecked {
-    uint256 overhead = provider.quoteDeliveryOverhead(targetChainId);
-    if (maxTransactionFee > overhead)
-      gasAmount = uint32(
-        min(
-          (maxTransactionFee - overhead) / provider.quoteGasPrice(targetChainId),
-          type(uint32).max
-        )
-      );
-  }}
+      gasLimit = uint32(min(
+        maxFeeSubOverhead / getCheckedGasPriceSource(targetChainId, provider),
+        type(uint32).max
+      ));
+    }}
+  }
 
-  /**
-   * Converts `sourceAmount` of source chain currency to units of target chain currency using the
-   *   prices of `provider` and also multiplying by a specified fraction
-   *   `multiplierNumerator/multiplierDenominator`, rounding up or down specified by `roundUp`, and
-   *   without performing intermediate rounding, i.e. the result should be as if float arithmetic
-   *   was done and the rounding performed at the end
-   */
-  function assetConversionHelper(
+  function getAssetPricesWithBuffer(
     uint16 sourceChainId,
-    uint256 sourceAmount,
     uint16 targetChainId,
-    uint256 multiplierNumerator,
-    uint256 multiplierDenominator,
-    bool roundUp,
     IRelayProvider provider
-  ) internal view returns (uint256 targetAmount) {
-    //We probably call this multiple times during a single transaction, however since the relay
-    //  provider contract is already hot at this point, calling it multiple times in a row
-    //  shouldn't be too gas inefficient (about 100 gas per call) and local caching in storage
-    //  would be ~equally expensive (SSTORE is 20k, but resetting to 0 refunds 19.9k, i.e. overall
-    //  cost would also be ~100 gas).
-    uint256 sourceNativeCurrencyPrice = getCheckedAssetPrice(provider, sourceChainId);
-    uint256 targetNativeCurrencyPrice = getCheckedAssetPrice(provider, targetChainId);
+  ) internal view returns (uint256 sourcePrice, uint256 targetPrice)
+  {
+    //percentage = premium/base
+    //e.g. premium = 5, base = 100 => 5 % premium, targetPrice is inflated by 5 % before conversion
+    (uint16 premium, uint16 base) =
+      provider.getAssetConversionBuffer(targetChainId);
 
-    uint256 numerator = sourceAmount * sourceNativeCurrencyPrice * multiplierNumerator;
-    uint256 denominator = targetNativeCurrencyPrice * multiplierDenominator;
-    targetAmount = (roundUp ? (numerator + denominator - 1) : numerator) / denominator;
+    uint256 factor;
+    unchecked {factor = uint256(base) + premium;}
+
+    sourcePrice = getCheckedAssetPrice(sourceChainId, provider) * base;
+    targetPrice = getCheckedAssetPrice(targetChainId, provider) * factor;
   }
 
   function getCheckedAssetPrice(
-    IRelayProvider provider,
-    uint16 chainId
+    uint16 chainId,
+    IRelayProvider provider
   ) internal view returns (uint256 price) {
-    //if (chainId != getChainId())
-    //  checkRelayProviderSupportsChain();
     price = provider.quoteAssetPrice(chainId);
     if (price == 0)
       revert RelayProviderQuotedBogusAssetPrice(address(provider), chainId, price);
   }
 
-  function checkRelayProviderSupportsChain(
-    IRelayProvider relayProvider,
-    uint16 targetChainId
-  ) internal view {
-    if (!relayProvider.isChainSupported(targetChainId))
-      revert RelayProviderDoesNotSupportTargetChain(address(relayProvider), targetChainId);
+  function getCheckedGasPriceSource(
+    uint16 targetChainId,
+    IRelayProvider provider
+  ) internal view returns (uint256 gasPriceSource) {
+    gasPriceSource = provider.quoteGasPrice(targetChainId);
+    if (gasPriceSource == 0)
+      revert RelayProviderQuotedBogusGasPrice(address(provider), targetChainId, gasPriceSource);
+  }
+
+  function convertAmount(
+    uint256 inputAmount,
+    uint256 inputPrice,
+    uint256 outputPrice,
+    bool roundUp
+  ) internal pure returns (uint256 ouputAmount) {
+    uint numerator = inputAmount * inputPrice;
+    uint denominator = outputPrice;
+    ouputAmount = (roundUp ? (numerator + denominator - 1) : numerator) / denominator;
   }
 }

--- a/ethereum/contracts/relayer/coreRelayer/CoreRelayerGovernance.sol
+++ b/ethereum/contracts/relayer/coreRelayer/CoreRelayerGovernance.sol
@@ -98,7 +98,7 @@ abstract contract CoreRelayerGovernance is CoreRelayerBase, ERC1967Upgrade {
     _upgradeTo(newImplementation);
 
     (bool success, bytes memory revertData) =
-      address(this).call(abi.encodeWithSelector(this.checkAndExecuteUpgradeMigration.selector));
+      address(this).call(abi.encodeCall(this.checkAndExecuteUpgradeMigration, ()));
 
     if (!success)
       revert ContractUpgradeFailed(revertData);

--- a/ethereum/contracts/relayer/coreRelayer/CoreRelayerGovernance.sol
+++ b/ethereum/contracts/relayer/coreRelayer/CoreRelayerGovernance.sol
@@ -72,7 +72,7 @@ abstract contract CoreRelayerGovernance is CoreRelayerBase, ERC1967Upgrade {
    * Action Parameters:
    *   - bytes32 newProvider - bytes32 instead of address for general consistency reasons
    */
-  uint8 private constant GOVERNANCE_ACTION_UPDATE_DEFAULT_PROVIDER = 4;
+  uint8 private constant GOVERNANCE_ACTION_UPDATE_DEFAULT_PROVIDER = 3;
 
   //By checking that only the contract can call itself, we can enforce that the migration code is
   //  executed upon program upgrade and that it can't be called externally by anyone else.

--- a/ethereum/contracts/relayer/coreRelayer/CoreRelayerSend.sol
+++ b/ethereum/contracts/relayer/coreRelayer/CoreRelayerSend.sol
@@ -145,7 +145,7 @@ abstract contract CoreRelayerSend is CoreRelayerBase, IWormholeRelayerSend {
         sendParams.targetChainId, sendParams.maxTransactionFee, relayProvider
       ),
       convertReceiverValueAmountToTarget(
-        sendParams.receiverValue, sendParams.targetChainId, relayProvider
+        sendParams.targetChainId, sendParams.receiverValue, relayProvider
       ),
       calculateTargetGasDeliveryAmount(
         sendParams.targetChainId, sendParams.maxTransactionFee, relayProvider
@@ -187,7 +187,7 @@ abstract contract CoreRelayerSend is CoreRelayerBase, IWormholeRelayerSend {
         targetChainId, newMaxTransactionFee, relayProvider
       ),
       newReceiverValueTarget: convertReceiverValueAmountToTarget(
-        newReceiverValue, targetChainId, relayProvider
+        targetChainId, newReceiverValue, relayProvider
       ),
       sourceRelayProvider: toWormholeFormat(relayProviderAddress),
       targetChainId: targetChainId,

--- a/ethereum/contracts/relayer/coreRelayer/CoreRelayerSerde.sol
+++ b/ethereum/contracts/relayer/coreRelayer/CoreRelayerSerde.sol
@@ -97,7 +97,7 @@ library CoreRelayerSerde {
   function decodeDeliveryInstruction(
     bytes memory encoded
   ) internal pure returns (DeliveryInstruction memory strct) {
-    uint offset = checkPayloadId(encoded, 0, PAYLOAD_ID_DELIVERY_INSTRUCTION);
+    uint offset = checkUint8(encoded, 0, PAYLOAD_ID_DELIVERY_INSTRUCTION);
     (strct.targetChainId,       offset) = encoded.asUint16Unchecked(offset);
     (strct.targetAddress,       offset) = encoded.asBytes32Unchecked(offset);
     (strct.refundChainId,       offset) = encoded.asUint16Unchecked(offset);
@@ -132,7 +132,7 @@ library CoreRelayerSerde {
   function decodeRedeliveryInstruction(
     bytes memory encoded
   ) internal pure returns (RedeliveryInstruction memory strct) {
-    uint256 offset = checkPayloadId(encoded, 0 , PAYLOAD_ID_REDELIVERY_INSTRUCTION);
+    uint256 offset = checkUint8(encoded, 0 , PAYLOAD_ID_REDELIVERY_INSTRUCTION);
     (strct.key,                    offset) = decodeVaaKey(encoded, offset);
     (strct.newMaximumRefundTarget, offset) = encoded.asUint256Unchecked(offset);
     (strct.newReceiverValueTarget, offset) = encoded.asUint256Unchecked(offset);
@@ -157,7 +157,7 @@ library CoreRelayerSerde {
   function decodeDeliveryOverride(
     bytes memory encoded
   ) internal pure returns (DeliveryOverride memory strct) {
-    uint offset = checkPayloadId(encoded, 0, VERSION_DELIVERY_OVERRIDE);
+    uint offset = checkUint8(encoded, 0, VERSION_DELIVERY_OVERRIDE);
     (strct.gasLimit,       offset) = encoded.asUint32Unchecked(offset);
     (strct.maximumRefund,  offset) = encoded.asUint256Unchecked(offset);
     (strct.receiverValue,  offset) = encoded.asUint256Unchecked(offset);
@@ -205,7 +205,7 @@ library CoreRelayerSerde {
     bytes memory encoded,
     uint startOffset
   ) private pure returns (VaaKey memory vaaKey, uint offset) {
-    offset = checkPayloadId(encoded, startOffset, VERSION_VAAKEY);
+    offset = checkUint8(encoded, startOffset, VERSION_VAAKEY);
 
     uint8 parsedVaaKeyType;
     (parsedVaaKeyType, offset) = encoded.asUint8Unchecked(offset);
@@ -254,11 +254,11 @@ library CoreRelayerSerde {
     bytes memory encoded,
     uint startOffset
   ) private pure returns (ExecutionParameters memory strct, uint offset) {
-    offset = checkPayloadId(encoded, startOffset, VERSION_EXECUTION_PARAMETERS);
+    offset = checkUint8(encoded, startOffset, VERSION_EXECUTION_PARAMETERS);
     (strct.gasLimit, offset) = encoded.asUint32Unchecked(offset);
   }
 
-  function checkPayloadId(
+  function checkUint8(
     bytes memory encoded,
     uint startOffset,
     uint8 expectedPayloadId

--- a/ethereum/forge-test/relayer/WormholeRelayerGovernance.t.sol
+++ b/ethereum/forge-test/relayer/WormholeRelayerGovernance.t.sol
@@ -30,7 +30,7 @@ import "forge-std/console.sol";
 import "forge-std/Vm.sol";
 
 contract Brick {
-    function executeUpgradeMigration() external view {}
+    function checkAndExecuteUpgradeMigration() external view {}
 }
 
 contract WormholeRelayerGovernanceTests is Test {


### PR DESCRIPTION
* rebased and further enhanced version of [PR2915](https://github.com/wormhole-foundation/wormhole/pull/2915) (which is now obsolete)
* refactor amount conversion code (source <-> target) to make it more uniform and legible
* improve contract upgrade mechanism in CoreRelayerGovernance
* check enum values before casting in CoreRelayerSerde to revert with intended error instead of panicking
* reorder checks in `payRefundToRefundAddress()` to check for `provider.isChainSupported()` first
* introduce and document distinction between versioning fields and payload ids
* remove TODOs and add documentation / make it more uniform

