### PR TITLE
scripts/update-guardian-set: move new-guardianset.prototxt to /tmp/

### DIFF
--- a/scripts/update-guardian-set.sh
+++ b/scripts/update-guardian-set.sh
@@ -18,7 +18,7 @@ echo "namespace ${namespace}"
 # file & path to save governance VAA
 tmpFile=$(mktemp -q)
 if [ $? -ne 0 ]; then
-    echo "$0: Can't create temp file, bye.."
+    echo "$0: Can't create temp file, bye.." 1>&2;
     exit 1
 fi
 trap 'rm -f -- "$tmpFile"' EXIT
@@ -119,8 +119,3 @@ else
 fi
 
 echo "update-guardian-set.sh succeeded."
-
-# clean up logic
-rm -f -- "$tmpFile"
-trap - EXIT
-exit


### PR DESCRIPTION
This PR fixes a race condition in CI tests where the creation of the new-guardianset.prototxt led to Tilt reloading some resources, causing their state to be modified, which then could lead to failed CI tests
The problem is addressed by instead creating the file in /tmp/
