### PR TITLE
EVM: Fix test token deployment script

### DIFF
--- a/ethereum/scripts/deploy_test_token.js
+++ b/ethereum/scripts/deploy_test_token.js
@@ -84,7 +84,7 @@ module.exports = async function(callback) {
 
     console.log("WETH token deployed at: " + wethAddress);
 
-    for (let idx = 2; idx < 11; idx++) {
+    for (let idx = 2; idx < 10; idx++) {
       await token.methods.mint(accounts[idx], "1000000000000000000000").send({
         from: accounts[0],
         gas: 1000000,


### PR DESCRIPTION
Using Wormhole Local Validator with EVM throws an error message

```
NFT deployed at: 0x5b9b42d6e4B2e4Bf8d42Eba32D46918e10899B66
WETH token deployed at: 0xDDb64fE46a91D46ee29420539FC25FD07c5FEa3E
Error: invalid address (argument="address", value=undefined, code=INVALID_ARGUMENT, version=address/5.6.1) (argument="to", value=undefined, code=INVALID_ARGUMENT, version=abi/5.6.4) ....
```

Which ultimately traces back to this deployment script where a single line was changed to set this value to 11 from 10. 

This pr reverts that change under the assumption that it was a typo, though it may have been intentional so marking as draft.