### PR TITLE
node/near: Fix unit tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -318,7 +318,7 @@ jobs:
           go-version: "1.20.4"
       # The go-ethereum and celo-blockchain packages both implement secp256k1 using the exact same header, but that causes duplicate symbols.
       - name: Run golang tests
-        run: cd node && go test -v -race -ldflags '-extldflags "-Wl,--allow-multiple-definition" ' ./...
+        run: cd node && go test -v -timeout 1m -race -ldflags '-extldflags "-Wl,--allow-multiple-definition" ' ./...
 
   # Run Rust lints and tests
   rust-lint-and-tests:

--- a/node/pkg/watchers/near/metrics.go
+++ b/node/pkg/watchers/near/metrics.go
@@ -74,10 +74,11 @@ func (e *Watcher) runMetrics(ctx context.Context) error {
 		case <-metricsIntervalTimer.C:
 			// compute and publish periodic metrics
 			l1 := e.transactionProcessingQueueCounter.Load()
-			l2 := len(e.chunkProcessingQueue)
+			l2 := len(e.transactionProcessingQueue)
+			l3 := len(e.chunkProcessingQueue)
 			txqueueLen.Set(float64(l1))
 			chunkqueueLen.Set(float64(l2))
-			logger.Debug("metrics", zap.Int64("txqueueLen", l1), zap.Int("chunkqueueLen", l2))
+			logger.Debug("metrics", zap.Int64("txqueueWaiting", l1), zap.Int("txqueueReady", l2), zap.Int("chunkqueueLen", l3))
 
 		case event := <-e.eventChan:
 			switch event {

--- a/node/pkg/watchers/near/nearapi/mock/mock_server.go
+++ b/node/pkg/watchers/near/nearapi/mock/mock_server.go
@@ -41,7 +41,7 @@ func NewForwardingCachingServer(logger *zap.Logger, upstreamHost string, cacheDi
 	}
 }
 
-func check(e error) {
+func panicIfError(e error) {
 	if e != nil {
 		panic(e)
 	}
@@ -67,14 +67,17 @@ func serveCache(w http.ResponseWriter, req *http.Request, cacheDir string) (stri
 
 func returnFile(w http.ResponseWriter, fileName string) {
 	dat, err := os.ReadFile(fileName)
-	check(err)
-	_, err = w.Write(dat)
-	check(err)
+	panicIfError(err)
+	_, _ = w.Write(dat) // don't care about errors
 }
 
-func (s *ForwardingCachingServer) ProxyReq(logger *zap.Logger, req *http.Request) *http.Request {
+func (s *ForwardingCachingServer) ProxyReq(logger *zap.Logger, req *http.Request) (*http.Request, error) {
 	reqBody, err := io.ReadAll(req.Body)
-	check(err)
+
+	if err != nil {
+		return nil, err
+	}
+
 	req.Body = io.NopCloser(bytes.NewReader(reqBody))
 
 	url := fmt.Sprintf("%s%s", s.upstreamHost, req.RequestURI)
@@ -97,7 +100,7 @@ func (s *ForwardingCachingServer) ProxyReq(logger *zap.Logger, req *http.Request
 			zap.String("value", val[0]),
 		)
 	}
-	return proxyReq
+	return proxyReq, nil
 }
 
 func (s *ForwardingCachingServer) RewriteReq(reqBody []byte) []byte {
@@ -134,14 +137,17 @@ func (s *ForwardingCachingServer) ServeHTTP(w http.ResponseWriter, req *http.Req
 	} else if errors.Is(err, os.ErrNotExist) && s.upstreamHost == "" {
 		// cached file does not exist and no upstreamHost defined
 		w.WriteHeader(http.StatusNotFound)
-		_, err = w.Write([]byte("Not Found"))
-		check(err)
+		_, _ = w.Write([]byte("Not Found")) // don't care about errors here
 		return
 	} else if errors.Is(err, os.ErrNotExist) {
 		// upstream host is defined so we query upstream and save the response
 		cache_status = "cache_miss"
 
-		proxyReq := s.ProxyReq(s.logger, req)
+		proxyReq, err := s.ProxyReq(s.logger, req)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
 
 		httpClient := http.Client{}
 		resp, err := httpClient.Do(proxyReq)
@@ -158,14 +164,13 @@ func (s *ForwardingCachingServer) ServeHTTP(w http.ResponseWriter, req *http.Req
 
 		// cache the result
 		err = os.WriteFile(filename, respBody, 0600)
-		check(err)
+		panicIfError(err)
 
 		// return the result
-		_, err = w.Write(respBody)
-		check(err)
+		_, _ = w.Write(respBody) // don't care about errors here
 	} else {
 		// Schrodinger: file may or may not exist. See err for details.
-		check(err)
+		panicIfError(err)
 	}
 
 	s.logger.Debug("request_received",

--- a/node/pkg/watchers/near/tx_processing.go
+++ b/node/pkg/watchers/near/tx_processing.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -53,6 +54,7 @@ func (e *Watcher) processTx(logger *zap.Logger, ctx context.Context, job *transa
 		err = e.processOutcome(logger, ctx, job, receiptOutcome)
 		if err != nil {
 			logger.Debug("ProcessOutcome error: ", zap.Error(err))
+			return err
 		}
 	}
 	return nil
@@ -97,7 +99,7 @@ func (e *Watcher) processOutcome(logger *zap.Logger, ctx context.Context, job *t
 	outcomeBlockHeader, isFinalized := e.finalizer.isFinalized(logger, ctx, outcomeBlockHash.String())
 	if !isFinalized {
 		// If it has not, we return an error such that this transaction can be put back into the queue.
-		return errors.New("block not finalized yet")
+		return fmt.Errorf("block %s not finalized yet", outcomeBlockHash.String())
 	}
 
 	successValue := outcome.Get("status.SuccessValue")

--- a/node/pkg/watchers/near/watcher.go
+++ b/node/pkg/watchers/near/watcher.go
@@ -78,7 +78,7 @@ type (
 
 		// events channels
 		eventChanTxProcessedDuration chan time.Duration
-		eventChan                    chan eventType // whenever a messages is confirmed, post true in here
+		eventChan                    chan eventType
 
 		// Error channel
 		errC chan error

--- a/node/pkg/watchers/near/watcher_test.go
+++ b/node/pkg/watchers/near/watcher_test.go
@@ -334,19 +334,19 @@ func TestWatcherDelayedFinal(t *testing.T) {
 	pl, _ := hex.DecodeString("0100000000000000000000000000000000000000000000000000000000000f42400000000000000000000000000000000000000000000000000000000000000000000f0108bc32f7de18a5f6e1e7d6ee7aff9f5fc858d0d87ac0da94dd8d2a5d267d6b00160000000000000000000000000000000000000000000000000000000000000000")
 	txHashBytes, _ := hex.DecodeString("88029cf0e7432cec04c266a3e72903ee6650b4624c7f9c8e22b04d78e18e87f8")
 
-	lfb := make([]string, 100)
-	for i := 0; i < 100; i++ {
+	lfb := make([]string, 30)
+	for i := 0; i < 30; i++ {
 		lfb[i] = BLOCKCHAIN_1[3]
 	}
 	lfb[0] = BLOCKCHAIN_1[0]
 	lfb[1] = BLOCKCHAIN_1[1]
 	lfb[2] = BLOCKCHAIN_1[2]
 	lfb[3] = BLOCKCHAIN_1[3]
-	lfb[99] = BLOCKCHAIN_1[7]
+	lfb[29] = BLOCKCHAIN_1[7]
 
 	tc := testCase{
 		name:              "TestWatcherDelayedFinal",
-		timeout:           time.Second * 3,
+		timeout:           time.Second * 2,
 		t:                 t,
 		wormholeContract:  WORMHOLE_CONTRACT,
 		upstreamHost:      "",

--- a/node/pkg/watchers/near/watcher_test.go
+++ b/node/pkg/watchers/near/watcher_test.go
@@ -334,23 +334,24 @@ func TestWatcherDelayedFinal(t *testing.T) {
 	pl, _ := hex.DecodeString("0100000000000000000000000000000000000000000000000000000000000f42400000000000000000000000000000000000000000000000000000000000000000000f0108bc32f7de18a5f6e1e7d6ee7aff9f5fc858d0d87ac0da94dd8d2a5d267d6b00160000000000000000000000000000000000000000000000000000000000000000")
 	txHashBytes, _ := hex.DecodeString("88029cf0e7432cec04c266a3e72903ee6650b4624c7f9c8e22b04d78e18e87f8")
 
+	lfb := make([]string, 100)
+	for i := 0; i < 100; i++ {
+		lfb[i] = BLOCKCHAIN_1[3]
+	}
+	lfb[0] = BLOCKCHAIN_1[0]
+	lfb[1] = BLOCKCHAIN_1[1]
+	lfb[2] = BLOCKCHAIN_1[2]
+	lfb[3] = BLOCKCHAIN_1[3]
+	lfb[99] = BLOCKCHAIN_1[7]
+
 	tc := testCase{
-		name:             "TestWatcherDelayedFinal",
-		timeout:          time.Second * 2,
-		t:                t,
-		wormholeContract: WORMHOLE_CONTRACT,
-		upstreamHost:     "",
-		cacheDir:         "nearapi/mock/success_mod1/",
-		latestFinalBlocks: []string{
-			BLOCKCHAIN_1[0],
-			BLOCKCHAIN_1[1],
-			BLOCKCHAIN_1[2],
-			BLOCKCHAIN_1[3],
-			BLOCKCHAIN_1[4],
-			BLOCKCHAIN_1[5],
-			BLOCKCHAIN_1[6],
-			BLOCKCHAIN_1[7],
-		},
+		name:              "TestWatcherDelayedFinal",
+		timeout:           time.Second * 3,
+		t:                 t,
+		wormholeContract:  WORMHOLE_CONTRACT,
+		upstreamHost:      "",
+		cacheDir:          "nearapi/mock/success_mod1/",
+		latestFinalBlocks: lfb,
 		expectedMsgObserved: []*common.MessagePublication{
 			{
 				TxHash:           eth_common.BytesToHash(txHashBytes),

--- a/node/pkg/watchers/near/watcher_test.go
+++ b/node/pkg/watchers/near/watcher_test.go
@@ -248,6 +248,48 @@ func TestWatcherSimple(t *testing.T) {
 	tc.setupAndRun(logger)
 }
 
+// TestWatcherSimple2() tests the case where the "final" API returns a sequence of real blocks which contain a single Wormhole transaction. No re-observation requests.
+func TestWatcherSimple2(t *testing.T) {
+	logger, _ := zap.NewDevelopment()
+
+	pl, _ := hex.DecodeString("0100000000000000000000000000000000000000000000000000000000000f42400000000000000000000000000000000000000000000000000000000000000000000f0108bc32f7de18a5f6e1e7d6ee7aff9f5fc858d0d87ac0da94dd8d2a5d267d6b00160000000000000000000000000000000000000000000000000000000000000000")
+	txHashBytes, _ := hex.DecodeString("88029cf0e7432cec04c266a3e72903ee6650b4624c7f9c8e22b04d78e18e87f8")
+
+	tc := testCase{
+		name:             "TestWatcherSimple2",
+		timeout:          time.Second * 2,
+		t:                t,
+		wormholeContract: WORMHOLE_CONTRACT,
+		upstreamHost:     "",
+		cacheDir:         "nearapi/mock/success/",
+		latestFinalBlocks: []string{
+			BLOCKCHAIN_1[0],
+			BLOCKCHAIN_1[1],
+			BLOCKCHAIN_1[2],
+			BLOCKCHAIN_1[3],
+			BLOCKCHAIN_1[4],
+			BLOCKCHAIN_1[5],
+			BLOCKCHAIN_1[6],
+			BLOCKCHAIN_1[7],
+		},
+		expectedMsgObserved: []*common.MessagePublication{
+			{
+				TxHash:           eth_common.BytesToHash(txHashBytes),
+				EmitterAddress:   portalEmitterAddress(),
+				ConsistencyLevel: 0,
+				EmitterChain:     vaa.ChainIDNear,
+				Nonce:            76538233,
+				Payload:          pl,
+				Sequence:         261,
+				Timestamp:        time.Unix(int64(1666142886047190991)/1_000_000_000, 0),
+				Unreliable:       false,
+			},
+		},
+	}
+
+	tc.setupAndRun(logger)
+}
+
 // TestWatcherReobservation() tests the simple re-observation case: The "final" endpoint returns
 // the same unrelated block and there is a re-observation request for past data.
 func TestWatcherReobservation(t *testing.T) {
@@ -283,49 +325,6 @@ func TestWatcherReobservation(t *testing.T) {
 			{
 				ChainId: uint32(vaa.ChainIDNear),
 				TxHash:  txHashBytes,
-			},
-		},
-	}
-
-	tc.setupAndRun(logger)
-}
-
-// TestWatcherDelayedFinal() tests the case where a block cannot be finalized by a parent having it as
-// last_final_block and instead needs to be finalized by having it observed as finalized during polling
-func TestWatcherSimple2(t *testing.T) {
-	logger, _ := zap.NewDevelopment()
-
-	pl, _ := hex.DecodeString("0100000000000000000000000000000000000000000000000000000000000f42400000000000000000000000000000000000000000000000000000000000000000000f0108bc32f7de18a5f6e1e7d6ee7aff9f5fc858d0d87ac0da94dd8d2a5d267d6b00160000000000000000000000000000000000000000000000000000000000000000")
-	txHashBytes, _ := hex.DecodeString("88029cf0e7432cec04c266a3e72903ee6650b4624c7f9c8e22b04d78e18e87f8")
-
-	tc := testCase{
-		name:             "TestWatcherSimple2",
-		timeout:          time.Second * 2,
-		t:                t,
-		wormholeContract: WORMHOLE_CONTRACT,
-		upstreamHost:     "",
-		cacheDir:         "nearapi/mock/success/",
-		latestFinalBlocks: []string{
-			BLOCKCHAIN_1[0],
-			BLOCKCHAIN_1[1],
-			BLOCKCHAIN_1[2],
-			BLOCKCHAIN_1[3],
-			BLOCKCHAIN_1[4],
-			BLOCKCHAIN_1[5],
-			BLOCKCHAIN_1[6],
-			BLOCKCHAIN_1[7],
-		},
-		expectedMsgObserved: []*common.MessagePublication{
-			{
-				TxHash:           eth_common.BytesToHash(txHashBytes),
-				EmitterAddress:   portalEmitterAddress(),
-				ConsistencyLevel: 0,
-				EmitterChain:     vaa.ChainIDNear,
-				Nonce:            76538233,
-				Payload:          pl,
-				Sequence:         261,
-				Timestamp:        time.Unix(int64(1666142886047190991)/1_000_000_000, 0),
-				Unreliable:       false,
 			},
 		},
 	}


### PR DESCRIPTION
The NEAR watcher unit tests have been intermittently failing, see e.g. 
https://github.com/wormhole-foundation/wormhole/actions/runs/4884237090/jobs/8716699257?pr=2850
https://github.com/wormhole-foundation/wormhole/actions/runs/4884164541/jobs/8716516861
https://github.com/wormhole-foundation/wormhole/actions/runs/4865612488/jobs/8676147944
https://github.com/wormhole-foundation/wormhole/actions/runs/4886760889/jobs/8722535032?pr=2858
https://github.com/wormhole-foundation/wormhole/actions/runs/5061553539/jobs/9085941996?pr=2968

The main issue seems to be in https://github.com/wormhole-foundation/wormhole/pull/2971/files#diff-541054d2cf5abedef3e9ef612b46f581e8d58ffab2479254b60986f57c7c12c2R57, where errors were previously not properly propagated. 

If the error is not properly propagated, the transaction processing job is not re-queued. Errors can occur if the block of the transaction receipt outcome is not yet in the finalized block cache. 

This unit test `TestWatcherDelayedFinal` is supposed to test this cache miss behavior, but due to a race condition it can be that more blocks are polled before the transaction is being processed, hence there not being a cache miss. 

I modified the unit test to cause an increased time between transaction processing and finalization of the outcomeReceipt block, thereby reducing the likelihood of encountering the race condition. Unfortunately, eliminating this race condition in the test would require extensive re-writes. 

This PR also adds some logging and fixes a few minor issues. 