### PR TITLE
add defaultRelayProvider as a parameter to initialize() and replace the current kludge

### DIFF
--- a/ethereum/contracts/relayer/coreRelayer/CoreRelayer.sol
+++ b/ethereum/contracts/relayer/coreRelayer/CoreRelayer.sol
@@ -17,25 +17,18 @@ contract CoreRelayer is
   CoreRelayerDelivery,
   IWormholeRelayer
 {
-  address private immutable initialDefaultRelayProvider;
-
   //the only normal storage variable - everything else uses slot pattern
   //no point doing it for this one since it is entirely one-off and of no interest to the rest
   //  of the contract and it also can't accidentally be moved because we are at the bottom of
   //  the inheritance hierarchy here
   bool private initialized;
 
-  constructor(
-    address wormhole,
-    address _initialDefaultRelayProvider
-  ) CoreRelayerBase(wormhole) {
-    initialDefaultRelayProvider = _initialDefaultRelayProvider;
-  }
+  constructor(address wormhole) CoreRelayerBase(wormhole) {}
 
   //needs to be called upon construction of the EC1967 proxy
-  function initialize() public {
+  function initialize(address defaultRelayProvider) public {
     assert(!initialized);
     initialized = true;
-    getDefaultRelayProviderState().defaultRelayProvider = initialDefaultRelayProvider;
+    getDefaultRelayProviderState().defaultRelayProvider = defaultRelayProvider;
   }
 }

--- a/ethereum/forge-test/relayer/TestHelpers.sol
+++ b/ethereum/forge-test/relayer/TestHelpers.sol
@@ -112,10 +112,9 @@ contract TestHelpers {
         address proxyAddressComputed =
             create2Factory.computeProxyAddress(address(this), "0xGenericRelayer");
 
-        CoreRelayer coreRelayerImplementation =
-            new CoreRelayer(address(wormhole), defaultRelayProvider);
+        CoreRelayer coreRelayerImplementation = new CoreRelayer(address(wormhole));
 
-        bytes memory initCall = abi.encodeCall(CoreRelayer.initialize, ());
+        bytes memory initCall = abi.encodeCall(CoreRelayer.initialize, (defaultRelayProvider));
 
         coreRelayer = IWormholeRelayer(
             create2Factory.create2Proxy(

--- a/ethereum/ts-scripts/relayer/coreRelayer/deployCoreRelayer.ts
+++ b/ethereum/ts-scripts/relayer/coreRelayer/deployCoreRelayer.ts
@@ -25,11 +25,11 @@ async function run() {
     console.log(`Deploying for chain ${chain.chainId}...`);
     const coreRelayerImplementation = await deployCoreRelayerImplementation(
       chain,
-      getRelayProviderAddress(chain)
     );
     const coreRelayerProxy = await deployCoreRelayerProxy(
       chain,
       coreRelayerImplementation.address,
+      getRelayProviderAddress(chain),
     );
 
     output.coreRelayerImplementations.push(coreRelayerImplementation);

--- a/ethereum/ts-scripts/relayer/coreRelayer/upgradeCoreRelayerSelfSign.ts
+++ b/ethereum/ts-scripts/relayer/coreRelayer/upgradeCoreRelayerSelfSign.ts
@@ -7,7 +7,6 @@ import {
   getCoreRelayer,
   writeOutputFiles,
   getOperatingChains,
-  getRelayProviderAddress,
 } from "../helpers/env";
 import {
   createCoreRelayerUpgradeVAA,
@@ -27,7 +26,6 @@ async function run() {
   for (const chain of chains) {
     const coreRelayerImplementation = await deployCoreRelayerImplementation(
       chain,
-      getRelayProviderAddress(chain)
     );
     await upgradeCoreRelayer(chain, coreRelayerImplementation.address);
 

--- a/ethereum/ts-scripts/relayer/helpers/deployments.ts
+++ b/ethereum/ts-scripts/relayer/helpers/deployments.ts
@@ -21,7 +21,7 @@ export const setupContractSalt = Buffer.from("0xSetup");
 export const proxyContractSalt = Buffer.from("0xGenericRelayer");
 
 export async function deployRelayProviderImplementation(
-  chain: ChainInfo
+  chain: ChainInfo,
 ): Promise<Deployment> {
   console.log("deployRelayProviderImplementation " + chain.chainId);
   const signer = getSigner(chain);
@@ -42,7 +42,7 @@ export async function deployRelayProviderImplementation(
 }
 
 export async function deployRelayProviderSetup(
-  chain: ChainInfo
+  chain: ChainInfo,
 ): Promise<Deployment> {
   console.log("deployRelayProviderSetup " + chain.chainId);
   const signer = getSigner(chain);
@@ -63,7 +63,7 @@ export async function deployRelayProviderSetup(
 export async function deployRelayProviderProxy(
   chain: ChainInfo,
   relayProviderSetupAddress: string,
-  relayProviderImplementationAddress: string
+  relayProviderImplementationAddress: string,
 ): Promise<Deployment> {
   console.log("deployRelayProviderProxy " + chain.chainId);
 
@@ -92,7 +92,7 @@ export async function deployRelayProviderProxy(
 }
 
 export async function deployMockIntegration(
-  chain: ChainInfo
+  chain: ChainInfo,
 ): Promise<Deployment> {
   console.log("deployMockIntegration " + chain.chainId);
 
@@ -115,7 +115,7 @@ export async function deployMockIntegration(
 }
 
 export async function deployCreate2Factory(
-  chain: ChainInfo
+  chain: ChainInfo,
 ): Promise<Deployment> {
   console.log("deployCreate2Factory " + chain.chainId);
 
@@ -128,12 +128,11 @@ export async function deployCreate2Factory(
 
 export async function deployCoreRelayerImplementation(
   chain: ChainInfo,
-  defaultRelayProvider: string,
 ): Promise<Deployment> {
   console.log("deployCoreRelayerImplementation " + chain.chainId);
 
   const result = await new CoreRelayer__factory(getSigner(chain))
-    .deploy(chain.wormholeAddress, ethers.utils.getAddress(defaultRelayProvider))
+    .deploy(chain.wormholeAddress)
     .then(deployed);
 
   console.log("Successfully deployed contract at " + result.address);
@@ -143,12 +142,16 @@ export async function deployCoreRelayerImplementation(
 export async function deployCoreRelayerProxy(
   chain: ChainInfo,
   coreRelayerImplementationAddress: string,
+  defaultRelayProvider: string,
 ): Promise<Deployment> {
   console.log("deployCoreRelayerProxy " + chain.chainId);
 
   const create2Factory = getCreate2Factory(chain);
 
-  const initData = CoreRelayer__factory.createInterface().encodeFunctionData("initialize")
+  const initData = CoreRelayer__factory.createInterface().encodeFunctionData(
+    "initialize",
+    [ethers.utils.getAddress(defaultRelayProvider)]
+  );
   const rx = await create2Factory
     .create2Proxy(proxyContractSalt, coreRelayerImplementationAddress, initData)
     .then(wait);


### PR DESCRIPTION
Originally, the defaultRelayProvider had to be baked into the bytecode via an immutable variable and then set in a parameter-less call to initialize() using said variable to aovid having a different deployment code (and hence a different deployment (=proxy) address) for the proxy.

Use of the create2 factory and its `Init` pattern (which always deploys the empty `Init` logic contract that is then immediately upgraded to the real logic contract) makes this kludge unnecessary and allows for a proper use of initialize()

(fixed version of [PR#2951](https://github.com/wormhole-foundation/wormhole/pull/2951))