### PR TITLE
Set WETH on Arbitrum - Do not merge

### DIFF
--- a/ethereum/contracts/bridge/BridgeImplementation.sol
+++ b/ethereum/contracts/bridge/BridgeImplementation.sol
@@ -29,6 +29,11 @@ contract BridgeImplementation is Bridge {
 
         setInitialized(impl);
 
+        if (evmChainId() == 42161) { // arbitrum
+            address wethAddr = 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1;
+            setWETH(wethAddr);
+        }
+
         _;
     }
 }


### PR DESCRIPTION
This PR updates the Token Bridge on Arbitrum mainnet to set the WETH address to `0x82af49447d8a07e3bd95bd0d56f35241523fbab1`, as requested in discussion #2896

NOTE: This PR should never be merged!