### PR TITLE
ethereum/Makefile: split test-identifiers from test-forge target

### DIFF
--- a/ethereum/Makefile
+++ b/ethereum/Makefile
@@ -57,7 +57,7 @@ flattened: $(patsubst contracts/%, flattened/%, $(FLATTEN_FILES))
 .env: .env.test
 	cp $< $@
 
-test: test-forge test-ganache
+test: test-forge test-identifiers test-ganache
 
 .PHONY: test-ganache
 test-ganache: build .env dependencies
@@ -72,10 +72,13 @@ test-upgrade: build .env node_modules
 	./simulate_upgrades
 
 .PHONY:
-test-forge: dependencies
+test-identifiers: dependencies
 	./compare-method-identifiers.sh contracts/Implementation.sol:Implementation contracts/interfaces/IWormhole.sol:IWormhole
 	./compare-method-identifiers.sh contracts/bridge/BridgeImplementation.sol:BridgeImplementation contracts/bridge/interfaces/ITokenBridge.sol:ITokenBridge
 	./compare-method-identifiers.sh contracts/nft/NFTBridgeImplementation.sol:NFTBridgeImplementation contracts/nft/interfaces/INFTBridge.sol:INFTBridge
+
+.PHONY:
+test-forge: dependencies
 	forge test
 
 clean:


### PR DESCRIPTION
This way, running `test-forge` is quicker. `make test` still runs all the tests.