### PR TITLE
Node/Watcher: Terra Classic fix

### DIFF
--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -1323,7 +1323,7 @@ func runNode(cmd *cobra.Command, args []string) {
 			common.MustRegisterReadinessSyncing(vaa.ChainIDTerra)
 			chainObsvReqC[vaa.ChainIDTerra] = make(chan *gossipv1.ObservationRequest, observationRequestBufferSize)
 			if err := supervisor.Run(ctx, "terrawatch",
-				common.WrapWithScissors(cosmwasm.NewWatcher(*terraWS, *terraLCD, *terraContract, chainMsgC[vaa.ChainIDTerra], chainObsvReqC[vaa.ChainIDTerra], vaa.ChainIDTerra).Run, "terrawatch")); err != nil {
+				common.WrapWithScissors(cosmwasm.NewWatcher(*terraWS, *terraLCD, *terraContract, chainMsgC[vaa.ChainIDTerra], chainObsvReqC[vaa.ChainIDTerra], vaa.ChainIDTerra, *unsafeDevMode).Run, "terrawatch")); err != nil {
 				return err
 			}
 		}
@@ -1333,7 +1333,7 @@ func runNode(cmd *cobra.Command, args []string) {
 			common.MustRegisterReadinessSyncing(vaa.ChainIDTerra2)
 			chainObsvReqC[vaa.ChainIDTerra2] = make(chan *gossipv1.ObservationRequest, observationRequestBufferSize)
 			if err := supervisor.Run(ctx, "terra2watch",
-				common.WrapWithScissors(cosmwasm.NewWatcher(*terra2WS, *terra2LCD, *terra2Contract, chainMsgC[vaa.ChainIDTerra2], chainObsvReqC[vaa.ChainIDTerra2], vaa.ChainIDTerra2).Run, "terra2watch")); err != nil {
+				common.WrapWithScissors(cosmwasm.NewWatcher(*terra2WS, *terra2LCD, *terra2Contract, chainMsgC[vaa.ChainIDTerra2], chainObsvReqC[vaa.ChainIDTerra2], vaa.ChainIDTerra2, *unsafeDevMode).Run, "terra2watch")); err != nil {
 				return err
 			}
 		}
@@ -1343,7 +1343,7 @@ func runNode(cmd *cobra.Command, args []string) {
 			common.MustRegisterReadinessSyncing(vaa.ChainIDXpla)
 			chainObsvReqC[vaa.ChainIDXpla] = make(chan *gossipv1.ObservationRequest, observationRequestBufferSize)
 			if err := supervisor.Run(ctx, "xplawatch",
-				common.WrapWithScissors(cosmwasm.NewWatcher(*xplaWS, *xplaLCD, *xplaContract, chainMsgC[vaa.ChainIDXpla], chainObsvReqC[vaa.ChainIDXpla], vaa.ChainIDXpla).Run, "xplawatch")); err != nil {
+				common.WrapWithScissors(cosmwasm.NewWatcher(*xplaWS, *xplaLCD, *xplaContract, chainMsgC[vaa.ChainIDXpla], chainObsvReqC[vaa.ChainIDXpla], vaa.ChainIDXpla, *unsafeDevMode).Run, "xplawatch")); err != nil {
 				return err
 			}
 		}
@@ -1417,7 +1417,7 @@ func runNode(cmd *cobra.Command, args []string) {
 			common.MustRegisterReadinessSyncing(vaa.ChainIDInjective)
 			chainObsvReqC[vaa.ChainIDInjective] = make(chan *gossipv1.ObservationRequest, observationRequestBufferSize)
 			if err := supervisor.Run(ctx, "injectivewatch",
-				common.WrapWithScissors(cosmwasm.NewWatcher(*injectiveWS, *injectiveLCD, *injectiveContract, chainMsgC[vaa.ChainIDInjective], chainObsvReqC[vaa.ChainIDInjective], vaa.ChainIDInjective).Run, "injectivewatch")); err != nil {
+				common.WrapWithScissors(cosmwasm.NewWatcher(*injectiveWS, *injectiveLCD, *injectiveContract, chainMsgC[vaa.ChainIDInjective], chainObsvReqC[vaa.ChainIDInjective], vaa.ChainIDInjective, *unsafeDevMode).Run, "injectivewatch")); err != nil {
 				return err
 			}
 		}

--- a/node/pkg/watchers/cosmwasm/watcher.go
+++ b/node/pkg/watchers/cosmwasm/watcher.go
@@ -102,14 +102,21 @@ func NewWatcher(
 	contract string,
 	msgC chan<- *common.MessagePublication,
 	obsvReqC <-chan *gossipv1.ObservationRequest,
-	chainID vaa.ChainID) *Watcher {
+	chainID vaa.ChainID,
+	unsafeDevMode bool,
+) *Watcher {
 
 	// CosmWasm 1.0.0
-	// Terra Classic upgraded CosmWasm versions, so they now use the new format. Here is a message from their Discord:
-	//		The v2.1.1 upgrade will occur on blockheight 13215800 on June 14th (2023) at approximately 14:00 UTC.
-	// Queries for transactions before that block no longer work, so we don't have to worry about supporting them.
 	contractAddressFilterKey := "execute._contract_address"
 	contractAddressLogKey := "_contract_address"
+	if chainID == vaa.ChainIDTerra && unsafeDevMode {
+		// Terra Classic upgraded CosmWasm versions, so they now use the new format. Here is a message from their Discord:
+		//		The v2.1.1 upgrade will occur on blockheight 13215800 on June 14th (2023) at approximately 14:00 UTC.
+		// Queries for transactions before that block no longer work, so we don't have to worry about supporting them.
+		// It is going to take some work to upgrade our tilt environment, so for now, stick with the old format in dev.
+		contractAddressFilterKey = "execute_contract.contract_address"
+		contractAddressLogKey = "contract_address"
+	}
 
 	// Do not add a leading slash
 	latestBlockURL := "blocks/latest"

--- a/node/pkg/watchers/cosmwasm/watcher.go
+++ b/node/pkg/watchers/cosmwasm/watcher.go
@@ -105,13 +105,11 @@ func NewWatcher(
 	chainID vaa.ChainID) *Watcher {
 
 	// CosmWasm 1.0.0
+	// Terra Classic upgraded CosmWasm versions, so they now use the new format. Here is a message from their Discord:
+	//		The v2.1.1 upgrade will occur on blockheight 13215800 on June 14th (2023) at approximately 14:00 UTC.
+	// Queries for transactions before that block no longer work, so we don't have to worry about supporting them.
 	contractAddressFilterKey := "execute._contract_address"
 	contractAddressLogKey := "_contract_address"
-	if chainID == vaa.ChainIDTerra {
-		// CosmWasm <1.0.0
-		contractAddressFilterKey = "execute_contract.contract_address"
-		contractAddressLogKey = "contract_address"
-	}
 
 	// Do not add a leading slash
 	latestBlockURL := "blocks/latest"
@@ -405,6 +403,10 @@ func EventsToMessagePublications(contract string, txHash string, events []gjson.
 				logger.Debug("duplicate key in events", zap.String("network", networkName), zap.String("tx_hash", txHash), zap.String("key", keyBase.String()), zap.String("value", valueBase.String()))
 				continue
 			}
+
+			logger.Debug("msg attribute",
+				zap.String("network", networkName),
+				zap.String("tx_hash", txHash), zap.String("key", string(key)), zap.String("value", string(value)))
 
 			mappedAttributes[string(key)] = string(value)
 		}


### PR DESCRIPTION
On June 14, 2023, Terra Classic upgraded their cosmwasm version, which changed the format of message publications. They change from using `contract_address` to using `_contract_address` (like the other cosmwasm chains). This PR updates the watcher to reflect that.