### PR TITLE
Tilt: force cargo to use git to fix SSL issue

### DIFF
--- a/solana/Dockerfile
+++ b/solana/Dockerfile
@@ -16,6 +16,7 @@ COPY Cargo.toml Cargo.toml
 COPY Cargo.lock Cargo.lock
 COPY solitaire solitaire
 COPY external external
+COPY config.toml config.toml
 
 ENV RUST_LOG="solana_runtime::system_instruction_processor=trace,solana_runtime::message_processor=trace,solana_bpf_loader=debug,solana_rbpf=debug"
 ENV RUST_BACKTRACE=1

--- a/solana/config.toml
+++ b/solana/config.toml
@@ -1,0 +1,3 @@
+[net]
+retry = 2 # network retries
+git-fetch-with-cli = true


### PR DESCRIPTION
While building the environment for the Solana container, cargo needs to fetch some index for dependencies. 

Locally this step was failing with a `SSL error: syscall failure: Connection reset by peer; class=Os (2)` error.

This seems to be a [common issue](
https://github.com/rust-lang/cargo/issues/6513) but forcing cargo to use git cli tool allows it to fetch dependencies. 

<details>
<summary>
environment
</summary>

```
> wsl --version
WSL version: 1.2.5.0
Kernel version: 5.15.90.1
WSLg version: 1.0.51
Windows version: 10.0.22621.1926
```

```
$ tilt doctor
Tilt: v0.32.4, built 2023-05-24
System: linux-amd64
---
Docker (cluster)
- Host: tcp://127.0.0.1:52109
- Server Version: 23.0.2
- API Version: 1.42
- Builder: 2
---
Docker (local)
- Host: unix:///var/run/docker.sock
- Server Version: 23.0.5
- Version: 1.42
- Builder: 2
- Compose Version: v2.17.3
---
Kubernetes
- Env: minikube
- Context: minikube
- Cluster Name: minikube
- Namespace: default
- Container Runtime: docker
- Version: v1.26.3
- Cluster Local Registry: none
---
```
</details>


Marked as draft since I'm not sure this is the _best_ fix or if there are any issues with this approach?