### PR TITLE
node/p2p: improve startup

### DIFF
--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -833,8 +833,10 @@ func runNode(cmd *cobra.Command, args []string) {
 				logger.Info("Error resolving guardian-0.guardian. Trying again...")
 				time.Sleep(time.Second)
 			}
-			// TODO this is a hack. If this is not the bootstrap Guardian, we wait 5s such that the bootstrap Guardian has enough time to start.
-			logger.Info("This is not a bootstrap Guardian. Waiting another 10 seconds so the bootstrap guardian to come online.")
+			// TODO this is a hack. If this is not the bootstrap Guardian, we wait 10s such that the bootstrap Guardian has enough time to start.
+			// This may no longer be necessary because now the p2p.go ensures that it can connect to at least one bootstrap peer and will
+			// exit the whole guardian if it is unable to. Sleeping here for a bit may reduce overall startup time by preventing unnecessary restarts, though.
+			logger.Info("This is not a bootstrap Guardian. Waiting another 10 seconds for the bootstrap guardian to come online.")
 			time.Sleep(time.Second * 10)
 		}
 	} else {

--- a/node/pkg/node/node_test.go
+++ b/node/pkg/node/node_test.go
@@ -542,6 +542,9 @@ func testConsensus(t *testing.T, testCases []testCase, numGuardians int) {
 		for i := 0; i < numGuardians; i++ {
 			gRun := mockGuardianRunnable(gs, uint(i), obsDb)
 			err := supervisor.Run(ctx, fmt.Sprintf("g-%d", i), gRun)
+			if i == 0 && numGuardians > 1 {
+				time.Sleep(time.Second) // give the bootstrap guardian some time to start up
+			}
 			assert.NoError(t, err)
 		}
 		logger.Info("All Guardians initiated.")

--- a/node/pkg/p2p/p2p.go
+++ b/node/pkg/p2p/p2p.go
@@ -255,6 +255,49 @@ func Run(
 			return fmt.Errorf("failed to subscribe topic: %w", err)
 		}
 
+		// Make sure we connect to at least 1 bootstrap node (this is particularly important in a local devnet and CI
+		// as peer discovery can take a long time).
+
+		// Count number of successful connection attempts. If we fail to connect to any bootstrap peer, kill the service
+		// TODO: Currently, returning from this function will lead to rootCtxCancel() being called in the defer() above.
+		// 		The service will then be restarted by Tilt/kubernetes
+		successes := 0
+		// Are we a bootstrap node? If so, it's okay to not have any peers.
+		bootstrapNode := false
+
+		for _, addr := range strings.Split(bootstrapPeers, ",") {
+			if addr == "" {
+				continue
+			}
+			ma, err := multiaddr.NewMultiaddr(addr)
+			if err != nil {
+				logger.Error("Invalid bootstrap address", zap.String("peer", addr), zap.Error(err))
+				continue
+			}
+			pi, err := peer.AddrInfoFromP2pAddr(ma)
+			if err != nil {
+				logger.Error("Invalid bootstrap address", zap.String("peer", addr), zap.Error(err))
+				continue
+			}
+
+			if pi.ID == h.ID() {
+				logger.Info("We're a bootstrap node")
+				bootstrapNode = true
+				continue
+			}
+
+			if err = h.Connect(ctx, *pi); err != nil {
+				logger.Error("Failed to connect to bootstrap peer", zap.String("peer", addr), zap.Error(err))
+			} else {
+				successes += 1
+			}
+		}
+
+		if successes == 0 && !bootstrapNode {
+			return fmt.Errorf("failed to connect to any bootstrap peer")
+		}
+		logger.Info("Connected to bootstrap peers", zap.Int("num", successes))
+
 		logger.Info("Node has been started", zap.String("peer_id", h.ID().String()),
 			zap.String("addrs", fmt.Sprintf("%v", h.Addrs())))
 

--- a/node/pkg/p2p/p2p.go
+++ b/node/pkg/p2p/p2p.go
@@ -135,6 +135,47 @@ func DefaultConnectionManager() (*connmgr.BasicConnMgr, error) {
 	)
 }
 
+// bootstrapAddrs takes a comma-separated string of multi-address strings and returns an array of []peer.AddrInfo that does not include `self`.
+// if `self` is part of `bootstrapPeers`, return isBootstrapNode=true
+func bootstrapAddrs(logger *zap.Logger, bootstrapPeers string, self peer.ID) (bootstrappers []peer.AddrInfo, isBootstrapNode bool) {
+	bootstrappers = make([]peer.AddrInfo, 0)
+	for _, addr := range strings.Split(bootstrapPeers, ",") {
+		if addr == "" {
+			continue
+		}
+		ma, err := multiaddr.NewMultiaddr(addr)
+		if err != nil {
+			logger.Error("Invalid bootstrap address", zap.String("peer", addr), zap.Error(err))
+			continue
+		}
+		pi, err := peer.AddrInfoFromP2pAddr(ma)
+		if err != nil {
+			logger.Error("Invalid bootstrap address", zap.String("peer", addr), zap.Error(err))
+			continue
+		}
+		if pi.ID == self {
+			logger.Info("We're a bootstrap node")
+			isBootstrapNode = true
+			continue
+		}
+		bootstrappers = append(bootstrappers, *pi)
+	}
+	return
+}
+
+// connectToPeers connects `h` to `peers` and returns the number of successful connections.
+func connectToPeers(ctx context.Context, logger *zap.Logger, h host.Host, peers []peer.AddrInfo) (successes int) {
+	successes = 0
+	for _, p := range peers {
+		if err := h.Connect(ctx, p); err != nil {
+			logger.Error("Failed to connect to bootstrap peer", zap.String("peer", p.String()), zap.Error(err))
+		} else {
+			successes += 1
+		}
+	}
+	return successes
+}
+
 func Run(
 	obsvC chan<- *gossipv1.SignedObservation,
 	obsvReqC chan<- *gossipv1.ObservationRequest,
@@ -189,27 +230,9 @@ func Run(
 			// Let this host use the DHT to find other hosts
 			libp2p.Routing(func(h host.Host) (routing.PeerRouting, error) {
 				logger.Info("Connecting to bootstrap peers", zap.String("bootstrap_peers", bootstrapPeers))
-				bootstrappers := make([]peer.AddrInfo, 0)
-				for _, addr := range strings.Split(bootstrapPeers, ",") {
-					if addr == "" {
-						continue
-					}
-					ma, err := multiaddr.NewMultiaddr(addr)
-					if err != nil {
-						logger.Error("Invalid bootstrap address", zap.String("peer", addr), zap.Error(err))
-						continue
-					}
-					pi, err := peer.AddrInfoFromP2pAddr(ma)
-					if err != nil {
-						logger.Error("Invalid bootstrap address", zap.String("peer", addr), zap.Error(err))
-						continue
-					}
-					if pi.ID == h.ID() {
-						logger.Info("We're a bootstrap node")
-						continue
-					}
-					bootstrappers = append(bootstrappers, *pi)
-				}
+
+				bootstrappers, _ := bootstrapAddrs(logger, bootstrapPeers, h.ID())
+
 				// TODO(leo): Persistent data store (i.e. address book)
 				idht, err := dht.New(ctx, h, dht.Mode(dht.ModeServer),
 					// This intentionally makes us incompatible with the global IPFS DHT
@@ -258,42 +281,16 @@ func Run(
 		// Make sure we connect to at least 1 bootstrap node (this is particularly important in a local devnet and CI
 		// as peer discovery can take a long time).
 
-		// Count number of successful connection attempts. If we fail to connect to any bootstrap peer, kill the service
-		// TODO: Currently, returning from this function will lead to rootCtxCancel() being called in the defer() above.
-		// 		The service will then be restarted by Tilt/kubernetes
-		successes := 0
-		// Are we a bootstrap node? If so, it's okay to not have any peers.
-		bootstrapNode := false
+		bootstrappers, bootstrapNode := bootstrapAddrs(logger, bootstrapPeers, h.ID())
+		successes := connectToPeers(ctx, logger, h, bootstrappers)
 
-		for _, addr := range strings.Split(bootstrapPeers, ",") {
-			if addr == "" {
-				continue
-			}
-			ma, err := multiaddr.NewMultiaddr(addr)
-			if err != nil {
-				logger.Error("Invalid bootstrap address", zap.String("peer", addr), zap.Error(err))
-				continue
-			}
-			pi, err := peer.AddrInfoFromP2pAddr(ma)
-			if err != nil {
-				logger.Error("Invalid bootstrap address", zap.String("peer", addr), zap.Error(err))
-				continue
-			}
-
-			if pi.ID == h.ID() {
-				logger.Info("We're a bootstrap node")
-				bootstrapNode = true
-				continue
-			}
-
-			if err = h.Connect(ctx, *pi); err != nil {
-				logger.Error("Failed to connect to bootstrap peer", zap.String("peer", addr), zap.Error(err))
-			} else {
-				successes += 1
-			}
+		if bootstrapNode {
+			logger.Info("We are a bootstrap node.")
 		}
 
-		if successes == 0 && !bootstrapNode {
+		if successes == 0 && !bootstrapNode { // If we're a bootstrap node it's okay to not have any peers.
+			// If we fail to connect to any bootstrap peer, kill the service
+			// returning from this function will lead to rootCtxCancel() being called in the defer() above. The service will then be restarted by Tilt/kubernetes.
 			return fmt.Errorf("failed to connect to any bootstrap peer")
 		}
 		logger.Info("Connected to bootstrap peers", zap.Int("num", successes))

--- a/node/pkg/p2p/p2p.go
+++ b/node/pkg/p2p/p2p.go
@@ -282,7 +282,9 @@ func Run(
 			ourAddr := ethcrypto.PubkeyToAddress(gk.PublicKey)
 
 			ctr := int64(0)
-			timer := time.NewTimer(time.Nanosecond) // Guardians should send out their first heartbeat immediately to speed up test runs.
+			// Guardians should send out their first heartbeat immediately to speed up test runs.
+			// But we also want to wait a little bit such that network connections can be established by then.
+			timer := time.NewTimer(time.Second * 2)
 			defer timer.Stop()
 
 			for {


### PR DESCRIPTION
This change reduces the runtime of TestConsensus() in node_test.go from ~16s to ~3s and makes startup more reliable in devnet. 

# Delay first heartbeat by 2 seconds
Before this change, the heartbeat was sent immediately (after 1ns), but by then the network connections are not established yet and the heartbeat gets lost, so the tests needed to wait another 15s for the next heartbeat. 

After this change, we wait 2s to send out the first heartbeat, and by then the network is likely to be established. 

# Enforce connection to bootstrap node on startup
This change solves a problem during Guardian startup in devnet / Tilt: 
guardian-1 may start up before guardian-0 and therefore has no bootstrap node to connect to. 
guardian-1's messages then go into the void. 
This has been previously addressed in https://github.com/wormhole-foundation/wormhole/pull/3096 by essentially having guardian-1 wait for 10s before startup. 
However, this 10s number is arbitrary and we don't want to depend on it. With this change, we instead force a connection to the bootstrap node and kill the guardian if not successful (at which point it would get restarted by Kubernetes/Tilt). 