### PR TITLE
Node/CCQ: Add ccqAllowedRequesters

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -300,7 +300,9 @@ def build_node_yaml():
             
             if ccq:
                 container["command"] += [
-                    "--ccqEnabled=true"
+                    "--ccqEnabled=true",
+                    "--ccqAllowedRequesters",
+                    "beFA429d57cD18b7F8A4d91A2da9AB4AF05d0FBe"
                 ]
 
     return encode_yaml_stream(node_yaml_with_replicas)

--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -216,7 +216,9 @@ var (
 	bigTableKeyPath            *string
 
 	chainGovernorEnabled *bool
+
 	ccqEnabled           *bool
+	ccqAllowedRequesters *string
 )
 
 func init() {
@@ -379,7 +381,9 @@ func init() {
 	bigTableKeyPath = NodeCmd.Flags().String("bigTableKeyPath", "", "Path to json Service Account key")
 
 	chainGovernorEnabled = NodeCmd.Flags().Bool("chainGovernorEnabled", false, "Run the chain governor")
+
 	ccqEnabled = NodeCmd.Flags().Bool("ccqEnabled", false, "Enable cross chain query support")
+	ccqAllowedRequesters = NodeCmd.Flags().String("ccqAllowedRequesters", "", "Comma separated list of signers allowed to submit cross chain queries")
 }
 
 var (
@@ -1587,7 +1591,14 @@ func runNode(cmd *cobra.Command, args []string) {
 		}
 
 		go handleReobservationRequests(rootCtx, clock.New(), logger, obsvReqReadC, chainObsvReqC)
-		go handleQueryRequests(rootCtx, logger, signedQueryReqReadC, chainQueryReqC, *ccqEnabled)
+
+		if *ccqEnabled {
+			ccqAllowedRequestersList, err := ccqParseAllowedRequesters(*ccqAllowedRequesters)
+			if err != nil {
+				logger.Fatal("failed to parse allowed requesters list", zap.String("ccqAllowedRequesters", *ccqAllowedRequesters), zap.Error(err), zap.String("component", "ccqconfig"))
+			}
+			go handleQueryRequests(rootCtx, logger, signedQueryReqReadC, chainQueryReqC, ccqAllowedRequestersList)
+		}
 
 		if acct != nil {
 			if err := acct.Start(ctx); err != nil {


### PR DESCRIPTION
This PR adds the ccqAllowedRequestors parameter to the guardian config.