### PR TITLE
sdk: add CalculateQuorum documentation and fuzz testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -270,9 +270,7 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: "1.20.4"
-      - run: cd sdk/vaa
-      - run: go test
-      - run: go test -v -fuzz FuzzCalculateQuorum -run FuzzCalculateQuorum -fuzztime 15s
+      - run: cd sdk/vaa && go test && go test -v -fuzz FuzzCalculateQuorum -run FuzzCalculateQuorum -fuzztime 15s
   
   # Run Go linters
   node-lint:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -262,7 +262,7 @@ jobs:
           git diff --name-only --exit-code && echo "✅ Generated proto matches committed proto" || (echo "❌ Generated proto differs from committed proto, run \`make proto -B\` and commit the result" >&2 && exit 1)
           make test
 
-  # Verify go sdk unit tests
+  # Verify go sdk unit/fuzz tests
   sdk_vaa:
     runs-on: ubuntu-20.04
     steps:
@@ -270,8 +270,10 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: "1.20.4"
-      - run: cd sdk/vaa && go test
-
+      - run: cd sdk/vaa
+      - run: go test
+      - run: go test -v -fuzz FuzzCalculateQuorum -run FuzzCalculateQuorum -fuzztime 15s
+  
   # Run Go linters
   node-lint:
     # The linter is slow enough that we want to run it on the self-hosted runner

--- a/sdk/vaa/quorum.go
+++ b/sdk/vaa/quorum.go
@@ -5,8 +5,18 @@ package vaa
 // The canonical source is the calculation in the contracts (solana/bridge/src/processor.rs and
 // ethereum/contracts/Wormhole.sol), and this needs to match the implementation in the contracts.
 func CalculateQuorum(numGuardians int) int {
+	// A safety check to avoid caller from ever supplying a negative
+	// number, because we're dealing with signed integers
 	if numGuardians < 0 {
 		panic("Invalid numGuardians is less than zero")
 	}
+
+	// The goal here is to acheive a 2/3 quorum, but since we're
+	// dividing on int, we need to +1 to avoid the rounding down
+	// effect of integer division
+	//
+	// For example sake, 5 / 2 == 2, but really that's not an
+	//   effective 2/3 quorum, so we add 1 for safety to get to 3
+	//
 	return ((numGuardians * 2) / 3) + 1
 }

--- a/sdk/vaa/quorum_test.go
+++ b/sdk/vaa/quorum_test.go
@@ -79,10 +79,10 @@ func FuzzCalculateQuorum(f *testing.F) {
 		num := CalculateQuorum(numGuardians)
 
 		// Let's always be sure that there are enough guardians to maintain quorum
-		assert.LessOrEqualf(t, num, numGuardians, "fuzz violation: quorum cannot be acheived because we require more guardians than we have")
+		assert.LessOrEqual(t, num, numGuardians, "fuzz violation: quorum cannot be acheived because we require more guardians than we have")
 
 		// Let's always be sure that num is never zero
-		assert.NotZerof(t, num, "fuzz violation: no guardians are required to acheive quorum")
+		assert.NotZero(t, num, "fuzz violation: no guardians are required to acheive quorum")
 
 		var floorFloat float64 = 0.66666666666666666
 		numGuardiansFloat := float64(numGuardians)
@@ -90,6 +90,6 @@ func FuzzCalculateQuorum(f *testing.F) {
 		actualFloat := numFloat / numGuardiansFloat
 
 		// Let's always make sure that the int division does not violate the floor of our float division
-		assert.Greaterf(t, actualFloat, floorFloat, "fuzz violation: quorum has dropped below 2/3rds threshold")
+		assert.Greater(t, actualFloat, floorFloat, "fuzz violation: quorum has dropped below 2/3rds threshold")
 	})
 }

--- a/sdk/vaa/quorum_test.go
+++ b/sdk/vaa/quorum_test.go
@@ -79,24 +79,17 @@ func FuzzCalculateQuorum(f *testing.F) {
 		num := CalculateQuorum(numGuardians)
 
 		// Let's always be sure that there are enough guardians to maintain quorum
-		if num > numGuardians {
-			t.Errorf("%v", "fuzz violation: quorum cannot be acheived because we require more guardians than we have")
-		}
+		assert.LessOrEqualf(t, num, numGuardians, "fuzz violation: quorum cannot be acheived because we require more guardians than we have")
 
 		// Let's always be sure that num is never zero
-		if num == 0 {
-			t.Errorf("%v", "fuzz violation: no guardians are required to acheive quorum")
-		}
+		assert.NotEqualf(t, num, 0, "fuzz violation: no guardians are required to acheive quorum")
 
-		// Let's always make sure that the int division does not violate the floor of our float division
 		var floorFloat float64 = 0.66666666666666666
 		numGuardiansFloat := float64(numGuardians)
 		numFloat := float64(num)
-
 		actualFloat := numFloat / numGuardiansFloat
 
-		if actualFloat < floorFloat {
-			t.Errorf("%v", "fuzz violation: quorum has dropped below 2/3rds threshold")
-		}
+		// Let's always make sure that the int division does not violate the floor of our float division
+		assert.Greaterf(t, actualFloat, floorFloat, "fuzz violation: quorum has dropped below 2/3rds threshold")
 	})
 }

--- a/sdk/vaa/quorum_test.go
+++ b/sdk/vaa/quorum_test.go
@@ -58,8 +58,6 @@ func TestCalculateQuorum(t *testing.T) {
 
 func FuzzCalculateQuorum(f *testing.F) {
 	// Add examples to our fuzz corpus
-	f.Add(-25)
-	f.Add(0)
 	f.Add(1)
 	f.Add(2)
 	f.Add(4)

--- a/sdk/vaa/quorum_test.go
+++ b/sdk/vaa/quorum_test.go
@@ -82,7 +82,7 @@ func FuzzCalculateQuorum(f *testing.F) {
 		assert.LessOrEqualf(t, num, numGuardians, "fuzz violation: quorum cannot be acheived because we require more guardians than we have")
 
 		// Let's always be sure that num is never zero
-		assert.NotEqualf(t, num, 0, "fuzz violation: no guardians are required to acheive quorum")
+		assert.NotZerof(t, num, "fuzz violation: no guardians are required to acheive quorum")
 
 		var floorFloat float64 = 0.66666666666666666
 		numGuardiansFloat := float64(numGuardians)

--- a/sdk/vaa/quorum_test.go
+++ b/sdk/vaa/quorum_test.go
@@ -55,3 +55,48 @@ func TestCalculateQuorum(t *testing.T) {
 		})
 	}
 }
+
+func FuzzCalculateQuorum(f *testing.F) {
+	// Add examples to our fuzz corpus
+	f.Add(-25)
+	f.Add(0)
+	f.Add(1)
+	f.Add(2)
+	f.Add(4)
+	f.Add(8)
+	f.Add(16)
+	f.Add(32)
+	f.Add(64)
+	f.Add(128)
+	f.Fuzz(func(t *testing.T, numGuardians int) {
+		// These are known cases, which the implementation will panic on and/or we have explicit
+		// unit-test coverage of above, so we can safely ignore it in our fuzz testing
+		if numGuardians <= 0 {
+			t.Skip()
+		}
+
+		// Let's determine how many guardians are needed for quorum
+		num := CalculateQuorum(numGuardians)
+
+		// Let's always be sure that there are enough guardians to maintain quorum
+		if num > numGuardians {
+			t.Errorf("%v", "fuzz violation: quorum cannot be acheived because we require more guardians than we have")
+		}
+
+		// Let's always be sure that num is never zero
+		if num == 0 {
+			t.Errorf("%v", "fuzz violation: no guardians are required to acheive quorum")
+		}
+
+		// Let's always make sure that the int division does not violate the floor of our float division
+		var floorFloat float64 = 0.66666666666666666
+		numGuardiansFloat := float64(numGuardians)
+		numFloat := float64(num)
+
+		actualFloat := numFloat / numGuardiansFloat
+
+		if actualFloat < floorFloat {
+			t.Errorf("%v", "fuzz violation: quorum has dropped below 2/3rds threshold")
+		}
+	})
+}


### PR DESCRIPTION
This PR adds comments to better document CalculateQuorum and additionally adds some fuzz testing and a shortened run to the GitHub action flow to ensure it's always run briefly during each CI run.