### PR TITLE
CCQ: Add enable flag and feature flag

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -62,6 +62,7 @@ config.define_bool("node_metrics", False, "Enable Prometheus & Grafana for Guard
 config.define_bool("guardiand_governor", False, "Enable chain governor in guardiand")
 config.define_bool("wormchain", False, "Enable a wormchain node")
 config.define_bool("ibc_relayer", False, "Enable IBC relayer between cosmos chains")
+config.define_bool("ccq", False, "Enable cross chain queries in guardiand")
 
 cfg = config.parse()
 num_guardians = int(cfg.get("num", "1"))
@@ -87,6 +88,7 @@ node_metrics = cfg.get("node_metrics", False)
 guardiand_governor = cfg.get("guardiand_governor", False)
 ibc_relayer = cfg.get("ibc_relayer", False)
 btc = cfg.get("btc", False)
+ccq = cfg.get("ccq", False)
 
 if cfg.get("manual", False):
     trigger_mode = TRIGGER_MODE_MANUAL
@@ -288,6 +290,11 @@ def build_node_yaml():
                     "wormhole14hj2tavq8fpesdwxxcu44rty3hh90vhujrvcmstl4zr3txmfvw9srrg465",
                     "--accountantCheckEnabled",
                     "true"
+                ]
+            
+            if ccq:
+                container["command"] += [
+                    "--ccqEnabled=true"
                 ]
 
     return encode_yaml_stream(node_yaml_with_replicas)

--- a/devnet/node.yaml
+++ b/devnet/node.yaml
@@ -170,6 +170,7 @@ spec:
             - --publicRpcLogDetail
             - "full"
             # - --chainGovernorEnabled=true
+            # - --ccqEnabled=true
             # - --logLevel=debug
           securityContext:
             capabilities:

--- a/node/cmd/guardiand/query.go
+++ b/node/cmd/guardiand/query.go
@@ -26,13 +26,22 @@ func handleQueryRequests(
 	logger *zap.Logger,
 	signedQueryReqC <-chan *gossipv1.SignedQueryRequest,
 	chainQueryReqC map[vaa.ChainID]chan *gossipv1.SignedQueryRequest,
+	enableFlag bool,
 ) {
 	qLogger := logger.With(zap.String("component", "queryHandler"))
+	if enableFlag {
+		qLogger.Info("cross chain queries are enabled")
+	}
+
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case signedQueryRequest := <-signedQueryReqC:
+			if !enableFlag {
+				qLogger.Debug("dropping query request, feature is not enabled")
+				continue
+			}
 			// requestor validation happens here
 			// request type validation is currently handled by the watcher
 			// in the future, it may be worthwhile to catch certain types of

--- a/node/cmd/spy/spy.go
+++ b/node/cmd/spy/spy.go
@@ -553,6 +553,7 @@ func runSpy(cmd *cobra.Command, args []string) {
 				nil,
 				components,
 				nil, // ibc feature string
+				nil, // cross chain query feature string
 				nil, // query requests
 				nil, // query responses
 

--- a/node/pkg/p2p/p2p.go
+++ b/node/pkg/p2p/p2p.go
@@ -155,6 +155,7 @@ func Run(
 	signedGovSt chan *gossipv1.SignedChainGovernorStatus,
 	components *Components,
 	ibcFeatures *string,
+	ccqFeatures *string,
 	signedQueryReqC chan<- *gossipv1.SignedQueryRequest,
 	queryResponseReadC <-chan *node_common.QueryResponsePublication,
 ) func(ctx context.Context) error {
@@ -311,6 +312,9 @@ func Run(
 						}
 						if ibcFeatures != nil && *ibcFeatures != "" {
 							features = append(features, *ibcFeatures)
+						}
+						if ccqFeatures != nil && *ccqFeatures != "" {
+							features = append(features, *ccqFeatures)
 						}
 
 						heartbeat := &gossipv1.Heartbeat{

--- a/node/pkg/p2p/watermark_test.go
+++ b/node/pkg/p2p/watermark_test.go
@@ -182,6 +182,7 @@ func startGuardian(t *testing.T, ctx context.Context, g *G) {
 			g.signedGovSt,
 			g.components,
 			nil, // ibc feature string
+			nil, // cross chain query feature string
 			nil, // signed query request channel
 			nil, // query response channel
 		))


### PR DESCRIPTION
This PR adds a `--ccqEnabled` flag to `node.yaml` as well as a `--ccq` flag to tilt. It also adds a "ccq" feature flag to the heartbeat messages.