### PR TITLE
node/acct: Wait for guardian set on startup

### DIFF
--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -920,7 +920,7 @@ func runNode(cmd *cobra.Command, args []string) {
 	msgReadC, msgWriteC := makeChannelPair[*common.MessagePublication](0)
 
 	// Ethereum incoming guardian set updates
-	setReadC, setWriteC := makeChannelPair[*common.GuardianSet](0)
+	setReadC, setWriteC := makeChannelPair[*common.GuardianSet](1)
 
 	// Inbound signed VAAs
 	signedInReadC, signedInWriteC := makeChannelPair[*gossipv1.SignedVAAWithQuorum](50)

--- a/node/pkg/accountant/accountant.go
+++ b/node/pkg/accountant/accountant.go
@@ -134,6 +134,13 @@ func NewAccountant(
 // Run initializes the accountant and starts the watcher runnable.
 func (acct *Accountant) Start(ctx context.Context) error {
 	acct.logger.Debug("entering Start", zap.Bool("enforceFlag", acct.enforceFlag))
+
+	// wait for GuardianSet TODO this could probably be refactored to cleanly define the dependencies first
+	for acct.gst.Get() == nil || len(acct.gst.Get().Keys) == 0 {
+		time.Sleep(time.Millisecond * 100)
+	}
+	acct.logger.Debug("guardianset found")
+
 	acct.pendingTransfersLock.Lock()
 	defer acct.pendingTransfersLock.Unlock()
 


### PR DESCRIPTION
I think this was causing ci tests to fail intermittently
