### PR TITLE
SDK: tweak typedefs to make doc generation easier

### DIFF
--- a/sdk/js/src/utils/consts.ts
+++ b/sdk/js/src/utils/consts.ts
@@ -41,7 +41,7 @@ export type ChainId = (typeof CHAINS)[ChainName];
  *
  * All the EVM-based chain names that Wormhole supports
  */
-export const EVMChainNames = [
+export const EVMChainNames: ReadonlyArray<ChainName> = [
   "ethereum",
   "bsc",
   "polygon",
@@ -70,10 +70,10 @@ export type NonEVMChainName = Exclude<ChainName, EVMChainName>
  *
  * All the Solana-based chain names that Wormhole supports
  */
-export const SolanaChainNames = ["solana", "pythnet"] as const;
+export const SolanaChainNames: ReadonlyArray<ChainName> = ["solana", "pythnet"] as const;
 export type SolanaChainName = (typeof SolanaChainNames)[number];
 
-export const CosmWasmChainNames = [
+export const CosmWasmChainNames: ReadonlyArray<ChainName> = [
   "terra",
   "terra2",
   "injective",
@@ -83,7 +83,7 @@ export const CosmWasmChainNames = [
 export type CosmWasmChainName = (typeof CosmWasmChainNames)[number];
 
 // TODO: why? these are dupe of entries in CosmWasm
-export const TerraChainNames = ["terra", "terra2"] as const;
+export const TerraChainNames: ReadonlyArray<ChainName> = ["terra", "terra2"] as const;
 export type TerraChainName = (typeof TerraChainNames)[number];
 
 export type Contracts = {
@@ -811,8 +811,8 @@ export function coalesceChainName(chain: ChainId | ChainName): ChainName {
 export function isEVMChain(
   chain: ChainId | ChainName
 ): chain is EVMChainId | EVMChainName {
-  let chainName = coalesceChainName(chain);
-  if (chainName in EVMChainNames){
+  const chainName = coalesceChainName(chain);
+  if (EVMChainNames.includes(chainName)){
     return isEVM(chainName as EVMChainName);
   } else {
     return notEVM(chainName as NonEVMChainName);
@@ -823,21 +823,21 @@ export function isCosmWasmChain(
   chain: ChainId | ChainName
 ): chain is CosmWasmChainId | CosmWasmChainName {
   const chainName = coalesceChainName(chain);
-  return chainName in CosmWasmChainNames;
+  return CosmWasmChainNames.includes(chainName);
 }
 
 export function isTerraChain(
   chain: ChainId | ChainName
 ): chain is TerraChainId | TerraChainName {
   const chainName = coalesceChainName(chain);
-  return chainName in TerraChainNames;
+  return TerraChainNames.includes(chainName);
 }
 
 export function isSolanaChain(
   chain: ChainId | ChainName
 ): chain is SolanaChainId | SolanaChainName {
   const chainName = coalesceChainName(chain);
-  return chainName in SolanaChainNames;
+  return SolanaChainNames.includes(chainName);
 }
 
 /**

--- a/sdk/js/src/utils/consts.ts
+++ b/sdk/js/src/utils/consts.ts
@@ -35,45 +35,56 @@ export const CHAINS = {
 } as const;
 
 export type ChainName = keyof typeof CHAINS;
-export type ChainId = typeof CHAINS[ChainName];
+export type ChainId = (typeof CHAINS)[ChainName];
 
 /**
  *
  * All the EVM-based chain names that Wormhole supports
  */
-export type EVMChainName =
-  | "ethereum"
-  | "bsc"
-  | "polygon"
-  | "avalanche"
-  | "oasis"
-  | "aurora"
-  | "fantom"
-  | "karura"
-  | "acala"
-  | "klaytn"
-  | "celo"
-  | "moonbeam"
-  | "neon"
-  | "arbitrum"
-  | "optimism"
-  | "gnosis"
-  | "base"
-  | "sepolia";
+export const EVMChainNames = [
+  "ethereum",
+  "bsc",
+  "polygon",
+  "avalanche",
+  "oasis",
+  "aurora",
+  "fantom",
+  "karura",
+  "acala",
+  "klaytn",
+  "celo",
+  "moonbeam",
+  "neon",
+  "arbitrum",
+  "optimism",
+  "gnosis",
+  "base",
+  "sepolia",
+] as const;
+export type EVMChainName = (typeof EVMChainNames)[number];
 
-/**
+
+export type NonEVMChainName = Exclude<ChainName, EVMChainName>
+
+/*
  *
  * All the Solana-based chain names that Wormhole supports
  */
-export type SolanaChainName = "solana" | "pythnet";
+export const SolanaChainNames = ["solana", "pythnet"] as const;
+export type SolanaChainName = (typeof SolanaChainNames)[number];
 
-export type CosmWasmChainName =
-  | "terra"
-  | "terra2"
-  | "injective"
-  | "xpla"
-  | "sei";
-export type TerraChainName = "terra" | "terra2";
+export const CosmWasmChainNames = [
+  "terra",
+  "terra2",
+  "injective",
+  "xpla",
+  "sei",
+] as const;
+export type CosmWasmChainName = (typeof CosmWasmChainNames)[number];
+
+// TODO: why? these are dupe of entries in CosmWasm
+export const TerraChainNames = ["terra", "terra2"] as const;
+export type TerraChainName = (typeof TerraChainNames)[number];
 
 export type Contracts = {
   core: string | undefined;
@@ -681,7 +692,7 @@ export const CHAIN_ID_SEPOLIA = CHAINS["sepolia"];
 
 // This inverts the [[CHAINS]] object so that we can look up a chain by id
 export type ChainIdToName = {
-  -readonly [key in keyof typeof CHAINS as typeof CHAINS[key]]: key;
+  -readonly [key in keyof typeof CHAINS as (typeof CHAINS)[key]]: key;
 };
 export const CHAIN_ID_TO_NAME: ChainIdToName = Object.entries(CHAINS).reduce(
   (obj, [name, id]) => {
@@ -695,11 +706,21 @@ export const CHAIN_ID_TO_NAME: ChainIdToName = Object.entries(CHAINS).reduce(
  *
  * All the EVM-based chain ids that Wormhole supports
  */
-export type EVMChainId = typeof CHAINS[EVMChainName];
+export type EVMChainId = (typeof CHAINS)[EVMChainName];
 
-export type CosmWasmChainId = typeof CHAINS[CosmWasmChainName];
+/**
+ *
+ * All the Solana-based chain ids that Wormhole supports
+ */
+export type SolanaChainId = (typeof CHAINS)[SolanaChainName];
 
-export type TerraChainId = typeof CHAINS[TerraChainName];
+/**
+ *
+ * All the CosmWasm-based chain ids that Wormhole supports
+ */
+export type CosmWasmChainId = (typeof CHAINS)[CosmWasmChainName];
+
+export type TerraChainId = (typeof CHAINS)[TerraChainName];
 /**
  *
  * Returns true when called with a valid chain, and narrows the type in the
@@ -790,51 +811,33 @@ export function coalesceChainName(chain: ChainId | ChainName): ChainName {
 export function isEVMChain(
   chain: ChainId | ChainName
 ): chain is EVMChainId | EVMChainName {
-  let chainId = coalesceChainId(chain);
-  if (
-    chainId === CHAIN_ID_ETH ||
-    chainId === CHAIN_ID_BSC ||
-    chainId === CHAIN_ID_AVAX ||
-    chainId === CHAIN_ID_POLYGON ||
-    chainId === CHAIN_ID_OASIS ||
-    chainId === CHAIN_ID_AURORA ||
-    chainId === CHAIN_ID_FANTOM ||
-    chainId === CHAIN_ID_KARURA ||
-    chainId === CHAIN_ID_ACALA ||
-    chainId === CHAIN_ID_KLAYTN ||
-    chainId === CHAIN_ID_CELO ||
-    chainId === CHAIN_ID_MOONBEAM ||
-    chainId === CHAIN_ID_NEON ||
-    chainId === CHAIN_ID_ARBITRUM ||
-    chainId === CHAIN_ID_OPTIMISM ||
-    chainId === CHAIN_ID_GNOSIS ||
-    chainId === CHAIN_ID_BASE ||
-    chainId === CHAIN_ID_SEPOLIA
-  ) {
-    return isEVM(chainId);
+  let chainName = coalesceChainName(chain);
+  if (chainName in EVMChainNames){
+    return isEVM(chainName as EVMChainName);
   } else {
-    return notEVM(chainId);
+    return notEVM(chainName as NonEVMChainName);
   }
 }
 
 export function isCosmWasmChain(
   chain: ChainId | ChainName
 ): chain is CosmWasmChainId | CosmWasmChainName {
-  const chainId = coalesceChainId(chain);
-  return (
-    chainId === CHAIN_ID_TERRA ||
-    chainId === CHAIN_ID_TERRA2 ||
-    chainId === CHAIN_ID_INJECTIVE ||
-    chainId === CHAIN_ID_XPLA ||
-    chainId === CHAIN_ID_SEI
-  );
+  const chainName = coalesceChainName(chain);
+  return chainName in CosmWasmChainNames;
 }
 
 export function isTerraChain(
   chain: ChainId | ChainName
 ): chain is TerraChainId | TerraChainName {
-  const chainId = coalesceChainId(chain);
-  return chainId === CHAIN_ID_TERRA || chainId === CHAIN_ID_TERRA2;
+  const chainName = coalesceChainName(chain);
+  return chainName in TerraChainNames;
+}
+
+export function isSolanaChain(
+  chain: ChainId | ChainName
+): chain is SolanaChainId | SolanaChainName {
+  const chainName = coalesceChainName(chain);
+  return chainName in SolanaChainNames;
 }
 
 /**

--- a/sdk/js/src/utils/consts.ts
+++ b/sdk/js/src/utils/consts.ts
@@ -64,8 +64,6 @@ export const EVMChainNames: ReadonlyArray<ChainName> = [
 export type EVMChainName = (typeof EVMChainNames)[number];
 
 
-export type NonEVMChainName = Exclude<ChainName, EVMChainName>
-
 /*
  *
  * All the Solana-based chain names that Wormhole supports
@@ -812,11 +810,7 @@ export function isEVMChain(
   chain: ChainId | ChainName
 ): chain is EVMChainId | EVMChainName {
   const chainName = coalesceChainName(chain);
-  if (EVMChainNames.includes(chainName)){
-    return isEVM(chainName as EVMChainName);
-  } else {
-    return notEVM(chainName as NonEVMChainName);
-  }
+  return EVMChainNames.includes(chainName)
 }
 
 export function isCosmWasmChain(
@@ -868,56 +862,3 @@ export const APTOS_TOKEN_BRIDGE_EMITTER_ADDRESS =
 
 export const TERRA_REDEEMED_CHECK_WALLET_ADDRESS =
   "terra1x46rqay4d3cssq8gxxvqz8xt6nwlz4td20k38v";
-
-////////////////////////////////////////////////////////////////////////////////
-// Utilities
-
-/**
- * The [[isEVM]] and [[notEVM]] functions improve type-safety in [[isEVMChain]].
- *
- * As it turns out, typescript type predicates are unsound on their own,
- * allowing us to write something like this:
- *
- * ```typescript
- * function unsafeCoerce(n: number): n is 1 {
- *   return true
- * }
- * ```
- *
- * which is completely bogus. This happens presumably because the typescript
- * authors think of the type predicate mechanism as an escape hatch mechanism.
- * We want a more principled function though, that keeps us honest.
- *
- * in [[isEVMChain]], checking that disjunctive boolean expression actually
- * refines the type of chainId in both branches. In the "true" branch,
- * the type of chainId is narrowed to exactly the EVM chains, so calling
- * [[isEVM]] on it will typecheck, and similarly the "false" branch for the negation.
- * However, if we extend the [[EVMChainId]] type with a new EVM chain, this
- * function will no longer compile until the condition is extended.
- */
-
-/**
- *
- * Returns true when called with an [[EVMChainId]] or [[EVMChainName]], and fails to compile
- * otherwise
- */
-function isEVM(_: EVMChainId | EVMChainName): true {
-  return true;
-}
-
-/**
- *
- * Returns false when called with a non-[[EVMChainId]] and non-[[EVMChainName]]
- * argument, and fails to compile otherwise
- */
-function notEVM<T>(_: T extends EVMChainId | EVMChainName ? never : T): false {
-  return false;
-}
-
-// This just serves as a type assertion to ensure that [[EVMChainName]] is a
-// subset of [[ChainName]], since typescript provides no built-in way to express
-// this.
-function evm_chain_subset(e: EVMChainName): ChainName {
-  // will fail to compile if 'e' can't be typed as a [[ChainName]]
-  return e;
-}


### PR DESCRIPTION
Typescript doesn't allow us to easily go from string literal types to array so lots of manual effort needs to happen in multiple places to do checks like isXXXChain. 

This modifies the chain name definitions to be arrays first and infer the string literal types from the arrays. 

1) should we export the XXXChainNames const?
2) should we add other chain types even for those that have only 1 instance? e.g. Algorand/Bitcoin
3) Left in a TODO for the terra chains since they're in both the CosmWasm and Terra definitions, do they need to be?