### PR TITLE
[rust-sdk] Fix wormhole_serde patch

### DIFF
--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -8,5 +8,3 @@ members = [
 opt-level = 3
 lto = "thin"
 
-[patch.crates-io]
-serde_wormhole = { path = "serde_wormhole" }

--- a/sdk/rust/core/Cargo.toml
+++ b/sdk/rust/core/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = "1"
 bstr = { version = "1", features = ["serde"] }
 schemars = { version = "0.8.8", optional = true }
 serde = { version = "1", default-features = false, features = ["alloc", "derive"] }
-serde_wormhole = "0.1.0"
+serde_wormhole = {path = "../serde_wormhole"}
 sha3 = "0.10.4"
 thiserror = "1"
 


### PR DESCRIPTION
This solves https://github.com/wormhole-foundation/wormhole/issues/2972
Currently any rust project that depends on wormhole-sdk needs to copy into their `Cargo.toml`: 
```

[patch.crates-io]
serde_wormhole = { path = "serde_wormhole" }

```
which is really annoying for everyone using it.
Specifying `serde_wormhole = { path = "../serde_wormhole", version = "0.1.0" }` is great because: 
- when using `wormhole-sdk` locally `serde_wormhole` will get resolved properly with the `path = "../serde_wormhole"`
- if `wormhole-sdk` gets published and `serde_wormhole` gets published as well, `serde_wormhole` will get resolved properly with the `version = "0.1.0"`