### PR TITLE
Relayer: Price according to whether they want delivery VAA verified

### DIFF
--- a/ethereum/contracts/interfaces/relayer/IWormholeReceiver.sol
+++ b/ethereum/contracts/interfaces/relayer/IWormholeReceiver.sol
@@ -49,3 +49,21 @@ interface IWormholeReceiver {
         bytes32 deliveryHash
     ) external payable;
 }
+
+interface IWormholeReceiverUnsafe {
+    /**
+     * @param additionalVaas - Additional VAAs which were requested to be included in this delivery.
+     * @param sourceAddress - the (wormhole format) address on the sending chain which requested
+     *     this delivery.
+     * @param sourceChain - the wormhole chain ID where this delivery was requested.
+     * @param deliveryHash - the VAA hash of the deliveryVAA.
+     * 
+     * 
+     */
+    function receiveWormholeMessagesUnsafe(
+        bytes[] memory additionalVaas,
+        bytes32 sourceAddress,
+        uint16 sourceChain,
+        bytes32 deliveryHash
+    ) external payable;
+}

--- a/ethereum/contracts/interfaces/relayer/IWormholeReceiver.sol
+++ b/ethereum/contracts/interfaces/relayer/IWormholeReceiver.sol
@@ -52,18 +52,9 @@ interface IWormholeReceiver {
 
 interface IWormholeReceiverUnsafe {
     /**
-     * @param additionalVaas - Additional VAAs which were requested to be included in this delivery.
-     * @param sourceAddress - the (wormhole format) address on the sending chain which requested
-     *     this delivery.
-     * @param sourceChain - the wormhole chain ID where this delivery was requested.
-     * @param deliveryHash - the VAA hash of the deliveryVAA.
-     * 
-     * 
+     * @param vaas - VAAs which were requested to be included in this delivery.
      */
     function receiveWormholeMessagesUnsafe(
-        bytes[] memory additionalVaas,
-        bytes32 sourceAddress,
-        uint16 sourceChain,
-        bytes32 deliveryHash
+        bytes[] memory vaas
     ) external payable;
 }

--- a/ethereum/contracts/interfaces/relayer/IWormholeRelayer.sol
+++ b/ethereum/contracts/interfaces/relayer/IWormholeRelayer.sol
@@ -260,8 +260,7 @@ interface IWormholeRelayerSend is IWormholeRelayerBase {
      * 
      * The difference between the two sides of the above inequality will be added to `paymentForExtraReceiverValue` of the first forward requested
      * 
-     * Any refunds (from leftover gas) will be paid to the delivery provider. In order to receive the refunds, use the 'forwardToEvm' function 
-     * with `refundChain` and `refundAddress` as parameters
+     * Any refunds (from leftover gas) from this forward will be paid to the same refundChain and refundAddress specified for the current delivery.
      * 
      * @param targetChain in Wormhole Chain ID format
      * @param targetAddress address to call on targetChain (that implements IWormholeReceiver), in Wormhole bytes32 format
@@ -296,8 +295,7 @@ interface IWormholeRelayerSend is IWormholeRelayerBase {
      * 
      * The difference between the two sides of the above inequality will be added to `paymentForExtraReceiverValue` of the first forward requested
      * 
-     * Any refunds (from leftover gas) will be paid to the delivery provider. In order to receive the refunds, use the 'forwardToEvm' function 
-     * with `refundChain` and `refundAddress` as parameters
+     * Any refunds (from leftover gas) from this forward will be paid to the same refundChain and refundAddress specified for the current delivery.
      * 
      * @param targetChain in Wormhole Chain ID format
      * @param targetAddress address to call on targetChain (that implements IWormholeReceiver), in Wormhole bytes32 format

--- a/ethereum/contracts/interfaces/relayer/IWormholeRelayer.sol
+++ b/ethereum/contracts/interfaces/relayer/IWormholeRelayer.sol
@@ -198,6 +198,25 @@ interface IWormholeRelayerSend is IWormholeRelayerBase {
         VaaKey[] memory vaaKeys,
         uint8 consistencyLevel
     ) external payable returns (uint64 sequence);
+
+    /**
+     * @notice Same as 'sendToEvm' above, except the delivery VAA will not be verified on the target chain, 
+     * 
+     * This function must be called with `msg.value` equal to 
+     * quoteEVMDeliveryPrice(targetChain, receiverValue, gasLimit, deliveryProviderAddress, false) + paymentForExtraReceiverValue
+     */
+    function sendVaasToEvmWithoutVerification(
+        uint16 targetChain,
+        address targetAddress,
+        uint256 receiverValue,
+        uint256 paymentForExtraReceiverValue,
+        uint256 gasLimit,
+        uint16 refundChain,
+        address refundAddress,
+        address deliveryProviderAddress,
+        VaaKey[] memory vaaKeys,
+        uint8 consistencyLevel
+    ) external payable returns (uint64 sequence);
     
     /**
      * @notice Publishes an instruction for the delivery provider at `deliveryProviderAddress` 
@@ -219,6 +238,7 @@ interface IWormholeRelayerSend is IWormholeRelayerBase {
      *        (in addition to the `receiverValue` specified)
      * @param encodedExecutionParameters encoded information on how to execute delivery that may impact pricing
      *        e.g. for version EVM_V1, this is a struct that encodes the `gasLimit` with which to call `targetAddress`
+     *             and whether or not to verify the delivery VAA
      * @param refundChain The chain to deliver any refund to, in Wormhole Chain ID format
      * @param refundAddress The address on `refundChain` to deliver any refund to, in Wormhole bytes32 format
      * @param deliveryProviderAddress The address of the desired delivery provider's implementation of IDeliveryProvider
@@ -348,6 +368,7 @@ interface IWormholeRelayerSend is IWormholeRelayerBase {
      * @param refundAddress The address on `refundChain` to deliver any refund to, in Wormhole bytes32 format
      * @param deliveryProviderAddress The address of the desired delivery provider's implementation of IDeliveryProvider
      * @param vaaKeys Additional VAAs to pass in as parameter in call to `targetAddress`
+     * @param verifyDeliveryVaa If true, the delivery VAA will be verified on the target chain prior to calling targetAddress
      * @param consistencyLevel Consistency level with which to publish the delivery instructions - see 
      *        https://book.wormhole.com/wormhole/3_coreLayerContracts.html?highlight=consistency#consistency-levels
      */
@@ -355,6 +376,23 @@ interface IWormholeRelayerSend is IWormholeRelayerBase {
         uint16 targetChain,
         address targetAddress,
         bytes memory payload,
+        uint256 receiverValue,
+        uint256 paymentForExtraReceiverValue,
+        uint256 gasLimit,
+        uint16 refundChain,
+        address refundAddress,
+        address deliveryProviderAddress,
+        VaaKey[] memory vaaKeys,
+        bool verifyDeliveryVaa,
+        uint8 consistencyLevel
+    ) external payable;
+
+    /**
+     * @notice Same as 'forwardToEvm' above, except the delivery VAA will not be verified on the target chain, 
+     */
+    function forwardVaasToEvmWithoutVerification(
+        uint16 targetChain,
+        address targetAddress,
         uint256 receiverValue,
         uint256 paymentForExtraReceiverValue,
         uint256 gasLimit,
@@ -396,6 +434,7 @@ interface IWormholeRelayerSend is IWormholeRelayerBase {
      *        (in addition to the `receiverValue` specified)
      * @param encodedExecutionParameters encoded information on how to execute delivery that may impact pricing
      *        e.g. for version EVM_V1, this is a struct that encodes the `gasLimit` with which to call `targetAddress`
+     *        and whether or not to verify the delivery VAA
      * @param refundChain The chain to deliver any refund to, in Wormhole Chain ID format
      * @param refundAddress The address on `refundChain` to deliver any refund to, in Wormhole bytes32 format
      * @param deliveryProviderAddress The address of the desired delivery provider's implementation of IDeliveryProvider
@@ -430,14 +469,22 @@ interface IWormholeRelayerSend is IWormholeRelayerBase {
      * @param newReceiverValue new msg.value that delivery provider should pass in for call to `targetAddress` (in targetChain currency units)
      * @param newGasLimit gas limit with which to call `targetAddress`. Any units of gas unused will be refunded according to the  
      *        `targetChainRefundPerGasUnused` rate quoted by the delivery provider, to the refund chain and address specified in the original request
+     * @param verifyDeliveryVaa If true, the delivery VAA will be verified on the target chain prior to calling targetAddress
      * @param newDeliveryProviderAddress The address of the desired delivery provider's implementation of IDeliveryProvider
      * @return sequence sequence number of published VAA containing redelivery instructions
+     * 
+     * @notice *** This will only be able to succeed if the following is true **
+     *         - newGasLimit >= gas limit of the old instruction
+     *         - newReceiverValue >= receiver value of the old instruction
+     *         - newDeliveryProvider's `targetChainRefundPerGasUnused` >= old relay provider's `targetChainRefundPerGasUnused`
+     *         - (verifyDeliveryVaa, oldVerifyDeliveryVaa) is not (false, true)
      */
     function resendToEvm(
         VaaKey memory deliveryVaaKey,
         uint16 targetChain,
         uint256 newReceiverValue,
         uint256 newGasLimit,
+        bool verifyDeliveryVaa,
         address newDeliveryProviderAddress
     ) external payable returns (uint64 sequence);
 
@@ -497,6 +544,26 @@ interface IWormholeRelayerSend is IWormholeRelayerBase {
         uint256 receiverValue,
         uint256 gasLimit,
         address deliveryProviderAddress
+    ) external view returns (uint256 nativePriceQuote, uint256 targetChainRefundPerGasUnused);
+
+     /**
+     * @notice Returns the price to request a relay to chain `targetChain`, using delivery provider `deliveryProviderAddress`
+     * 
+     * @param targetChain in Wormhole Chain ID format
+     * @param receiverValue msg.value that delivery provider should pass in for call to `targetAddress` (in targetChain currency units)
+     * @param gasLimit gas limit with which to call `targetAddress`. 
+     * @param deliveryProviderAddress The address of the desired delivery provider's implementation of IDeliveryProvider
+     * @param verifyDeliveryVaa If true, the delivery VAA will be verified on the target chain prior to calling targetAddress
+     * @return nativePriceQuote Price, in units of current chain currency, that the delivery provider charges to perform the relay
+     * @return targetChainRefundPerGasUnused amount of target chain currency that will be refunded per unit of gas unused, 
+     *         if a refundAddress is specified
+     */
+    function quoteEVMDeliveryPrice(
+        uint16 targetChain,
+        uint256 receiverValue,
+        uint256 gasLimit,
+        address deliveryProviderAddress,
+        bool verifyDeliveryVaa
     ) external view returns (uint256 nativePriceQuote, uint256 targetChainRefundPerGasUnused);
 
     /**
@@ -684,6 +751,8 @@ error InvalidOverrideGasLimit();
 error InvalidOverrideReceiverValue();
 //When a `DeliveryOverride` contains a 'refund per unit of gas unused' that's less than the original
 error InvalidOverrideRefundPerGasUnused();
+//When a `DeliveryOverride` has `verifyDeliveryVaa` = false, when the old value was true
+error InvalidOverrideVerifyDeliveryVaa();
 
 //When the delivery provider doesn't pass in sufficient funds (i.e. msg.value does not cover the
 // maximum possible refund to the user)

--- a/ethereum/contracts/interfaces/relayer/IWormholeRelayer.sol
+++ b/ethereum/contracts/interfaces/relayer/IWormholeRelayer.sol
@@ -355,7 +355,7 @@ interface IWormholeRelayerSend is IWormholeRelayerBase {
      * 
      * The following equation must be satisfied (sum_f indicates summing over all forwards requested in `receiveWormholeMessages`):
      * (refund amount from current execution of receiveWormholeMessages) + sum_f [msg.value_f]
-     * >= sum_f [quoteEVMDeliveryPrice(targetChain_f, receiverValue_f, gasLimit_f, deliveryProviderAddress_f) + paymentForExtraReceiverValue_f]
+     * >= sum_f [quoteEVMDeliveryPrice(targetChain_f, receiverValue_f, gasLimit_f, deliveryProviderAddress_f, verifyDeliveryVaa_f) + paymentForExtraReceiverValue_f]
      * 
      * The difference between the two sides of the above inequality will be added to `paymentForExtraReceiverValue` of the first forward requested
      * 
@@ -450,7 +450,7 @@ interface IWormholeRelayerSend is IWormholeRelayerBase {
      * (e.g. with a different delivery provider)
      *
      * This function must be called with `msg.value` equal to 
-     * quoteEVMDeliveryPrice(targetChain, newReceiverValue, newGasLimit, newDeliveryProviderAddress)
+     * quoteEVMDeliveryPrice(targetChain, newReceiverValue, newGasLimit, newDeliveryProviderAddress, verifyDeliveryVaa)
      * 
      * @param deliveryVaaKey VaaKey identifying the wormhole message containing the 
      *        previously published delivery instructions

--- a/ethereum/contracts/interfaces/relayer/IWormholeRelayer.sol
+++ b/ethereum/contracts/interfaces/relayer/IWormholeRelayer.sol
@@ -200,7 +200,10 @@ interface IWormholeRelayerSend is IWormholeRelayerBase {
     ) external payable returns (uint64 sequence);
 
     /**
-     * @notice Same as 'sendToEvm' above, except the delivery VAA will not be verified on the target chain, 
+     * @notice Same as 'sendToEvm' above, except:
+     * - The delivery VAA will not be verified on the target chain, 
+     * - targetAddress must implement IWormholeReceiverUnsafe instead of IWormholeReceiver
+     * - the IWormholeReceiverUnsafe.receiveWormholeMessagesUnsafe endpoint will be called instead!
      * 
      * This function must be called with `msg.value` equal to 
      * quoteEVMDeliveryPrice(targetChain, receiverValue, gasLimit, deliveryProviderAddress, false) + paymentForExtraReceiverValue
@@ -369,6 +372,8 @@ interface IWormholeRelayerSend is IWormholeRelayerBase {
      * @param deliveryProviderAddress The address of the desired delivery provider's implementation of IDeliveryProvider
      * @param vaaKeys Additional VAAs to pass in as parameter in call to `targetAddress`
      * @param verifyDeliveryVaa If true, the delivery VAA will be verified on the target chain prior to calling targetAddress
+     *        Note: If this is false, then targetAddress must implement IWormholeReceiverUnsafe instead of IWormholeReceiver,
+     *        and the IWormholeReceiverUnsafe.receiveWormholeMessagesUnsafe endpoint will be called instead!
      * @param consistencyLevel Consistency level with which to publish the delivery instructions - see 
      *        https://book.wormhole.com/wormhole/3_coreLayerContracts.html?highlight=consistency#consistency-levels
      */
@@ -454,6 +459,8 @@ interface IWormholeRelayerSend is IWormholeRelayerBase {
      * @param newGasLimit gas limit with which to call `targetAddress`. Any units of gas unused will be refunded according to the  
      *        `targetChainRefundPerGasUnused` rate quoted by the delivery provider, to the refund chain and address specified in the original request
      * @param verifyDeliveryVaa If true, the delivery VAA will be verified on the target chain prior to calling targetAddress
+     *        Note: If this is false, targetAddress must implement IWormholeReceiverUnsafe instead of IWormholeReceiver,
+     *        and the IWormholeReceiverUnsafe.receiveWormholeMessagesUnsafe endpoint will be called instead!
      * @param newDeliveryProviderAddress The address of the desired delivery provider's implementation of IDeliveryProvider
      * @return sequence sequence number of published VAA containing redelivery instructions
      * 

--- a/ethereum/contracts/interfaces/relayer/IWormholeRelayer.sol
+++ b/ethereum/contracts/interfaces/relayer/IWormholeRelayer.sol
@@ -388,22 +388,6 @@ interface IWormholeRelayerSend is IWormholeRelayerBase {
     ) external payable;
 
     /**
-     * @notice Same as 'forwardToEvm' above, except the delivery VAA will not be verified on the target chain, 
-     */
-    function forwardVaasToEvmWithoutVerification(
-        uint16 targetChain,
-        address targetAddress,
-        uint256 receiverValue,
-        uint256 paymentForExtraReceiverValue,
-        uint256 gasLimit,
-        uint16 refundChain,
-        address refundAddress,
-        address deliveryProviderAddress,
-        VaaKey[] memory vaaKeys,
-        uint8 consistencyLevel
-    ) external payable;
-
-    /**
      * @notice Performs the same function as a `send`, except:
      * 1)  Can only be used during a delivery (i.e. in execution of `receiveWormholeMessages`)
      * 2)  Is paid for (along with any other calls to forward) by (any msg.value passed in) + (refund leftover from current delivery)

--- a/ethereum/contracts/interfaces/relayer/IWormholeRelayer.sol
+++ b/ethereum/contracts/interfaces/relayer/IWormholeRelayer.sol
@@ -238,7 +238,7 @@ interface IWormholeRelayerSend is IWormholeRelayerBase {
      *        (in addition to the `receiverValue` specified)
      * @param encodedExecutionParameters encoded information on how to execute delivery that may impact pricing
      *        e.g. for version EVM_V1, this is a struct that encodes the `gasLimit` with which to call `targetAddress`
-     *             and whether or not to verify the delivery VAA
+     *        and whether or not to verify the delivery VAA
      * @param refundChain The chain to deliver any refund to, in Wormhole Chain ID format
      * @param refundAddress The address on `refundChain` to deliver any refund to, in Wormhole bytes32 format
      * @param deliveryProviderAddress The address of the desired delivery provider's implementation of IDeliveryProvider
@@ -485,6 +485,7 @@ interface IWormholeRelayerSend is IWormholeRelayerBase {
      * @param newReceiverValue new msg.value that delivery provider should pass in for call to `targetAddress` (in targetChain currency units)
      * @param newEncodedExecutionParameters new encoded information on how to execute delivery that may impact pricing
      *        e.g. for version EVM_V1, this is a struct that encodes the `gasLimit` with which to call `targetAddress`
+     *        and whether or not to verify the delivery VAA
      * @param newDeliveryProviderAddress The address of the desired delivery provider's implementation of IDeliveryProvider
      * @return sequence sequence number of published VAA containing redelivery instructions
      */
@@ -557,10 +558,11 @@ interface IWormholeRelayerSend is IWormholeRelayerBase {
      * @param receiverValue msg.value that delivery provider should pass in for call to `targetAddress` (in targetChain currency units)
      * @param encodedExecutionParameters encoded information on how to execute delivery that may impact pricing
      *        e.g. for version EVM_V1, this is a struct that encodes the `gasLimit` with which to call `targetAddress`
+     *        and whether or not to verify the delivery VAA
      * @param deliveryProviderAddress The address of the desired delivery provider's implementation of IDeliveryProvider
      * @return nativePriceQuote Price, in units of current chain currency, that the delivery provider charges to perform the relay
      * @return encodedExecutionInfo encoded information on how the delivery will be executed
-     *        e.g. for version EVM_V1, this is a struct that encodes the `gasLimit` and `targetChainRefundPerGasUnused`
+     *        e.g. for version EVM_V1, this is a struct that encodes the `gasLimit`, `verifyDeliveryVaa`, and `targetChainRefundPerGasUnused`
      *             (which is the amount of target chain currency that will be refunded per unit of gas unused, 
      *              if a refundAddress is specified)
      */

--- a/ethereum/contracts/interfaces/relayer/IWormholeRelayerTyped.sol
+++ b/ethereum/contracts/interfaces/relayer/IWormholeRelayerTyped.sol
@@ -390,22 +390,6 @@ interface IWormholeRelayerSend is IWormholeRelayerBase {
     ) external payable;
 
     /**
-     * @notice Same as 'forwardToEvm' above, except the delivery VAA will not be verified on the target chain, 
-     */
-    function forwardVaasToEvmWithoutVerification(
-        uint16 targetChain,
-        address targetAddress,
-        TargetNative receiverValue,
-        LocalNative paymentForExtraReceiverValue,
-        Gas gasLimit,
-        uint16 refundChain,
-        address refundAddress,
-        address deliveryProviderAddress,
-        VaaKey[] memory vaaKeys,
-        uint8 consistencyLevel
-    ) external payable;
-
-    /**
      * @notice Performs the same function as a `send`, except:
      * 1)  Can only be used during a delivery (i.e. in execution of `receiveWormholeMessages`)
      * 2)  Is paid for (along with any other calls to forward) by (any msg.value passed in) + (refund leftover from current delivery)

--- a/ethereum/contracts/interfaces/relayer/IWormholeRelayerTyped.sol
+++ b/ethereum/contracts/interfaces/relayer/IWormholeRelayerTyped.sol
@@ -202,7 +202,10 @@ interface IWormholeRelayerSend is IWormholeRelayerBase {
     ) external payable returns (uint64 sequence);
 
     /**
-     * @notice Same as 'sendToEvm' above, except the delivery VAA will not be verified on the target chain, 
+     * @notice Same as 'sendToEvm' above, except:
+     * - The delivery VAA will not be verified on the target chain, 
+     * - targetAddress must implement IWormholeReceiverUnsafe instead of IWormholeReceiver
+     * - the IWormholeReceiverUnsafe.receiveWormholeMessagesUnsafe endpoint will be called instead!
      * 
      * This function must be called with `msg.value` equal to 
      * quoteEVMDeliveryPrice(targetChain, receiverValue, gasLimit, deliveryProviderAddress, false) + paymentForExtraReceiverValue
@@ -371,6 +374,8 @@ interface IWormholeRelayerSend is IWormholeRelayerBase {
      * @param deliveryProviderAddress The address of the desired delivery provider's implementation of IDeliveryProvider
      * @param vaaKeys Additional VAAs to pass in as parameter in call to `targetAddress`
      * @param verifyDeliveryVaa If true, the delivery VAA will be verified on the target chain prior to calling targetAddress
+     *        Note: If this is false, then targetAddress must implement IWormholeReceiverUnsafe instead of IWormholeReceiver,
+     *        and the IWormholeReceiverUnsafe.receiveWormholeMessagesUnsafe endpoint will be called instead!
      * @param consistencyLevel Consistency level with which to publish the delivery instructions - see 
      *        https://book.wormhole.com/wormhole/3_coreLayerContracts.html?highlight=consistency#consistency-levels
      */
@@ -456,6 +461,8 @@ interface IWormholeRelayerSend is IWormholeRelayerBase {
      * @param newGasLimit gas limit with which to call `targetAddress`. Any units of gas unused will be refunded according to the  
      *        `targetChainRefundPerGasUnused` rate quoted by the delivery provider, to the refund chain and address specified in the original request
      * @param verifyDeliveryVaa If true, the delivery VAA will be verified on the target chain prior to calling targetAddress
+     *        Note: If this is false, targetAddress must implement IWormholeReceiverUnsafe instead of IWormholeReceiver,
+     *        and the IWormholeReceiverUnsafe.receiveWormholeMessagesUnsafe endpoint will be called instead!
      * @param newDeliveryProviderAddress The address of the desired delivery provider's implementation of IDeliveryProvider
      * @return sequence sequence number of published VAA containing redelivery instructions
      * 

--- a/ethereum/contracts/interfaces/relayer/IWormholeRelayerTyped.sol
+++ b/ethereum/contracts/interfaces/relayer/IWormholeRelayerTyped.sol
@@ -357,7 +357,7 @@ interface IWormholeRelayerSend is IWormholeRelayerBase {
      * 
      * The following equation must be satisfied (sum_f indicates summing over all forwards requested in `receiveWormholeMessages`):
      * (refund amount from current execution of receiveWormholeMessages) + sum_f [msg.value_f]
-     * >= sum_f [quoteEVMDeliveryPrice(targetChain_f, receiverValue_f, gasLimit_f, deliveryProviderAddress_f) + paymentForExtraReceiverValue_f]
+     * >= sum_f [quoteEVMDeliveryPrice(targetChain_f, receiverValue_f, gasLimit_f, deliveryProviderAddress_f, verifyDeliveryVaa_f) + paymentForExtraReceiverValue_f]
      * 
      * The difference between the two sides of the above inequality will be added to `paymentForExtraReceiverValue` of the first forward requested
      * 
@@ -452,7 +452,7 @@ interface IWormholeRelayerSend is IWormholeRelayerBase {
      * (e.g. with a different delivery provider)
      *
      * This function must be called with `msg.value` equal to 
-     * quoteEVMDeliveryPrice(targetChain, newReceiverValue, newGasLimit, newDeliveryProviderAddress)
+     * quoteEVMDeliveryPrice(targetChain, newReceiverValue, newGasLimit, newDeliveryProviderAddress, verifyDeliveryVaa)
      * 
      * @param deliveryVaaKey VaaKey identifying the wormhole message containing the 
      *        previously published delivery instructions

--- a/ethereum/contracts/interfaces/relayer/IWormholeRelayerTyped.sol
+++ b/ethereum/contracts/interfaces/relayer/IWormholeRelayerTyped.sol
@@ -262,8 +262,7 @@ interface IWormholeRelayerSend is IWormholeRelayerBase {
      * 
      * The difference between the two sides of the above inequality will be added to `paymentForExtraReceiverValue` of the first forward requested
      * 
-     * Any refunds (from leftover gas) will be paid to the delivery provider. In order to receive the refunds, use the 'forwardToEvm' function 
-     * with `refundChain` and `refundAddress` as parameters
+     * Any refunds (from leftover gas) from this forward will be paid to the same refundChain and refundAddress specified for the current delivery.
      * 
      * @param targetChain in Wormhole Chain ID format
      * @param targetAddress address to call on targetChain (that implements IWormholeReceiver), in Wormhole bytes32 format
@@ -298,8 +297,7 @@ interface IWormholeRelayerSend is IWormholeRelayerBase {
      * 
      * The difference between the two sides of the above inequality will be added to `paymentForExtraReceiverValue` of the first forward requested
      * 
-     * Any refunds (from leftover gas) will be paid to the delivery provider. In order to receive the refunds, use the 'forwardToEvm' function 
-     * with `refundChain` and `refundAddress` as parameters
+     * Any refunds (from leftover gas) from this forward will be paid to the same refundChain and refundAddress specified for the current delivery.
      * 
      * @param targetChain in Wormhole Chain ID format
      * @param targetAddress address to call on targetChain (that implements IWormholeReceiver), in Wormhole bytes32 format

--- a/ethereum/contracts/interfaces/relayer/IWormholeRelayerTyped.sol
+++ b/ethereum/contracts/interfaces/relayer/IWormholeRelayerTyped.sol
@@ -240,7 +240,7 @@ interface IWormholeRelayerSend is IWormholeRelayerBase {
      *        (in addition to the `receiverValue` specified)
      * @param encodedExecutionParameters encoded information on how to execute delivery that may impact pricing
      *        e.g. for version EVM_V1, this is a struct that encodes the `gasLimit` with which to call `targetAddress`
-     *             and whether or not to verify the delivery VAA
+     *        and whether or not to verify the delivery VAA
      * @param refundChain The chain to deliver any refund to, in Wormhole Chain ID format
      * @param refundAddress The address on `refundChain` to deliver any refund to, in Wormhole bytes32 format
      * @param deliveryProviderAddress The address of the desired delivery provider's implementation of IDeliveryProvider
@@ -487,6 +487,7 @@ interface IWormholeRelayerSend is IWormholeRelayerBase {
      * @param newReceiverValue new msg.value that delivery provider should pass in for call to `targetAddress` (in targetChain currency units)
      * @param newEncodedExecutionParameters new encoded information on how to execute delivery that may impact pricing
      *        e.g. for version EVM_V1, this is a struct that encodes the `gasLimit` with which to call `targetAddress`
+     *        and whether or not to verify the delivery VAA
      * @param newDeliveryProviderAddress The address of the desired delivery provider's implementation of IDeliveryProvider
      * @return sequence sequence number of published VAA containing redelivery instructions
      */
@@ -559,10 +560,11 @@ interface IWormholeRelayerSend is IWormholeRelayerBase {
      * @param receiverValue msg.value that delivery provider should pass in for call to `targetAddress` (in targetChain currency units)
      * @param encodedExecutionParameters encoded information on how to execute delivery that may impact pricing
      *        e.g. for version EVM_V1, this is a struct that encodes the `gasLimit` with which to call `targetAddress`
+     *        and whether or not to verify the delivery VAA
      * @param deliveryProviderAddress The address of the desired delivery provider's implementation of IDeliveryProvider
      * @return nativePriceQuote Price, in units of current chain currency, that the delivery provider charges to perform the relay
      * @return encodedExecutionInfo encoded information on how the delivery will be executed
-     *        e.g. for version EVM_V1, this is a struct that encodes the `gasLimit` and `targetChainRefundPerGasUnused`
+     *        e.g. for version EVM_V1, this is a struct that encodes the `gasLimit`, `verifyDeliveryVaa`, and `targetChainRefundPerGasUnused`
      *             (which is the amount of target chain currency that will be refunded per unit of gas unused, 
      *              if a refundAddress is specified)
      */

--- a/ethereum/contracts/libraries/relayer/ExecutionParameters.sol
+++ b/ethereum/contracts/libraries/relayer/ExecutionParameters.sol
@@ -19,12 +19,14 @@ enum ExecutionParamsVersion {EVM_V1}
 
 struct EvmExecutionParamsV1 {
     Gas gasLimit;
+    bool verifyDeliveryVaa;
 }
 
 enum ExecutionInfoVersion {EVM_V1}
 
 struct EvmExecutionInfoV1 {
     Gas gasLimit;
+    bool verifyDeliveryVaa;
     GasPrice targetChainRefundPerGasUnused;
 }
 
@@ -46,7 +48,7 @@ function encodeEvmExecutionParamsV1(EvmExecutionParamsV1 memory executionParams)
     pure
     returns (bytes memory)
 {
-    return abi.encode(uint8(ExecutionParamsVersion.EVM_V1), executionParams.gasLimit);
+    return abi.encode(uint8(ExecutionParamsVersion.EVM_V1), executionParams.gasLimit, executionParams.verifyDeliveryVaa);
 }
 
 function decodeEvmExecutionParamsV1(bytes memory data)
@@ -54,7 +56,7 @@ function decodeEvmExecutionParamsV1(bytes memory data)
     returns (EvmExecutionParamsV1 memory executionParams)
 {
     uint8 version;
-    (version, executionParams.gasLimit) = abi.decode(data, (uint8, Gas));
+    (version, executionParams.gasLimit, executionParams.verifyDeliveryVaa) = abi.decode(data, (uint8, Gas, bool));
 
     if (version != uint8(ExecutionParamsVersion.EVM_V1)) {
         revert UnexpectedExecutionParamsVersion(version, uint8(ExecutionParamsVersion.EVM_V1));
@@ -68,6 +70,7 @@ function encodeEvmExecutionInfoV1(EvmExecutionInfoV1 memory executionInfo)
     return abi.encode(
         uint8(ExecutionInfoVersion.EVM_V1),
         executionInfo.gasLimit,
+        executionInfo.verifyDeliveryVaa,
         executionInfo.targetChainRefundPerGasUnused
     );
 }
@@ -77,8 +80,8 @@ function decodeEvmExecutionInfoV1(bytes memory data)
     returns (EvmExecutionInfoV1 memory executionInfo)
 {
     uint8 version;
-    (version, executionInfo.gasLimit, executionInfo.targetChainRefundPerGasUnused) =
-        abi.decode(data, (uint8, Gas, GasPrice));
+    (version, executionInfo.gasLimit, executionInfo.verifyDeliveryVaa, executionInfo.targetChainRefundPerGasUnused) =
+        abi.decode(data, (uint8, Gas, bool, GasPrice));
 
     if (version != uint8(ExecutionInfoVersion.EVM_V1)) {
         revert UnexpectedExecutionInfoVersion(version, uint8(ExecutionInfoVersion.EVM_V1));

--- a/ethereum/contracts/libraries/relayer/ExecutionParameters.sol
+++ b/ethereum/contracts/libraries/relayer/ExecutionParameters.sol
@@ -93,5 +93,6 @@ function getEmptyEvmExecutionParamsV1()
     returns (EvmExecutionParamsV1 memory executionParams)
 {
     executionParams.gasLimit = Gas.wrap(uint256(0));
+    executionParams.verifyDeliveryVaa = false;
 }
 

--- a/ethereum/contracts/libraries/relayer/RelayerInternalStructs.sol
+++ b/ethereum/contracts/libraries/relayer/RelayerInternalStructs.sol
@@ -29,6 +29,7 @@ struct EvmDeliveryInstruction {
   Gas gasLimit;
   TargetNative totalReceiverValue;
   GasPrice targetChainRefundPerGasUnused;
+  bool verifyDeliveryVaa;
   bytes32 senderAddress;
   bytes32 deliveryHash;
   bytes[] signedVaas;

--- a/ethereum/contracts/mock/relayer/MockRelayerIntegration.sol
+++ b/ethereum/contracts/mock/relayer/MockRelayerIntegration.sol
@@ -232,6 +232,7 @@ contract MockRelayerIntegration is IWormholeReceiver {
             targetChain,
             TargetNative.wrap(newReceiverValue),
             Gas.wrap(newGasLimit),
+            true,
             relayer.getDefaultDeliveryProvider()
         );
     }
@@ -268,6 +269,7 @@ contract MockRelayerIntegration is IWormholeReceiver {
                 getRegisteredContractAddress(sourceChain),
                 relayer.getDefaultDeliveryProvider(),
                 new VaaKey[](0),
+                true,
                 15
             );
         }
@@ -283,6 +285,7 @@ contract MockRelayerIntegration is IWormholeReceiver {
                 getRegisteredContractAddress(wormhole.chainId()),
                 relayer.getDefaultDeliveryProvider(),
                 new VaaKey[](0),
+                true,
                 15
             );
         }

--- a/ethereum/contracts/mock/relayer/MockRelayerIntegration.sol
+++ b/ethereum/contracts/mock/relayer/MockRelayerIntegration.sol
@@ -23,7 +23,7 @@ struct DeliveryData {
     bytes[] additionalVaas;
 }
 
-contract MockRelayerIntegration is IWormholeReceiver {
+contract MockRelayerIntegration is IWormholeReceiver, IWormholeReceiverUnsafe {
     using BytesLib for bytes;
 
     // wormhole instance on this chain
@@ -289,6 +289,14 @@ contract MockRelayerIntegration is IWormholeReceiver {
                 15
             );
         }
+    }
+
+    function receiveWormholeMessagesUnsafe(
+        bytes[] memory vaas
+    ) public payable {
+        (IWormhole.VM memory vm,,) = wormhole.parseAndVerifyVM(vaas[0]);
+        messageHistory.push(vm.payload);
+
     }
 
     function getMessage() public view returns (bytes memory) {

--- a/ethereum/contracts/relayer/deliveryProvider/DeliveryProvider.sol
+++ b/ethereum/contracts/relayer/deliveryProvider/DeliveryProvider.sol
@@ -38,7 +38,7 @@ contract DeliveryProvider is DeliveryProviderGovernance, IDeliveryProvider {
         targetChainRefundPerUnitGasUnused = gasPrice(targetChain);
         Wei costOfProvidingFullGasLimit = gasLimit.toWei(targetChainRefundPerUnitGasUnused);
         Wei transactionFee =
-            quoteDeliveryOverhead(targetChain) + gasLimit.toWei(quoteGasPrice(targetChain));
+            quoteDeliveryOverhead(targetChain, verifyDeliveryVaa) + gasLimit.toWei(quoteGasPrice(targetChain));
         Wei receiverValueCost = quoteAssetCost(targetChain, receiverValue);
         nativePriceQuote = (
             transactionFee.max(costOfProvidingFullGasLimit) + receiverValueCost
@@ -125,8 +125,8 @@ contract DeliveryProvider is DeliveryProviderGovernance, IDeliveryProvider {
     }
 
     //Returns the delivery overhead fee required to deliver a message to the target chain, denominated in this chain's wei.
-    function quoteDeliveryOverhead(uint16 targetChain) public view returns (Wei nativePriceQuote) {
-        Gas overhead = deliverGasOverhead(targetChain);
+    function quoteDeliveryOverhead(uint16 targetChain, bool verifyDeliveryVaa) public view returns (Wei nativePriceQuote) {
+        Gas overhead = deliverGasOverhead(targetChain) - (verifyDeliveryVaa ? Gas.wrap(0) : vaaVerificationGasOverhead(targetChain));
         Wei targetFees = overhead.toWei(gasPrice(targetChain));
         Wei result = assetConversion(targetChain, targetFees, chainId());
         require(result.unwrap() <= type(uint128).max, "Overflow");

--- a/ethereum/contracts/relayer/deliveryProvider/DeliveryProvider.sol
+++ b/ethereum/contracts/relayer/deliveryProvider/DeliveryProvider.sol
@@ -28,7 +28,8 @@ contract DeliveryProvider is DeliveryProviderGovernance, IDeliveryProvider {
     function quoteEvmDeliveryPrice(
         uint16 targetChain,
         Gas gasLimit,
-        TargetNative receiverValue
+        TargetNative receiverValue,
+        bool verifyDeliveryVaa
     )
         public
         view
@@ -59,11 +60,11 @@ contract DeliveryProvider is DeliveryProviderGovernance, IDeliveryProvider {
             EvmExecutionParamsV1 memory parsed = decodeEvmExecutionParamsV1(encodedExecutionParams);
             GasPrice targetChainRefundPerUnitGasUnused;
             (nativePriceQuote, targetChainRefundPerUnitGasUnused) =
-                quoteEvmDeliveryPrice(targetChain, parsed.gasLimit, receiverValue);
+                quoteEvmDeliveryPrice(targetChain, parsed.gasLimit, receiverValue, parsed.verifyDeliveryVaa);
             return (
                 nativePriceQuote,
                 encodeEvmExecutionInfoV1(
-                    EvmExecutionInfoV1(parsed.gasLimit, targetChainRefundPerUnitGasUnused)
+                    EvmExecutionInfoV1(parsed.gasLimit, parsed.verifyDeliveryVaa, targetChainRefundPerUnitGasUnused)
                     )
             );
         } else {

--- a/ethereum/contracts/relayer/deliveryProvider/DeliveryProviderGetters.sol
+++ b/ethereum/contracts/relayer/deliveryProvider/DeliveryProviderGetters.sol
@@ -41,6 +41,10 @@ contract DeliveryProviderGetters is DeliveryProviderState {
         return _state.deliverGasOverhead[targetChain];
     }
 
+    function vaaVerificationGasOverhead(uint16 targetChain) public view returns (Gas) {
+        return _state.vaaVerificationGasOverhead[targetChain];
+    }
+
     function maximumBudget(uint16 targetChain) public view returns (Wei) {
         return _state.maximumBudget[targetChain];
     }

--- a/ethereum/contracts/relayer/deliveryProvider/DeliveryProviderGovernance.sol
+++ b/ethereum/contracts/relayer/deliveryProvider/DeliveryProviderGovernance.sol
@@ -38,6 +38,7 @@ abstract contract DeliveryProviderGovernance is
     event RewardAddressUpdated(address indexed newAddress);
     event TargetChainAddressUpdated(uint16 indexed targetChain, bytes32 indexed newAddress);
     event DeliverGasOverheadUpdated(Gas indexed oldGasOverhead, Gas indexed newGasOverhead);
+    event VaaVerificationGasOverheadUpdated(Gas indexed oldVaaVerificationGasOverhead, Gas indexed newVaaVerificationGasOverhead);
     event WormholeRelayerUpdated(address coreRelayer);
     event AssetConversionBufferUpdated(uint16 targetChain, uint16 buffer, uint16 bufferDenominator);
 
@@ -128,6 +129,30 @@ abstract contract DeliveryProviderGovernance is
         setDeliverGasOverhead(chainId, newGasOverhead);
         emit DeliverGasOverheadUpdated(currentGasOverhead, newGasOverhead);
     }
+
+    function updateVaaVerificationGasOverhead(uint16 chainId, Gas newVaaVerificationGasOverhead) external onlyOwner {
+        updateVaaVerificationGasOverheadImpl(chainId, newVaaVerificationGasOverhead);
+    }
+
+    function updateVaaVerificationGasOverheads(
+        DeliveryProviderStructs.VaaVerificationGasOverheadUpdate[] memory vaaVerificationGasOverheadUpdates
+    ) external onlyOwner {
+        uint256 updatesLength = vaaVerificationGasOverheadUpdates.length;
+        for (uint256 i = 0; i < updatesLength;) {
+            DeliveryProviderStructs.VaaVerificationGasOverheadUpdate memory update = vaaVerificationGasOverheadUpdates[i];
+            updateVaaVerificationGasOverheadImpl(update.chainId, update.newVaaVerificationGasOverhead);
+            unchecked {
+                i += 1;
+            }
+        }
+    }
+
+    function updateVaaVerificationGasOverheadImpl(uint16 chainId, Gas newVaaVerificationGasOverhead) internal {
+        Gas currentVaaVerificationGasOverhead = vaaVerificationGasOverhead(chainId);
+        setVaaVerificationGasOverhead(chainId, newVaaVerificationGasOverhead);
+        emit VaaVerificationGasOverheadUpdated(currentVaaVerificationGasOverhead, newVaaVerificationGasOverhead);
+    }
+
 
     function updatePrice(
         uint16 updateChainId,

--- a/ethereum/contracts/relayer/deliveryProvider/DeliveryProviderSetters.sol
+++ b/ethereum/contracts/relayer/deliveryProvider/DeliveryProviderSetters.sol
@@ -41,6 +41,11 @@ contract DeliveryProviderSetters is Context, DeliveryProviderState {
         _state.deliverGasOverhead[chainId] = deliverGasOverhead;
     }
 
+    function setVaaVerificationGasOverhead(uint16 chainId, Gas vaaVerificationGasOverhead) internal {
+        require(Gas.unwrap(vaaVerificationGasOverhead) <= type(uint32).max, "vaaVerificationGasOverhead too large");
+        _state.vaaVerificationGasOverhead[chainId] = vaaVerificationGasOverhead;
+    }
+
     function setRewardAddress(address payable rewardAddress) internal {
         _state.rewardAddress = rewardAddress;
     }

--- a/ethereum/contracts/relayer/deliveryProvider/DeliveryProviderState.sol
+++ b/ethereum/contracts/relayer/deliveryProvider/DeliveryProviderState.sol
@@ -40,6 +40,8 @@ contract DeliveryProviderStorage {
         mapping(uint16 => PriceData) data;
         // The delivery overhead gas required to deliver a message to targetChain, denominated in targetChain's gas.
         mapping(uint16 => Gas) deliverGasOverhead;
+        // overhead gas required to verify a VAA on targetChain, denominated in targetChain's gas.
+        mapping(uint16 => Gas) vaaVerificationGasOverhead;
         // The maximum budget that is allowed for a delivery on target chain, denominated in the targetChain's wei.
         mapping(uint16 => Wei) maximumBudget;
         // Dictionary of wormhole chain id -> assetConversion

--- a/ethereum/contracts/relayer/deliveryProvider/DeliveryProviderStructs.sol
+++ b/ethereum/contracts/relayer/deliveryProvider/DeliveryProviderStructs.sol
@@ -43,6 +43,18 @@ abstract contract DeliveryProviderStructs {
         Wei maximumTotalBudget;
     }
 
+    struct VaaVerificationGasOverheadUpdate {
+        /**
+         * Wormhole chain id
+         */
+        uint16 chainId;
+        /**
+         * The overhead for verifying a delivery VAA on ´chainId´ chain.
+         * Should be less than 'deliverGasOverhead'
+         */
+        Gas newVaaVerificationGasOverhead;
+    }
+
     struct DeliverGasOverheadUpdate {
         /**
          * Wormhole chain id

--- a/ethereum/contracts/relayer/wormholeRelayer/WormholeRelayerBase.sol
+++ b/ethereum/contracts/relayer/wormholeRelayer/WormholeRelayerBase.sol
@@ -101,7 +101,7 @@ abstract contract WormholeRelayerBase is IWormholeRelayerBase {
 
     // ----------------------- delivery transaction temorary storage functions -----------------------
 
-    function startDelivery(address targetAddress, address deliveryProvider) internal {
+    function startDelivery(address targetAddress, address deliveryProvider, uint16 refundChain, bytes32 refundAddress) internal {
         DeliveryTmpState storage state = getDeliveryTmpState();
         if (state.deliveryInProgress) {
             revert ReentrantDelivery(msg.sender, state.deliveryTarget);
@@ -110,6 +110,8 @@ abstract contract WormholeRelayerBase is IWormholeRelayerBase {
         state.deliveryInProgress = true;
         state.deliveryTarget = targetAddress;
         state.deliveryProvider = deliveryProvider;
+        state.refundChain = refundChain;
+        state.refundAddress = refundAddress;
     }
 
     function finishDelivery() internal {
@@ -117,6 +119,8 @@ abstract contract WormholeRelayerBase is IWormholeRelayerBase {
         state.deliveryInProgress = false;
         state.deliveryTarget = address(0);
         state.deliveryProvider = address(0);
+        state.refundChain = 0;
+        state.refundAddress = bytes32(0);
         delete state.forwardInstructions;
     }
 
@@ -130,6 +134,14 @@ abstract contract WormholeRelayerBase is IWormholeRelayerBase {
 
     function getOriginalDeliveryProvider() internal view returns (address) {
         return getDeliveryTmpState().deliveryProvider;
+    }
+
+    function getCurrentRefundChain() internal view returns (uint16) {
+        return getDeliveryTmpState().refundChain;
+    }
+
+    function getCurrentRefundAddress() internal view returns (bytes32) {
+        return getDeliveryTmpState().refundAddress;
     }
 
     function checkMsgSenderInDelivery() internal view {

--- a/ethereum/contracts/relayer/wormholeRelayer/WormholeRelayerDelivery.sol
+++ b/ethereum/contracts/relayer/wormholeRelayer/WormholeRelayerDelivery.sol
@@ -71,7 +71,9 @@ abstract contract WormholeRelayerDelivery is WormholeRelayerBase, IWormholeRelay
         //  cost of the happy path.
         startDelivery(
             fromWormholeFormat(instruction.targetAddress),
-            fromWormholeFormat(instruction.refundDeliveryProvider)
+            fromWormholeFormat(instruction.refundDeliveryProvider),
+            instruction.refundChain,
+            instruction.refundAddress
         );
 
         DeliveryVAAInfo memory deliveryVaaInfo = DeliveryVAAInfo({

--- a/ethereum/contracts/relayer/wormholeRelayer/WormholeRelayerDelivery.sol
+++ b/ethereum/contracts/relayer/wormholeRelayer/WormholeRelayerDelivery.sol
@@ -368,8 +368,15 @@ abstract contract WormholeRelayerDelivery is WormholeRelayerBase, IWormholeRelay
         bool success;
         {
             address payable deliveryTarget = payable(fromWormholeFormat(evmInstruction.targetAddress));
-            bytes memory callData = abi.encodeCall(evmInstruction.verifyDeliveryVaa ? IWormholeReceiver.receiveWormholeMessages : IWormholeReceiverUnsafe.receiveWormholeMessagesUnsafe, (
+            bytes memory callData = evmInstruction.verifyDeliveryVaa ? abi.encodeCall(IWormholeReceiver.receiveWormholeMessages, (
                 evmInstruction.payload,
+                evmInstruction.signedVaas,
+                evmInstruction.senderAddress,
+                evmInstruction.sourceChain,
+                evmInstruction.deliveryHash
+            )) 
+            : 
+            abi.encodeCall(IWormholeReceiverUnsafe.receiveWormholeMessagesUnsafe, (
                 evmInstruction.signedVaas,
                 evmInstruction.senderAddress,
                 evmInstruction.sourceChain,

--- a/ethereum/contracts/relayer/wormholeRelayer/WormholeRelayerDelivery.sol
+++ b/ethereum/contracts/relayer/wormholeRelayer/WormholeRelayerDelivery.sol
@@ -377,10 +377,7 @@ abstract contract WormholeRelayerDelivery is WormholeRelayerBase, IWormholeRelay
             )) 
             : 
             abi.encodeCall(IWormholeReceiverUnsafe.receiveWormholeMessagesUnsafe, (
-                evmInstruction.signedVaas,
-                evmInstruction.senderAddress,
-                evmInstruction.sourceChain,
-                evmInstruction.deliveryHash
+                evmInstruction.signedVaas
             ));
 
             Gas preGas = Gas.wrap(gasleft());

--- a/ethereum/contracts/relayer/wormholeRelayer/WormholeRelayerDelivery.sol
+++ b/ethereum/contracts/relayer/wormholeRelayer/WormholeRelayerDelivery.sol
@@ -22,7 +22,7 @@ import {
     IWormholeRelayerSend,
     RETURNDATA_TRUNCATION_THRESHOLD
 } from "../../interfaces/relayer/IWormholeRelayerTyped.sol";
-import {IWormholeReceiver} from "../../interfaces/relayer/IWormholeReceiver.sol";
+import {IWormholeReceiver, IWormholeReceiverUnsafe} from "../../interfaces/relayer/IWormholeReceiver.sol";
 import {IDeliveryProvider} from "../../interfaces/relayer/IDeliveryProviderTyped.sol";
 
 import {pay, min, toWormholeFormat, fromWormholeFormat, returnLengthBoundedCall} from "../../libraries/relayer/Utils.sol";
@@ -283,6 +283,7 @@ abstract contract WormholeRelayerDelivery is WormholeRelayerBase, IWormholeRelay
                 gasLimit: vaaInfo.gasLimit,
                 totalReceiverValue: vaaInfo.totalReceiverValue,
                 targetChainRefundPerGasUnused: vaaInfo.targetChainRefundPerGasUnused,
+                verifyDeliveryVaa: vaaInfo.verifyDeliveryVaa,
                 senderAddress: vaaInfo.deliveryInstruction.senderAddress,
                 deliveryHash: vaaInfo.deliveryVaaHash,
                 signedVaas: vaaInfo.encodedVMs
@@ -367,7 +368,7 @@ abstract contract WormholeRelayerDelivery is WormholeRelayerBase, IWormholeRelay
         bool success;
         {
             address payable deliveryTarget = payable(fromWormholeFormat(evmInstruction.targetAddress));
-            bytes memory callData = abi.encodeCall(IWormholeReceiver.receiveWormholeMessages, (
+            bytes memory callData = abi.encodeCall(evmInstruction.verifyDeliveryVaa ? IWormholeReceiver.receiveWormholeMessages : IWormholeReceiverUnsafe.receiveWormholeMessagesUnsafe, (
                 evmInstruction.payload,
                 evmInstruction.signedVaas,
                 evmInstruction.senderAddress,

--- a/ethereum/contracts/relayer/wormholeRelayer/WormholeRelayerSend.sol
+++ b/ethereum/contracts/relayer/wormholeRelayer/WormholeRelayerSend.sol
@@ -162,17 +162,17 @@ abstract contract WormholeRelayerSend is WormholeRelayerBase, IWormholeRelayerSe
         TargetNative receiverValue,
         Gas gasLimit
     ) external payable {
-        (address deliveryProvider, address deliveryProviderOnTarget) =
+        (address deliveryProvider,) =
             getOriginalOrDefaultDeliveryProvider(targetChain);
-        forwardToEvm(
+        forward(
             targetChain,
-            targetAddress,
+            toWormholeFormat(targetAddress),
             payload,
             receiverValue,
             LocalNative.wrap(0),
-            gasLimit,
-            targetChain,
-            deliveryProviderOnTarget,
+            encodeEvmExecutionParamsV1(EvmExecutionParamsV1(gasLimit)),
+            getCurrentRefundChain(),
+            getCurrentRefundAddress(),
             deliveryProvider,
             new VaaKey[](0),
             CONSISTENCY_LEVEL_FINALIZED
@@ -187,17 +187,17 @@ abstract contract WormholeRelayerSend is WormholeRelayerBase, IWormholeRelayerSe
         Gas gasLimit,
         VaaKey[] memory vaaKeys
     ) external payable {
-        (address deliveryProvider, address deliveryProviderOnTarget) =
+        (address deliveryProvider,) =
             getOriginalOrDefaultDeliveryProvider(targetChain);
-        forwardToEvm(
+        forward(
             targetChain,
-            targetAddress,
+            toWormholeFormat(targetAddress),
             payload,
             receiverValue,
             LocalNative.wrap(0),
-            gasLimit,
-            targetChain,
-            deliveryProviderOnTarget,
+            encodeEvmExecutionParamsV1(EvmExecutionParamsV1(gasLimit)),
+            getCurrentRefundChain(),
+            getCurrentRefundAddress(),
             deliveryProvider,
             vaaKeys,
             CONSISTENCY_LEVEL_FINALIZED

--- a/ethereum/contracts/relayer/wormholeRelayer/WormholeRelayerSend.sol
+++ b/ethereum/contracts/relayer/wormholeRelayer/WormholeRelayerSend.sol
@@ -265,38 +265,6 @@ abstract contract WormholeRelayerSend is WormholeRelayerBase, IWormholeRelayerSe
         );
     }
 
-    function forwardVaasToEvmWithoutVerification(
-        uint16 targetChain,
-        address targetAddress,
-        TargetNative receiverValue,
-        LocalNative paymentForExtraReceiverValue,
-        Gas gasLimit,
-        uint16 refundChain,
-        address refundAddress,
-        address deliveryProviderAddress,
-        VaaKey[] memory vaaKeys,
-        uint8 consistencyLevel
-    ) public payable {
-        // provide ability to use original relay provider
-        if (deliveryProviderAddress == address(0)) {
-            deliveryProviderAddress = getOriginalDeliveryProvider();
-        }
-
-        forward(
-            targetChain,
-            toWormholeFormat(targetAddress),
-            bytes(""),
-            receiverValue,
-            paymentForExtraReceiverValue,
-            encodeEvmExecutionParamsV1(EvmExecutionParamsV1(gasLimit, false)),
-            refundChain,
-            toWormholeFormat(refundAddress),
-            deliveryProviderAddress,
-            vaaKeys,
-            consistencyLevel
-        );
-    }
-
     function resendToEvm(
         VaaKey memory deliveryVaaKey,
         uint16 targetChain,

--- a/ethereum/contracts/relayer/wormholeRelayer/WormholeRelayerStorage.sol
+++ b/ethereum/contracts/relayer/wormholeRelayer/WormholeRelayerStorage.sol
@@ -82,6 +82,10 @@ struct DeliveryTmpState {
     address deliveryTarget;
     // the target relay provider address for the in-progress delivery
     address deliveryProvider;
+    // the refund chain for the in-progress delivery
+    uint16 refundChain;
+    // the refund address for the in-progress delivery
+    bytes32 refundAddress;
     // Requests which will be forwarded from the current delivery.
     ForwardInstruction[] forwardInstructions;
 }

--- a/ethereum/forge-test/relayer/AttackForwardIntegration.sol
+++ b/ethereum/forge-test/relayer/AttackForwardIntegration.sol
@@ -70,6 +70,7 @@ contract AttackForwardIntegration is IWormholeReceiver {
             attackerRewardAddress,
             coreRelayer.getDefaultDeliveryProvider(),
             new VaaKey[](0),
+            true,
             15
         );
     }

--- a/ethereum/forge-test/relayer/MockWormhole.sol
+++ b/ethereum/forge-test/relayer/MockWormhole.sol
@@ -59,6 +59,11 @@ contract MockWormhole is IWormhole {
         vm = _parseVM(encodedVm);
     }
 
+    function verifyVM(VM memory vm) external view returns (bool valid, string memory reason) {
+        valid = !invalidVMs[vm.hash];
+        reason = "";
+    }
+
     function parseAndVerifyVM(bytes calldata encodedVm)
         external
         view
@@ -66,8 +71,7 @@ contract MockWormhole is IWormhole {
     {
         vm = _parseVM(encodedVm);
         //behold the rigorous checking!
-        valid = !invalidVMs[vm.hash];
-        reason = "";
+        (valid, reason) = this.verifyVM(vm);
     }
 
     function _parseVM(bytes calldata encodedVm) internal pure returns (VM memory vm) {
@@ -205,14 +209,6 @@ contract MockWormhole is IWormhole {
 
     function nextSequence(address emitter) external view returns (uint64) {
         return sequences[emitter];
-    }
-
-    function verifyVM(VM memory /*vm*/ )
-        external
-        pure
-        returns (bool, /*valid*/ string memory /*reason*/ )
-    {
-        revert("unsupported verifyVM in wormhole mock");
     }
 
     function verifySignatures(

--- a/ethereum/forge-test/relayer/WormholeRelayer.t.sol
+++ b/ethereum/forge-test/relayer/WormholeRelayer.t.sol
@@ -1336,7 +1336,7 @@ contract WormholeRelayerTests is Test {
         );
 
         bytes memory encodedExecutionInfo = abi.encode(
-            uint8(ExecutionInfoVersion.EVM_V1), params.gasLimit, targetChainRefundPerGasUnused
+            uint8(ExecutionInfoVersion.EVM_V1), params.gasLimit, true, targetChainRefundPerGasUnused
         );
         TargetNative extraReceiverValue = setup.source.coreRelayer.quoteNativeForChain(
             setup.targetChain,
@@ -1397,11 +1397,12 @@ contract WormholeRelayerTests is Test {
             setup.targetChain,
             TargetNative.wrap(params.newReceiverValue),
             Gas.wrap(params.newGasLimit),
+            true,
             address(setup.source.deliveryProvider)
         );
 
         bytes memory encodedExecutionInfo = abi.encode(
-            uint8(ExecutionInfoVersion.EVM_V1), params.newGasLimit, targetChainRefundPerGasUnused
+            uint8(ExecutionInfoVersion.EVM_V1), params.newGasLimit, true, targetChainRefundPerGasUnused
         );
 
         RedeliveryInstruction memory expectedInstruction = RedeliveryInstruction({
@@ -1565,16 +1566,7 @@ contract WormholeRelayerTests is Test {
      */
 
     function invalidateVM(bytes memory message, WormholeSimulator simulator) internal {
-        change(message, message.length - 1);
         simulator.invalidateVM(message);
-    }
-
-    function change(bytes memory message, uint256 index) internal pure {
-        if (message[index] == 0x02) {
-            message[index] = 0x04;
-        } else {
-            message[index] = 0x02;
-        }
     }
 
     struct DeliveryStack {
@@ -1862,6 +1854,7 @@ contract WormholeRelayerTests is Test {
             encodeEvmExecutionInfoV1(
                 EvmExecutionInfoV1({
                     gasLimit: executionInfo.gasLimit - Gas.wrap(1),
+                    verifyDeliveryVaa: true,
                     targetChainRefundPerGasUnused: executionInfo.targetChainRefundPerGasUnused
                 })
             ),
@@ -1936,6 +1929,7 @@ contract WormholeRelayerTests is Test {
             encodeEvmExecutionInfoV1(
                 EvmExecutionInfoV1({
                     gasLimit: executionInfo.gasLimit,
+                    verifyDeliveryVaa: true,
                     targetChainRefundPerGasUnused: GasPrice.wrap(
                         executionInfo.targetChainRefundPerGasUnused.unwrap() - 1
                         )

--- a/ethereum/ts-scripts/relayer/config/ci/scriptConfigs/configureDeliveryProvider.json
+++ b/ethereum/ts-scripts/relayer/config/ci/scriptConfigs/configureDeliveryProvider.json
@@ -26,6 +26,7 @@
     {
       "chainId": 2,
       "deliverGasOverhead": "350000",
+      "vaaVerificationGasOverhead": "160000",
       "updatePriceGas": "300000000000",
       "updatePriceNative": "100000",
       "maximumBudget": "1000000000000000000"
@@ -33,6 +34,7 @@
     {
       "chainId": 4,
       "deliverGasOverhead": "350000",
+      "vaaVerificationGasOverhead": "160000",
       "updatePriceGas": "300000000000",
       "updatePriceNative": "100000",
       "maximumBudget": "1000000000000000000"

--- a/ethereum/ts-scripts/relayer/deliveryProvider/configureDeliveryProvider.ts
+++ b/ethereum/ts-scripts/relayer/deliveryProvider/configureDeliveryProvider.ts
@@ -20,6 +20,7 @@ import type { DeliveryProviderStructs } from "../../../ethers-contracts/Delivery
 interface PricingInfo {
   chainId: ChainId
   deliverGasOverhead: BigNumberish
+  vaaVerificationGasOverhead: BigNumberish
   updatePriceGas: BigNumberish
   updatePriceNative: BigNumberish
   maximumBudget: BigNumberish
@@ -93,6 +94,7 @@ async function configureChainsDeliveryProvider(chain: ChainInfo) {
       bufferDenominator: 100,
       newWormholeFee: 0,
       newGasOverhead: targetChainPriceUpdate.deliverGasOverhead,
+      newVaaVerificationGasOverhead: targetChainPriceUpdate.vaaVerificationGasOverhead,
       gasPrice: targetChainPriceUpdate.updatePriceGas,
       nativeCurrencyPrice: targetChainPriceUpdate.updatePriceNative,
       targetChainAddress: remoteDeliveryProvider,

--- a/sdk/js/src/relayer/__tests__/wormhole_relayer.ts
+++ b/sdk/js/src/relayer/__tests__/wormhole_relayer.ts
@@ -388,12 +388,12 @@ describe("Wormhole Relayer Tests", () => {
     const value = await relayer.getPrice(sourceChain, targetChain, REASONABLE_GAS_LIMIT, optionalParams);
     console.log(`Quoted gas delivery fee: ${value}`);
     const tx = await source.wormholeRelayer.sendVaasToEvmWithoutVerification(
-      targetChain,
+      target.chainId,
       target.mockIntegrationAddress,
       0,
       0,
       REASONABLE_GAS_LIMIT,
-      sourceChain,
+      source.chainId,
       source.wallet.address,
       await source.wormholeRelayer.getDefaultDeliveryProvider(),
       [relayer.createVaaKey(

--- a/sdk/js/src/relayer/main/main.ts
+++ b/sdk/js/src/relayer/main/main.ts
@@ -381,6 +381,7 @@ export async function resendRaw(
   vaaKey: VaaKey,
   newGasLimit: BigNumber | number,
   newReceiverValue: BigNumber | number,
+  verifyDeliveryVaa: boolean,
   deliveryProviderAddress: string,
   overrides?: ethers.PayableOverrides
 ) {
@@ -395,6 +396,7 @@ export async function resendRaw(
     CHAINS[targetChain],
     newReceiverValue,
     newGasLimit,
+    verifyDeliveryVaa,
     deliveryProviderAddress,
     overrides
   );
@@ -408,6 +410,7 @@ export async function resend(
   vaaKey: VaaKey,
   newGasLimit: BigNumber | number,
   newReceiverValue: BigNumber | number,
+  verifyDeliveryVaa: boolean,
   deliveryProviderAddress: string,
   wormholeRPCs: string[],
   overrides: ethers.PayableOverrides,
@@ -429,6 +432,7 @@ export async function resend(
   const originalRefund = originalExecutionInfo.targetChainRefundPerGasUnused;
   const originalReceiverValue = originalVAAparsed.requestedReceiverValue;
   const originalTargetChain = originalVAAparsed.targetChainId;
+  const originalVerifyDeliveryVaa = originalExecutionInfo.verifyDeliveryVaa;
 
   
 
@@ -447,6 +451,12 @@ export async function resend(
   if (newGasLimit < originalGasLimit) {
     throw Error(
       `New gas limit too low. Minimum is ${originalReceiverValue.toString()}`
+    );
+  }
+
+  if (originalVerifyDeliveryVaa && !verifyDeliveryVaa) {
+    throw Error(
+      `Cannot request unverified delivery VAA if originally the request was to verify the delivery VAA.`
     );
   }
 
@@ -479,6 +489,7 @@ export async function resend(
     vaaKey,
     newGasLimit,
     newReceiverValue,
+    verifyDeliveryVaa,
     deliveryProviderAddress,
     overrides
   );

--- a/sdk/js/src/relayer/structs.ts
+++ b/sdk/js/src/relayer/structs.ts
@@ -78,6 +78,7 @@ export type RedeliveryInstructionPrintable = {
 
 export interface EVMExecutionInfoV1 {
   gasLimit: BigNumber;
+  verifyDeliveryVaa: boolean;
   targetChainRefundPerGasUnused: BigNumber;
 }
 
@@ -223,12 +224,15 @@ export function parseEVMExecutionInfoV1(
   const gasLimit = ethers.BigNumber.from(
     Uint8Array.prototype.subarray.call(bytes, idx, idx + 32)
   );
+  idx += 31;
+  const verifyDeliveryVaa = bytes.readUInt8(idx) == 1;
+  idx += 1;
   idx += 32;
   const targetChainRefundPerGasUnused = ethers.BigNumber.from(
     Uint8Array.prototype.subarray.call(bytes, idx, idx + 32)
   );
   idx += 32;
-  return [{ gasLimit, targetChainRefundPerGasUnused }, idx];
+  return [{ gasLimit, verifyDeliveryVaa, targetChainRefundPerGasUnused }, idx];
 }
 
 export function parseWormholeRelayerResend(


### PR DESCRIPTION
Allows a codepath where you can request your delivery to be executed without verifying the delivery vaa

In which case, it will call the IWormholeReceiverUnsafe.receiveWormholeMessagesUnsafe endpoint

---------------------------------
**Note 1: The SLA changes** - it becomes: 'we guarantee that in all scenarios, an event will be emitted for your delivery instruction **where the 'deliveryVaa' input is a correctly signed VAA' and all 'additionalVaa's are correctly signed VAAs**

This means that we'd want the SDK to check that the delivery VAA (and all additional VAAs) are indeed signed correctly to truly validate the SLA. 

As such, I updated the SDK to make this check (so it ignores any relays that have invalid delivery VAAs or invalid additional VAAs)

(I think we should make this part of the SLA whether or not we do not implement this feature, because relayers can pass in invalid 'additionalVaas' even currently and get the event to show up. It should be the case that if you did a relay with invalid 'additionalVaas', the SLA is not satisfied, and we can easily check this when we check for status in the SDK)

Note 2: We also make the optimization of not having the delivery VAA be verified for cross-chain refunds! No reason for this to be verified as long as it is clear that the SLA involves it being signed correctly. 

Note 3: It is important to think about how users could accidently request their delivery to be unverified if they intended for it to be verified. The only way a user could possibly do this is if:

- they use the most generic 'send' and specifically request their delivery VAA to not be verified, by encoding it into executionparams
- they use the most generic 'forward' and specifically request their delivery VAA to not be verified, by encoding it into executionparams

(note: only power users are ever going to touch these most generic functions probably)

- they use the most generic 'forward' and specifically request their delivery VAA to not be verified. If this is a big concern, we can have a seperate forwardVaasToEvmWithoutVerification() endpoint just like we do for send

- they use the function sendVaasToEvmWithoutVerification() endpoint **which doesn't have a payload field**

But in all four of these cases, the user would also have to explicitly implement a IWormholeReceiverUnsafe endpoint that explicitly only has a 'vaas' field and no other fields!
`function receiveWormholeMessagesUnsafe(
        bytes[] memory vaas
    ) external payable;`