### PR TITLE
Revert "ethereum: fix view error with newer version of forge"

### DIFF
--- a/ethereum/forge-test/TokenImplementation.t.sol
+++ b/ethereum/forge-test/TokenImplementation.t.sol
@@ -78,7 +78,7 @@ contract TestTokenImplementation is TokenImplementation, Test {
         address spender,
         uint256 amount,
         uint256 deadline
-    ) public returns (SignatureSetup memory output) {
+    ) public view returns (SignatureSetup memory output) {
         // prepare signer allowing for tokens to be spent
         uint256 sk = uint256(walletPrivateKey);
         output.allower = vm.addr(sk);


### PR DESCRIPTION
This reverts commit 05cec3d7293d056baffa6bde5ad84da893155fe3 (#3059)

The commit was erroneously included in anticipation of a forge version update, but it actually only generates an error with an outdated forge-stdlib version.

The old version's `vm.addr` function
(see
https://github.com/foundry-rs/forge-std/blob/ddb69063e4c9cc4aa863b224fc8a166be5d330ce/src/Vm.sol#L15) has no `pure` modifier, thus any function using it can not be `pure` (or `view`). The new version (see
https://github.com/foundry-rs/forge-std/blob/66bf4e2c92cf507531599845e8d5a08cc2e3b5bb/src/Vm.sol#L55) on the other hand does. In fact, with the new version, removing the modifier produces a warning.