### PR TITLE
terra2: Fix broken CI tests due to LocalTerra v2.4.0 update

### DIFF
--- a/cosmwasm/deployment/terra2/test/src/__tests__/bridge.ts
+++ b/cosmwasm/deployment/terra2/test/src/__tests__/bridge.ts
@@ -1159,8 +1159,7 @@ function failInShutdownModeTests(shutdownMode: boolean, pass: number) {
               submitVaa,
             ]);
           } catch (e) {
-            const errorMsg: string = e.response.data.message;
-            expectedErrorFound = errorMsg.includes(
+            expectedErrorFound = e.message.includes(
               "transfers with payload can only be redeemed by the recipient"
             );
           }
@@ -1387,7 +1386,9 @@ function alwaysPassTests(shutdownMode: boolean, pass: number) {
             },
           });
           expect(result).toStrictEqual({
-            address: Buffer.from(FOREIGN_TOKEN_BRIDGE, "hex").toString("base64")
+            address: Buffer.from(FOREIGN_TOKEN_BRIDGE, "hex").toString(
+              "base64"
+            ),
           });
           done();
         } catch (e) {

--- a/cosmwasm/deployment/terra2/test/src/helpers/client.ts
+++ b/cosmwasm/deployment/terra2/test/src/helpers/client.ts
@@ -5,6 +5,7 @@ import {
   MnemonicKey,
   Msg,
   Wallet,
+  isTxError,
 } from "@terra-money/terra.js";
 
 export const GAS_PRICE = 0.15; // uluna
@@ -43,9 +44,14 @@ export async function transact(
   const tx = await wallet.createAndSignTx({
     msgs: msgs,
     memo: memo,
+    gas: "10000000",
   });
 
-  return client.tx.broadcastBlock(tx);
+  const result = await client.tx.broadcastBlock(tx);
+  if (isTxError(result)) {
+    throw new Error(`tx error: ${JSON.stringify(result)}`);
+  }
+  return result;
 }
 
 export async function transactWithoutMemo(


### PR DESCRIPTION
LocalTerra was updated to v2.4.0 and the LCD no longer returns HTTP errors on some transaction failures (not enough gas still returns an HTTP error). This caused some of the integration tests to break, because the typescript SDK would throw on those HTTP errors.

https://github.com/terra-money/LocalTerra/releases/tag/v2.4.0