### PR TITLE
Update forge-std to the latest

### DIFF
--- a/ethereum/Makefile
+++ b/ethereum/Makefile
@@ -35,7 +35,7 @@ node_modules: package-lock.json
 forge_dependencies: lib/forge-std
 
 lib/forge-std:
-	forge install foundry-rs/forge-std@2c7cbfc6fbede6d7c9e6b17afe997e3fdfe22fef --no-git --no-commit
+	forge install foundry-rs/forge-std@v1.5.5 --no-git --no-commit
 
 dependencies: node_modules forge_dependencies
 

--- a/ethereum/forge-test/Bridge.t.sol
+++ b/ethereum/forge-test/Bridge.t.sol
@@ -5,32 +5,57 @@ pragma solidity ^0.8.0;
 import "../contracts/bridge/Bridge.sol";
 import "forge-std/Test.sol";
 
-contract TestBridge is Bridge, Test {
+// @dev ensure some internal methods are public for testing
+contract ExportedBridge is Bridge {
+    function _truncateAddressPub(bytes32 b) public pure returns (address) {
+        return super._truncateAddress(b);
+    }
+
+    function setChainIdPub(uint16 chainId) public {
+        return super.setChainId(chainId);
+    }
+
+    function setEvmChainIdPub(uint256 evmChainId) public {
+        return super.setEvmChainId(evmChainId);
+    }
+}
+
+contract TestBridge is Test {
+    ExportedBridge bridge;
+
+    function setUp() public {
+        bridge = new ExportedBridge();
+    }
+
     function testTruncate(bytes32 b) public {
-        if (bytes12(b) != 0) {
+        bool invalidAddress = bytes12(b) != 0;
+        if (invalidAddress) {
             vm.expectRevert( "invalid EVM address");
         }
-        bytes32 converted = bytes32(uint256(uint160(bytes20(_truncateAddress(b)))));
-        require(converted == b, "truncate does not roundrip");
+        bytes32 converted = bytes32(uint256(uint160(bytes20(bridge._truncateAddressPub(b)))));
+
+        if (!invalidAddress) {
+            require(converted == b, "truncate does not roundrip");
+        }
     }
 
     function testEvmChainId() public {
         vm.chainId(1);
-        setChainId(1);
-        setEvmChainId(1);
-        assertEq(chainId(), 1);
-        assertEq(evmChainId(), 1);
+        bridge.setChainIdPub(1);
+        bridge.setEvmChainIdPub(1);
+        assertEq(bridge.chainId(), 1);
+        assertEq(bridge.evmChainId(), 1);
 
         // fork occurs, block.chainid changes
         vm.chainId(10001);
 
-        setEvmChainId(10001);
-        assertEq(chainId(), 1);
-        assertEq(evmChainId(), 10001);
+        bridge.setEvmChainIdPub(10001);
+        assertEq(bridge.chainId(), 1);
+        assertEq(bridge.evmChainId(), 10001);
 
         // evmChainId must equal block.chainid
         vm.expectRevert("invalid evmChainId");
-        setEvmChainId(1337);
+        bridge.setEvmChainIdPub(1337);
 
     }
 }

--- a/ethereum/forge-test/Messages.t.sol
+++ b/ethereum/forge-test/Messages.t.sol
@@ -8,7 +8,13 @@ import "../contracts/Setters.sol";
 import "../contracts/Structs.sol";
 import "forge-std/Test.sol";
 
-contract TestMessages is Messages, Test, Setters {
+contract ExportedMessages is Messages, Setters {
+    function storeGuardianSetPub(Structs.GuardianSet memory set, uint32 index) public {
+        return super.storeGuardianSet(set, index);
+    }
+}
+
+contract TestMessages is Test {
   address constant testGuardianPub = 0xbeFA429d57cD18b7F8A4d91A2da9AB4AF05d0FBe;
 
   // A valid VM with one signature from the testGuardianPublic key
@@ -16,12 +22,12 @@ contract TestMessages is Messages, Test, Setters {
 
   uint256 constant testGuardian = 93941733246223705020089879371323733820373732307041878556247502674739205313440;
 
-  Messages messages;
+  ExportedMessages messages;
 
   Structs.GuardianSet guardianSet;
 
   function setUp() public {
-    messages = new Messages();
+    messages = new ExportedMessages();
 
     // initialize guardian set with one guardian
     address[] memory keys = new address[](1);
@@ -135,10 +141,10 @@ contract TestMessages is Messages, Test, Setters {
       expirationTime: 0
     });
 
-    storeGuardianSet(initialGuardianSet, uint32(0));
+    messages.storeGuardianSetPub(initialGuardianSet, uint32(0));
 
     // Confirm that the test VM is valid
-    (Structs.VM memory parsedValidVm, bool valid, string memory reason) = this.parseAndVerifyVM(validVM);
+    (Structs.VM memory parsedValidVm, bool valid, string memory reason) = messages.parseAndVerifyVM(validVM);
     require(valid, reason);
     assertEq(valid, true);
     assertEq(reason, "");
@@ -151,7 +157,7 @@ contract TestMessages is Messages, Test, Setters {
     );
 
     // Confirm that the verifyVM fails on invalid VM
-    (valid, reason) = this.verifyVM(invalidVm);
+    (valid, reason) = messages.verifyVM(invalidVm);
     assertEq(valid, false);
     assertEq(reason, "vm.hash doesn't match body");
   }

--- a/ethereum/forge-test/TokenImplementation.t.sol
+++ b/ethereum/forge-test/TokenImplementation.t.sol
@@ -78,7 +78,7 @@ contract TestTokenImplementation is TokenImplementation, Test {
         address spender,
         uint256 amount,
         uint256 deadline
-    ) public returns (SignatureSetup memory output) {
+    ) public view returns (SignatureSetup memory output) {
         // prepare signer allowing for tokens to be spent
         uint256 sk = uint256(walletPrivateKey);
         output.allower = vm.addr(sk);

--- a/ethereum/foundry
+++ b/ethereum/foundry
@@ -11,7 +11,7 @@
 set -eo pipefail
 
 # This is a known-to-be-working build.
-DOCKER_IMAGE="ghcr.io/foundry-rs/foundry:nightly-0d4468765c264d00ac961275fe176ce003d3e4ca@sha256:88fe2ea1005b9a3a7f8068645fef4cfb0fa7c16a5dd3b35582c70a1e36d16c25"
+DOCKER_IMAGE="ghcr.io/foundry-rs/foundry:nightly-6defdcebf7f59ee471086b1b51ff85392aafd445@sha256:cd9a68e7bd69d9d5f9025eaeb525efd7f162f11e4566792da8ec4891b080a415"
 
 args=$(printf '"%s" ' "$@")
 

--- a/ethereum/foundry.toml
+++ b/ethereum/foundry.toml
@@ -1,4 +1,4 @@
-[default]
+[profile.default]
 solc_version = "0.8.4"
 optimizer = true
 optimizer_runs = 200


### PR DESCRIPTION
Newer versions of forge-std [like v1.0.0+](https://twitter.com/msolomon44/status/1587171153918840833?lang=en) include much improved fuzzing and invariant testing. To take advantage of that functionality, this PR upgrades both forge and forge-std.

To do that, it required changing the inheritance of the forge tests. I changed a bit of the logs in the test for truncateAddress with some help from @scnale since the previous version led to somewhat undefined behavior. I verified the changed tests run ✅ with the old and new version of forge-std.

It is highly recommended in your local checkout you run:

    rm -rf ethereum/lib/forge-std
    make forge_dependencies