### PR TITLE
node: Wait for bootstrap guardian in devnet

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -15,6 +15,16 @@ def set_replicas_in_statefulset(config_yaml, statefulset_name,  num_replicas):
             obj["spec"]["replicas"] = num_replicas
     return config_yaml
 
+# set the env value of all containers in all jobs
+def set_env_in_jobs(config_yaml, name, value):
+    for obj in config_yaml:
+        if obj["kind"] == "Job":
+            for container in obj["spec"]["template"]["spec"]["containers"]:
+                if not "env" in container:
+                    container["env"] = []
+                container["env"].append({"name": name, "value": value})
+    return config_yaml
+
 allow_k8s_contexts("ci")
 
 # Disable telemetry by default
@@ -615,7 +625,7 @@ if ci_tests:
         ],
     )
 
-    k8s_yaml_with_ns("devnet/tests.yaml")
+    k8s_yaml_with_ns(encode_yaml_stream(set_env_in_jobs(read_yaml_stream("devnet/tests.yaml"), "NUM_GUARDIANS", str(num_guardians))))
 
     # separate resources to parallelize docker builds
     k8s_resource(

--- a/devnet/tests.yaml
+++ b/devnet/tests.yaml
@@ -38,7 +38,7 @@ spec:
           command:
             - /bin/sh
             - -c
-            - "sh /app/testing/spydk.sh && touch /app/testing/success"
+            - "bash /app/testing/spydk.sh && touch /app/testing/success"
           readinessProbe:
             exec:
               command:

--- a/testing/Dockerfile.spydk.test
+++ b/testing/Dockerfile.spydk.test
@@ -1,6 +1,7 @@
-FROM node:16-alpine@sha256:004dbac84fed48e20f9888a23e32fa7cf83c2995e174a78d41d9a9dd1e051a20
+FROM node:19.6.1-slim@sha256:a1ba21bf0c92931d02a8416f0a54daad66cb36a85d2b73af9d73b044f5f57cfc
 
-RUN apk update && apk add g++ make python3 curl
+RUN apt-get update && apt-get -y install \
+  git python3 make curl netcat
 
 RUN mkdir -p /app
 WORKDIR /app

--- a/testing/sdk.sh
+++ b/testing/sdk.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 set -e
-while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' guardian:6060/readyz)" != "200" ]]; do sleep 5; done
+num=${NUM_GUARDIANS:-1} # default value for NUM_GUARDIANS = 1
+for ((i=0; i<num; i++)); do
+    while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' guardian-$i.guardian:6060/readyz)" != "200" ]]; do sleep 5; echo "waiting for guardian $i"; done
+done
+
 while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' spy:6060/metrics)" != "200" ]]; do sleep 5; done
 while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' ibc-relayer:7597/debug/pprof/)" != "200" ]]; do sleep 5; done
 while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' relayer-engine:3000/metrics)" != "200" ]]; do sleep 5; done

--- a/testing/spydk.sh
+++ b/testing/spydk.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 set -e
-while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' guardian:6060/readyz)" != "200" ]]; do sleep 5; done
+num=${NUM_GUARDIANS:-1} # default value for NUM_GUARDIANS = 1
+for ((i=0; i<num; i++)); do
+    while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' guardian-$i.guardian:6060/readyz)" != "200" ]]; do sleep 5; done
+done
 while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' spy:6060/metrics)" != "200" ]]; do sleep 5; done
 CI=true npm --prefix ../spydk/js run test-ci

--- a/wormchain/contracts/tools/test_accountant.sh
+++ b/wormchain/contracts/tools/test_accountant.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
 set -e
-while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' guardian:6060/readyz)" != "200" ]]; do sleep 5; done
+num=${NUM_GUARDIANS:-1} # default value for NUM_GUARDIANS = 1
+for ((i=0; i<num; i++)); do
+    while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' guardian-$i.guardian:6060/readyz)" != "200" ]]; do sleep 5; done
+done
 CI=true npm run test-accountant


### PR DESCRIPTION
This PR fixes a race condition in devnet where the p2p network may silently fail to start because at the time guardian-1 tries to connect to guardian-0 (bootstrat node) it may not be online yet. The race condition was more frequenly hit after a refactor, see https://github.com/wormhole-foundation/wormhole/pull/3024#issuecomment-1591803726
