### PR TITLE
Node: Make IBC watcher publish wormchain version

### DIFF
--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -1144,7 +1144,7 @@ func runNode(cmd *cobra.Command, args []string) {
 			nil,
 			nil,
 			components,
-			&ibc.Features)); err != nil {
+			ibc.GetFeatures)); err != nil {
 			return err
 		}
 

--- a/node/pkg/p2p/p2p.go
+++ b/node/pkg/p2p/p2p.go
@@ -154,7 +154,7 @@ func Run(
 	signedGovCfg chan *gossipv1.SignedChainGovernorConfig,
 	signedGovSt chan *gossipv1.SignedChainGovernorStatus,
 	components *Components,
-	ibcFeatures *string,
+	ibcFeaturesFunc func() string,
 ) func(ctx context.Context) error {
 	if components == nil {
 		components = DefaultComponents()
@@ -307,8 +307,11 @@ func Run(
 						if acct != nil {
 							features = append(features, acct.FeatureString())
 						}
-						if ibcFeatures != nil && *ibcFeatures != "" {
-							features = append(features, *ibcFeatures)
+						if ibcFeaturesFunc != nil {
+							ibcFlags := ibcFeaturesFunc()
+							if ibcFlags != "" {
+								features = append(features, ibcFlags)
+							}
 						}
 
 						heartbeat := &gossipv1.Heartbeat{

--- a/node/pkg/watchers/ibc/watcher.go
+++ b/node/pkg/watchers/ibc/watcher.go
@@ -47,7 +47,7 @@ type (
 	}
 )
 
-// Returns the IBC feature string that can be published in heartbeat messages.
+// GetFeatures returns the IBC feature string that can be published in heartbeat messages.
 func GetFeatures() string {
 	featuresMutex.Lock()
 	defer featuresMutex.Unlock()

--- a/node/pkg/watchers/ibc/watcher.go
+++ b/node/pkg/watchers/ibc/watcher.go
@@ -396,7 +396,7 @@ func (w *Watcher) handleQueryBlockHeight(ctx context.Context, queryUrl string) e
 			}
 
 			readiness.SetReady(common.ReadinessIBCSyncing)
-			setFeatures(w.baseFeatures + "|" + abciInfo.Result.Response.Version)
+			setFeatures(w.baseFeatures + ":" + abciInfo.Result.Response.Version)
 		}
 	}
 }


### PR DESCRIPTION
This PR adds the wormchain version string to the IBC feature flag. The flag will look something like this:
`ibc:sei|v0.0.1` where `v0.0.1` is the wormchain version string from devnet.