### PR TITLE
CCQ: Add request retries

### DIFF
--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -994,23 +994,26 @@ func runNode(cmd *cobra.Command, args []string) {
 	// Per-chain query requests
 	chainQueryReqC := make(map[vaa.ChainID]chan *gossipv1.SignedQueryRequest)
 
-	// Query responses from watchers aggregated across all chains
-	queryResponseReadC, queryResponseWriteC := makeChannelPair[*common.QueryResponsePublication](0)
+	// Query responses from watchers to query handler aggregated across all chains
+	queryResponseReadC, queryResponseWriteC := makeChannelPair[*common.QueryResponse](0)
+
+	// Query responses from query handler to p2p
+	queryResponsePublicationReadC, queryResponsePublicationWriteC := makeChannelPair[*common.QueryResponsePublication](0)
 
 	// Per-chain query response channel
-	chainQueryResponseC := make(map[vaa.ChainID]chan *common.QueryResponsePublication)
+	chainQueryResponseC := make(map[vaa.ChainID]chan *common.QueryResponse)
 	// aggregate per-chain msgC into msgC.
 	// SECURITY defense-in-depth: This way we enforce that a watcher must set the msg.EmitterChain to its chainId, which makes the code easier to audit
 	for _, chainId := range vaa.GetAllNetworkIDs() {
-		chainQueryResponseC[chainId] = make(chan *common.QueryResponsePublication)
-		go func(c <-chan *common.QueryResponsePublication, chainId vaa.ChainID) {
+		chainQueryResponseC[chainId] = make(chan *common.QueryResponse)
+		go func(c <-chan *common.QueryResponse, chainId vaa.ChainID) {
 			for {
 				select {
 				case <-rootCtx.Done():
 					return
 				case response := <-c:
 					var queryRequest gossipv1.QueryRequest
-					err = proto.Unmarshal(response.Request.QueryRequest, &queryRequest)
+					err = proto.Unmarshal(response.Msg.Request.QueryRequest, &queryRequest)
 					if err != nil {
 						logger.Error("received invalid response from watcher", zap.Stringer("watcherChainId", chainId))
 						continue
@@ -1215,7 +1218,7 @@ func runNode(cmd *cobra.Command, args []string) {
 			&ibc.Features,
 			*ccqEnabled,
 			signedQueryReqWriteC,
-			queryResponseReadC)); err != nil {
+			queryResponsePublicationReadC)); err != nil {
 			return err
 		}
 
@@ -1600,7 +1603,7 @@ func runNode(cmd *cobra.Command, args []string) {
 			if err != nil {
 				logger.Fatal("failed to parse allowed requesters list", zap.String("ccqAllowedRequesters", *ccqAllowedRequesters), zap.Error(err), zap.String("component", "ccqconfig"))
 			}
-			go handleQueryRequests(rootCtx, logger, signedQueryReqReadC, chainQueryReqC, ccqAllowedRequestersList, env)
+			go handleQueryRequests(rootCtx, logger, signedQueryReqReadC, chainQueryReqC, ccqAllowedRequestersList, queryResponseReadC, queryResponsePublicationWriteC, env)
 		}
 
 		if acct != nil {

--- a/node/cmd/guardiand/query.go
+++ b/node/cmd/guardiand/query.go
@@ -39,13 +39,6 @@ type (
 	}
 )
 
-// TODO: should this use a different standard of signing messages, like https://eips.ethereum.org/EIPS/eip-712
-var queryRequestPrefix = []byte("mainnet_query_request_000000000000|")
-
-func queryRequestDigest(b []byte) ethCommon.Hash {
-	return ethCrypto.Keccak256Hash(append(queryRequestPrefix, b...))
-}
-
 // handleQueryRequests multiplexes observation requests to the appropriate chain
 func handleQueryRequests(
 	ctx context.Context,

--- a/node/pkg/common/queryResponse.go
+++ b/node/pkg/common/queryResponse.go
@@ -3,6 +3,7 @@ package common
 import (
 	"bytes"
 	"encoding/binary"
+	"encoding/hex"
 	"fmt"
 	"math"
 	"math/big"
@@ -14,6 +15,18 @@ import (
 	"github.com/wormhole-foundation/wormhole/sdk/vaa"
 	"google.golang.org/protobuf/proto"
 )
+
+type QueryResponse struct {
+	Success bool
+	Msg     *QueryResponsePublication
+}
+
+func (resp *QueryResponse) RequestID() string {
+	if resp == nil || resp.Msg == nil {
+		return "nil"
+	}
+	return resp.Msg.RequestID()
+}
 
 var queryResponsePrefix = []byte("query_response_0000000000000000000|")
 
@@ -27,6 +40,13 @@ type EthCallQueryResponse struct {
 type QueryResponsePublication struct {
 	Request  *gossipv1.SignedQueryRequest
 	Response EthCallQueryResponse
+}
+
+func (resp *QueryResponsePublication) RequestID() string {
+	if resp == nil || resp.Request == nil {
+		return "nil"
+	}
+	return hex.EncodeToString(resp.Request.Signature)
 }
 
 // Marshal serializes the binary representation of a query response

--- a/node/pkg/p2p/p2p.go
+++ b/node/pkg/p2p/p2p.go
@@ -446,7 +446,12 @@ func Run(
 					if err != nil {
 						logger.Error("failed to publish query response", zap.Error(err), zap.String("component", "ccqp2p"))
 					} else {
-						logger.Info("published signed query response", zap.Any("query_response", msg), zap.Any("signature", sig), zap.String("component", "ccqp2p"))
+						logger.Info("published signed query response",
+							zap.String("requestID", msg.RequestID()),
+							zap.Any("query_response", msg),
+							zap.Any("signature", sig),
+							zap.String("component", "ccqp2p"),
+						)
 					}
 				}
 			}

--- a/node/pkg/watchers/evm/watcher.go
+++ b/node/pkg/watchers/evm/watcher.go
@@ -549,14 +549,14 @@ func (w *Watcher) Run(parentCtx context.Context) error {
 				var queryRequest gossipv1.QueryRequest
 				err := proto.Unmarshal(signedQueryRequest.QueryRequest, &queryRequest)
 				if err != nil {
-					logger.Error("received invalid message from query module")
+					logger.Error("received invalid message from query module", zap.String("component", "ccqevm"))
 					continue
 				}
 
 				// This can't happen unless there is a programming error - the caller
 				// is expected to send us only requests for our chainID.
 				if vaa.ChainID(queryRequest.ChainId) != w.chainID {
-					panic("invalid chain ID")
+					panic("ccqevm: invalid chain ID")
 				}
 
 				switch req := queryRequest.Message.(type) {
@@ -568,7 +568,9 @@ func (w *Watcher) Run(parentCtx context.Context) error {
 						zap.String("eth_network", w.networkName),
 						zap.String("to", to.Hex()),
 						zap.Any("data", data),
-						zap.String("block", block))
+						zap.String("block", block),
+						zap.String("component", "ccqevm"),
+					)
 
 					timeout, cancel := context.WithTimeout(ctx, 5*time.Second)
 					// like https://github.com/ethereum/go-ethereum/blob/master/ethclient/ethclient.go#L610
@@ -632,7 +634,9 @@ func (w *Watcher) Run(parentCtx context.Context) error {
 							zap.Error(err), zap.String("eth_network", w.networkName),
 							zap.String("to", to.Hex()),
 							zap.Any("data", data),
-							zap.String("block", block))
+							zap.String("block", block),
+							zap.String("component", "ccqevm"),
+						)
 						continue
 					}
 
@@ -641,7 +645,9 @@ func (w *Watcher) Run(parentCtx context.Context) error {
 							zap.Error(blockError), zap.String("eth_network", w.networkName),
 							zap.String("to", to.Hex()),
 							zap.Any("data", data),
-							zap.String("block", block))
+							zap.String("block", block),
+							zap.String("component", "ccqevm"),
+						)
 						continue
 					}
 
@@ -650,7 +656,9 @@ func (w *Watcher) Run(parentCtx context.Context) error {
 							zap.String("eth_network", w.networkName),
 							zap.String("to", to.Hex()),
 							zap.Any("data", data),
-							zap.String("block", block))
+							zap.String("block", block),
+							zap.String("component", "ccqevm"),
+						)
 						continue
 					}
 
@@ -659,7 +667,9 @@ func (w *Watcher) Run(parentCtx context.Context) error {
 							zap.Error(callErr), zap.String("eth_network", w.networkName),
 							zap.String("to", to.Hex()),
 							zap.Any("data", data),
-							zap.String("block", block))
+							zap.String("block", block),
+							zap.String("component", "ccqevm"),
+						)
 						continue
 					}
 
@@ -670,7 +680,9 @@ func (w *Watcher) Run(parentCtx context.Context) error {
 							zap.String("eth_network", w.networkName),
 							zap.String("to", to.Hex()),
 							zap.Any("data", data),
-							zap.String("block", block))
+							zap.String("block", block),
+							zap.String("component", "ccqevm"),
+						)
 						continue
 					}
 
@@ -695,12 +707,16 @@ func (w *Watcher) Run(parentCtx context.Context) error {
 						zap.String("blockNumber", blockResult.Number.String()),
 						zap.String("blockHash", blockResult.Hash.Hex()),
 						zap.String("blockTime", blockResult.Time.String()),
-						zap.String("result", callResult.String()))
+						zap.String("result", callResult.String()),
+						zap.String("component", "ccqevm"),
+					)
 
 					w.queryResponseC <- &queryResponse
 				default:
 					logger.Warn("received unsupported request type",
-						zap.Any("payload", queryRequest.Message))
+						zap.Any("payload", queryRequest.Message),
+						zap.String("component", "ccqevm"),
+					)
 				}
 			}
 		}

--- a/node/pkg/watchers/evm/watcher.go
+++ b/node/pkg/watchers/evm/watcher.go
@@ -100,7 +100,7 @@ type (
 		queryReqC <-chan *gossipv1.SignedQueryRequest
 
 		// Outbound query responses to query requests
-		queryResponseC chan<- *common.QueryResponsePublication
+		queryResponseC chan<- *common.QueryResponse
 
 		pending   map[pendingKey]*pendingMessage
 		pendingMu sync.Mutex
@@ -152,7 +152,7 @@ func NewEthWatcher(
 	setC chan<- *common.GuardianSet,
 	obsvReqC <-chan *gossipv1.ObservationRequest,
 	queryReqC <-chan *gossipv1.SignedQueryRequest,
-	queryResponseC chan<- *common.QueryResponsePublication,
+	queryResponseC chan<- *common.QueryResponse,
 	unsafeDevMode bool,
 ) *Watcher {
 
@@ -674,13 +674,16 @@ func (w *Watcher) Run(parentCtx context.Context) error {
 						continue
 					}
 
-					queryResponse := common.QueryResponsePublication{
-						Request: signedQueryRequest,
-						Response: common.EthCallQueryResponse{
-							Number: blockResult.Number.ToInt(),
-							Hash:   blockResult.Hash,
-							Time:   time.Unix(int64(blockResult.Time), 0),
-							Result: callResult,
+					queryResponse := common.QueryResponse{
+						Success: true,
+						Msg: &common.QueryResponsePublication{
+							Request: signedQueryRequest,
+							Response: common.EthCallQueryResponse{
+								Number: blockResult.Number.ToInt(),
+								Hash:   blockResult.Hash,
+								Time:   time.Unix(int64(blockResult.Time), 0),
+								Result: callResult,
+							},
 						},
 					}
 


### PR DESCRIPTION
This PR changes it so that query responses flow through the query handler, rather than directly from the watcher to p2p. This allows the handler to keep a cache of pending queries, and retry them. It retries a query every ten seconds for up to a minute, before giving up.