### PR TITLE
node: Add benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ bigtable-writer.json
 /ethereum/cache/
 sui.log.*
 sui/examples/wrapped_coin
+*.prof

--- a/node/pkg/accountant/accountant_test.go
+++ b/node/pkg/accountant/accountant_test.go
@@ -24,6 +24,7 @@ import (
 	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
 	"github.com/wormhole-foundation/wormhole/sdk/vaa"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 )
 
 const (
@@ -323,7 +324,7 @@ func TestInterestingTransferShouldBeBlockedWhenEnforcingAccountant(t *testing.T)
 
 func TestForDeadlock(t *testing.T) {
 	ctx := context.Background()
-	logger, _ := zap.NewDevelopment()
+	logger := zaptest.NewLogger(t)
 	obsvReqWriteC := make(chan *gossipv1.ObservationRequest, 10)
 	acctChan := make(chan *common.MessagePublication, MsgChannelCapacity)
 	wormchainConn := MockAccountantWormchainConn{}

--- a/node/pkg/db/open.go
+++ b/node/pkg/db/open.go
@@ -30,7 +30,7 @@ func (l badgerZapLogger) Debugf(f string, v ...interface{}) {
 }
 
 func OpenDb(logger *zap.Logger, dataDir *string) *Database {
-	var options badger.Options
+	options := badger.DefaultOptions(dbPath)
 
 	if dataDir != nil {
 		dbPath := path.Join(*dataDir, "db")

--- a/node/pkg/db/open.go
+++ b/node/pkg/db/open.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"fmt"
 	"os"
 	"path"
 
@@ -8,8 +9,28 @@ import (
 	"go.uber.org/zap"
 )
 
+type badgerZapLogger struct {
+	*zap.Logger
+}
+
+func (l badgerZapLogger) Errorf(f string, v ...interface{}) {
+	l.Error(fmt.Sprintf(f, v...))
+}
+
+func (l badgerZapLogger) Warningf(f string, v ...interface{}) {
+	l.Warn(fmt.Sprintf(f, v...))
+}
+
+func (l badgerZapLogger) Infof(f string, v ...interface{}) {
+	l.Info(fmt.Sprintf(f, v...))
+}
+
+func (l badgerZapLogger) Debugf(f string, v ...interface{}) {
+	l.Debug(fmt.Sprintf(f, v...))
+}
+
 func OpenDb(logger *zap.Logger, dataDir *string) *Database {
-	var options badger.Options
+	options := badger.DefaultOptions(dbPath)
 
 	if dataDir != nil {
 		dbPath := path.Join(*dataDir, "db")
@@ -21,6 +42,8 @@ func OpenDb(logger *zap.Logger, dataDir *string) *Database {
 	} else {
 		options = badger.DefaultOptions("").WithInMemory(true)
 	}
+
+	options = options.WithLogger(badgerZapLogger{logger})
 
 	db, err := badger.Open(options)
 	if err != nil {

--- a/node/pkg/db/open.go
+++ b/node/pkg/db/open.go
@@ -30,7 +30,7 @@ func (l badgerZapLogger) Debugf(f string, v ...interface{}) {
 }
 
 func OpenDb(logger *zap.Logger, dataDir *string) *Database {
-	options := badger.DefaultOptions(dbPath)
+	var options badger.Options
 
 	if dataDir != nil {
 		dbPath := path.Join(*dataDir, "db")

--- a/node/pkg/node/logcounter.go
+++ b/node/pkg/node/logcounter.go
@@ -1,0 +1,42 @@
+package node
+
+import (
+	"sync/atomic"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+type LogSizeCounter struct {
+	level zapcore.Level
+	ctr   atomic.Uint64
+}
+
+func NewLogSizeCounter(lvl zapcore.Level) *LogSizeCounter {
+	return &LogSizeCounter{
+		level: lvl,
+	}
+}
+
+func (lc *LogSizeCounter) Reset() uint64 {
+	n := lc.ctr.Load()
+	lc.ctr.Store(0)
+	return n
+}
+
+func (lc *LogSizeCounter) Sync() error { return nil }
+
+func (lc *LogSizeCounter) Write(p []byte) (n int, err error) {
+	n = len(p)
+	lc.ctr.Add(uint64(n))
+	return n, nil
+}
+
+func (lc *LogSizeCounter) Core() zapcore.Core {
+	var output zapcore.WriteSyncer = lc
+	encoder := zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig())
+	priority := zap.LevelEnablerFunc(func(lvl zapcore.Level) bool {
+		return lvl >= lc.level
+	})
+	return zapcore.NewCore(encoder, output, priority)
+}

--- a/node/pkg/node/node.go
+++ b/node/pkg/node/node.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	inboundObservationBufferSize         = 50
+	inboundObservationBufferSize         = 5000
 	inboundSignedVaaBufferSize           = 50
 	observationRequestOutboundBufferSize = 50
 	observationRequestInboundBufferSize  = 50

--- a/node/pkg/node/node_test.go
+++ b/node/pkg/node/node_test.go
@@ -154,7 +154,7 @@ func mockGuardianRunnable(testId uint, gs []*mockGuardian, mockGuardianIndex uin
 				ChainID:          vaa.ChainIDSolana,
 				MockObservationC: gs[mockGuardianIndex].MockObservationC,
 				MockSetC:         gs[mockGuardianIndex].MockSetC,
-				ObservationDb:    obsDb, // TODO(future work) add observation DB to support re-observation request
+				ObservationDb:    obsDb,
 			},
 		}
 
@@ -249,7 +249,7 @@ func waitForHeartbeatsInLogs(t testing.TB, zapObserver *observer.ObservedLogs, g
 	}
 }
 
-// waitForPromMetricExceed waits until prometheus metric `metric` >= `min` on all guardians in `gs`.
+// waitForPromMetricGte waits until prometheus metric `metric` >= `min` on all guardians in `gs`.
 // WARNING: Currently, there is only a global registry for all prometheus metrics, leading to all guardian nodes writing to the same one.
 //
 //	As long as this is the case, you probably don't want to use this function.
@@ -257,7 +257,6 @@ func waitForPromMetricGte(t testing.TB, testId uint, ctx context.Context, gs []*
 	metricBytes := []byte(metric)
 	requests := make([]*http.Request, len(gs))
 	readyFlags := make([]bool, len(gs))
-	//logger := supervisor.Logger(ctx)
 
 	// create the prom api clients
 	for i := range gs {
@@ -304,7 +303,6 @@ func waitForPromMetricGte(t testing.TB, testId uint, ctx context.Context, gs []*
 				readyFlags[i] = true
 				readyCounter++
 			}
-
 		}
 		time.Sleep(time.Second * 5) // TODO
 	}
@@ -315,7 +313,6 @@ func waitForVaa(ctx context.Context, c publicrpcv1.PublicRPCServiceClient, msgId
 	var r *publicrpcv1.GetSignedVAAResponse
 	var err error
 
-	//logger := supervisor.Logger(ctx)
 	for {
 		select {
 		case <-ctx.Done():
@@ -862,7 +859,6 @@ func testGuardianConfigurations(t *testing.T, testCases []testCaseGuardianConfig
 			// wait for all options to get applied
 			// If we were expecting an error, we should never get past this point.
 			for len(zapObserver.FilterMessage("GuardianNode initialization done.").All()) == 0 {
-				//logger.Info("Guardian not yet initialized. Waiting 10ms...")
 				time.Sleep(time.Millisecond * 10)
 			}
 
@@ -973,7 +969,6 @@ func BenchmarkCrypto(b *testing.B) {
 	b.Run("ethcrypto (secp256k1)", func(b *testing.B) {
 
 		gk := devnet.InsecureDeterministicEcdsaKeyByIndex(ethcrypto.S256(), 0)
-		//gkc := ethcrypto.CompressPubkey(&gk.PublicKey)
 
 		b.Run("sign", func(b *testing.B) {
 			msgs := signingMsgs(b.N)
@@ -990,7 +985,6 @@ func BenchmarkCrypto(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_, err := ethcrypto.Ecrecover(msgs[i], signatures[i])
 				assert.NoError(b, err)
-				//assert.Equal(b, signer, gkc)
 			}
 		})
 	})
@@ -1143,8 +1137,8 @@ func benchmarkConsensus(t *testing.B, name string, numGuardians int, numMessages
 		assert.NotEqual(t, rootCtx.Err(), context.DeadlineExceeded)
 		zapLogger.Info("Test root context cancelled, exiting...")
 
-		// wait for everything to shut down gracefully TODO since switching to portIds by `testId`, this is no longer necessary
-		//time.Sleep(time.Second * 11) // 11s is needed to gracefully shutdown libp2p
+		// wait for everything to shut down gracefully
+		//time.Sleep(time.Second * 11) // 11s is needed to gracefully shutdown libp2p, but since switching to dedicated ports per `testId`, this is no longer necessary
 		time.Sleep(time.Second * 1) // 1s is needed to gracefully shutdown BadgerDB
 	})
 }

--- a/node/pkg/node/node_test.go
+++ b/node/pkg/node/node_test.go
@@ -175,6 +175,9 @@ func mockGuardianRunnable(testId uint, gs []*mockGuardian, mockGuardianIndex uin
 		adminSocketPath := mockAdminStocket(testId, mockGuardianIndex)
 		rpcMap := make(map[string]string)
 
+		// We set this to None because we don't want to count these logs when counting the amount of logs generated per message
+		publicRpcLogDetail := common.GrpcLogDetailNone
+
 		// assemble all the options
 		guardianOptions := []*GuardianOption{
 			GuardianOptionDatabase(db),
@@ -182,8 +185,8 @@ func mockGuardianRunnable(testId uint, gs []*mockGuardian, mockGuardianIndex uin
 			GuardianOptionNoAccountant(), // disable accountant
 			GuardianOptionGovernor(true),
 			GuardianOptionP2P(gs[mockGuardianIndex].p2pKey, networkID, bootstrapPeers, nodeName, false, p2pPort, func() string { return "" }),
-			GuardianOptionPublicRpcSocket(publicSocketPath, common.GrpcLogDetailFull),
-			GuardianOptionPublicrpcTcpService(publicRpc, common.GrpcLogDetailFull),
+			GuardianOptionPublicRpcSocket(publicSocketPath, publicRpcLogDetail),
+			GuardianOptionPublicrpcTcpService(publicRpc, publicRpcLogDetail),
 			GuardianOptionPublicWeb(mockPublicWeb(testId, mockGuardianIndex), publicSocketPath, "", false, ""),
 			GuardianOptionAdminService(adminSocketPath, nil, nil, rpcMap),
 			GuardianOptionStatusServer(fmt.Sprintf("[::]:%d", mockStatusPort(testId, mockGuardianIndex))),
@@ -208,11 +211,12 @@ func mockGuardianRunnable(testId uint, gs []*mockGuardian, mockGuardianIndex uin
 }
 
 // setupLogsCapture is a helper function for making a zap logger/observer combination for testing that certain logs have been made
-func setupLogsCapture(options ...zap.Option) (*zap.Logger, *observer.ObservedLogs) {
+func setupLogsCapture(options ...zap.Option) (*zap.Logger, *observer.ObservedLogs, *LogSizeCounter) {
 	observedCore, observedLogs := observer.New(zap.DebugLevel)
 	consoleLogger, _ := zap.NewDevelopment(zap.IncreaseLevel(CONSOLE_LOG_LEVEL))
-	parentLogger := zap.New(zapcore.NewTee(observedCore, consoleLogger.Core()), options...)
-	return parentLogger, observedLogs
+	lc := NewLogSizeCounter(zap.InfoLevel)
+	parentLogger := zap.New(zapcore.NewTee(observedCore, consoleLogger.Core(), lc.Core()), options...)
+	return parentLogger, observedLogs, lc
 }
 
 func waitForHeartbeatsInLogs(t testing.TB, zapObserver *observer.ObservedLogs, gs []*mockGuardian) {
@@ -574,7 +578,7 @@ func testConsensus(t *testing.T, testCases []testCase, numGuardians int) {
 	rootCtx, rootCtxCancel := context.WithTimeout(context.Background(), testTimeout)
 	defer rootCtxCancel()
 
-	zapLogger, zapObserver := setupLogsCapture()
+	zapLogger, zapObserver, _ := setupLogsCapture()
 
 	supervisor.New(rootCtx, zapLogger, func(ctx context.Context) error {
 		logger := supervisor.Logger(ctx)
@@ -839,7 +843,7 @@ func testGuardianConfigurations(t *testing.T, testCases []testCaseGuardianConfig
 		// The panic will be subsequently caught by the supervisor
 		fatalHook := make(fatalHook)
 		defer close(fatalHook)
-		zapLogger, zapObserver := setupLogsCapture(zap.WithFatalHook(fatalHook))
+		zapLogger, zapObserver, _ := setupLogsCapture(zap.WithFatalHook(fatalHook))
 
 		supervisor.New(rootCtx, zapLogger, func(ctx context.Context) error {
 			// Create a sub-context with cancel function that we can pass to G.run.
@@ -996,7 +1000,8 @@ func BenchmarkConsensus(b *testing.B) {
 	//CONSOLE_LOG_LEVEL = zap.DebugLevel
 	//CONSOLE_LOG_LEVEL = zap.InfoLevel
 	CONSOLE_LOG_LEVEL = zap.WarnLevel
-	benchmarkConsensus(b, "1", 19, 1000, 2) // ~28s
+	//benchmarkConsensus(b, "1", 19, 1000, 2) // ~28s
+	benchmarkConsensus(b, "1", 19, 100, 1) // ~3s
 	//benchmarkConsensus(b, "1", 19, 100, 2) // ~2s
 	//benchmarkConsensus(b, "1", 19, 100, 3) // sometimes fails, i.e. too much parallelism
 	//benchmarkConsensus(b, "1", 19, 100, 10) // sometimes fails, i.e. too much parallelism
@@ -1018,7 +1023,7 @@ func benchmarkConsensus(t *testing.B, name string, numGuardians int, numMessages
 		rootCtx, rootCtxCancel := context.WithTimeout(context.Background(), testTimeout)
 		defer rootCtxCancel()
 
-		zapLogger, zapObserver := setupLogsCapture()
+		zapLogger, zapObserver, setupLogsCapture := setupLogsCapture()
 
 		supervisor.New(rootCtx, zapLogger, func(ctx context.Context) error {
 			logger := supervisor.Logger(ctx)
@@ -1079,6 +1084,7 @@ func benchmarkConsensus(t *testing.B, name string, numGuardians int, numMessages
 			c := publicrpcv1.NewPublicRPCServiceClient(conn)
 
 			logger.Info("-----------Beginning benchmark-----------")
+			setupLogsCapture.Reset()
 			t.ResetTimer()
 
 			// nextObsReadyC ensures that there are not more than `maxPendingObs` observations pending at any given point in time.
@@ -1125,6 +1131,9 @@ func benchmarkConsensus(t *testing.B, name string, numGuardians int, numMessages
 			// We're done!
 			logger.Info("Tests completed.")
 			t.StopTimer()
+			logsize := setupLogsCapture.Reset()
+			logsize = logsize / uint64(numMessages) / uint64(numGuardians) // normalize
+			logger.Warn("benchmarkConsensus: logsize report", zap.Uint64("logbytes_per_msg", logsize))
 			supervisor.Signal(ctx, supervisor.SignalDone)
 			rootCtxCancel()
 			return nil

--- a/node/pkg/node/node_test.go
+++ b/node/pkg/node/node_test.go
@@ -994,20 +994,17 @@ func BenchmarkCrypto(b *testing.B) {
 	})
 }
 
-// How to run: go test -v -ldflags '-extldflags "-Wl,--allow-multiple-definition" ' -bench ^BenchmarkConsensus -benchtime=1x -count 1 -run ^$ > bench.log; tail bench.log
+// How to run:
+//
+//	go test -v -ldflags '-extldflags "-Wl,--allow-multiple-definition" ' -bench ^BenchmarkConsensus -benchtime=1x -count 1 -run ^$ > bench.log; tail bench.log
 func BenchmarkConsensus(b *testing.B) {
 	require.Equal(b, b.N, 1)
 	//CONSOLE_LOG_LEVEL = zap.DebugLevel
 	//CONSOLE_LOG_LEVEL = zap.InfoLevel
 	CONSOLE_LOG_LEVEL = zap.WarnLevel
-	//benchmarkConsensus(b, "1", 19, 1000, 2) // ~28s
-	benchmarkConsensus(b, "1", 19, 100, 1) // ~3s
-	//benchmarkConsensus(b, "1", 19, 100, 2) // ~2s
-	//benchmarkConsensus(b, "1", 19, 100, 3) // sometimes fails, i.e. too much parallelism
-	//benchmarkConsensus(b, "1", 19, 100, 10) // sometimes fails, i.e. too much parallelism
-	//benchmarkConsensus(b, "1", 19, 100, 1) // 3s
-	//benchmarkConsensus(b, "1", 19, 20, 1) // 0.6s
-	//benchmarkConsensus(b, "1", 19, 5, 1) // 0.2s
+	benchmarkConsensus(b, "1", 19, 1000, 10) // ~10s
+	//benchmarkConsensus(b, "1", 19, 1000, 5) // ~10s
+	//benchmarkConsensus(b, "1", 19, 1000, 1) // ~13s
 }
 
 func benchmarkConsensus(t *testing.B, name string, numGuardians int, numMessages int, maxPendingObs int) {

--- a/node/pkg/node/node_test.go
+++ b/node/pkg/node/node_test.go
@@ -59,7 +59,7 @@ var PROMETHEUS_METRIC_VALID_HEARTBEAT_RECEIVED = "wormhole_p2p_broadcast_message
 const WAIT_FOR_LOGS = true
 const WAIT_FOR_METRICS = false
 
-// The level at which logs will be written to console; During testing, logs are produced and buffered at Debug level, because some tests need to look for certain entries.
+// The level at which logs will be written to console; During testing, logs are produced and buffered at Info level, because some tests need to look for certain entries.
 var CONSOLE_LOG_LEVEL = zap.InfoLevel
 
 var TEST_ID_CTR atomic.Uint32
@@ -212,7 +212,7 @@ func mockGuardianRunnable(testId uint, gs []*mockGuardian, mockGuardianIndex uin
 
 // setupLogsCapture is a helper function for making a zap logger/observer combination for testing that certain logs have been made
 func setupLogsCapture(options ...zap.Option) (*zap.Logger, *observer.ObservedLogs, *LogSizeCounter) {
-	observedCore, observedLogs := observer.New(zap.DebugLevel)
+	observedCore, observedLogs := observer.New(zap.InfoLevel)
 	consoleLogger, _ := zap.NewDevelopment(zap.IncreaseLevel(CONSOLE_LOG_LEVEL))
 	lc := NewLogSizeCounter(zap.InfoLevel)
 	parentLogger := zap.New(zapcore.NewTee(observedCore, consoleLogger.Core(), lc.Core()), options...)
@@ -221,7 +221,7 @@ func setupLogsCapture(options ...zap.Option) (*zap.Logger, *observer.ObservedLog
 
 func waitForHeartbeatsInLogs(t testing.TB, zapObserver *observer.ObservedLogs, gs []*mockGuardian) {
 	// example log entry that we're looking for:
-	// 		DEBUG	root.g-2.g.p2p	p2p/p2p.go:465	valid signed heartbeat received	{"value": "node_name:\"g-0\"  timestamp:1685677055425243683  version:\"development\"  guardian_addr:\"0xeF2a03eAec928DD0EEAf35aD31e34d2b53152c07\"  boot_timestamp:1685677040424855922  p2p_node_id:\"\\x00$\\x08\\x01\\x12 \\x97\\xf3\\xbd\\x87\\x13\\x15(\\x1e\\x8b\\x83\\xedǩ\\xfd\\x05A\\x06aTD\\x90p\\xcc\\xdb<\\xddB\\xcfi\\xccވ\"", "from": "12D3KooWL3XJ9EMCyZvmmGXL2LMiVBtrVa2BuESsJiXkSj7333Jw"}
+	// 		INFO	root.g-2.g.p2p	p2p/p2p.go:465	valid signed heartbeat received	{"value": "node_name:\"g-0\"  timestamp:1685677055425243683  version:\"development\"  guardian_addr:\"0xeF2a03eAec928DD0EEAf35aD31e34d2b53152c07\"  boot_timestamp:1685677040424855922  p2p_node_id:\"\\x00$\\x08\\x01\\x12 \\x97\\xf3\\xbd\\x87\\x13\\x15(\\x1e\\x8b\\x83\\xedǩ\\xfd\\x05A\\x06aTD\\x90p\\xcc\\xdb<\\xddB\\xcfi\\xccވ\"", "from": "12D3KooWL3XJ9EMCyZvmmGXL2LMiVBtrVa2BuESsJiXkSj7333Jw"}
 	re := regexp.MustCompile("g-[0-9]+")
 
 	for readyCounter := 0; readyCounter < len(gs); {

--- a/node/pkg/node/options.go
+++ b/node/pkg/node/options.go
@@ -48,6 +48,7 @@ func GuardianOptionP2P(p2pKey libp2p_crypto.PrivKey, networkId string, bootstrap
 
 			if g.env == common.GoTest {
 				components.WarnChannelOverflow = true
+				components.SignedHeartbeatLogLevel = zapcore.InfoLevel
 			}
 
 			g.runnables["p2p"] = p2p.Run(

--- a/node/pkg/node/options.go
+++ b/node/pkg/node/options.go
@@ -46,6 +46,10 @@ func GuardianOptionP2P(p2pKey libp2p_crypto.PrivKey, networkId string, bootstrap
 			components := p2p.DefaultComponents()
 			components.Port = port
 
+			if g.env == common.GoTest {
+				components.WarnChannelOverflow = true
+			}
+
 			g.runnables["p2p"] = p2p.Run(
 				g.obsvC,
 				g.obsvReqC.writeC,

--- a/node/pkg/node/options.go
+++ b/node/pkg/node/options.go
@@ -338,7 +338,7 @@ func GuardianOptionWatchers(watcherConfigs []watchers.WatcherConfig, ibcWatcherC
 					readiness.RegisterComponent(common.ReadinessIBCSyncing)
 					g.runnablesWithScissors["ibcwatch"] = ibc.NewWatcher(ibcWatcherConfig.Websocket, ibcWatcherConfig.Lcd, ibcWatcherConfig.Contract, chainConfig).Run
 				} else {
-					return errors.New("Although IBC is enabled, there are no chains for it to monitor")
+					return errors.New("although IBC is enabled, there are no chains for it to monitor")
 				}
 			}
 
@@ -370,7 +370,7 @@ func GuardianOptionAdminService(socketPath string, ethRpc *string, ethContract *
 				rpcMap,
 			)
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to create admin service: %w", err)
 			}
 			g.runnables["admin"] = adminService
 
@@ -388,7 +388,7 @@ func GuardianOptionPublicRpcSocket(publicGRPCSocketPath string, publicRpcLogDeta
 			// local public grpc service socket
 			publicrpcUnixService, publicrpcServer, err := publicrpcUnixServiceRunnable(logger, publicGRPCSocketPath, publicRpcLogDetail, g.db, g.gst, g.gov)
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to create publicrpc service: %w", err)
 			}
 
 			g.runnables["publicrpcsocket"] = publicrpcUnixService

--- a/node/pkg/p2p/p2p.go
+++ b/node/pkg/p2p/p2p.go
@@ -34,6 +34,7 @@ import (
 	libp2ptls "github.com/libp2p/go-libp2p/p2p/security/tls"
 	libp2pquic "github.com/libp2p/go-libp2p/p2p/transport/quic"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"google.golang.org/protobuf/proto"
 
 	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
@@ -95,6 +96,8 @@ type Components struct {
 	ProtectedHostByGuardianKeyLock sync.Mutex
 	// WarnChannelOverflow: If true, errors due to overflowing channels will produce logger.Warn
 	WarnChannelOverflow bool
+	// SignedHeartbeatLogLevel is the log level at which SignedHeartbeatReceived events will be logged.
+	SignedHeartbeatLogLevel zapcore.Level
 }
 
 func (f *Components) ListeningAddresses() []string {
@@ -122,6 +125,7 @@ func DefaultComponents() *Components {
 		Port:                       DefaultPort,
 		ConnMgr:                    mgr,
 		ProtectedHostByGuardianKey: make(map[eth_common.Address]peer.ID),
+		SignedHeartbeatLogLevel:    zapcore.DebugLevel,
 	}
 }
 
@@ -511,14 +515,14 @@ func Run(
 				gs := gst.Get()
 				if gs == nil {
 					// No valid guardian set yet - dropping heartbeat
-					logger.Debug("skipping heartbeat - no guardian set",
+					logger.Log(components.SignedHeartbeatLogLevel, "skipping heartbeat - no guardian set",
 						zap.Any("value", s),
 						zap.String("from", envelope.GetFrom().String()))
 					break
 				}
 				if heartbeat, err := processSignedHeartbeat(envelope.GetFrom(), s, gs, gst, disableHeartbeatVerify); err != nil {
 					p2pMessagesReceived.WithLabelValues("invalid_heartbeat").Inc()
-					logger.Debug("invalid signed heartbeat received",
+					logger.Log(components.SignedHeartbeatLogLevel, "invalid signed heartbeat received",
 						zap.Error(err),
 						zap.Any("payload", msg.Message),
 						zap.Any("value", s),
@@ -526,7 +530,7 @@ func Run(
 						zap.String("from", envelope.GetFrom().String()))
 				} else {
 					p2pMessagesReceived.WithLabelValues("valid_heartbeat").Inc()
-					logger.Debug("valid signed heartbeat received",
+					logger.Log(components.SignedHeartbeatLogLevel, "valid signed heartbeat received",
 						zap.Any("value", heartbeat),
 						zap.String("from", envelope.GetFrom().String()))
 

--- a/node/pkg/p2p/p2p.go
+++ b/node/pkg/p2p/p2p.go
@@ -3,6 +3,7 @@ package p2p
 import (
 	"context"
 	"crypto/ecdsa"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"strings"
@@ -10,10 +11,10 @@ import (
 	"time"
 
 	"github.com/certusone/wormhole/node/pkg/accountant"
-	node_common "github.com/certusone/wormhole/node/pkg/common"
+	"github.com/certusone/wormhole/node/pkg/common"
 	"github.com/certusone/wormhole/node/pkg/governor"
 	"github.com/certusone/wormhole/node/pkg/version"
-	"github.com/ethereum/go-ethereum/common"
+	eth_common "github.com/ethereum/go-ethereum/common"
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -71,11 +72,11 @@ var signedObservationRequestPrefix = []byte("signed_observation_request|")
 // heartbeatMaxTimeDifference specifies the maximum time difference between the local clock and the timestamp in incoming heartbeat messages. Heartbeats that are this old or this much into the future will be dropped. This value should encompass clock skew and network delay.
 var heartbeatMaxTimeDifference = time.Minute * 15
 
-func heartbeatDigest(b []byte) common.Hash {
+func heartbeatDigest(b []byte) eth_common.Hash {
 	return ethcrypto.Keccak256Hash(append(heartbeatMessagePrefix, b...))
 }
 
-func signedObservationRequestDigest(b []byte) common.Hash {
+func signedObservationRequestDigest(b []byte) eth_common.Hash {
 	return ethcrypto.Keccak256Hash(append(signedObservationRequestPrefix, b...))
 }
 
@@ -88,10 +89,12 @@ type Components struct {
 	// ConnMgr is the ConnectionManager that the Guardian is going to use
 	ConnMgr *connmgr.BasicConnMgr
 	// ProtectedHostByGuardianKey is used to ensure that only one p2p peer can be protected by any given known guardian key
-	ProtectedHostByGuardianKey map[common.Address]peer.ID
+	ProtectedHostByGuardianKey map[eth_common.Address]peer.ID
 	// ProtectedHostByGuardianKeyLock is only useful to prevent a race condition in test as ProtectedHostByGuardianKey
 	// is only accessed by a single routine at any given time in a running Guardian.
 	ProtectedHostByGuardianKeyLock sync.Mutex
+	// WarnChannelOverflow: If true, errors due to overflowing channels will produce logger.Warn
+	WarnChannelOverflow bool
 }
 
 func (f *Components) ListeningAddresses() []string {
@@ -118,7 +121,7 @@ func DefaultComponents() *Components {
 		},
 		Port:                       DefaultPort,
 		ConnMgr:                    mgr,
-		ProtectedHostByGuardianKey: make(map[common.Address]peer.ID),
+		ProtectedHostByGuardianKey: make(map[eth_common.Address]peer.ID),
 	}
 }
 
@@ -184,7 +187,7 @@ func Run(
 	signedInC chan<- *gossipv1.SignedVAAWithQuorum,
 	priv crypto.PrivKey,
 	gk *ecdsa.PrivateKey,
-	gst *node_common.GuardianSetState,
+	gst *common.GuardianSetState,
 	networkID string,
 	bootstrapPeers string,
 	nodeName string,
@@ -539,7 +542,7 @@ func Run(
 									zap.Binary("raw", envelope.Data),
 									zap.String("from", envelope.GetFrom().String()))
 							} else {
-								guardianAddr := common.BytesToAddress(s.GuardianAddr)
+								guardianAddr := eth_common.BytesToAddress(s.GuardianAddr)
 								prevPeerId, ok := components.ProtectedHostByGuardianKey[guardianAddr]
 								if ok {
 									if prevPeerId != peerId {
@@ -569,6 +572,9 @@ func Run(
 				case obsvC <- m.SignedObservation:
 					p2pMessagesReceived.WithLabelValues("observation").Inc()
 				default:
+					if components.WarnChannelOverflow {
+						logger.Warn("Ignoring SignedObservation because obsvC full", zap.String("hash", hex.EncodeToString(m.SignedObservation.Hash)))
+					}
 					p2pReceiveChannelOverflow.WithLabelValues("observation").Inc()
 				}
 			case *gossipv1.GossipMessage_SignedVaaWithQuorum:
@@ -576,6 +582,14 @@ func Run(
 				case signedInC <- m.SignedVaaWithQuorum:
 					p2pMessagesReceived.WithLabelValues("signed_vaa_with_quorum").Inc()
 				default:
+					if components.WarnChannelOverflow {
+						// TODO do not log this in production
+						var hexStr string
+						if vaa, err := vaa.Unmarshal(m.SignedVaaWithQuorum.Vaa); err == nil {
+							hexStr = vaa.HexDigest()
+						}
+						logger.Warn("Ignoring SignedVaaWithQuorum because signedInC full", zap.String("hash", hexStr))
+					}
 					p2pReceiveChannelOverflow.WithLabelValues("signed_vaa_with_quorum").Inc()
 				}
 			case *gossipv1.GossipMessage_SignedObservationRequest:
@@ -649,10 +663,10 @@ func createSignedHeartbeat(gk *ecdsa.PrivateKey, heartbeat *gossipv1.Heartbeat) 
 	}
 }
 
-func processSignedHeartbeat(from peer.ID, s *gossipv1.SignedHeartbeat, gs *node_common.GuardianSet, gst *node_common.GuardianSetState, disableVerify bool) (*gossipv1.Heartbeat, error) {
-	envelopeAddr := common.BytesToAddress(s.GuardianAddr)
+func processSignedHeartbeat(from peer.ID, s *gossipv1.SignedHeartbeat, gs *common.GuardianSet, gst *common.GuardianSetState, disableVerify bool) (*gossipv1.Heartbeat, error) {
+	envelopeAddr := eth_common.BytesToAddress(s.GuardianAddr)
 	idx, ok := gs.KeyIndex(envelopeAddr)
-	var pk common.Address
+	var pk eth_common.Address
 	if !ok {
 		if !disableVerify {
 			return nil, fmt.Errorf("invalid message: %s not in guardian set", envelopeAddr)
@@ -673,7 +687,7 @@ func processSignedHeartbeat(from peer.ID, s *gossipv1.SignedHeartbeat, gs *node_
 		return nil, errors.New("failed to recover public key")
 	}
 
-	signerAddr := common.BytesToAddress(ethcrypto.Keccak256(pubKey[1:])[12:])
+	signerAddr := eth_common.BytesToAddress(ethcrypto.Keccak256(pubKey[1:])[12:])
 	if pk != signerAddr && !disableVerify {
 		return nil, fmt.Errorf("invalid signer: %v", signerAddr)
 	}
@@ -702,10 +716,10 @@ func processSignedHeartbeat(from peer.ID, s *gossipv1.SignedHeartbeat, gs *node_
 	return &h, nil
 }
 
-func processSignedObservationRequest(s *gossipv1.SignedObservationRequest, gs *node_common.GuardianSet) (*gossipv1.ObservationRequest, error) {
-	envelopeAddr := common.BytesToAddress(s.GuardianAddr)
+func processSignedObservationRequest(s *gossipv1.SignedObservationRequest, gs *common.GuardianSet) (*gossipv1.ObservationRequest, error) {
+	envelopeAddr := eth_common.BytesToAddress(s.GuardianAddr)
 	idx, ok := gs.KeyIndex(envelopeAddr)
-	var pk common.Address
+	var pk eth_common.Address
 	if !ok {
 		return nil, fmt.Errorf("invalid message: %s not in guardian set", envelopeAddr)
 	} else {
@@ -724,7 +738,7 @@ func processSignedObservationRequest(s *gossipv1.SignedObservationRequest, gs *n
 		return nil, errors.New("failed to recover public key")
 	}
 
-	signerAddr := common.BytesToAddress(ethcrypto.Keccak256(pubKey[1:])[12:])
+	signerAddr := eth_common.BytesToAddress(ethcrypto.Keccak256(pubKey[1:])[12:])
 	if pk != signerAddr {
 		return nil, fmt.Errorf("invalid signer: %v", signerAddr)
 	}

--- a/node/pkg/p2p/p2p.go
+++ b/node/pkg/p2p/p2p.go
@@ -152,12 +152,12 @@ func bootstrapAddrs(logger *zap.Logger, bootstrapPeers string, self peer.ID) (bo
 		}
 		ma, err := multiaddr.NewMultiaddr(addr)
 		if err != nil {
-			logger.Error("Invalid bootstrap address", zap.String("peer", addr), zap.Error(err))
+			logger.Error("invalid bootstrap address", zap.String("peer", addr), zap.Error(err))
 			continue
 		}
 		pi, err := peer.AddrInfoFromP2pAddr(ma)
 		if err != nil {
-			logger.Error("Invalid bootstrap address", zap.String("peer", addr), zap.Error(err))
+			logger.Error("invalid bootstrap address", zap.String("peer", addr), zap.Error(err))
 			continue
 		}
 		if pi.ID == self {
@@ -175,7 +175,7 @@ func connectToPeers(ctx context.Context, logger *zap.Logger, h host.Host, peers 
 	successes = 0
 	for _, p := range peers {
 		if err := h.Connect(ctx, p); err != nil {
-			logger.Error("Failed to connect to bootstrap peer", zap.String("peer", p.String()), zap.Error(err))
+			logger.Error("failed to connect to bootstrap peer", zap.String("peer", p.String()), zap.Error(err))
 		} else {
 			successes += 1
 		}
@@ -263,7 +263,7 @@ func Run(
 
 		defer func() {
 			if err := h.Close(); err != nil {
-				logger.Error("Error closing the host", zap.Error(err))
+				logger.Error("error closing the host", zap.Error(err))
 			}
 		}()
 

--- a/node/pkg/watchers/near/nearapi/nearapi_test.go
+++ b/node/pkg/watchers/near/nearapi/nearapi_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	mockserver "github.com/certusone/wormhole/node/pkg/watchers/near/nearapi/mock"
-	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 
 	"github.com/certusone/wormhole/node/pkg/watchers/near/nearapi"
 	"github.com/stretchr/testify/assert"
@@ -52,7 +52,7 @@ func TestNearApi(t *testing.T) {
 	ctx, cancelFunc := context.WithTimeout(parentCtx, time.Second*5)
 	defer cancelFunc()
 
-	logger, _ := zap.NewDevelopment()
+	logger := zaptest.NewLogger(t)
 
 	mockServer := mockserver.NewForwardingCachingServer(logger, "https://rpc.mainnet.near.org", "mock/apitest/", nil)
 	mockHttpServer := httptest.NewServer(mockServer)


### PR DESCRIPTION
* [increase inboundObservationBufferSize to 5000](https://github.com/wormhole-foundation/wormhole/pull/3135/commits/366c19740a42dff7f354b78905af55a537c37e98) because otherwise this channel too quickly reaches capacity. The 5000 is somewhat arbitrary and we can think more about the appropriate size, but for now it's large enough to run the benchmarks and not too large that it would take up too much memory or potentially add too much latency because processing 5000 observations should take ca. 1 second. 
* Implement BenchmarkConsensus in node_test.go to measure how long it takes to reach consensus on `n` messages with `m` guardian nodes. 
* Warn on certain channel overflows in p2p if in GoTest mode
* Count and report amount of logs generated per message during benchmarking
* Switch to zaptest logger in tests such that logs are only written if running with `go test -v` or of the test fails
* Use the zap logger for badgerDB logging