### PR TITLE
node: rm dep github.com/test-go/testify

### DIFF
--- a/node/go.mod
+++ b/node/go.mod
@@ -57,7 +57,6 @@ require (
 	github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d
 	github.com/holiman/uint256 v1.2.1
 	github.com/prometheus/client_model v0.3.0
-	github.com/test-go/testify v1.1.4
 	github.com/wormhole-foundation/wormchain v0.0.0-00010101000000-000000000000
 	github.com/wormhole-foundation/wormhole/sdk v0.0.0-20220926172624-4b38dc650bb0
 	golang.org/x/exp v0.0.0-20230321023759-10a507213a29

--- a/node/pkg/common/scissors_test.go
+++ b/node/pkg/common/scissors_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/test-go/testify/require"
+	"github.com/stretchr/testify/require"
 
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"

--- a/node/pkg/governor/governor_monitoring_test.go
+++ b/node/pkg/governor/governor_monitoring_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/certusone/wormhole/node/pkg/common"
 	"github.com/stretchr/testify/assert"
-	"github.com/test-go/testify/require"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 )
 

--- a/node/pkg/p2p/watermark_test.go
+++ b/node/pkg/p2p/watermark_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/test-go/testify/require"
+	"github.com/stretchr/testify/require"
 
 	"github.com/certusone/wormhole/node/pkg/accountant"
 	node_common "github.com/certusone/wormhole/node/pkg/common"

--- a/node/pkg/watchers/near/nearapi/nearapi_test.go
+++ b/node/pkg/watchers/near/nearapi/nearapi_test.go
@@ -11,7 +11,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/certusone/wormhole/node/pkg/watchers/near/nearapi"
-	"github.com/test-go/testify/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 type (

--- a/node/pkg/watchers/near/watcher_test.go
+++ b/node/pkg/watchers/near/watcher_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/certusone/wormhole/node/pkg/supervisor"
 	mockserver "github.com/certusone/wormhole/node/pkg/watchers/near/nearapi/mock"
 	eth_common "github.com/ethereum/go-ethereum/common"
-	"github.com/test-go/testify/assert"
+	"github.com/stretchr/testify/assert"
 	"github.com/wormhole-foundation/wormhole/sdk/vaa"
 	"go.uber.org/zap"
 )


### PR DESCRIPTION
Remove github.com/test-go/testify since there is github.com/stretchr/testify already. 
