### PR TITLE
node: (cleanup) change injectC to common.MessagePublication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ bigtable-writer.json
 /ethereum/cache/
 sui.log.*
 sui/examples/wrapped_coin
+*.prof

--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -826,8 +826,10 @@ func runNode(cmd *cobra.Command, args []string) {
 				logger.Info("Error resolving guardian-0.guardian. Trying again...")
 				time.Sleep(time.Second)
 			}
-			// TODO this is a hack. If this is not the bootstrap Guardian, we wait 5s such that the bootstrap Guardian has enough time to start.
-			logger.Info("This is not a bootstrap Guardian. Waiting another 10 seconds so the bootstrap guardian to come online.")
+			// TODO this is a hack. If this is not the bootstrap Guardian, we wait 10s such that the bootstrap Guardian has enough time to start.
+			// This may no longer be necessary because now the p2p.go ensures that it can connect to at least one bootstrap peer and will
+			// exit the whole guardian if it is unable to. Sleeping here for a bit may reduce overall startup time by preventing unnecessary restarts, though.
+			logger.Info("This is not a bootstrap Guardian. Waiting another 10 seconds for the bootstrap guardian to come online.")
 			time.Sleep(time.Second * 10)
 		}
 	} else {

--- a/node/pkg/adminrpc/adminserver.go
+++ b/node/pkg/adminrpc/adminserver.go
@@ -36,7 +36,7 @@ import (
 type nodePrivilegedService struct {
 	nodev1.UnimplementedNodePrivilegedServiceServer
 	db              *db.Database
-	injectC         chan<- *vaa.VAA
+	injectC         chan<- *common.MessagePublication
 	obsvReqSendC    chan<- *gossipv1.ObservationRequest
 	logger          *zap.Logger
 	signedInC       chan<- *gossipv1.SignedVAAWithQuorum
@@ -50,7 +50,7 @@ type nodePrivilegedService struct {
 
 func NewPrivService(
 	db *db.Database,
-	injectC chan<- *vaa.VAA,
+	injectC chan<- *common.MessagePublication,
 	obsvReqSendC chan<- *gossipv1.ObservationRequest,
 	logger *zap.Logger,
 	signedInC chan<- *gossipv1.SignedVAAWithQuorum,
@@ -508,7 +508,17 @@ func (s *nodePrivilegedService) InjectGovernanceVAA(ctx context.Context, req *no
 			zap.String("digest", digest.String()),
 		)
 
-		s.injectC <- v
+		s.injectC <- &common.MessagePublication{
+			TxHash:           ethcommon.Hash{},
+			Timestamp:        v.Timestamp,
+			Nonce:            v.Nonce,
+			Sequence:         v.Sequence,
+			ConsistencyLevel: v.ConsistencyLevel,
+			EmitterChain:     v.EmitterChain,
+			EmitterAddress:   v.EmitterAddress,
+			Payload:          v.Payload,
+			Unreliable:       false,
+		}
 
 		digests[i] = digest.Bytes()
 	}

--- a/node/pkg/common/utils.go
+++ b/node/pkg/common/utils.go
@@ -1,0 +1,18 @@
+package common
+
+import "golang.org/x/exp/constraints"
+
+func Min[K constraints.Ordered](v []K) *K {
+	if len(v) == 0 {
+		return nil
+	}
+
+	lowest := v[0]
+	for _, k := range v {
+		if k < lowest {
+			lowest = k
+		}
+	}
+
+	return &lowest
+}

--- a/node/pkg/node/adminServiceRunnable.go
+++ b/node/pkg/node/adminServiceRunnable.go
@@ -18,7 +18,6 @@ import (
 	"github.com/certusone/wormhole/node/pkg/publicrpc"
 	"github.com/certusone/wormhole/node/pkg/supervisor"
 	"github.com/certusone/wormhole/node/pkg/watchers/evm/connectors"
-	"github.com/wormhole-foundation/wormhole/sdk/vaa"
 	"go.uber.org/zap"
 
 	ethcommon "github.com/ethereum/go-ethereum/common"
@@ -28,7 +27,7 @@ import (
 func adminServiceRunnable(
 	logger *zap.Logger,
 	socketPath string,
-	injectC chan<- *vaa.VAA,
+	injectC chan<- *common.MessagePublication,
 	signedInC chan<- *gossipv1.SignedVAAWithQuorum,
 	obsvReqSendC chan<- *gossipv1.ObservationRequest,
 	db *db.Database,

--- a/node/pkg/node/node.go
+++ b/node/pkg/node/node.go
@@ -13,7 +13,6 @@ import (
 	"github.com/certusone/wormhole/node/pkg/reporter"
 	"github.com/certusone/wormhole/node/pkg/supervisor"
 
-	"github.com/wormhole-foundation/wormhole/sdk/vaa"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 )
@@ -66,7 +65,7 @@ type G struct {
 	// Outbound observation requests
 	obsvReqSendC channelPair[*gossipv1.ObservationRequest]
 	// Injected VAAs (manually generated rather than created via observation)
-	injectC channelPair[*vaa.VAA]
+	injectC channelPair[*common.MessagePublication]
 	// acctC is the channel where messages will be put after they reached quorum in the accountant.
 	acctC channelPair[*common.MessagePublication]
 }
@@ -94,7 +93,7 @@ func (g *G) initializeBasic(logger *zap.Logger, rootCtxCancel context.CancelFunc
 	g.signedInC = makeChannelPair[*gossipv1.SignedVAAWithQuorum](inboundSignedVaaBufferSize)
 	g.obsvReqC = makeChannelPair[*gossipv1.ObservationRequest](observationRequestOutboundBufferSize)
 	g.obsvReqSendC = makeChannelPair[*gossipv1.ObservationRequest](observationRequestInboundBufferSize)
-	g.injectC = makeChannelPair[*vaa.VAA](0)
+	g.injectC = makeChannelPair[*common.MessagePublication](0)
 	g.acctC = makeChannelPair[*common.MessagePublication](accountant.MsgChannelCapacity)
 
 	// Guardian set state managed by processor

--- a/node/pkg/node/node_test.go
+++ b/node/pkg/node/node_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/rand"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"math/big"
 	math_rand "math/rand"
@@ -18,6 +19,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"sync/atomic"
 
 	"github.com/certusone/wormhole/node/pkg/common"
 	"github.com/certusone/wormhole/node/pkg/db"
@@ -47,9 +50,9 @@ import (
 )
 
 const LOCAL_RPC_PORTRANGE_START = 10000
-const LOCAL_P2P_PORTRANGE_START = 10100
-const LOCAL_STATUS_PORTRANGE_START = 10200
-const LOCAL_PUBLICWEB_PORTRANGE_START = 10300
+const LOCAL_P2P_PORTRANGE_START = 11000
+const LOCAL_STATUS_PORTRANGE_START = 12000
+const LOCAL_PUBLICWEB_PORTRANGE_START = 13000
 
 var PROMETHEUS_METRIC_VALID_HEARTBEAT_RECEIVED = "wormhole_p2p_broadcast_messages_received_total{type=\"valid_heartbeat\"}"
 
@@ -57,7 +60,13 @@ const WAIT_FOR_LOGS = true
 const WAIT_FOR_METRICS = false
 
 // The level at which logs will be written to console; During testing, logs are produced and buffered at Debug level, because some tests need to look for certain entries.
-const CONSOLE_LOG_LEVEL = zap.InfoLevel
+var CONSOLE_LOG_LEVEL = zap.InfoLevel
+
+var TEST_ID_CTR atomic.Uint32
+
+func getTestId() uint {
+	return uint(TEST_ID_CTR.Add(1))
+}
 
 type mockGuardian struct {
 	p2pKey           libp2p_crypto.PrivKey
@@ -98,28 +107,32 @@ func mockGuardianSetToGuardianAddrList(gs []*mockGuardian) []eth_common.Address 
 	return result
 }
 
-func mockPublicSocket(mockGuardianIndex uint) string {
-	return fmt.Sprintf("/tmp/test_guardian_%d_public.socket", mockGuardianIndex)
+func mockPublicSocket(testId uint, mockGuardianIndex uint) string {
+	return fmt.Sprintf("/tmp/test_guardian_%d_public.socket", mockGuardianIndex+testId*20)
 }
 
-func mockAdminStocket(mockGuardianIndex uint) string {
-	return fmt.Sprintf("/tmp/test_guardian_%d_admin.socket", mockGuardianIndex)
+func mockAdminStocket(testId uint, mockGuardianIndex uint) string {
+	return fmt.Sprintf("/tmp/test_guardian_%d_admin.socket", mockGuardianIndex+testId*20)
 }
 
-func mockPublicRpc(mockGuardianIndex uint) string {
-	return fmt.Sprintf("127.0.0.1:%d", mockGuardianIndex+LOCAL_RPC_PORTRANGE_START)
+func mockPublicRpc(testId uint, mockGuardianIndex uint) string {
+	return fmt.Sprintf("127.0.0.1:%d", mockGuardianIndex+LOCAL_RPC_PORTRANGE_START+testId*20)
 }
 
-func mockPublicWeb(mockGuardianIndex uint) string {
-	return fmt.Sprintf("127.0.0.1:%d", mockGuardianIndex+LOCAL_PUBLICWEB_PORTRANGE_START)
+func mockPublicWeb(testId uint, mockGuardianIndex uint) string {
+	return fmt.Sprintf("127.0.0.1:%d", mockGuardianIndex+LOCAL_PUBLICWEB_PORTRANGE_START+testId*20)
 }
 
-func mockStatusPort(mockGuardianIndex uint) uint {
-	return mockGuardianIndex + LOCAL_STATUS_PORTRANGE_START
+func mockStatusPort(testId uint, mockGuardianIndex uint) uint {
+	return mockGuardianIndex + LOCAL_STATUS_PORTRANGE_START + testId*20
+}
+
+func mockP2PPort(testId uint, mockGuardianIndex uint) uint {
+	return mockGuardianIndex + LOCAL_P2P_PORTRANGE_START + testId*20
 }
 
 // mockGuardianRunnable returns a runnable that first sets up a mock guardian an then runs it.
-func mockGuardianRunnable(gs []*mockGuardian, mockGuardianIndex uint, obsDb mock.ObservationDb) supervisor.Runnable {
+func mockGuardianRunnable(testId uint, gs []*mockGuardian, mockGuardianIndex uint, obsDb mock.ObservationDb) supervisor.Runnable {
 	return func(ctx context.Context) error {
 		// Create a sub-context with cancel function that we can pass to G.run.
 		ctx, ctxCancel := context.WithCancel(ctx)
@@ -153,15 +166,15 @@ func mockGuardianRunnable(gs []*mockGuardian, mockGuardianIndex uint, obsDb mock
 		if err != nil {
 			return err
 		}
-		bootstrapPeers := fmt.Sprintf("/ip4/127.0.0.1/udp/%d/quic/p2p/%s", LOCAL_P2P_PORTRANGE_START, zeroPeerId.String())
-		p2pPort := uint(LOCAL_P2P_PORTRANGE_START + mockGuardianIndex)
+		bootstrapPeers := fmt.Sprintf("/ip4/127.0.0.1/udp/%d/quic/p2p/%s", mockP2PPort(testId, 0), zeroPeerId.String())
+		p2pPort := mockP2PPort(testId, mockGuardianIndex)
 
 		// configure publicRpc
-		publicSocketPath := mockPublicSocket(mockGuardianIndex)
-		publicRpc := mockPublicRpc(mockGuardianIndex)
+		publicSocketPath := mockPublicSocket(testId, mockGuardianIndex)
+		publicRpc := mockPublicRpc(testId, mockGuardianIndex)
 
 		// configure adminservice
-		adminSocketPath := mockAdminStocket(mockGuardianIndex)
+		adminSocketPath := mockAdminStocket(testId, mockGuardianIndex)
 		rpcMap := make(map[string]string)
 
 		// assemble all the options
@@ -173,9 +186,9 @@ func mockGuardianRunnable(gs []*mockGuardian, mockGuardianIndex uint, obsDb mock
 			GuardianOptionP2P(gs[mockGuardianIndex].p2pKey, networkID, bootstrapPeers, nodeName, false, p2pPort, func() string { return "" }),
 			GuardianOptionPublicRpcSocket(publicSocketPath, common.GrpcLogDetailFull),
 			GuardianOptionPublicrpcTcpService(publicRpc, common.GrpcLogDetailFull),
-			GuardianOptionPublicWeb(mockPublicWeb(mockGuardianIndex), publicSocketPath, "", false, path.Join(dataDir, "autocert")),
+			GuardianOptionPublicWeb(mockPublicWeb(testId, mockGuardianIndex), publicSocketPath, "", false, path.Join(dataDir, "autocert")),
 			GuardianOptionAdminService(adminSocketPath, nil, nil, rpcMap),
-			GuardianOptionStatusServer(fmt.Sprintf("[::]:%d", mockStatusPort(mockGuardianIndex))),
+			GuardianOptionStatusServer(fmt.Sprintf("[::]:%d", mockStatusPort(testId, mockGuardianIndex))),
 			GuardianOptionProcessor(),
 		}
 
@@ -189,9 +202,9 @@ func mockGuardianRunnable(gs []*mockGuardian, mockGuardianIndex uint, obsDb mock
 		}
 
 		<-ctx.Done()
-
-		// cleanup
-		// _ = os.RemoveAll(dataDir) // we don't do this for now since this could run before BadgerDB's flush(), causing an error; Meh
+		time.Sleep(time.Second * 1) // Wait 1s for all sorts of things to complete.
+		db.Close()                  // close BadgerDb
+		_ = os.RemoveAll(dataDir)   // cleanup disk
 
 		return nil
 	}
@@ -230,7 +243,7 @@ func waitForHeartbeatsInLogs(t testing.TB, zapObserver *observer.ObservedLogs, g
 				}
 			}
 		}
-		time.Sleep(time.Microsecond * 100)
+		time.Sleep(time.Millisecond)
 	}
 }
 
@@ -238,14 +251,15 @@ func waitForHeartbeatsInLogs(t testing.TB, zapObserver *observer.ObservedLogs, g
 // WARNING: Currently, there is only a global registry for all prometheus metrics, leading to all guardian nodes writing to the same one.
 //
 //	As long as this is the case, you probably don't want to use this function.
-func waitForPromMetricGte(t testing.TB, ctx context.Context, gs []*mockGuardian, metric string, min int) {
+func waitForPromMetricGte(t testing.TB, testId uint, ctx context.Context, gs []*mockGuardian, metric string, min int) {
 	metricBytes := []byte(metric)
 	requests := make([]*http.Request, len(gs))
+	ready := make([]bool, len(gs))
 	//logger := supervisor.Logger(ctx)
 
 	// create the prom api clients
 	for i := range gs {
-		url := fmt.Sprintf("http://localhost:%d/metrics", mockStatusPort(uint(i)))
+		url := fmt.Sprintf("http://localhost:%d/metrics", mockStatusPort(testId, uint(i)))
 		req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 		assert.NoError(t, err)
 		requests[i] = req
@@ -253,8 +267,8 @@ func waitForPromMetricGte(t testing.TB, ctx context.Context, gs []*mockGuardian,
 
 	// query them
 	for readyCounter := 0; readyCounter < len(gs); {
-		for i, g := range gs {
-			if g.ready {
+		for i := range gs {
+			if ready[i] {
 				continue
 			}
 
@@ -271,7 +285,7 @@ func waitForPromMetricGte(t testing.TB, ctx context.Context, gs []*mockGuardian,
 					res, err := strconv.Atoi(string(bytes.Split(line, []byte(" "))[1])) // split at the space and convert to integer
 					assert.NoError(t, err)
 					if res >= min {
-						g.ready = true
+						ready[i] = true
 						readyCounter++
 						break
 					}
@@ -280,7 +294,34 @@ func waitForPromMetricGte(t testing.TB, ctx context.Context, gs []*mockGuardian,
 
 			//logger.Info("node not ready yet", zap.Int("i", i))
 		}
-		time.Sleep(time.Second * 5)
+		time.Sleep(time.Second * 5) // TODO
+	}
+}
+
+// waitForVaa polls the publicRpc service every 5ms until there is a response.
+func waitForVaa(ctx context.Context, c publicrpcv1.PublicRPCServiceClient, msgId *publicrpcv1.MessageID, mustNotReachQuorum bool) (*publicrpcv1.GetSignedVAAResponse, error) {
+	var r *publicrpcv1.GetSignedVAAResponse
+	var err error
+
+	//logger := supervisor.Logger(ctx)
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, errors.New("context canceled")
+		default:
+			queryCtx, queryCancel := context.WithTimeout(ctx, time.Second)
+			r, err = c.GetSignedVAA(queryCtx, &publicrpcv1.GetSignedVAARequest{MessageId: msgId})
+			queryCancel()
+		}
+		if err == nil && r != nil {
+			// success
+			return r, err
+		}
+		if mustNotReachQuorum {
+			// no need to re-try because we're expecting an error.
+			return r, err
+		}
+		time.Sleep(time.Millisecond * 10)
 	}
 }
 
@@ -305,6 +346,8 @@ func randomTime() time.Time {
 }
 
 var someMsgSequenceCounter uint64 = 0
+var someMsgEmitter vaa.Address = [32]byte{1, 2, 3}
+var someMsgEmitterChain vaa.ChainID = vaa.ChainIDSolana
 
 func someMessage() *common.MessagePublication {
 	someMsgSequenceCounter++
@@ -314,8 +357,8 @@ func someMessage() *common.MessagePublication {
 		Nonce:            math_rand.Uint32(), //nolint
 		Sequence:         someMsgSequenceCounter,
 		ConsistencyLevel: 1,
-		EmitterChain:     vaa.ChainIDSolana,
-		EmitterAddress:   [32]byte{1, 2, 3},
+		EmitterChain:     someMsgEmitterChain,
+		EmitterAddress:   someMsgEmitter,
 		Payload:          []byte{},
 		Unreliable:       false,
 	}
@@ -433,7 +476,7 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-// TestBasicConsensus tests that a set of guardians can form consensus on certain messages and reject certain other messages
+// TestConsensus tests that a set of guardians can form consensus on certain messages and reject certain other messages
 func TestConsensus(t *testing.T) {
 	const numGuardians = 4 // Quorum will be 3 out of 4 guardians.
 
@@ -503,6 +546,7 @@ func testConsensus(t *testing.T, testCases []testCase, numGuardians int) {
 	const guardianSetIndex = 5           // index of the active guardian set (can be anything, just needs to be set to something)
 	const vaaCheckGuardianIndex uint = 0 // we will query this guardian's publicrpc for VAAs
 	const adminRpcGuardianIndex uint = 0 // we will query this guardian's adminRpc
+	testId := getTestId()
 
 	// Test's main lifecycle context.
 	rootCtx, rootCtxCancel := context.WithTimeout(context.Background(), testTimeout)
@@ -520,7 +564,7 @@ func testConsensus(t *testing.T, testCases []testCase, numGuardians int) {
 
 		// run the guardians
 		for i := 0; i < numGuardians; i++ {
-			gRun := mockGuardianRunnable(gs, uint(i), obsDb)
+			gRun := mockGuardianRunnable(testId, gs, uint(i), obsDb)
 			err := supervisor.Run(ctx, fmt.Sprintf("g-%d", i), gRun)
 			assert.NoError(t, err)
 		}
@@ -539,7 +583,7 @@ func testConsensus(t *testing.T, testCases []testCase, numGuardians int) {
 
 		// wait for the status server to come online and check that it works
 		for i := range gs {
-			err := testStatusServer(ctx, logger, fmt.Sprintf("http://127.0.0.1:%d/metrics", mockStatusPort(uint(i))))
+			err := testStatusServer(ctx, logger, fmt.Sprintf("http://127.0.0.1:%d/metrics", mockStatusPort(testId, uint(i))))
 			assert.NoError(t, err)
 		}
 
@@ -548,7 +592,7 @@ func testConsensus(t *testing.T, testCases []testCase, numGuardians int) {
 		assert.True(t, WAIT_FOR_LOGS || WAIT_FOR_METRICS)
 		assert.False(t, WAIT_FOR_LOGS && WAIT_FOR_METRICS) // can't do both, because they both write to gs[].ready
 		if WAIT_FOR_METRICS {
-			waitForPromMetricGte(t, ctx, gs, PROMETHEUS_METRIC_VALID_HEARTBEAT_RECEIVED, 1)
+			waitForPromMetricGte(t, testId, ctx, gs, PROMETHEUS_METRIC_VALID_HEARTBEAT_RECEIVED, 1)
 		}
 		if WAIT_FOR_LOGS {
 			waitForHeartbeatsInLogs(t, zapObserver, gs)
@@ -574,14 +618,14 @@ func testConsensus(t *testing.T, testCases []testCase, numGuardians int) {
 		}
 
 		// Wait for adminrpc to come online
-		for zapObserver.FilterMessage("admin server listening on").FilterField(zap.String("path", mockAdminStocket(adminRpcGuardianIndex))).Len() == 0 {
+		for zapObserver.FilterMessage("admin server listening on").FilterField(zap.String("path", mockAdminStocket(testId, adminRpcGuardianIndex))).Len() == 0 {
 			logger.Info("admin server seems to be offline (according to logs). Waiting 100ms...")
 			time.Sleep(time.Microsecond * 100)
 		}
 
 		// Send manual re-observation requests
 		func() { // put this in own function to use defer
-			s := fmt.Sprintf("unix:///%s", mockAdminStocket(vaaCheckGuardianIndex))
+			s := fmt.Sprintf("unix:///%s", mockAdminStocket(testId, vaaCheckGuardianIndex))
 			conn, err := grpc.DialContext(ctx, s, grpc.WithTransportCredentials(insecure.NewCredentials()))
 			require.NoError(t, err)
 			defer conn.Close()
@@ -606,14 +650,14 @@ func testConsensus(t *testing.T, testCases []testCase, numGuardians int) {
 		}()
 
 		// Wait for publicrpc to come online
-		for zapObserver.FilterMessage("publicrpc server listening").FilterField(zap.String("addr", mockPublicRpc(vaaCheckGuardianIndex))).Len() == 0 {
+		for zapObserver.FilterMessage("publicrpc server listening").FilterField(zap.String("addr", mockPublicRpc(testId, vaaCheckGuardianIndex))).Len() == 0 {
 			logger.Info("publicrpc seems to be offline (according to logs). Waiting 100ms...")
 			time.Sleep(time.Microsecond * 100)
 		}
 
 		// check that the VAAs were generated
 		logger.Info("Connecting to publicrpc...")
-		conn, err := grpc.DialContext(ctx, mockPublicRpc(vaaCheckGuardianIndex), grpc.WithTransportCredentials(insecure.NewCredentials()))
+		conn, err := grpc.DialContext(ctx, mockPublicRpc(testId, vaaCheckGuardianIndex), grpc.WithTransportCredentials(insecure.NewCredentials()))
 		require.NoError(t, err)
 
 		defer conn.Close()
@@ -628,38 +672,12 @@ func testConsensus(t *testing.T, testCases []testCase, numGuardians int) {
 			logger.Info("Checking result of testcase", zap.Int("test_case", i))
 
 			// poll the API until we get a response without error
-			var r *publicrpcv1.GetSignedVAAResponse
-			var err error
-			for {
-				select {
-				case <-ctx.Done():
-					break
-				default:
-					// timeout for grpc query
-					logger.Info("attempting to query for VAA", zap.Int("test_case", i))
-					queryCtx, queryCancel := context.WithTimeout(ctx, time.Second)
-					r, err = c.GetSignedVAA(queryCtx, &publicrpcv1.GetSignedVAARequest{
-						MessageId: &publicrpcv1.MessageID{
-							EmitterChain:   publicrpcv1.ChainID(msg.EmitterChain),
-							EmitterAddress: msg.EmitterAddress.String(),
-							Sequence:       msg.Sequence,
-						},
-					})
-					queryCancel()
-					if err != nil {
-						logger.Info("error querying for VAA. Trying agin in 100ms.", zap.Int("test_case", i), zap.Error(err))
-					}
-				}
-				if err == nil && r != nil {
-					logger.Info("Received VAA from publicrpc", zap.Int("test_case", i), zap.Binary("vaa_bytes", r.VaaBytes))
-					break
-				}
-				if testCase.mustNotReachQuorum {
-					// no need to re-try because we're expecting an error. (and later we'll assert that's indeed an error)
-					break
-				}
-				time.Sleep(time.Millisecond * 100)
+			msgId := &publicrpcv1.MessageID{
+				EmitterChain:   publicrpcv1.ChainID(msg.EmitterChain),
+				EmitterAddress: msg.EmitterAddress.String(),
+				Sequence:       msg.Sequence,
 			}
+			r, err := waitForVaa(ctx, c, msgId, testCase.mustNotReachQuorum)
 
 			assert.NotEqual(t, testCase.mustNotReachQuorum, testCase.mustReachQuorum) // either or
 			if testCase.mustNotReachQuorum {
@@ -858,4 +876,239 @@ func (c fatalHook) OnWrite(ce *zapcore.CheckedEntry, fields []zapcore.Field) {
 
 	c <- sb.String()
 	panic(ce.Message)
+}
+
+func signingMsgs(n int) [][]byte {
+	msgs := make([][]byte, n)
+	for i := 0; i < len(msgs); i++ {
+		msgs[i] = ethcrypto.Keccak256Hash([]byte{byte(i)}).Bytes()
+	}
+	return msgs
+}
+
+func signMsgsP2p(pk libp2p_crypto.PrivKey, msgs [][]byte) [][]byte {
+	n := len(msgs)
+	signatures := make([][]byte, n)
+	// Ed25519.Sign
+	for i := 0; i < n; i++ {
+		sig, err := pk.Sign(msgs[i])
+		if err != nil {
+			panic(err)
+		}
+		signatures[i] = sig
+	}
+	return signatures
+}
+
+func signMsgsEth(pk *ecdsa.PrivateKey, msgs [][]byte) [][]byte {
+	n := len(msgs)
+	signatures := make([][]byte, n)
+	// Ed25519.Sign
+	for i := 0; i < n; i++ {
+		sig, err := ethcrypto.Sign(msgs[i], pk)
+		if err != nil {
+			panic(err)
+		}
+		signatures[i] = sig
+	}
+	return signatures
+}
+
+func BenchmarkCrypto(b *testing.B) {
+	b.Run("libp2p (Ed25519)", func(b *testing.B) {
+
+		p2pKey := devnet.DeterministicP2PPrivKeyByIndex(1)
+
+		b.Run("sign", func(b *testing.B) {
+			msgs := signingMsgs(b.N)
+			b.ResetTimer()
+			signMsgsP2p(p2pKey, msgs)
+		})
+
+		b.Run("verify", func(b *testing.B) {
+			msgs := signingMsgs(b.N)
+			signatures := signMsgsP2p(p2pKey, msgs)
+			b.ResetTimer()
+
+			// Ed25519.Verify
+			for i := 0; i < b.N; i++ {
+				ok, err := p2pKey.GetPublic().Verify(msgs[i], signatures[i])
+				assert.NoError(b, err)
+				assert.True(b, ok)
+			}
+		})
+	})
+
+	b.Run("ethcrypto (secp256k1)", func(b *testing.B) {
+
+		gk := devnet.InsecureDeterministicEcdsaKeyByIndex(ethcrypto.S256(), 0)
+		//gkc := ethcrypto.CompressPubkey(&gk.PublicKey)
+
+		b.Run("sign", func(b *testing.B) {
+			msgs := signingMsgs(b.N)
+			b.ResetTimer()
+			signMsgsEth(gk, msgs)
+		})
+
+		b.Run("verify", func(b *testing.B) {
+			msgs := signingMsgs(b.N)
+			signatures := signMsgsEth(gk, msgs)
+			b.ResetTimer()
+
+			// Ed25519.Verify
+			for i := 0; i < b.N; i++ {
+				_, err := ethcrypto.Ecrecover(msgs[i], signatures[i])
+				assert.NoError(b, err)
+				//assert.Equal(b, signer, gkc)
+			}
+		})
+	})
+}
+
+// How to run: go test -v -ldflags '-extldflags "-Wl,--allow-multiple-definition" ' -bench ^BenchmarkConsensus -benchtime=1x -count 1 -run ^$ > bench.log; tail bench.log
+func BenchmarkConsensus(b *testing.B) {
+	require.Equal(b, b.N, 1)
+	//CONSOLE_LOG_LEVEL = zap.DebugLevel
+	//CONSOLE_LOG_LEVEL = zap.InfoLevel
+	CONSOLE_LOG_LEVEL = zap.WarnLevel
+	benchmarkConsensus(b, "1", 19, 1000, 2) // ~28s
+	//benchmarkConsensus(b, "1", 19, 100, 2) // ~2s
+	//benchmarkConsensus(b, "1", 19, 100, 3) // sometimes fails, i.e. too much parallelism
+	//benchmarkConsensus(b, "1", 19, 100, 10) // sometimes fails, i.e. too much parallelism
+	//benchmarkConsensus(b, "1", 19, 100, 1) // 3s
+	//benchmarkConsensus(b, "1", 19, 20, 1) // 0.6s
+	//benchmarkConsensus(b, "1", 19, 5, 1) // 0.2s
+}
+
+func benchmarkConsensus(t *testing.B, name string, numGuardians int, numMessages int, maxPendingObs int) {
+	t.Run(name, func(t *testing.B) {
+		require.Equal(t, t.N, 1)
+		testId := getTestId()
+		msgSeqStart := someMsgSequenceCounter
+
+		const testTimeout = time.Minute * 2
+		const guardianSetIndex = 5 // index of the active guardian set (can be anything, just needs to be set to something)
+
+		// Test's main lifecycle context.
+		rootCtx, rootCtxCancel := context.WithTimeout(context.Background(), testTimeout)
+		defer rootCtxCancel()
+
+		zapLogger, zapObserver := setupLogsCapture()
+
+		supervisor.New(rootCtx, zapLogger, func(ctx context.Context) error {
+			logger := supervisor.Logger(ctx)
+
+			// create the Guardian Set
+			gs := newMockGuardianSet(numGuardians)
+
+			var obsDb mock.ObservationDb = nil // TODO
+
+			// run the guardians
+			for i := 0; i < numGuardians; i++ {
+				gRun := mockGuardianRunnable(testId, gs, uint(i), obsDb)
+				err := supervisor.Run(ctx, fmt.Sprintf("g-%d", i), gRun)
+				assert.NoError(t, err)
+			}
+			logger.Info("All Guardians initiated.")
+			supervisor.Signal(ctx, supervisor.SignalHealthy)
+
+			// Inform them of the Guardian Set
+			commonGuardianSet := common.GuardianSet{
+				Keys:  mockGuardianSetToGuardianAddrList(gs),
+				Index: guardianSetIndex,
+			}
+			for i, g := range gs {
+				logger.Info("Sending guardian set update", zap.Int("guardian_index", i))
+				g.MockSetC <- &commonGuardianSet
+			}
+
+			// wait for the status server to come online and check that it works
+			for i := range gs {
+				err := testStatusServer(ctx, logger, fmt.Sprintf("http://127.0.0.1:%d/metrics", mockStatusPort(testId, uint(i))))
+				assert.NoError(t, err)
+			}
+
+			// Wait for them to connect each other and receive at least one heartbeat.
+			// This is necessary because if they have not joined the p2p network yet, gossip messages may get dropped silently.
+			assert.True(t, WAIT_FOR_LOGS || WAIT_FOR_METRICS)
+			if WAIT_FOR_METRICS {
+				waitForPromMetricGte(t, testId, ctx, gs, PROMETHEUS_METRIC_VALID_HEARTBEAT_RECEIVED, 1)
+			}
+			if WAIT_FOR_LOGS {
+				waitForHeartbeatsInLogs(t, zapObserver, gs)
+			}
+			logger.Info("All Guardians have received at least one heartbeat.")
+
+			// Wait for publicrpc to come online.
+			for zapObserver.FilterMessage("publicrpc server listening").FilterField(zap.String("addr", mockPublicRpc(testId, 0))).Len() == 0 {
+				logger.Info("publicrpc seems to be offline (according to logs). Waiting 100ms...")
+				time.Sleep(time.Microsecond * 100)
+			}
+			// now that it's online, connect to publicrpc of guardian-0
+			conn, err := grpc.DialContext(ctx, mockPublicRpc(testId, 0), grpc.WithTransportCredentials(insecure.NewCredentials()))
+			require.NoError(t, err)
+			defer conn.Close()
+			c := publicrpcv1.NewPublicRPCServiceClient(conn)
+
+			logger.Info("-----------Beginning benchmark-----------")
+			t.ResetTimer()
+
+			// nextObsReadyC ensures that there are not more than `maxPendingObs` observations pending at any given point in time.
+			nextObsReadyC := make(chan struct{}, maxPendingObs)
+			for j := 0; j < maxPendingObs; j++ {
+				nextObsReadyC <- struct{}{}
+			}
+
+			go func() {
+				// feed observations to nodes
+				for i := 0; i < numMessages; i++ {
+					select {
+					case <-ctx.Done():
+						return
+					case <-nextObsReadyC:
+						msg := someMessage()
+						for _, g := range gs {
+							msgCopy := *msg
+							g.MockObservationC <- &msgCopy
+						}
+					}
+				}
+			}()
+
+			// check that the VAAs were generated
+			for i := 0; i < numMessages; i++ {
+				msgId := &publicrpcv1.MessageID{
+					EmitterChain:   publicrpcv1.ChainID(someMsgEmitterChain),
+					EmitterAddress: someMsgEmitter.String(),
+					Sequence:       msgSeqStart + uint64(i+1),
+				}
+				// a VAA should not take longer than 10s to be produced, no matter what.
+				waitCtx, cancelFunc := context.WithTimeout(ctx, time.Second*10)
+				_, err := waitForVaa(waitCtx, c, msgId, false)
+				cancelFunc()
+				assert.NoError(t, err)
+				if err != nil {
+					// early cancel the benchmark
+					rootCtxCancel()
+				}
+				nextObsReadyC <- struct{}{}
+			}
+
+			// We're done!
+			logger.Info("Tests completed.")
+			t.StopTimer()
+			supervisor.Signal(ctx, supervisor.SignalDone)
+			rootCtxCancel()
+			return nil
+		},
+			supervisor.WithPropagatePanic)
+
+		<-rootCtx.Done()
+		assert.NotEqual(t, rootCtx.Err(), context.DeadlineExceeded)
+		zapLogger.Info("Test root context cancelled, exiting...")
+
+		// wait for everything to shut down gracefully TODO since switching to portIds by `testId`, this is no longer necessary
+		//time.Sleep(time.Second * 11) // 11s is needed to gracefully shutdown libp2p
+		time.Sleep(time.Second * 1) // 1s is needed to gracefully shutdown BadgerDB
+	})
 }

--- a/node/pkg/node/options.go
+++ b/node/pkg/node/options.go
@@ -46,6 +46,10 @@ func GuardianOptionP2P(p2pKey libp2p_crypto.PrivKey, networkId string, bootstrap
 			components := p2p.DefaultComponents()
 			components.Port = port
 
+			if g.env == common.GoTest {
+				components.WarnChannelOverflow = true
+			}
+
 			g.runnables["p2p"] = p2p.Run(
 				g.obsvC,
 				g.obsvReqC.writeC,

--- a/node/pkg/p2p/p2p.go
+++ b/node/pkg/p2p/p2p.go
@@ -3,6 +3,7 @@ package p2p
 import (
 	"context"
 	"crypto/ecdsa"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"strings"
@@ -10,10 +11,10 @@ import (
 	"time"
 
 	"github.com/certusone/wormhole/node/pkg/accountant"
-	node_common "github.com/certusone/wormhole/node/pkg/common"
+	"github.com/certusone/wormhole/node/pkg/common"
 	"github.com/certusone/wormhole/node/pkg/governor"
 	"github.com/certusone/wormhole/node/pkg/version"
-	"github.com/ethereum/go-ethereum/common"
+	eth_common "github.com/ethereum/go-ethereum/common"
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -71,11 +72,11 @@ var signedObservationRequestPrefix = []byte("signed_observation_request|")
 // heartbeatMaxTimeDifference specifies the maximum time difference between the local clock and the timestamp in incoming heartbeat messages. Heartbeats that are this old or this much into the future will be dropped. This value should encompass clock skew and network delay.
 var heartbeatMaxTimeDifference = time.Minute * 15
 
-func heartbeatDigest(b []byte) common.Hash {
+func heartbeatDigest(b []byte) eth_common.Hash {
 	return ethcrypto.Keccak256Hash(append(heartbeatMessagePrefix, b...))
 }
 
-func signedObservationRequestDigest(b []byte) common.Hash {
+func signedObservationRequestDigest(b []byte) eth_common.Hash {
 	return ethcrypto.Keccak256Hash(append(signedObservationRequestPrefix, b...))
 }
 
@@ -88,10 +89,12 @@ type Components struct {
 	// ConnMgr is the ConnectionManager that the Guardian is going to use
 	ConnMgr *connmgr.BasicConnMgr
 	// ProtectedHostByGuardianKey is used to ensure that only one p2p peer can be protected by any given known guardian key
-	ProtectedHostByGuardianKey map[common.Address]peer.ID
+	ProtectedHostByGuardianKey map[eth_common.Address]peer.ID
 	// ProtectedHostByGuardianKeyLock is only useful to prevent a race condition in test as ProtectedHostByGuardianKey
 	// is only accessed by a single routine at any given time in a running Guardian.
 	ProtectedHostByGuardianKeyLock sync.Mutex
+	// WarnChannelOverflow: If true, errors due to overflowing channels will produce logger.Warn
+	WarnChannelOverflow bool
 }
 
 func (f *Components) ListeningAddresses() []string {
@@ -118,7 +121,7 @@ func DefaultComponents() *Components {
 		},
 		Port:                       DefaultPort,
 		ConnMgr:                    mgr,
-		ProtectedHostByGuardianKey: make(map[common.Address]peer.ID),
+		ProtectedHostByGuardianKey: make(map[eth_common.Address]peer.ID),
 	}
 }
 
@@ -143,7 +146,7 @@ func Run(
 	signedInC chan<- *gossipv1.SignedVAAWithQuorum,
 	priv crypto.PrivKey,
 	gk *ecdsa.PrivateKey,
-	gst *node_common.GuardianSetState,
+	gst *common.GuardianSetState,
 	networkID string,
 	bootstrapPeers string,
 	nodeName string,
@@ -230,14 +233,14 @@ func Run(
 		go func() {
 			// gracefully shutdown p2p once context is canceled.
 			<-ctx.Done()
-			logger.Info("context canceled, shutting down p2p...")
+			logger.Info("context canceled, shutting down p2p...", zap.Error(ctx.Err()))
 
 			if sub != nil {
 				sub.Cancel()
 			}
 
 			if th != nil {
-				if err := th.Close(); err != nil {
+				if err := th.Close(); err != nil && !errors.Is(err, context.Canceled) {
 					logger.Error("Error closing the topic", zap.Error(err))
 				}
 			}
@@ -251,7 +254,9 @@ func Run(
 
 		defer func() {
 			// TODO: Right now we're canceling the root context because it used to be the case that libp2p cannot be cleanly restarted.
-			// But that seems to no longer be the case. We may want to revisit this. See (https://github.com/libp2p/go-libp2p/issues/992) for background.
+			// But that seems to no longer be the case. We may want to revisit this.
+			// After some testing, it seems like we would need to wait 10s for all listeners to get GC'd
+			// See (https://github.com/libp2p/go-libp2p/issues/992) for background.
 			logger.Error("p2p routine has exited, cancelling root context...")
 			rootCtxCancel()
 		}()
@@ -553,7 +558,7 @@ func Run(
 									zap.Binary("raw", envelope.Data),
 									zap.String("from", envelope.GetFrom().String()))
 							} else {
-								guardianAddr := common.BytesToAddress(s.GuardianAddr)
+								guardianAddr := eth_common.BytesToAddress(s.GuardianAddr)
 								prevPeerId, ok := components.ProtectedHostByGuardianKey[guardianAddr]
 								if ok {
 									if prevPeerId != peerId {
@@ -583,6 +588,9 @@ func Run(
 				case obsvC <- m.SignedObservation:
 					p2pMessagesReceived.WithLabelValues("observation").Inc()
 				default:
+					if components.WarnChannelOverflow {
+						logger.Warn("Ignoring SignedObservation because obsvC full", zap.String("hash", hex.EncodeToString(m.SignedObservation.Hash)))
+					}
 					p2pReceiveChannelOverflow.WithLabelValues("observation").Inc()
 				}
 			case *gossipv1.GossipMessage_SignedVaaWithQuorum:
@@ -590,6 +598,14 @@ func Run(
 				case signedInC <- m.SignedVaaWithQuorum:
 					p2pMessagesReceived.WithLabelValues("signed_vaa_with_quorum").Inc()
 				default:
+					if components.WarnChannelOverflow {
+						// TODO do not log this in production
+						var hexStr string
+						if vaa, err := vaa.Unmarshal(m.SignedVaaWithQuorum.Vaa); err == nil {
+							hexStr = vaa.HexDigest()
+						}
+						logger.Warn("Ignoring SignedVaaWithQuorum because signedInC full", zap.String("hash", hexStr))
+					}
 					p2pReceiveChannelOverflow.WithLabelValues("signed_vaa_with_quorum").Inc()
 				}
 			case *gossipv1.GossipMessage_SignedObservationRequest:
@@ -663,10 +679,10 @@ func createSignedHeartbeat(gk *ecdsa.PrivateKey, heartbeat *gossipv1.Heartbeat) 
 	}
 }
 
-func processSignedHeartbeat(from peer.ID, s *gossipv1.SignedHeartbeat, gs *node_common.GuardianSet, gst *node_common.GuardianSetState, disableVerify bool) (*gossipv1.Heartbeat, error) {
-	envelopeAddr := common.BytesToAddress(s.GuardianAddr)
+func processSignedHeartbeat(from peer.ID, s *gossipv1.SignedHeartbeat, gs *common.GuardianSet, gst *common.GuardianSetState, disableVerify bool) (*gossipv1.Heartbeat, error) {
+	envelopeAddr := eth_common.BytesToAddress(s.GuardianAddr)
 	idx, ok := gs.KeyIndex(envelopeAddr)
-	var pk common.Address
+	var pk eth_common.Address
 	if !ok {
 		if !disableVerify {
 			return nil, fmt.Errorf("invalid message: %s not in guardian set", envelopeAddr)
@@ -687,7 +703,7 @@ func processSignedHeartbeat(from peer.ID, s *gossipv1.SignedHeartbeat, gs *node_
 		return nil, errors.New("failed to recover public key")
 	}
 
-	signerAddr := common.BytesToAddress(ethcrypto.Keccak256(pubKey[1:])[12:])
+	signerAddr := eth_common.BytesToAddress(ethcrypto.Keccak256(pubKey[1:])[12:])
 	if pk != signerAddr && !disableVerify {
 		return nil, fmt.Errorf("invalid signer: %v", signerAddr)
 	}
@@ -716,10 +732,10 @@ func processSignedHeartbeat(from peer.ID, s *gossipv1.SignedHeartbeat, gs *node_
 	return &h, nil
 }
 
-func processSignedObservationRequest(s *gossipv1.SignedObservationRequest, gs *node_common.GuardianSet) (*gossipv1.ObservationRequest, error) {
-	envelopeAddr := common.BytesToAddress(s.GuardianAddr)
+func processSignedObservationRequest(s *gossipv1.SignedObservationRequest, gs *common.GuardianSet) (*gossipv1.ObservationRequest, error) {
+	envelopeAddr := eth_common.BytesToAddress(s.GuardianAddr)
 	idx, ok := gs.KeyIndex(envelopeAddr)
-	var pk common.Address
+	var pk eth_common.Address
 	if !ok {
 		return nil, fmt.Errorf("invalid message: %s not in guardian set", envelopeAddr)
 	} else {
@@ -738,7 +754,7 @@ func processSignedObservationRequest(s *gossipv1.SignedObservationRequest, gs *n
 		return nil, errors.New("failed to recover public key")
 	}
 
-	signerAddr := common.BytesToAddress(ethcrypto.Keccak256(pubKey[1:])[12:])
+	signerAddr := eth_common.BytesToAddress(ethcrypto.Keccak256(pubKey[1:])[12:])
 	if pk != signerAddr {
 		return nil, fmt.Errorf("invalid signer: %v", signerAddr)
 	}

--- a/node/pkg/processor/injection.go
+++ b/node/pkg/processor/injection.go
@@ -10,8 +10,8 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"go.uber.org/zap"
 
+	"github.com/certusone/wormhole/node/pkg/common"
 	"github.com/certusone/wormhole/node/pkg/supervisor"
-	"github.com/wormhole-foundation/wormhole/sdk/vaa"
 )
 
 var (
@@ -23,8 +23,9 @@ var (
 )
 
 // handleInjection processes a pre-populated VAA injected locally.
-func (p *Processor) handleInjection(ctx context.Context, v *vaa.VAA) {
+func (p *Processor) handleInjection(ctx context.Context, msg *common.MessagePublication) {
 	// Generate digest of the unsigned VAA.
+	v := msg.CreateVAA(0) // The guardian set index is not part of the digest, so we can pass in zero.
 	digest := v.SigningDigest()
 
 	// The internal originator is responsible for logging the full VAA, just log the digest here.

--- a/node/pkg/processor/processor.go
+++ b/node/pkg/processor/processor.go
@@ -96,7 +96,7 @@ type Processor struct {
 	signedInC <-chan *gossipv1.SignedVAAWithQuorum
 
 	// injectC is a channel of VAAs injected locally.
-	injectC <-chan *vaa.VAA
+	injectC <-chan *common.MessagePublication
 
 	// gk is the node's guardian private key
 	gk *ecdsa.PrivateKey
@@ -137,7 +137,7 @@ func NewProcessor(
 	gossipSendC chan<- []byte,
 	obsvC chan *gossipv1.SignedObservation,
 	obsvReqSendC chan<- *gossipv1.ObservationRequest,
-	injectC <-chan *vaa.VAA,
+	injectC <-chan *common.MessagePublication,
 	signedInC <-chan *gossipv1.SignedVAAWithQuorum,
 	gk *ecdsa.PrivateKey,
 	gst *common.GuardianSetState,


### PR DESCRIPTION
It makes more sense to use the MessagePublication type in the injectC channel because they are not VAAs yet. 
