### PR TITLE
node/telemetry: Bugfix and additional debug options

### DIFF
--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"path"
+	"runtime"
 	"strings"
 	"syscall"
 
@@ -1029,6 +1030,9 @@ func runNode(cmd *cobra.Command, args []string) {
 	} else {
 		logger.Info("Telemetry disabled")
 	}
+
+	// log golang version
+	logger.Info("golang version", zap.String("golang_version", runtime.Version()))
 
 	// Redirect ipfs logs to plain zap
 	ipfslog.SetPrimaryCore(logger.Core())

--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -1015,7 +1015,8 @@ func runNode(cmd *cobra.Command, args []string) {
 			"version":       version.Version(),
 		}
 
-		tm, err := telemetry.New(context.Background(), *telemetryProject, *publicRpcLogToTelemetry, labels, options...)
+		skipPrivateLogs := !*publicRpcLogToTelemetry
+		tm, err := telemetry.New(context.Background(), *telemetryProject, skipPrivateLogs, labels, options...)
 		if err != nil {
 			logger.Fatal("Failed to initialize telemetry", zap.Error(err))
 		}

--- a/node/cmd/guardiand/telemetry.go
+++ b/node/cmd/guardiand/telemetry.go
@@ -11,9 +11,9 @@ package guardiand
 // By using a separate key, we can keep the configuration decoupled from the telemetry backend,
 // allowing the key to be replaced or even a different provider to be used without changing the config.
 
-const telemetryProject = "projects/wormhole-logging"
+const defaultTelemetryProject = "projects/wormhole-logging"
 
-const telemetryServiceAccount = `
+const defaultTelemetryServiceAccountEnc = `
 RcLwG218oFn9tVWlsl6ZbYQdiny2w13G49Be5UucgwFAdxYP5DilBQhhd0lN900VM25k3joR2VHwtZ90
 GCQQjjbjqQ7Pm9aAkH0Yp3ngHO111IhFm6yCQMYXl+t7hjEN/0rvju19sm+vdLJx1ECzogAnBRFAlf8I
 k1jTzxA+elAWIT6/C6wfFpE69eJbFCKt6g4LnpajOu1OI812gR+3k8r6gyoVUlhUY36RjTjsE/2Fxxz9

--- a/node/pkg/telemetry/telemetry.go
+++ b/node/pkg/telemetry/telemetry.go
@@ -33,12 +33,14 @@ type ExternalLoggerGoogleCloud struct {
 }
 
 func (logger *ExternalLoggerGoogleCloud) log(time time.Time, message json.RawMessage, level zapcore.Level) {
-	logger.Log(google_cloud_logging.Entry{
+	entry := google_cloud_logging.Entry{
 		Timestamp: time,
 		Payload:   message,
 		Severity:  logLevelSeverity[level],
 		Labels:    logger.labels,
-	})
+	}
+	// call google cloud logger
+	logger.Log(entry)
 }
 
 func (logger *ExternalLoggerGoogleCloud) flush() error {
@@ -111,8 +113,8 @@ func NewExternalLogger(skipPrivateLogs bool, externalLogger ExternalLogger) (*Te
 
 // New creates a new Telemetry logger with Google Cloud Logging
 // skipPrivateLogs: if set to `true`, logs with the field zap.Bool("_privateLogEntry", true) will not be logged by telemetry.
-func New(ctx context.Context, project string, serviceAccountJSON []byte, skipPrivateLogs bool, labels map[string]string) (*Telemetry, error) {
-	gc, err := google_cloud_logging.NewClient(ctx, project, option.WithCredentialsJSON(serviceAccountJSON))
+func New(ctx context.Context, project string, skipPrivateLogs bool, labels map[string]string, opts ...option.ClientOption) (*Telemetry, error) {
+	gc, err := google_cloud_logging.NewClient(ctx, project, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create logging client: %v", err)
 	}


### PR DESCRIPTION
# Bugfix
The semantics of `--logPublicRpcToTelemetry` was inverted. 

# Additional options for debugging
The following options were added to `node`: 
* `--telemetryServiceAccountFile` lets one specify a Google Cloud credentials json to use instead of the encrypted default. This lets Guardian operators use their own Google Cloud logging project instead of the default one and also allows easier testing/debugging with a separate Google Cloud project. 
* `--telemetryProject` the name of the Google Cloud project where logs shall be sent to. 