### PR TITLE
node: processor v2 (refactor)

### DIFF
--- a/node/pkg/common/utils.go
+++ b/node/pkg/common/utils.go
@@ -1,0 +1,18 @@
+package common
+
+import "golang.org/x/exp/constraints"
+
+func Min[K constraints.Ordered](v []K) *K {
+	if len(v) == 0 {
+		return nil
+	}
+
+	lowest := v[0]
+	for _, k := range v {
+		if k < lowest {
+			lowest = k
+		}
+	}
+
+	return &lowest
+}

--- a/node/pkg/node/node.go
+++ b/node/pkg/node/node.go
@@ -18,12 +18,13 @@ import (
 )
 
 const (
-	inboundObservationBufferSize         = 50
-	inboundSignedVaaBufferSize           = 50
-	observationRequestOutboundBufferSize = 50
-	observationRequestInboundBufferSize  = 50
+	gossipSendBufferSize                 = 1000
+	inboundObservationBufferSize         = 5000
+	inboundSignedVaaBufferSize           = 500
+	observationRequestOutboundBufferSize = 500
+	observationRequestInboundBufferSize  = 500
 	// observationRequestBufferSize is the buffer size of the per-network reobservation channel
-	observationRequestBufferSize = 25
+	observationRequestBufferSize = 250
 )
 
 type PrometheusCtxKey struct{}
@@ -84,7 +85,7 @@ func (g *G) initializeBasic(logger *zap.Logger, rootCtxCancel context.CancelFunc
 	g.rootCtxCancel = rootCtxCancel
 
 	// Setup various channels...
-	g.gossipSendC = make(chan []byte)
+	g.gossipSendC = make(chan []byte, gossipSendBufferSize)
 	g.obsvC = make(chan *gossipv1.SignedObservation, inboundObservationBufferSize)
 	g.msgC = makeChannelPair[*common.MessagePublication](0)
 	g.setC = makeChannelPair[*common.GuardianSet](1) // This needs to be a buffered channel because of a circular dependency between processor and accountant during startup.

--- a/node/pkg/node/node_test.go
+++ b/node/pkg/node/node_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/certusone/wormhole/node/pkg/common"
 	"github.com/certusone/wormhole/node/pkg/db"
 	"github.com/certusone/wormhole/node/pkg/devnet"
+	"github.com/certusone/wormhole/node/pkg/processor2"
+	"github.com/certusone/wormhole/node/pkg/processor2/reactor"
 	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
 	publicrpcv1 "github.com/certusone/wormhole/node/pkg/proto/publicrpc/v1"
 	"github.com/certusone/wormhole/node/pkg/readiness"
@@ -982,6 +984,8 @@ func BenchmarkConsensus(b *testing.B) {
 	require.Equal(b, b.N, 1)
 	CONSOLE_LOG_LEVEL = zap.WarnLevel
 	PROCESSOR_VERSION = 2
+	processor2.PARALLELISM = 2
+	reactor.PARALLELISM = 2
 	//CONSOLE_LOG_LEVEL = zap.InfoLevel
 	//CONSOLE_LOG_LEVEL = zap.DebugLevel
 
@@ -989,7 +993,7 @@ func BenchmarkConsensus(b *testing.B) {
 	//benchmarkConsensus(b, "1", 19, 500, 20) // panic: could not find [reactor-0x4b2863a46b48ca330fe7b82857bff6fa5d5e46bbd268fd17a8dad7c8fbd5c00b] (root.g-0.g.processor.vaa-reactor-manager.reactor-0x4b2863a46b48ca330fe7b82857bff6fa5d5e46bbd268fd17a8dad7c8fbd5c00b) in root.g-0.g.processor.vaa-reactor-manager (NODE_STATE_NEW)
 	//benchmarkConsensus(b, "1", 19, 200, 10) // panic (same as above)
 	//benchmarkConsensus(b, "1", 19, 100, 50) // with processor-v2: 50s
-	//benchmarkConsensus(b, "1", 19, 100, 10) // with processor-v2: 27s
+	benchmarkConsensus(b, "1", 19, 100, 10) // with processor-v2: 27s
 
 	//benchmarkConsensus(b, "1", 19, 1000, 30) // with processor-v1: 37s
 	//benchmarkConsensus(b, "1", 19, 1000, 20) // with processor-v1: 36s

--- a/node/pkg/processor2/reactor/manager.go
+++ b/node/pkg/processor2/reactor/manager.go
@@ -1,0 +1,283 @@
+package reactor
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"runtime"
+	"sync"
+
+	"github.com/benbjohnson/clock"
+
+	"github.com/certusone/wormhole/node/pkg/common"
+	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
+	"github.com/certusone/wormhole/node/pkg/supervisor"
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/wormhole-foundation/wormhole/sdk/vaa"
+	"go.uber.org/zap"
+)
+
+// Manager handles the creation and maintenance of reactors for incoming local and foreign observations
+type Manager[K Observation] struct {
+	// group of the manager. This is a label for this manager and all associated reactors.
+	group string
+	// observationC is a channel of observed emitted messages
+	observationC <-chan K
+
+	// confirmationC is a channel of inbound decoded observations from p2p
+	confirmationC <-chan *gossipv1.SignedObservation
+
+	// reactors are the current live reactors. This list may contain prepared reactors in StateInitialized. This field
+	// may only be touched by removeReactor and loadOrCreateReactor.
+	reactors              map[ethcommon.Hash]*ConsensusReactor[K]
+	reactorsReverseLookup map[*ConsensusReactor[K]]ethcommon.Hash
+	reactorsLock          sync.Mutex
+
+	// stateTransitionChan is a channel of state transitions. This channel is used to communicate state transitions from
+	// the reactors to the manager.
+	stateTransitionChan chan *StateTransition[K]
+
+	// gst is managed by the processor and allows concurrent access to the
+	// guardian set by other components.
+	gst *common.GuardianSetState
+
+	// config template for the reactors
+	config Config
+	// handler for manager events
+	handler ManagerEventHandler[K]
+
+	// storage for storing state and signed observations
+	storage ConsensusStorage[K]
+
+	logger *zap.Logger
+	clock  clock.Clock
+}
+
+// ManagerEventHandler handles significant consensus event from reactors
+type ManagerEventHandler[K Observation] interface {
+	HandleQuorum(observation K, signatures []*vaa.Signature)
+	HandleFinalization(observation K, signatures []*vaa.Signature)
+	HandleTimeout(previousState State, digest ethcommon.Hash, observation K, signatures []*vaa.Signature)
+}
+
+// NewManager creates a new reactor manager
+func NewManager[K Observation](group string, observationC <-chan K, confirmationC <-chan *gossipv1.SignedObservation, gst *common.GuardianSetState, config Config, handler ManagerEventHandler[K], storage ConsensusStorage[K]) *Manager[K] {
+	m := &Manager[K]{
+		group:                 group,
+		observationC:          observationC,
+		confirmationC:         confirmationC,
+		reactors:              map[ethcommon.Hash]*ConsensusReactor[K]{},
+		reactorsReverseLookup: map[*ConsensusReactor[K]]ethcommon.Hash{},
+		gst:                   gst,
+		config:                config,
+		handler:               handler,
+		storage:               storage,
+		stateTransitionChan:   make(chan *StateTransition[K], 1000),
+		clock:                 clock.New(),
+	}
+
+	return m
+}
+
+func (p *Manager[K]) Run(ctx context.Context) error {
+	// Share a logger between runners
+	p.logger = supervisor.Logger(ctx)
+	p.logger = p.logger.With(zap.String("group", p.group))
+
+	wg := sync.WaitGroup{}
+	for i := 0; i < runtime.NumCPU()/2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case s := <-p.stateTransitionChan:
+					p.reactorsLock.Lock()
+					digest, exists := p.reactorsReverseLookup[s.Reactor]
+					p.reactorsLock.Unlock()
+					if !exists {
+						p.logger.Warn("received state transition for unknown reactor - dropping", zap.Any("transition", s))
+						continue
+					}
+					p.transitionHook(digest, s)
+				case k := <-p.observationC:
+					messagesObservedTotal.WithLabelValues(p.group).Inc()
+
+					digest := k.SigningDigest()
+					p.logger.Debug("received observation", zap.Stringer("digest", digest), zap.Any("observation", k))
+
+					r, err := p.loadOrCreateReactor(ctx, digest, p.gst.Get(), p.storageObservationFilter(k.MessageID()))
+					if err != nil {
+						p.logger.Error("failed to load or create reactor", zap.Error(err), zap.Stringer("digest", digest))
+						continue
+					}
+					r.ObservationChannel() <- k
+				case m := <-p.confirmationC:
+					digest := ethcommon.BytesToHash(m.Hash)
+
+					gs := p.gst.Get()
+
+					r, err := p.loadOrCreateReactor(ctx, digest, gs, chainNewReactorFilters(
+						// Signed observations have to be verified before creating reactors to prevent DoS.
+						// They will also be verified in the reactor; This duplication is intended as the overhead of verifying
+						// signatures twice is worth the reduced complexity and security risk from not having a code
+						// path in the reactor that skips verification. It also only evaluates if a new reactor would be created.
+						p.signedObservationSignatureFilter(gs, m),
+						p.storageObservationFilter(m.MessageId),
+					))
+					if err != nil {
+						p.logger.Error("failed to load or create reactor", zap.Error(err), zap.Stringer("digest", digest))
+						continue
+					}
+					r.ForeignObservationChannel() <- m
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	return nil
+}
+
+func (p *Manager[K]) IterateReactors(iterF func(digest ethcommon.Hash, reactor *ConsensusReactor[K])) {
+	p.reactorsLock.Lock()
+	defer p.reactorsLock.Unlock()
+
+	for digest, reactor := range p.reactors {
+		iterF(digest, reactor)
+	}
+}
+
+func (p *Manager[K]) transitionHook(digest ethcommon.Hash, s *StateTransition[K]) {
+	switch s.ToState {
+	case StateQuorum:
+		p.logger.Debug("reactor reached quorum", zap.Stringer("digest", digest), zap.String("message_id", s.Reactor.Observation().MessageID()))
+
+		// Store in the database
+		if p.storage != nil {
+			err := p.storage.StoreSignedObservation(s.Reactor.Observation(), s.Reactor.VAASignatures())
+			if err != nil {
+				p.logger.Error("failed to store signed observation on quorum", zap.String("message_id", s.Reactor.Observation().MessageID()), zap.Stringer("digest", s.Reactor.Observation().SigningDigest()), zap.Error(err))
+			}
+		}
+
+		// Handle consensus
+		go p.handler.HandleQuorum(s.Reactor.Observation(), s.Reactor.VAASignatures())
+	case StateFinalized:
+		// Remove from the reactors list
+		p.removeReactor(digest)
+
+		// Store in the database. The Signed Observation will already be in storage from reaching StateQuorum. It is
+		// stored again because more signatures may have been collected before reaching finalization.
+		if p.storage != nil {
+			err := p.storage.StoreSignedObservation(s.Reactor.Observation(), s.Reactor.VAASignatures())
+			if err != nil {
+				p.logger.Error("failed to store signed observation on finalization", zap.String("message_id", s.Reactor.Observation().MessageID()), zap.Stringer("digest", s.Reactor.Observation().SigningDigest()), zap.Error(err))
+			}
+		}
+
+		p.logger.Debug("reactor finalized and removed from manager", zap.Stringer("digest", digest), zap.String("message_id", s.Reactor.Observation().MessageID()))
+		go p.handler.HandleFinalization(s.Reactor.Observation(), s.Reactor.VAASignatures())
+	case StateTimedOut:
+		// Remove from the reactors list
+		p.removeReactor(digest)
+
+		p.logger.Debug("reactor timed out and removed from manager", zap.Stringer("digest", digest))
+		go p.handler.HandleTimeout(s.FromState, digest, s.Reactor.Observation(), s.Reactor.VAASignatures())
+	}
+}
+
+func (p *Manager[K]) loadOrCreateReactor(ctx context.Context, digest ethcommon.Hash, gs *common.GuardianSet, filter func(digest ethcommon.Hash) bool) (*ConsensusReactor[K], error) {
+	p.reactorsLock.Lock()
+	defer p.reactorsLock.Unlock()
+
+	var r *ConsensusReactor[K]
+	if reactor, exists := p.reactors[digest]; exists {
+		p.logger.Debug("found existing reactor", zap.Stringer("digest", digest))
+		r = reactor
+	} else {
+		if filter != nil && !filter(digest) {
+			return nil, fmt.Errorf("filter prevented creation of new reactor")
+		}
+
+		p.logger.Debug("creating new reactor", zap.Stringer("digest", digest))
+		r = NewReactor[K](p.group, &p.config, gs, p.stateTransitionChan)
+		r.clock = p.clock
+		err := supervisor.Run(ctx, fmt.Sprintf("reactor-%s", digest.String()), r.Run)
+		if err != nil {
+			return nil, fmt.Errorf("failed to spawn reactor routine: %w", err)
+		}
+		p.reactors[digest] = r
+		p.reactorsReverseLookup[r] = digest
+		reactorNum.WithLabelValues(p.group).Set(float64(len(p.reactors)))
+	}
+
+	return r, nil
+}
+
+func (p *Manager[K]) removeReactor(digest ethcommon.Hash) {
+	p.reactorsLock.Lock()
+	defer p.reactorsLock.Unlock()
+	r, exists := p.reactors[digest]
+	if exists {
+		delete(p.reactors, digest)
+		delete(p.reactorsReverseLookup, r)
+	}
+	reactorNum.WithLabelValues(p.group).Set(float64(len(p.reactors)))
+}
+
+// newReactorFilter is a filter function that returns true if a reactor should be created for a given digest.
+type newReactorFilter func(digest ethcommon.Hash) bool
+
+// chainNewReactorFilters returns a newReactorFilter that chains multiple filters together.
+func chainNewReactorFilters(filters ...newReactorFilter) newReactorFilter {
+	return func(digest ethcommon.Hash) bool {
+		for _, f := range filters {
+			if !f(digest) {
+				return false
+			}
+		}
+		return true
+	}
+}
+
+// signedObservationSignatureFilter returns a newReactorFilter that filters out signed observations that are not signed by
+// a guardian in the guardian set.
+func (p *Manager[K]) signedObservationSignatureFilter(gs *common.GuardianSet, m *gossipv1.SignedObservation) newReactorFilter {
+	return func(digest ethcommon.Hash) bool {
+		err := verifySignedObservation(p.group, m, gs)
+		if err != nil {
+			p.logger.Debug("failed to verify signed observation - dropping",
+				zap.Error(err),
+				zap.Stringer("digest", digest),
+				zap.String("signature", hex.EncodeToString(m.Signature)),
+				zap.String("addr", hex.EncodeToString(m.Addr)),
+			)
+			return false
+		}
+
+		return true
+	}
+}
+
+// storageObservationFilter returns a newReactorFilter that checks if a message is already in storage.
+func (p *Manager[K]) storageObservationFilter(messageID string) newReactorFilter {
+	return func(digest ethcommon.Hash) bool {
+		if p.storage != nil {
+			existingObservation, _, found, err := p.storage.GetSignedObservation(messageID)
+			if err != nil {
+				p.logger.Warn("failed to check db for existing signed observation", zap.String("message_id", messageID), zap.Stringer("digest", digest), zap.Error(err))
+			}
+			if found {
+				p.logger.Debug("ignoring confirmation - already in storage and no live reactor", zap.String("message_id", messageID), zap.Stringer("digest", digest), zap.Stringer("digest_stored", existingObservation.SigningDigest()))
+				return false
+			}
+		}
+
+		return true
+	}
+}

--- a/node/pkg/processor2/reactor/manager.go
+++ b/node/pkg/processor2/reactor/manager.go
@@ -17,6 +17,8 @@ import (
 	"go.uber.org/zap"
 )
 
+var PARALLELISM = runtime.NumCPU() / 2
+
 // Manager handles the creation and maintenance of reactors for incoming local and foreign observations
 type Manager[K Observation] struct {
 	// group of the manager. This is a label for this manager and all associated reactors.
@@ -85,7 +87,7 @@ func (p *Manager[K]) Run(ctx context.Context) error {
 	p.logger = p.logger.With(zap.String("group", p.group))
 
 	wg := sync.WaitGroup{}
-	for i := 0; i < runtime.NumCPU()/2; i++ {
+	for i := 0; i < PARALLELISM; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/node/pkg/processor2/reactor/manager_persistence.go
+++ b/node/pkg/processor2/reactor/manager_persistence.go
@@ -1,0 +1,11 @@
+package reactor
+
+import "github.com/wormhole-foundation/wormhole/sdk/vaa"
+
+// ConsensusStorage is used to store observations and consensus reactor state
+type ConsensusStorage[K Observation] interface {
+	// StoreSignedObservation stores a signed observation
+	StoreSignedObservation(observation K, signatures []*vaa.Signature) error
+	// GetSignedObservation retrieves a signed observation from the DB using the message id as key
+	GetSignedObservation(id string) (observation K, signatures []*vaa.Signature, found bool, err error)
+}

--- a/node/pkg/processor2/reactor/manager_test.go
+++ b/node/pkg/processor2/reactor/manager_test.go
@@ -1,0 +1,481 @@
+package reactor
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/benbjohnson/clock"
+
+	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/wormhole-foundation/wormhole/sdk/vaa"
+
+	"go.uber.org/zap"
+
+	common2 "github.com/certusone/wormhole/node/pkg/common"
+	"github.com/certusone/wormhole/node/pkg/supervisor"
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type (
+	managerTestContext struct {
+		guardianKeys []*ecdsa.PrivateKey
+		gs           *common2.GuardianSet
+
+		obsC       chan<- *testObservation
+		signedObsC chan<- *gossipv1.SignedObservation
+
+		storage      *testConsensusStorage
+		eventHandler *testManagerEventHandler[*testObservation]
+
+		clock *clock.Mock
+	}
+
+	managerTestAction interface {
+		Evaluate(t *testing.T, r *Manager[*testObservation], testContext *managerTestContext)
+	}
+
+	// managerInjectForeignObservationAction injects an observation with hash `hash`, signed by the guardian with index `guardianIndex`.
+	// If `invalid == true`, the signature will be random bytes.
+	managerInjectForeignObservationAction struct {
+		hash          [32]byte
+		guardianIndex int
+		invalid       bool
+	}
+
+	// managerInjectOwnObservationAction injects an observation into `obsC`, as if this Guardian has made that observation.
+	managerInjectOwnObservationAction struct {
+		observation *testObservation
+	}
+
+	// managerAssertNumReactorsAction asserts that there are currently exactly `numReactors` active reactors
+	managerAssertNumReactorsAction struct {
+		numReactors int
+	}
+
+	// managerAssertHasReactorAction asserts that there exists at least one reactor for `digest`.
+	managerAssertHasReactorAction struct {
+		digest common.Hash
+	}
+
+	// managerAssertQuorumEventAction assets that the oldest observation that received quorum is equal to `observation`.
+	// It then removes that observation from the storage.
+	managerAssertQuorumEventAction struct {
+		observation *testObservation
+	}
+
+	// managerAssertFinalizationEventAction assets that the oldest observation that has been finalized
+	// (i.e. timed out after reaching quorum) is equal to `observation`.
+	// It then removes that observation from the storage.
+	managerAssertFinalizationEventAction struct {
+		observation *testObservation
+	}
+
+	// managerAssertTimeoutEventAction asserts that there has been exactly one timeout event (as specified)
+	// and then removes that event from the storage
+	managerAssertTimeoutEventAction struct {
+		previousState State
+		observation   *testObservation
+		lenSignatures int
+	}
+
+	// managerAssertNoEvents asserts that there are no events in the cache
+	managerAssertNoEvents struct {
+	}
+
+	// managerAssertMessageInStorageAction asserts that a message with id `id` exists or does not exist in storage
+	managerAssertMessageInStorageAction struct {
+		id             string
+		shouldNotExist bool
+	}
+
+	// managerWaitAction advances the clock by `duration`
+	managerWaitAction struct {
+		duration time.Duration
+	}
+)
+
+func (m managerAssertNoEvents) Evaluate(t *testing.T, r *Manager[*testObservation], testContext *managerTestContext) {
+	testContext.eventHandler.l.Lock()
+	defer testContext.eventHandler.l.Unlock()
+
+	require.Empty(t, testContext.eventHandler.quorumEvents, m)
+	require.Empty(t, testContext.eventHandler.timeoutEvents, m)
+	require.Empty(t, testContext.eventHandler.finalizationEvents, m)
+}
+
+func (m managerAssertMessageInStorageAction) Evaluate(t *testing.T, r *Manager[*testObservation], testContext *managerTestContext) {
+	_, _, found, err := testContext.storage.GetSignedObservation(m.id)
+	require.NoError(t, err, m)
+	require.Equal(t, !m.shouldNotExist, found, m)
+}
+
+func (m managerAssertQuorumEventAction) Evaluate(t *testing.T, r *Manager[*testObservation], testContext *managerTestContext) {
+	testContext.eventHandler.l.Lock()
+	defer testContext.eventHandler.l.Unlock()
+
+	require.GreaterOrEqual(t, len(testContext.eventHandler.quorumEvents), 1, m)
+	event := testContext.eventHandler.quorumEvents[0]
+
+	require.Equal(t, m.observation, event.observation, m)
+	require.GreaterOrEqual(t, len(event.signatures), vaa.CalculateQuorum(len(testContext.gs.Keys)), m)
+
+	testContext.eventHandler.quorumEvents = testContext.eventHandler.quorumEvents[1:]
+}
+
+func (m managerAssertFinalizationEventAction) Evaluate(t *testing.T, r *Manager[*testObservation], testContext *managerTestContext) {
+	testContext.eventHandler.l.Lock()
+	defer testContext.eventHandler.l.Unlock()
+
+	require.GreaterOrEqual(t, len(testContext.eventHandler.finalizationEvents), 1, m)
+	event := testContext.eventHandler.finalizationEvents[0]
+
+	require.Equal(t, m.observation, event.observation, m)
+	require.GreaterOrEqual(t, len(event.signatures), vaa.CalculateQuorum(len(testContext.gs.Keys)), m)
+
+	testContext.eventHandler.finalizationEvents = testContext.eventHandler.finalizationEvents[1:]
+}
+
+func (m managerAssertTimeoutEventAction) Evaluate(t *testing.T, r *Manager[*testObservation], testContext *managerTestContext) {
+	testContext.eventHandler.l.Lock()
+	defer testContext.eventHandler.l.Unlock()
+
+	require.GreaterOrEqual(t, len(testContext.eventHandler.timeoutEvents), 1, m)
+	event := testContext.eventHandler.timeoutEvents[0]
+
+	require.Equal(t, m.observation, event.observation, m)
+	require.Equal(t, len(event.signatures), m.lenSignatures, m)
+	require.Equal(t, event.previousState, m.previousState, m)
+
+	testContext.eventHandler.timeoutEvents = testContext.eventHandler.timeoutEvents[1:]
+}
+
+func (m managerAssertNumReactorsAction) Evaluate(t *testing.T, r *Manager[*testObservation], testContext *managerTestContext) {
+	n := 0
+	r.IterateReactors(func(digest common.Hash, reactor *ConsensusReactor[*testObservation]) {
+		n++
+	})
+
+	require.Equal(t, m.numReactors, n, m)
+}
+
+func (m managerAssertHasReactorAction) Evaluate(t *testing.T, r *Manager[*testObservation], testContext *managerTestContext) {
+	has := false
+	r.IterateReactors(func(digest common.Hash, reactor *ConsensusReactor[*testObservation]) {
+		if digest == m.digest {
+			has = true
+		}
+	})
+
+	require.True(t, has, m)
+}
+
+func (i managerInjectOwnObservationAction) Evaluate(t *testing.T, m *Manager[*testObservation], testContext *managerTestContext) {
+	testContext.obsC <- i.observation
+}
+
+func (i managerInjectForeignObservationAction) Evaluate(t *testing.T, m *Manager[*testObservation], testContext *managerTestContext) {
+	sig, err := ethcrypto.Sign(i.hash[:], testContext.guardianKeys[i.guardianIndex])
+	require.NoError(t, err, m)
+	signedObservation := &gossipv1.SignedObservation{
+		Addr:      testContext.gs.Keys[i.guardianIndex].Bytes(),
+		Hash:      i.hash[:],
+		Signature: sig,
+		TxHash:    []byte{12, 13},
+		MessageId: "test/message",
+	}
+	if i.invalid {
+		n, err := rand.Read(signedObservation.Signature)
+		require.NoError(t, err, m)
+		require.Equal(t, 65, n, m)
+	}
+	testContext.signedObsC <- signedObservation
+}
+
+func (w managerWaitAction) Evaluate(t *testing.T, r *Manager[*testObservation], testContext *managerTestContext) {
+	testContext.clock.Set(testContext.clock.Now().Add(w.duration))
+}
+
+// testConsensusStorage stores observations and their signatures in a dict
+type (
+	testConsensusStorage struct {
+		signatures map[string]testConsensusStorageEntry
+		l          sync.Mutex
+	}
+
+	testConsensusStorageEntry struct {
+		observation *testObservation
+		signatures  []*vaa.Signature
+	}
+)
+
+func (t *testConsensusStorage) StoreSignedObservation(observation *testObservation, signatures []*vaa.Signature) error {
+	t.l.Lock()
+	defer t.l.Unlock()
+	t.signatures[observation.MessageID()] = testConsensusStorageEntry{
+		observation: observation,
+		signatures:  signatures,
+	}
+
+	return nil
+}
+
+func (t *testConsensusStorage) GetSignedObservation(id string) (observation *testObservation, signatures []*vaa.Signature, found bool, err error) {
+	t.l.Lock()
+	defer t.l.Unlock()
+	v, exists := t.signatures[id]
+	if !exists {
+		return nil, nil, false, nil
+	}
+
+	return v.observation, v.signatures, true, nil
+}
+
+// testManagerEventHandler stores incoming events in the respective local array
+type testManagerEventHandler[K Observation] struct {
+	quorumEvents []struct {
+		observation K
+		signatures  []*vaa.Signature
+	}
+	finalizationEvents []struct {
+		observation K
+		signatures  []*vaa.Signature
+	}
+	timeoutEvents []struct {
+		previousState State
+		digest        common.Hash
+		observation   K
+		signatures    []*vaa.Signature
+	}
+	l sync.Mutex
+}
+
+func (t *testManagerEventHandler[K]) HandleQuorum(observation K, signatures []*vaa.Signature) {
+	t.l.Lock()
+	defer t.l.Unlock()
+	t.quorumEvents = append(t.quorumEvents, struct {
+		observation K
+		signatures  []*vaa.Signature
+	}{observation: observation, signatures: signatures})
+}
+
+func (t *testManagerEventHandler[K]) HandleFinalization(observation K, signatures []*vaa.Signature) {
+	t.l.Lock()
+	defer t.l.Unlock()
+	t.finalizationEvents = append(t.finalizationEvents, struct {
+		observation K
+		signatures  []*vaa.Signature
+	}{observation: observation, signatures: signatures})
+}
+
+func (t *testManagerEventHandler[K]) HandleTimeout(previousState State, digest common.Hash, observation K, signatures []*vaa.Signature) {
+	t.l.Lock()
+	defer t.l.Unlock()
+	t.timeoutEvents = append(t.timeoutEvents, struct {
+		previousState State
+		digest        common.Hash
+		observation   K
+		signatures    []*vaa.Signature
+	}{previousState: previousState, digest: digest, observation: observation, signatures: signatures})
+}
+
+func TestManager(t *testing.T) {
+	testObservation2 := &testObservation{
+		id: []byte{1, 5, 0, 2, 3},
+	}
+	tests := []struct {
+		name         string
+		actions      []managerTestAction
+		config       *Config
+		numGuardians int
+		notAGuardian bool
+	}{
+		{
+			name:         "NormalFlow2Guardians",
+			numGuardians: 2,
+			actions: []managerTestAction{
+				managerInjectOwnObservationAction{observation: &testObservation{}},
+				managerAssertNumReactorsAction{1},
+				managerAssertNoEvents{},
+				managerInjectForeignObservationAction{
+					hash:          testObservationHash(),
+					guardianIndex: 1,
+				},
+				managerAssertQuorumEventAction{observation: &testObservation{}},
+				managerAssertMessageInStorageAction{id: (&testObservation{}).MessageID()},
+				managerWaitAction{duration: time.Millisecond * 24},
+				managerAssertFinalizationEventAction{observation: &testObservation{}},
+				managerAssertNumReactorsAction{0},
+			},
+		},
+		{
+			name:         "ForeignFirst2Guardians",
+			numGuardians: 2,
+			actions: []managerTestAction{
+				managerInjectForeignObservationAction{
+					hash:          testObservationHash(),
+					guardianIndex: 1,
+				},
+				managerAssertNumReactorsAction{1},
+				managerAssertNoEvents{},
+				managerInjectOwnObservationAction{observation: &testObservation{}},
+				managerAssertQuorumEventAction{observation: &testObservation{}},
+				managerAssertMessageInStorageAction{id: (&testObservation{}).MessageID()},
+				managerWaitAction{duration: time.Millisecond * 24},
+				managerAssertFinalizationEventAction{observation: &testObservation{}},
+				managerAssertNumReactorsAction{0},
+			},
+		},
+		{
+			name:         "NoQuorum2Guardians",
+			numGuardians: 2,
+			actions: []managerTestAction{
+				managerInjectOwnObservationAction{observation: &testObservation{}},
+				managerAssertNumReactorsAction{1},
+				managerAssertNoEvents{},
+				managerWaitAction{duration: time.Millisecond * 26},
+				managerAssertNumReactorsAction{0},
+				managerAssertTimeoutEventAction{observation: &testObservation{}, previousState: StateObserved, lenSignatures: 1},
+				managerAssertMessageInStorageAction{id: (&testObservation{}).MessageID(), shouldNotExist: true},
+			},
+		},
+		{
+			name:         "DuplicateProtectionUsingStorage",
+			numGuardians: 2,
+			actions: []managerTestAction{
+				managerInjectOwnObservationAction{observation: &testObservation{}},
+				managerInjectForeignObservationAction{
+					hash:          testObservationHash(),
+					guardianIndex: 1,
+				},
+				managerAssertNumReactorsAction{1},
+				managerWaitAction{duration: time.Millisecond * 40},
+				managerAssertFinalizationEventAction{observation: &testObservation{}},
+				managerAssertNumReactorsAction{0},
+				managerInjectOwnObservationAction{observation: &testObservation{}},
+				managerAssertNumReactorsAction{0},
+			},
+		},
+		{
+			name:         "SignatureVerification",
+			numGuardians: 2,
+			actions: []managerTestAction{
+				managerInjectForeignObservationAction{
+					hash:          testObservationHash(),
+					guardianIndex: 1,
+					invalid:       true,
+				},
+				managerWaitAction{duration: time.Millisecond * 20},
+				managerAssertNumReactorsAction{0},
+			},
+		},
+		{
+			name:         "MultipleReactors",
+			numGuardians: 4,
+			actions: []managerTestAction{
+				managerInjectForeignObservationAction{
+					hash:          testObservationHash(),
+					guardianIndex: 1,
+				},
+				managerInjectForeignObservationAction{
+					hash:          testObservationHash(),
+					guardianIndex: 2,
+				},
+				managerAssertNumReactorsAction{1},
+				managerInjectOwnObservationAction{observation: testObservation2},
+				managerInjectForeignObservationAction{
+					hash:          testObservation2.SigningDigest(),
+					guardianIndex: 2,
+				},
+				managerAssertNumReactorsAction{2},
+				managerAssertHasReactorAction{digest: testObservationHash()},
+				managerAssertHasReactorAction{digest: testObservation2.SigningDigest()},
+				managerAssertNoEvents{},
+				managerInjectOwnObservationAction{observation: &testObservation{}},
+				managerAssertQuorumEventAction{observation: &testObservation{}},
+				managerAssertNoEvents{},
+				managerAssertMessageInStorageAction{id: (&testObservation{}).MessageID()},
+				managerInjectForeignObservationAction{hash: testObservation2.SigningDigest(), guardianIndex: 1},
+				managerAssertQuorumEventAction{observation: testObservation2},
+				managerAssertNoEvents{},
+				managerWaitAction{time.Millisecond * 26},
+				managerAssertNumReactorsAction{0},
+				managerAssertFinalizationEventAction{&testObservation{}},
+				managerAssertFinalizationEventAction{observation: testObservation2},
+				managerAssertNoEvents{},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.NotEqual(t, test.numGuardians, 0)
+			gst := &common2.GuardianSetState{}
+			gs := &common2.GuardianSet{}
+			keys := make([]*ecdsa.PrivateKey, test.numGuardians)
+			for i := 0; i < test.numGuardians; i++ {
+				var err error
+				keys[i], err = ethcrypto.GenerateKey()
+				require.NoError(t, err)
+				gs.Keys = append(gs.Keys, ethcrypto.PubkeyToAddress(keys[i].PublicKey))
+			}
+			gst.Set(gs)
+
+			var signer Signer
+			if !test.notAGuardian {
+				signer = &testSigner{privKey: keys[0]}
+			}
+
+			config := &Config{
+				RetransmitFrequency: time.Millisecond * 10,
+				QuorumGracePeriod:   time.Millisecond * 20,
+				QuorumTimeout:       time.Millisecond * 20,
+				UnobservedTimeout:   time.Millisecond * 20,
+				Signer:              signer,
+			}
+			if test.config != nil {
+				config = test.config
+				// Make sure we set a signer
+				if config.Signer == nil {
+					config.Signer = signer
+				}
+			}
+			obsC := make(chan *testObservation, 10)
+			signedObsC := make(chan *gossipv1.SignedObservation, 10)
+			storage := &testConsensusStorage{
+				signatures: make(map[string]testConsensusStorageEntry),
+			}
+			eventHandler := &testManagerEventHandler[*testObservation]{}
+			tCtx := &managerTestContext{
+				guardianKeys: keys,
+				gs:           gs,
+				obsC:         obsC,
+				signedObsC:   signedObsC,
+				storage:      storage,
+				eventHandler: eventHandler,
+				clock:        clock.NewMock(),
+			}
+
+			r := NewManager[*testObservation]("test", obsC, signedObsC, gst, *config, eventHandler, storage)
+			r.clock = tCtx.clock
+
+			func() {
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+				logger, err := zap.NewDevelopment()
+				require.NoError(t, err)
+				supervisor.New(ctx, logger, r.Run)
+
+				for _, action := range test.actions {
+					action.Evaluate(t, r, tCtx)
+					time.Sleep(time.Millisecond * 10)
+				}
+			}()
+		})
+	}
+}

--- a/node/pkg/processor2/reactor/metrics.go
+++ b/node/pkg/processor2/reactor/metrics.go
@@ -1,0 +1,72 @@
+package reactor
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	observationsReceivedTotalVec = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "wormhole_observations_received_total_2",
+			Help: "Total number of raw observations received from gossip",
+		}, []string{"reactor_group"})
+	observationsReceivedByGuardianAddressTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "wormhole_observations_signed_by_guardian_total_2",
+			Help: "Total number of signed and verified observations grouped by guardian address",
+		}, []string{"reactor_group", "addr"})
+	observationsFailedTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "wormhole_observations_verification_failures_total_2",
+			Help: "Total number of observations verification failure, grouped by failure reason",
+		}, []string{"reactor_group", "cause"})
+	observationsBroadcastTotalVec = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "wormhole_observations_broadcast_total_2",
+			Help: "Total number of signed observations queued for broadcast",
+		}, []string{"reactor_group"})
+
+	messagesObservedTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "wormhole_message_observations_total_2",
+			Help: "Total number of messages observed",
+		}, []string{"reactor_group"})
+
+	messagesSignedTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "wormhole_message_observations_signed_total_2",
+			Help: "Total number of message observations that were successfully signed",
+		}, []string{"reactor_group"})
+
+	reactorNum = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "wormhole_consensus_num_reactors",
+			Help: "Current number of consensus reactors",
+		}, []string{"reactor_group"})
+	reactorTimedOut = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "wormhole_consensus_num_reactors_timed_out_total",
+			Help: "Total number of timed out reactors",
+		}, []string{"reactor_group", "time_out_state"})
+	reactorObservedLate = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "wormhole_consensus_late_observations_total",
+			Help: "Total number of late observations (cluster achieved consensus without us)",
+		}, []string{"reactor_group"})
+	reactorResubmission = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "wormhole_consensus_retransmission_total",
+			Help: "Total number of signed observation retransmissions",
+		}, []string{"reactor_group"})
+	reactorQuorum = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "wormhole_consensus_quorum_total",
+			Help: "Total number of reactors that reached quorum",
+		}, []string{"reactor_group", "type"})
+	reactorFinalized = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "wormhole_consensus_finalized_total",
+			Help: "Total number of reactors that were finalized, counted after waiting a fixed amount of time",
+		}, []string{"reactor_group"})
+)

--- a/node/pkg/processor2/reactor/reactor.go
+++ b/node/pkg/processor2/reactor/reactor.go
@@ -1,0 +1,544 @@
+package reactor
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/benbjohnson/clock"
+
+	"github.com/certusone/wormhole/node/pkg/supervisor"
+
+	node_common "github.com/certusone/wormhole/node/pkg/common"
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"go.uber.org/zap"
+
+	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
+	"github.com/wormhole-foundation/wormhole/sdk/vaa"
+)
+
+// ConsensusReactor implements the full consensus processor for a single Observation. It cannot be reused after being
+// finalized.
+type (
+	ConsensusReactor[K Observation] struct {
+		// group is the name of the reactor group
+		group string
+
+		// Copy of the guardian set valid at observation/injection time.
+		gs *node_common.GuardianSet
+
+		// Channel for receiving local observations
+		observationChannel chan K
+		// Channel for receiving foreign observations
+		foreignObservationChannel chan *gossipv1.SignedObservation
+
+		// Hook to be called on a state transition
+		stateTransitionChan chan<- *StateTransition[K]
+		// Configuration of the reactor
+		config *Config
+
+		// reactorState holds all mutable fields of the reactor. They may only be used while holding the
+		// reactorState.mutex.
+		state reactorState[K]
+
+		clock clock.Clock
+
+		logger *zap.Logger
+	}
+
+	reactorState[K Observation] struct {
+		// Current state of the reactor
+		currentState State
+		// First time this digest was seen (possibly even before we observed it ourselves).
+		firstSeen time.Time
+		// Time of the last new observation received
+		lastObservation time.Time
+		// The most recent time that the signature / observation has been transmitted
+		lastTransmission time.Time
+		// Time quorum was reached
+		timeQuorum time.Time
+
+		// Copy of our observation.
+		observation K
+		// Map of signatures seen by guardian. During guardian set updates, this may contain signatures belonging
+		// to either the old or new guardian set.
+		signatures map[ethcommon.Address][]byte
+		// Copy of the bytes we submitted (ourObservation, but signed and serialized). Used for retransmissions.
+		localSignature []byte
+
+		mutex sync.Mutex
+	}
+
+	// StateTransition is a struct containing the old and new state of the reactor
+	StateTransition[K Observation] struct {
+		FromState State
+		ToState   State
+		Reactor   *ConsensusReactor[K]
+	}
+)
+
+// Config allows to parametrize the consensus reactor
+type Config struct {
+	// RetransmitFrequency is the frequency of observation rebroadcasts
+	RetransmitFrequency time.Duration
+	// QuorumGracePeriod is the time to wait for more signatures after quorum before finalizing the reactor
+	QuorumGracePeriod time.Duration
+	// QuorumTimeout is the time to wait for quorum before finalizing the reactor
+	QuorumTimeout time.Duration
+	// UnobservedTimeout is the time to wait for either a completed VAA or a local observation before finalizing the
+	// reactor after only having received remote observations.
+	UnobservedTimeout time.Duration
+	// Signer to use for local observations. If Signer is nil, the reactor will not participate in consensus.
+	Signer Signer
+	// NetworkAdapter used for broadcasting signatures. If NetworkAdapter is nil, the reactor will not broadcast local
+	// signatures.
+	NetworkAdapter NetworkAdapter
+}
+
+// Observation defines the interface for any message observed by the guardian.
+type Observation interface {
+	// MessageID returns a human-readable message-id. Message IDs are expected to be stable and may be used as storage
+	// keys.
+	MessageID() string
+	// SigningDigest returns the hash of the signing body of the message. This is used
+	// for signature generation and verification.
+	SigningDigest() ethcommon.Hash
+}
+
+// State of the reactor
+type State string
+
+const (
+	// StateInitialized is used for a freshly created reactor. A reactor in the StateInitialized will wait for either
+	// a local or foreign observation.
+	StateInitialized State = "initialized"
+	// StateObserved indicates that the reactor has seen =1 local observation and >= 0 foreign observations. It is able
+	// to produce a full VAA upon reaching quorum.
+	StateObserved State = "observed"
+	// StateUnobserved indicates that the reactor has seen >= 1 foreign observations but no local observation. It is not
+	// able to produce a full VAA without a local observation.
+	StateUnobserved State = "unobserved"
+	// StateQuorum indicates that the reactor has seen a local observation and a quorum of foreign observations. It has
+	// all data to produce a full VAA.
+	StateQuorum State = "quorum"
+	// StateQuorumUnobserved indicates that the reactor has seen a quorum of foreign observations but no local observation.
+	// It can only produce a full VAA after receiving a local observation.
+	StateQuorumUnobserved State = "quorum_unobserved"
+	// StateFinalized is a reactor that has gone through a full lifecycle. It holds all information required to produce
+	// a full VAA.
+	StateFinalized State = "finalized"
+	// StateTimedOut is a reactor that has gone through a full lifecycle. It did not manage to achieve locally confirmed
+	// quorum (i.e. both a local observation and quorum) within the configured timeouts.
+	StateTimedOut State = "timed_out"
+)
+
+func NewReactor[K Observation](group string, config *Config, gs *node_common.GuardianSet, s chan *StateTransition[K]) *ConsensusReactor[K] {
+	c := &ConsensusReactor[K]{
+		group: group,
+		state: reactorState[K]{
+			currentState: StateInitialized,
+			signatures:   map[ethcommon.Address][]byte{},
+		},
+		gs:                        gs,
+		stateTransitionChan:       s,
+		config:                    config,
+		foreignObservationChannel: make(chan *gossipv1.SignedObservation, 20),
+		observationChannel:        make(chan K, 1),
+		clock:                     clock.New(),
+	}
+
+	return c
+}
+
+func (c *ConsensusReactor[K]) Run(ctx context.Context) error {
+	c.logger = supervisor.Logger(ctx)
+	c.logger.With(zap.String("group", c.group))
+
+	supervisor.Signal(ctx, supervisor.SignalHealthy)
+	supervisor.Signal(ctx, supervisor.SignalEphemeral)
+
+	if c.State() == StateFinalized {
+		supervisor.Signal(ctx, supervisor.SignalDone)
+		return nil
+	}
+
+	tickFrequency := *node_common.Min([]time.Duration{
+		c.config.UnobservedTimeout, c.config.RetransmitFrequency, c.config.QuorumTimeout, c.config.QuorumGracePeriod,
+	}) / 2
+	ticker := c.clock.Ticker(tickFrequency)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case o := <-c.observationChannel:
+			c.observed(ctx, o)
+		case o := <-c.foreignObservationChannel:
+			c.foreignObservationReceived(o)
+		case <-ticker.C:
+			terminate, err := c.triggerTimeouts(ctx)
+			if err != nil {
+				c.logger.Warn("triggering timeouts failed", zap.Error(err))
+			}
+			if terminate {
+				c.logger.Debug("reactor concluded; shutting down processing loop")
+				// Signal done such that the routine does not restart
+				supervisor.Signal(ctx, supervisor.SignalDone)
+				return nil
+			}
+		}
+	}
+}
+
+func (c *ConsensusReactor[K]) ObservationChannel() chan<- K {
+	return c.observationChannel
+}
+
+func (c *ConsensusReactor[K]) ForeignObservationChannel() chan<- *gossipv1.SignedObservation {
+	return c.foreignObservationChannel
+}
+
+// State returns the current state of the reactor
+func (c *ConsensusReactor[K]) State() State {
+	c.state.mutex.Lock()
+	defer c.state.mutex.Unlock()
+	return c.state.currentState
+}
+
+// Observation returns the current observation stored in the reactor.
+func (c *ConsensusReactor[K]) Observation() K {
+	c.state.mutex.Lock()
+	defer c.state.mutex.Unlock()
+	return c.state.observation
+}
+
+// HasQuorum returns whether the reactor holds a quorum of signatures.
+func (c *ConsensusReactor[K]) HasQuorum() bool {
+	c.state.mutex.Lock()
+	defer c.state.mutex.Unlock()
+	return c.hasQuorum()
+}
+
+// LastObservation the time the last signed observation was received.
+func (c *ConsensusReactor[K]) LastObservation() time.Time {
+	c.state.mutex.Lock()
+	defer c.state.mutex.Unlock()
+	return c.state.lastObservation
+}
+
+// VAASignatures returns the stored signatures in the order required by a VAA.
+func (c *ConsensusReactor[K]) VAASignatures() []*vaa.Signature {
+	c.state.mutex.Lock()
+	defer c.state.mutex.Unlock()
+	var sigs []*vaa.Signature
+	for i, a := range c.gs.Keys {
+		s, ok := c.state.signatures[a]
+
+		if ok {
+			var bs [65]byte
+			if n := copy(bs[:], s); n != 65 {
+				panic(fmt.Sprintf("invalid sig len: %d", n))
+			}
+
+			sigs = append(sigs, &vaa.Signature{
+				Index:     uint8(i),
+				Signature: bs,
+			})
+		}
+	}
+	return sigs
+}
+
+// triggerTimeouts checks if any of the timeouts have been reached and triggers a timeout if so.
+// It also processes retransmissions. It returns true if the reactor has concluded and should be shut down.
+func (c *ConsensusReactor[K]) triggerTimeouts(ctx context.Context) (bool, error) {
+	c.state.mutex.Lock()
+	defer c.state.mutex.Unlock()
+	defer c.logger.Debug("timeout checks completed")
+
+	c.logger.Debug("starting timeout checks")
+
+	switch c.state.currentState {
+	case StateUnobserved:
+		if c.clock.Since(c.state.firstSeen) > c.config.UnobservedTimeout {
+			c.logger.Debug("timing out", zap.String("reason", "unobserved_timeout"))
+			// Time out
+			c.timeOut()
+		}
+	case StateObserved:
+		if c.clock.Since(c.state.lastObservation) > c.config.QuorumTimeout {
+			c.logger.Debug("timing out", zap.String("reason", "quorum_timeout"))
+			// Time out
+			c.timeOut()
+		}
+
+		if c.clock.Since(c.state.lastTransmission) > c.config.RetransmitFrequency {
+			// TODO backoff when transmission fails
+			c.logger.Debug("retransmitting")
+			reactorResubmission.WithLabelValues(c.group).Inc()
+			// Retransmit signature
+			err := c.transmitSignature(ctx)
+			if err != nil {
+				c.logger.Error("failed to retransmit signature", zap.Error(err))
+			}
+		}
+	case StateQuorum:
+		if c.clock.Since(c.state.timeQuorum) > c.config.QuorumGracePeriod || len(c.gs.Keys) == len(c.state.signatures) {
+			c.logger.Debug("timing out", zap.String("reason", "quorum_grace"))
+			// Time out
+			c.timeOut()
+		}
+	case StateQuorumUnobserved:
+		if c.clock.Since(c.state.firstSeen) > c.config.UnobservedTimeout {
+			c.logger.Debug("timing out", zap.String("reason", "quorum_unobserved_timeout"))
+			// Time out
+			c.timeOut()
+		}
+	case StateFinalized, StateTimedOut:
+		// This is the final iteration. Do cleanup
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func (c *ConsensusReactor[K]) foreignObservationReceived(m *gossipv1.SignedObservation) {
+	c.state.mutex.Lock()
+	defer c.state.mutex.Unlock()
+
+	observationsReceivedTotalVec.WithLabelValues(c.group).Inc()
+
+	c.logger.Debug("received foreign observation", zap.Any("observation", m))
+
+	if c.state.currentState != StateObserved && c.state.currentState != StateUnobserved && c.state.currentState != StateQuorum && c.state.currentState != StateQuorumUnobserved && c.state.currentState != StateInitialized {
+		return
+	}
+
+	hash := hex.EncodeToString(m.Hash)
+
+	// Hooray! Now, we have verified all fields on SignedObservation and know that it includes
+	// a valid signature by an active guardian. We still don't fully trust them, as they may be
+	// byzantine, but now we know who we're dealing with.
+	err := verifySignedObservation(c.group, m, c.gs)
+	if err != nil {
+		c.logger.Info("failed to verify signed observation",
+			zap.Error(err),
+			zap.String("digest", hash),
+			zap.String("signature", hex.EncodeToString(m.Signature)),
+			zap.String("addr", hex.EncodeToString(m.Addr)),
+		)
+		return
+	}
+	theirAddr := ethcommon.BytesToAddress(m.Addr)
+	observationsReceivedByGuardianAddressTotal.WithLabelValues(c.group, theirAddr.Hex()).Inc()
+
+	c.logger.Debug("accepted foreign observation", zap.Any("observation", m), zap.Stringer("address", theirAddr))
+
+	// Have we already received this observation
+	if _, has := c.state.signatures[theirAddr]; has {
+		// TODO log duplicate
+		return
+	}
+
+	// Store their signature
+	c.state.signatures[theirAddr] = m.Signature
+	c.state.lastObservation = c.clock.Now()
+
+	if c.state.currentState == StateInitialized {
+		c.logger.Debug("received observation before own observation", zap.Any("observation", m))
+		c.state.firstSeen = c.clock.Now()
+		c.stateTransition(StateUnobserved)
+	}
+
+	// If we haven't reached quorum yet, there is nothing more to do
+	if !c.hasQuorum() {
+		return
+	}
+
+	// Transition to quorum states
+	switch c.state.currentState {
+	case StateObserved:
+		reactorQuorum.WithLabelValues(c.group, "quorum").Inc()
+		c.state.timeQuorum = c.clock.Now()
+		c.stateTransition(StateQuorum)
+	case StateUnobserved:
+		reactorQuorum.WithLabelValues(c.group, "quorum_unobserved").Inc()
+		c.stateTransition(StateQuorumUnobserved)
+	}
+}
+
+func (c *ConsensusReactor[K]) observed(ctx context.Context, o K) {
+	c.state.mutex.Lock()
+	defer c.state.mutex.Unlock()
+
+	c.logger.Debug("observed", zap.Any("observation", o))
+
+	if c.state.currentState != StateInitialized && c.state.currentState != StateUnobserved && c.state.currentState != StateQuorumUnobserved {
+		return
+	}
+
+	// Late observation
+	if c.state.currentState == StateQuorumUnobserved {
+		reactorObservedLate.WithLabelValues(c.group).Inc()
+	}
+
+	c.state.observation = o
+
+	if c.config.Signer != nil {
+		// Generate digest of the unsigned VAA.
+		digest := o.SigningDigest()
+
+		// Sign the digest using our node's guardian key.
+		timeout, cancel := context.WithTimeout(ctx, time.Second*5)
+		defer cancel()
+		localAddr, err := c.config.Signer.Address(timeout)
+		if err != nil {
+			panic(err)
+		}
+		s, err := c.config.Signer.Sign(timeout, digest.Bytes())
+		if err != nil {
+			panic(err)
+		}
+		c.state.localSignature = s
+
+		messagesSignedTotal.WithLabelValues(c.group).Inc()
+
+		// Store in signatures array
+		c.state.signatures[localAddr] = s
+
+		err = c.transmitSignature(ctx)
+		if err != nil {
+			c.logger.Error("failed to transmit signature on observation", zap.Error(err))
+		}
+
+	}
+
+	// Transition to quorum states
+	switch c.state.currentState {
+	case StateInitialized:
+		c.state.firstSeen = c.clock.Now()
+		c.state.lastObservation = c.clock.Now()
+		c.stateTransition(StateObserved)
+	case StateUnobserved:
+		c.state.lastObservation = c.clock.Now()
+		c.stateTransition(StateObserved)
+	case StateQuorumUnobserved:
+		reactorQuorum.WithLabelValues(c.group, "quorum").Inc()
+		c.state.timeQuorum = c.clock.Now()
+		c.stateTransition(StateQuorum)
+		return
+	}
+
+	// If we haven't reached quorum in this event, there is nothing more to do
+	if !c.hasQuorum() {
+		return
+	}
+
+	// We immediately reached quorum
+	switch c.state.currentState {
+	case StateObserved:
+		reactorQuorum.WithLabelValues(c.group, "quorum").Inc()
+		c.state.timeQuorum = c.clock.Now()
+		c.stateTransition(StateQuorum)
+	}
+}
+
+// timeOut triggers the timeout state transition. It must only be called while holding the reactorState.mutex.
+func (c *ConsensusReactor[K]) timeOut() {
+	if c.state.currentState == StateQuorum {
+		reactorFinalized.WithLabelValues(c.group).Inc()
+		c.stateTransition(StateFinalized)
+	} else {
+		reactorTimedOut.WithLabelValues(c.group, string(c.state.currentState)).Inc()
+		c.stateTransition(StateTimedOut)
+	}
+}
+
+// stateTransition updates the state and triggers the hook. It must only be called while holding the reactorState.mutex.
+func (c *ConsensusReactor[K]) stateTransition(to State) {
+	c.logger.Debug("state transition", zap.String("from", string(c.state.currentState)), zap.String("to", string(to)))
+	previousState := c.state.currentState
+	c.state.currentState = to
+
+	if c.stateTransitionChan != nil {
+		transition := &StateTransition[K]{FromState: previousState, ToState: to, Reactor: c}
+		select {
+		case c.stateTransitionChan <- transition:
+		default:
+			c.logger.Warn("state transition channel full; dropped update", zap.Any("transition", transition))
+		}
+	}
+}
+
+// hasQuorum returns whether the reactor holds a quorum of signatures. It must only be called while holding reactorState.mutex.
+func (c *ConsensusReactor[K]) hasQuorum() bool {
+	return len(c.state.signatures) >= vaa.CalculateQuorum(len(c.gs.Keys))
+}
+
+// transmitSignature broadcasts the localSignature of the reactor. It must only be called while holding stateMutex.
+func (c *ConsensusReactor[K]) transmitSignature(ctx context.Context) error {
+	if c.config.Signer == nil {
+		return fmt.Errorf("can't broadcast signature without signer")
+	}
+	if c.config.NetworkAdapter == nil {
+		return fmt.Errorf("can't broadcast signature without network adapter")
+	}
+
+	timeout, cancel := context.WithTimeout(ctx, time.Second*5)
+	defer cancel()
+	addr, err := c.config.Signer.Address(timeout)
+	if err != nil {
+		return fmt.Errorf("failed to get signer address for signature broadcast: %w", err)
+	}
+	signedO := &gossipv1.SignedObservation{
+		Addr:      addr.Bytes(),
+		Hash:      c.state.observation.SigningDigest().Bytes(),
+		Signature: c.state.localSignature,
+		TxHash:    []byte{},
+		MessageId: c.state.observation.MessageID(),
+	}
+	timeout, cancel = context.WithTimeout(ctx, time.Second*5)
+	defer cancel()
+	err = c.config.NetworkAdapter.BroadcastObservation(timeout, signedO)
+	if err != nil {
+		return fmt.Errorf("failed to broadcast observation: %w", err)
+	}
+
+	observationsBroadcastTotalVec.WithLabelValues(c.group).Inc()
+	c.state.lastTransmission = c.clock.Now()
+
+	return nil
+}
+
+func verifySignedObservation(group string, m *gossipv1.SignedObservation, gs *node_common.GuardianSet) error {
+	// Verify the Guardian's signature. This verifies that m.Signature matches m.Hash and recovers
+	// the public key that was used to sign the payload.
+	pk, err := crypto.Ecrecover(m.Hash, m.Signature)
+	if err != nil {
+		observationsFailedTotal.WithLabelValues(group, "invalid_signature").Inc()
+		return fmt.Errorf("failed to verify signature: %w", err)
+	}
+
+	// Verify that m.Addr matches the public key that signed m.Hash.
+	theirAddr := ethcommon.BytesToAddress(m.Addr)
+	sigPub := ethcommon.BytesToAddress(crypto.Keccak256(pk[1:])[12:])
+
+	if theirAddr != sigPub {
+		observationsFailedTotal.WithLabelValues(group, "pubkey_mismatch").Inc()
+		return fmt.Errorf("address does not match pubkey: %s != %s", theirAddr.Hex(), sigPub.Hex())
+	}
+
+	// Verify that m.Addr is included in the guardian set. If it's not, drop the message. In case it's us
+	// who have the outdated guardian set, we'll just wait for the message to be retransmitted eventually.
+	_, ok := gs.KeyIndex(theirAddr)
+	if !ok {
+		observationsFailedTotal.WithLabelValues(group, "unknown_guardian").Inc()
+		return fmt.Errorf("unknown guardian: %s", theirAddr.Hex())
+	}
+
+	return nil
+}

--- a/node/pkg/processor2/reactor/reactor_networking.go
+++ b/node/pkg/processor2/reactor/reactor_networking.go
@@ -1,0 +1,42 @@
+package reactor
+
+import (
+	"context"
+	"fmt"
+
+	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
+	"google.golang.org/protobuf/proto"
+)
+
+// NetworkAdapter allows to participate in the outbound communication in a consensus network
+type NetworkAdapter interface {
+	// BroadcastObservation broadcasts a signed observation on the consensus network
+	BroadcastObservation(ctx context.Context, observation *gossipv1.SignedObservation) error
+}
+
+// ChannelNetworkAdapter implements NetworkAdapter on a byte slice IO channel. The channel must have a buffer of at
+// least length 1 to prevent observations from being dropped.
+type ChannelNetworkAdapter struct {
+	ch chan<- []byte
+}
+
+// NewChannelNetworkAdapter creates a ChannelNetworkAdapter
+func NewChannelNetworkAdapter(ch chan<- []byte) *ChannelNetworkAdapter {
+	return &ChannelNetworkAdapter{ch: ch}
+}
+
+func (c *ChannelNetworkAdapter) BroadcastObservation(_ context.Context, observation *gossipv1.SignedObservation) error {
+	w := gossipv1.GossipMessage{Message: &gossipv1.GossipMessage_SignedObservation{SignedObservation: observation}}
+
+	msg, err := proto.Marshal(&w)
+	if err != nil {
+		return fmt.Errorf("failed to serialize observation: %w", err)
+	}
+
+	select {
+	case c.ch <- msg:
+		return nil
+	default:
+		return fmt.Errorf("broadcast channel is full")
+	}
+}

--- a/node/pkg/processor2/reactor/reactor_signer.go
+++ b/node/pkg/processor2/reactor/reactor_signer.go
@@ -1,0 +1,35 @@
+package reactor
+
+import (
+	"context"
+	"crypto/ecdsa"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// Signer enables cryptographic operations of a guardian in consensus
+type Signer interface {
+	// Sign signs a digest using the guardian key
+	Sign(ctx context.Context, digest []byte) (signature []byte, err error)
+	// Address returns the guardian key
+	Address(ctx context.Context) (common.Address, error)
+}
+
+// EcdsaKeySigner implements Signer using an in-memory ecdsa key
+type EcdsaKeySigner struct {
+	gk *ecdsa.PrivateKey
+}
+
+// NewEcdsaKeySigner creates a new EcdsaKeySigner
+func NewEcdsaKeySigner(key *ecdsa.PrivateKey) *EcdsaKeySigner {
+	return &EcdsaKeySigner{gk: key}
+}
+
+func (e *EcdsaKeySigner) Sign(_ context.Context, digest []byte) (signature []byte, err error) {
+	return crypto.Sign(digest, e.gk)
+}
+
+func (e *EcdsaKeySigner) Address(_ context.Context) (common.Address, error) {
+	return crypto.PubkeyToAddress(e.gk.PublicKey), nil
+}

--- a/node/pkg/processor2/reactor/reactor_test.go
+++ b/node/pkg/processor2/reactor/reactor_test.go
@@ -1,0 +1,594 @@
+//nolint:forcetypeassert
+package reactor
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"encoding/hex"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/benbjohnson/clock"
+
+	"go.uber.org/zap"
+
+	wormhole_common "github.com/certusone/wormhole/node/pkg/common"
+	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
+	"github.com/certusone/wormhole/node/pkg/supervisor"
+	ethereum_common "github.com/ethereum/go-ethereum/common"
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/require"
+)
+
+type testContext struct {
+	guardianKeys     []*ecdsa.PrivateKey
+	gs               *wormhole_common.GuardianSet
+	clock            *clock.Mock
+	stateTransitions chan *StateTransition[*testObservation]
+}
+
+// testObservation is a mock implementation of the Observation interface that returns the constant `testObservationHash()` as SigningDigest().
+type testObservation struct {
+	id []byte
+}
+
+func (t *testObservation) MessageID() string {
+	if t.id == nil {
+		return "test/message"
+	} else {
+		return "test/message/" + hex.EncodeToString(t.id)
+	}
+}
+
+func testObservationHash() [32]byte {
+
+	return [32]byte{1, 2, 3} // because golang doesn't support constant slices
+}
+
+func (t *testObservation) SigningDigest() ethereum_common.Hash {
+	if t.id == nil {
+		return testObservationHash()
+	} else {
+		var out [32]byte
+		copy(out[:], t.id)
+		return out
+	}
+}
+
+// testGossipSender is a mock implementation of the NetworkAdapter interface.
+// Instead of sending out observations, it keeps them in the sentMessages array.
+type testGossipSender struct {
+	sentMessages     []*gossipv1.SignedObservation
+	sentMessagesLock sync.Mutex
+}
+
+func (t *testGossipSender) BroadcastObservation(ctx context.Context, observation *gossipv1.SignedObservation) error {
+	t.sentMessagesLock.Lock()
+	defer t.sentMessagesLock.Unlock()
+	t.sentMessages = append(t.sentMessages, observation)
+	return nil
+}
+
+type testSigner struct {
+	privKey *ecdsa.PrivateKey
+}
+
+func (t testSigner) Sign(ctx context.Context, digest []byte) (signature []byte, err error) {
+	return ethcrypto.Sign(digest, t.privKey)
+}
+
+func (t testSigner) Address(ctx context.Context) (ethereum_common.Address, error) {
+	return ethcrypto.PubkeyToAddress(t.privKey.PublicKey), nil
+}
+
+// Define different types of Test Actions
+type (
+	// Tests consist of multiple `Actions` executed in sequence.
+	// An Action may modify the state of the reactor or make assertions on the state of the reactor.
+	// By using this pattern, we can easily define and test different sequences of events.
+	testAction interface {
+		Evaluate(t *testing.T, r *ConsensusReactor[*testObservation], testContext *testContext)
+	}
+
+	// waitAction sleeps for `duration`.
+	waitAction struct {
+		duration time.Duration
+	}
+
+	// injectForeignObservationAction injects a `SignedObservation` into the reactor as if it was coming from a different Guardian
+	injectForeignObservationAction struct {
+		hash          [32]byte
+		guardianIndex int  // Index of the Guardian this observation was coming from in testContext.guardianKeys
+		invalid       bool // If invalid = true, the Signature on the SignedObservation will be random data instead of a valid signature.
+	}
+
+	// injectOwnObservationAction injects a testObservation as if it was observed by the local Guardian.
+	injectOwnObservationAction struct {
+		observation *testObservation
+	}
+
+	// assertObservation asserts the observation in the reactor state
+	assertObservation struct {
+		observation *testObservation
+	}
+
+	// assertLenVAASignatures asserts that the reactor has `expectedLen` many signatures.
+	assertLenVAASignatures struct {
+		expectedLen int
+	}
+
+	// assertSignedObservationOnGossip asserts that the `testGossipSender` has `observation` in its buffer and nothing else.
+	// it then clears the buffer.
+	assertSignedObservationOnGossip struct {
+		observation Observation
+	}
+
+	// assertStateAction asserts that the Reactor is in a certain state.
+	assertStateAction struct {
+		expectedState State
+	}
+
+	// assertStateTransitionAction asserts that the Reactor transitions from `fromState` into `expectedState` within `timeout`.
+	// If `fromState` is nil, it will only assert `expectedState`.
+	// The default `timeout` is 10 * time.Millisecond.
+	assertStateTransitionAction struct {
+		fromState     *State
+		expectedState State
+		timeout       time.Duration
+	}
+
+	// assertStateTransitionAction asserts that the Reactor does not do a state transition within timeout.
+	assertNoStateTransitionAction struct {
+		timeout time.Duration
+	}
+)
+
+func (w waitAction) Evaluate(t *testing.T, r *ConsensusReactor[*testObservation], testContext *testContext) {
+	testContext.clock.Set(testContext.clock.Now().Add(w.duration))
+}
+
+func (i injectForeignObservationAction) Evaluate(t *testing.T, r *ConsensusReactor[*testObservation], testContext *testContext) {
+	sig, err := ethcrypto.Sign(i.hash[:], testContext.guardianKeys[i.guardianIndex])
+	require.NoError(t, err)
+	signedObservation := &gossipv1.SignedObservation{
+		Addr:      testContext.gs.Keys[i.guardianIndex].Bytes(),
+		Hash:      i.hash[:],
+		Signature: sig,
+		TxHash:    []byte{12, 13},
+		MessageId: "test/message",
+	}
+	if i.invalid {
+		n, err := rand.Read(signedObservation.Signature)
+		require.NoError(t, err)
+		require.Equal(t, 65, n)
+	}
+	r.ForeignObservationChannel() <- signedObservation
+}
+
+func (i injectOwnObservationAction) Evaluate(t *testing.T, r *ConsensusReactor[*testObservation], testContext *testContext) {
+	r.ObservationChannel() <- i.observation
+}
+
+func (a assertObservation) Evaluate(t *testing.T, r *ConsensusReactor[*testObservation], testContext *testContext) {
+	require.Equal(t, a.observation, r.Observation(), a)
+}
+
+func (a assertLenVAASignatures) Evaluate(t *testing.T, r *ConsensusReactor[*testObservation], testContext *testContext) {
+	require.Len(t, r.VAASignatures(), a.expectedLen, a)
+}
+
+func (a assertSignedObservationOnGossip) Evaluate(t *testing.T, r *ConsensusReactor[*testObservation], testContext *testContext) {
+	// Sleep a little to make sure timeouts can process
+	time.Sleep(time.Millisecond * 10)
+
+	r.config.NetworkAdapter.(*testGossipSender).sentMessagesLock.Lock()
+	defer r.config.NetworkAdapter.(*testGossipSender).sentMessagesLock.Unlock()
+	if a.observation == nil {
+		require.Len(t, r.config.NetworkAdapter.(*testGossipSender).sentMessages, 0, a)
+		return
+	}
+	require.Len(t, r.config.NetworkAdapter.(*testGossipSender).sentMessages, 1, a)
+
+	msg := r.config.NetworkAdapter.(*testGossipSender).sentMessages[0]
+	require.Equal(t, a.observation.SigningDigest().Bytes(), msg.Hash, a)
+	require.Equal(t, a.observation.MessageID(), msg.MessageId, a)
+
+	r.config.NetworkAdapter.(*testGossipSender).sentMessages = nil
+}
+
+func (a assertStateAction) Evaluate(t *testing.T, r *ConsensusReactor[*testObservation], testContext *testContext) {
+	require.Equal(t, a.expectedState, r.State(), a)
+}
+
+func (a assertStateTransitionAction) Evaluate(t *testing.T, r *ConsensusReactor[*testObservation], testContext *testContext) {
+	timeout := a.timeout
+	if timeout == 0 {
+		timeout = 10 * time.Millisecond
+	}
+	select {
+	case lastStateTransition := <-testContext.stateTransitions:
+		if a.fromState != nil {
+			require.Equal(t, *a.fromState, lastStateTransition.FromState, a)
+		}
+		require.Equal(t, a.expectedState, lastStateTransition.ToState, a)
+	case <-time.After(timeout):
+		require.Fail(t, "state transition timeout", a)
+	}
+}
+
+func (a assertNoStateTransitionAction) Evaluate(t *testing.T, r *ConsensusReactor[*testObservation], testContext *testContext) {
+	timeout := a.timeout
+	if timeout == 0 {
+		timeout = 10 * time.Millisecond
+	}
+	select {
+	case lastStateTransition := <-testContext.stateTransitions:
+		require.Fail(t, "unexpected state transition", lastStateTransition)
+	case <-time.After(timeout):
+		return
+	}
+}
+
+func Test(t *testing.T) {
+	tests := []struct {
+		name         string
+		actions      []testAction
+		config       *Config
+		numGuardians int
+		notAGuardian bool // TODO what is this?
+	}{
+		{
+			name: "NormalFlow2Guardians",
+			actions: []testAction{
+				assertStateAction{expectedState: StateInitialized},
+				injectOwnObservationAction{observation: &testObservation{}},
+				assertStateTransitionAction{expectedState: StateObserved},
+				assertLenVAASignatures{expectedLen: 1},
+				assertSignedObservationOnGossip{observation: &testObservation{}},
+				injectForeignObservationAction{
+					hash:          testObservationHash(),
+					guardianIndex: 1,
+				},
+				assertStateTransitionAction{expectedState: StateQuorum},
+				assertLenVAASignatures{expectedLen: 2},
+				waitAction{time.Millisecond * 11},
+				assertStateTransitionAction{expectedState: StateFinalized},
+			},
+		},
+		{
+			name: "NormalFlow4Guardians",
+			actions: []testAction{
+				assertStateAction{expectedState: StateInitialized},
+				injectOwnObservationAction{observation: &testObservation{}},
+				assertStateTransitionAction{expectedState: StateObserved},
+				assertSignedObservationOnGossip{observation: &testObservation{}},
+				injectForeignObservationAction{
+					hash:          testObservationHash(),
+					guardianIndex: 1,
+				},
+				injectForeignObservationAction{
+					hash:          testObservationHash(),
+					guardianIndex: 2,
+				},
+				assertStateTransitionAction{expectedState: StateQuorum},
+				// Make sure the quorum grace period is considered
+				assertNoStateTransitionAction{},
+				waitAction{time.Millisecond * 15},
+				assertStateTransitionAction{expectedState: StateFinalized},
+			},
+			numGuardians: 4,
+		},
+		{
+			name: "TimeoutNoQuorum",
+			actions: []testAction{
+				assertStateAction{expectedState: StateInitialized},
+				injectOwnObservationAction{observation: &testObservation{}},
+				assertStateTransitionAction{expectedState: StateObserved},
+				assertSignedObservationOnGossip{observation: &testObservation{}},
+				injectForeignObservationAction{
+					hash:          testObservationHash(),
+					guardianIndex: 1,
+				},
+				assertNoStateTransitionAction{},
+				waitAction{time.Millisecond * 20},
+				assertStateTransitionAction{expectedState: StateTimedOut},
+			},
+			numGuardians: 4,
+		},
+		{
+			name: "TimeoutNoObservation",
+			actions: []testAction{
+				assertStateAction{expectedState: StateInitialized},
+				injectForeignObservationAction{
+					hash:          testObservationHash(),
+					guardianIndex: 1,
+				},
+				assertStateTransitionAction{expectedState: StateUnobserved},
+				waitAction{time.Millisecond * 15},
+				assertStateTransitionAction{expectedState: StateTimedOut},
+			},
+			numGuardians: 4,
+		},
+		{
+			name: "LateObservation",
+			actions: []testAction{
+				assertStateAction{expectedState: StateInitialized},
+				injectForeignObservationAction{
+					hash:          testObservationHash(),
+					guardianIndex: 1,
+				},
+				assertStateTransitionAction{expectedState: StateUnobserved},
+				assertLenVAASignatures{expectedLen: 1},
+				assertObservation{observation: nil},
+				injectOwnObservationAction{observation: &testObservation{}},
+				assertStateTransitionAction{expectedState: StateObserved},
+				assertObservation{observation: &testObservation{}},
+				assertSignedObservationOnGossip{observation: &testObservation{}},
+				injectForeignObservationAction{
+					hash:          testObservationHash(),
+					guardianIndex: 2,
+				},
+				assertStateTransitionAction{expectedState: StateQuorum},
+				waitAction{time.Millisecond * 15},
+				assertStateTransitionAction{expectedState: StateFinalized},
+			},
+			numGuardians: 4,
+		},
+		{
+			name: "LateObservationNoQuorum",
+			actions: []testAction{
+				assertStateAction{expectedState: StateInitialized},
+				injectForeignObservationAction{
+					hash:          testObservationHash(),
+					guardianIndex: 1,
+				},
+				assertStateTransitionAction{expectedState: StateUnobserved},
+				injectOwnObservationAction{observation: &testObservation{}},
+				assertStateTransitionAction{expectedState: StateObserved},
+				assertSignedObservationOnGossip{observation: &testObservation{}},
+				waitAction{time.Millisecond * 15},
+				assertStateTransitionAction{expectedState: StateTimedOut},
+			},
+			numGuardians: 4,
+		},
+		{
+			name: "NoObservationQuorum",
+			actions: []testAction{
+				assertStateAction{expectedState: StateInitialized},
+				injectForeignObservationAction{
+					hash:          testObservationHash(),
+					guardianIndex: 1,
+				},
+				assertStateTransitionAction{expectedState: StateUnobserved},
+				injectForeignObservationAction{
+					hash:          testObservationHash(),
+					guardianIndex: 2,
+				},
+				injectForeignObservationAction{
+					hash:          testObservationHash(),
+					guardianIndex: 3,
+				},
+				assertStateTransitionAction{expectedState: StateQuorumUnobserved},
+				waitAction{time.Millisecond * 15},
+				assertStateTransitionAction{expectedState: StateTimedOut},
+			},
+			numGuardians: 4,
+		},
+		{
+			name: "NoObservationQuorumLateObservation",
+			actions: []testAction{
+				assertStateAction{expectedState: StateInitialized},
+				injectForeignObservationAction{
+					hash:          testObservationHash(),
+					guardianIndex: 1,
+				},
+				assertStateTransitionAction{expectedState: StateUnobserved},
+				injectForeignObservationAction{
+					hash:          testObservationHash(),
+					guardianIndex: 2,
+				},
+				injectForeignObservationAction{
+					hash:          testObservationHash(),
+					guardianIndex: 3,
+				},
+				assertStateTransitionAction{expectedState: StateQuorumUnobserved},
+				injectOwnObservationAction{observation: &testObservation{}},
+				assertStateTransitionAction{expectedState: StateQuorum},
+				assertSignedObservationOnGossip{observation: &testObservation{}},
+				waitAction{time.Millisecond * 15},
+				assertStateTransitionAction{expectedState: StateFinalized},
+			},
+			numGuardians: 4,
+		},
+		{
+			name: "Resubmission",
+			actions: []testAction{
+				assertStateAction{expectedState: StateInitialized},
+				injectOwnObservationAction{observation: &testObservation{}},
+				assertStateTransitionAction{expectedState: StateObserved},
+				assertSignedObservationOnGossip{observation: &testObservation{}},
+				injectForeignObservationAction{
+					hash:          testObservationHash(),
+					guardianIndex: 1,
+				},
+				assertStateAction{expectedState: StateObserved},
+				waitAction{duration: time.Millisecond * 17},
+				assertSignedObservationOnGossip{observation: &testObservation{}},
+				injectForeignObservationAction{
+					hash:          testObservationHash(),
+					guardianIndex: 2,
+				},
+				assertStateTransitionAction{expectedState: StateQuorum},
+				waitAction{time.Millisecond * 45},
+				assertStateTransitionAction{expectedState: StateFinalized},
+			},
+			numGuardians: 4,
+			config: &Config{
+				RetransmitFrequency: time.Millisecond * 10,
+				QuorumGracePeriod:   time.Millisecond * 30,
+				QuorumTimeout:       time.Millisecond * 30,
+				UnobservedTimeout:   time.Millisecond * 30,
+			},
+		},
+		{
+			name: "NoAGuardianObservation",
+			actions: []testAction{
+				assertStateAction{expectedState: StateInitialized},
+				injectOwnObservationAction{observation: &testObservation{}},
+				assertStateTransitionAction{expectedState: StateObserved},
+				assertSignedObservationOnGossip{observation: nil},
+				injectForeignObservationAction{
+					hash:          testObservationHash(),
+					guardianIndex: 1,
+				},
+				assertNoStateTransitionAction{},
+				injectForeignObservationAction{
+					hash:          testObservationHash(),
+					guardianIndex: 2,
+				},
+				assertNoStateTransitionAction{},
+				injectForeignObservationAction{
+					hash:          testObservationHash(),
+					guardianIndex: 3,
+				},
+				assertStateTransitionAction{expectedState: StateQuorum},
+				waitAction{time.Millisecond * 15},
+				assertStateTransitionAction{expectedState: StateFinalized},
+			},
+			numGuardians: 4,
+			notAGuardian: true,
+		},
+		{
+			name: "SingleGuardian",
+			actions: []testAction{
+				assertStateAction{expectedState: StateInitialized},
+				injectOwnObservationAction{observation: &testObservation{}},
+				assertStateTransitionAction{expectedState: StateObserved},
+				assertStateTransitionAction{expectedState: StateQuorum},
+				waitAction{time.Millisecond * 15},
+				assertStateTransitionAction{expectedState: StateFinalized},
+			},
+			numGuardians: 1,
+		},
+		{
+			name: "DuplicateObservation",
+			actions: []testAction{
+				assertStateAction{expectedState: StateInitialized},
+				injectOwnObservationAction{observation: &testObservation{}},
+				assertStateTransitionAction{expectedState: StateObserved},
+				assertSignedObservationOnGossip{observation: &testObservation{}},
+				injectForeignObservationAction{
+					hash:          testObservationHash(),
+					guardianIndex: 1,
+				},
+				injectForeignObservationAction{
+					hash:          testObservationHash(),
+					guardianIndex: 1,
+				},
+				assertNoStateTransitionAction{},
+				injectForeignObservationAction{
+					hash:          testObservationHash(),
+					guardianIndex: 2,
+				},
+				assertStateTransitionAction{expectedState: StateQuorum},
+				waitAction{time.Millisecond * 15},
+				assertStateTransitionAction{expectedState: StateFinalized},
+			},
+			numGuardians: 4,
+		},
+		{
+			name: "InvalidSignature",
+			actions: []testAction{
+				assertStateAction{expectedState: StateInitialized},
+				injectOwnObservationAction{observation: &testObservation{}},
+				assertStateTransitionAction{expectedState: StateObserved},
+				assertSignedObservationOnGossip{observation: &testObservation{}},
+				injectForeignObservationAction{
+					hash:          testObservationHash(),
+					guardianIndex: 2,
+				},
+				injectForeignObservationAction{
+					hash:          testObservationHash(),
+					guardianIndex: 1,
+					invalid:       true,
+				},
+				assertNoStateTransitionAction{},
+				injectForeignObservationAction{
+					hash:          testObservationHash(),
+					guardianIndex: 1,
+				},
+				assertStateTransitionAction{expectedState: StateQuorum},
+				waitAction{time.Millisecond * 15},
+				assertStateTransitionAction{expectedState: StateFinalized},
+			},
+			numGuardians: 4,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.numGuardians == 0 {
+				test.numGuardians = 2
+			}
+			gs := &wormhole_common.GuardianSet{}
+			keys := make([]*ecdsa.PrivateKey, test.numGuardians)
+			for i := 0; i < test.numGuardians; i++ {
+				var err error
+				keys[i], err = ethcrypto.GenerateKey()
+				require.NoError(t, err)
+				gs.Keys = append(gs.Keys, ethcrypto.PubkeyToAddress(keys[i].PublicKey))
+			}
+			tCtx := &testContext{
+				guardianKeys:     keys,
+				gs:               gs,
+				stateTransitions: make(chan *StateTransition[*testObservation], 10),
+				clock:            clock.NewMock(),
+			}
+
+			var signer Signer
+			isAGuardian := !test.notAGuardian
+			if isAGuardian {
+				signer = &testSigner{privKey: keys[0]}
+			}
+
+			// If no test-specific Reactor config is given, use the default one
+			if test.config == nil {
+
+				defaultReactorConfig := &Config{
+					RetransmitFrequency: time.Millisecond * 10,
+					QuorumGracePeriod:   time.Millisecond * 10,
+					QuorumTimeout:       time.Millisecond * 10,
+					UnobservedTimeout:   time.Millisecond * 10,
+				}
+
+				test.config = defaultReactorConfig
+			}
+
+			// Make sure we set a signer
+			if test.config.Signer == nil {
+				test.config.Signer = signer
+			}
+
+			// Set the NetworkAdapter to &testGossipSender{} unless it was overwritten in the test config
+			if test.config.NetworkAdapter == nil {
+				test.config.NetworkAdapter = &testGossipSender{}
+			}
+
+			r := NewReactor[*testObservation]("test", test.config, gs, tCtx.stateTransitions)
+			r.clock = tCtx.clock
+
+			func() {
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+				logger, err := zap.NewDevelopment()
+				require.NoError(t, err)
+				supervisor.New(ctx, logger, r.Run)
+
+				for _, action := range test.actions {
+					action.Evaluate(t, r, tCtx)
+				}
+			}()
+		})
+	}
+}

--- a/node/pkg/processor2/vaa_processor.go
+++ b/node/pkg/processor2/vaa_processor.go
@@ -25,6 +25,8 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+var PARALLELISM = runtime.NumCPU() / 2
+
 // VAAConsensusProcessor is a reactor for performing consensus on v1 VAA messages. It sits on top of a reactor.Manager and implements
 // VAA specific logic like persistence, signed VAA broadcasts, accounting and governor.
 type VAAConsensusProcessor struct {
@@ -110,12 +112,12 @@ func (p *VAAConsensusProcessor) Run(ctx context.Context) error {
 	wg := &sync.WaitGroup{}
 
 	// Processor for local message observations
-	for i := 0; i < runtime.NumCPU()/2; i++ {
+	for i := 0; i < PARALLELISM; i++ {
 		spawnChannelProcessor(ctx, wg, p.msgC, p.processMessageObservation)
 	}
 
 	// Processors for inbound signed VAAs
-	for i := 0; i < runtime.NumCPU()/2; i++ {
+	for i := 0; i < PARALLELISM; i++ {
 		spawnChannelProcessor(ctx, wg, p.signedInC, p.handleSignedVAA)
 	}
 

--- a/node/pkg/processor2/vaa_processor.go
+++ b/node/pkg/processor2/vaa_processor.go
@@ -1,0 +1,522 @@
+package processor2
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"encoding/hex"
+	"fmt"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/certusone/wormhole/node/pkg/accountant"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+
+	"github.com/certusone/wormhole/node/pkg/common"
+	"github.com/certusone/wormhole/node/pkg/db"
+	"github.com/certusone/wormhole/node/pkg/governor"
+	"github.com/certusone/wormhole/node/pkg/processor2/reactor"
+	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
+	"github.com/certusone/wormhole/node/pkg/reporter"
+	"github.com/certusone/wormhole/node/pkg/supervisor"
+	"github.com/wormhole-foundation/wormhole/sdk/vaa"
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/proto"
+)
+
+// VAAConsensusProcessor is a reactor for performing consensus on v1 VAA messages. It sits on top of a reactor.Manager and implements
+// VAA specific logic like persistence, signed VAA broadcasts, accounting and governor.
+type VAAConsensusProcessor struct {
+	// msgC is a channel of observed emitted messages
+	msgC <-chan *common.MessagePublication
+	// obsC is a channel of VAAs used to forward to the reactor manager
+	obsC chan *vaaObservation
+	// obsvReqSendC is a send-only channel of outbound re-observation requests to broadcast on p2p
+	obsvReqSendC chan<- *gossipv1.ObservationRequest
+	// signedInC is a channel of inbound signed VAA observations from p2p
+	signedInC <-chan *gossipv1.SignedVAAWithQuorum
+	// gossipSendC is a channel of outbound messages to broadcast on p2p
+	gossipSendC chan<- []byte
+
+	attestationEvents *reporter.AttestationEventReporter
+	logger            *zap.Logger
+	db                *db.Database
+
+	manager *reactor.Manager[*vaaObservation]
+	gst     *common.GuardianSetState
+
+	governor        *governor.ChainGovernor
+	acct            *accountant.Accountant
+	acctReadC       <-chan *common.MessagePublication
+	pythnetVaas     map[string]PythNetVaaEntry
+	pythnetVAAsLock sync.Mutex
+}
+
+// NewVAAConsensusProcessor creates a new VAAConsensusProcessor.
+func NewVAAConsensusProcessor(
+	db *db.Database,
+	msgC <-chan *common.MessagePublication,
+	gossipSendC chan<- []byte,
+	obsvC <-chan *gossipv1.SignedObservation,
+	obsvReqSendC chan<- *gossipv1.ObservationRequest,
+	signedInC <-chan *gossipv1.SignedVAAWithQuorum,
+	gk *ecdsa.PrivateKey,
+	gst *common.GuardianSetState,
+	attestationEvents *reporter.AttestationEventReporter,
+	g *governor.ChainGovernor,
+	acct *accountant.Accountant,
+	acctReadC <-chan *common.MessagePublication,
+) *VAAConsensusProcessor {
+	// obsC is an internal buffer that is used to forward pre-filtered messages to the reactor manager.
+	// See VAAConsensusProcessor.Run for filtering logic.
+	obsC := make(chan *vaaObservation, 10)
+
+	r := &VAAConsensusProcessor{
+		obsvReqSendC:      obsvReqSendC,
+		signedInC:         signedInC,
+		msgC:              msgC,
+		obsC:              obsC,
+		gossipSendC:       gossipSendC,
+		db:                db,
+		attestationEvents: attestationEvents,
+		governor:          g,
+		acct:              acct,
+		acctReadC:         acctReadC,
+		pythnetVaas:       map[string]PythNetVaaEntry{},
+		gst:               gst,
+	}
+
+	manager := reactor.NewManager[*vaaObservation]("vaa", obsC, obsvC, gst, reactor.Config{
+		RetransmitFrequency: 5 * time.Minute,
+		QuorumGracePeriod:   2 * time.Minute,
+		QuorumTimeout:       24 * time.Hour,
+		UnobservedTimeout:   24 * time.Hour,
+		Signer:              reactor.NewEcdsaKeySigner(gk),
+		NetworkAdapter:      reactor.NewChannelNetworkAdapter(gossipSendC),
+	}, r, r)
+	r.manager = manager
+
+	return r
+}
+
+func (p *VAAConsensusProcessor) Run(ctx context.Context) error {
+	p.logger = supervisor.Logger(ctx)
+
+	err := supervisor.Run(ctx, "vaa-reactor-manager", p.manager.Run)
+	if err != nil {
+		return fmt.Errorf("failed to start reactor manager: %w", err)
+	}
+	wg := &sync.WaitGroup{}
+
+	// Processor for local message observations
+	for i := 0; i < runtime.NumCPU()/2; i++ {
+		spawnChannelProcessor(ctx, wg, p.msgC, p.processMessageObservation)
+	}
+
+	// Processors for inbound signed VAAs
+	for i := 0; i < runtime.NumCPU()/2; i++ {
+		spawnChannelProcessor(ctx, wg, p.signedInC, p.handleSignedVAA)
+	}
+
+	// Processor for accountant messages
+	spawnChannelProcessor(ctx, wg, p.acctReadC, p.processAccountantMessage)
+
+	spawnTickerRunnable(ctx, wg, 30*time.Second, p.cleanPythnetVAAs)
+	spawnTickerRunnable(ctx, wg, 5*time.Minute, p.checkReobservations)
+	spawnTickerRunnable(ctx, wg, time.Minute, p.processGovernorPending)
+
+	// Wait for all goroutines to exit.
+	wg.Wait()
+
+	return nil
+}
+
+func (p *VAAConsensusProcessor) cleanPythnetVAAs() {
+	// Clean up old pythnet VAAs.
+	oldestTime := time.Now().Add(-time.Hour)
+	p.pythnetVAAsLock.Lock()
+	for key, pe := range p.pythnetVaas {
+		if pe.updateTime.Before(oldestTime) {
+			delete(p.pythnetVaas, key)
+		}
+	}
+	p.pythnetVAAsLock.Unlock()
+}
+
+func (p *VAAConsensusProcessor) processAccountantMessage(k *common.MessagePublication) {
+	if p.acct == nil {
+		panic("acct: received an accountant event when accountant is not configured")
+	}
+	// SECURITY defense-in-depth: Make sure the accountant did not generate an unexpected message.
+	if !p.acct.IsMessageCoveredByAccountant(k) {
+		p.logger.Error("acct: accountant published a message that is not covered by it", zap.String("message_id", k.MessageIDString()))
+		return
+	}
+	gs := p.gst.Get()
+	if gs == nil {
+		p.logger.Warn("received observation before guardian set was known - skipping")
+		return
+	}
+	p.obsC <- &vaaObservation{
+		MessagePublication: k,
+		gsIndex:            gs.Index,
+	}
+}
+
+func (p *VAAConsensusProcessor) processMessageObservation(k *common.MessagePublication) {
+	if k.EmitterAddress == vaa.GovernanceEmitter && k.EmitterChain == vaa.GovernanceChain {
+		p.logger.Error(
+			"EMERGENCY: PLEASE REPORT THIS IMMEDIATELY! A Solana message was emitted from the governance emitter. This should never be possible.",
+			zap.Stringer("emitter_chain", k.EmitterChain),
+			zap.Stringer("emitter_address", k.EmitterAddress),
+			zap.Uint32("nonce", k.Nonce),
+			zap.Stringer("txhash", k.TxHash),
+			zap.Time("timestamp", k.Timestamp))
+		return
+	}
+
+	if p.governor != nil {
+		if !p.governor.ProcessMsg(k) {
+			return
+		}
+	}
+	if p.acct != nil {
+		shouldPub, err := p.acct.SubmitObservation(k)
+		if err != nil {
+			p.logger.Error("acct: failed to process message", zap.String("message_id", k.MessageIDString()), zap.Error(err))
+			return
+		}
+		if !shouldPub {
+			return
+		}
+	}
+
+	// Ignore incoming observations when our database already has a quorum VAA for it.
+	// This can occur when we're receiving late observations due to node catchup.
+	if existing, err := p.getSignedVAA(*db.VaaIDFromVAA(k.CreateVAA(0))); err == nil {
+		p.logger.Debug("ignoring observation since we already have a quorum VAA for it",
+			zap.Stringer("emitter_chain", k.EmitterChain),
+			zap.Stringer("emitter_address", k.EmitterAddress),
+			zap.Uint32("nonce", k.Nonce),
+			zap.Stringer("txhash", k.TxHash),
+			zap.Time("timestamp", k.Timestamp),
+			zap.String("message_id", existing.MessageID()),
+		)
+		return
+	}
+
+	gs := p.gst.Get()
+	if gs == nil {
+		p.logger.Warn("received observation before guardian set was known - skipping")
+		return
+	}
+
+	v := k.CreateVAA(gs.Index)
+	p.attestationEvents.ReportMessagePublication(&reporter.MessagePublication{
+		VAA:            *v,
+		InitiatingTxID: k.TxHash,
+	})
+	p.obsC <- &vaaObservation{
+		MessagePublication: k,
+		gsIndex:            gs.Index,
+	}
+}
+
+// processGovernorPending checks the governor for pending messages and publishes them.
+func (p *VAAConsensusProcessor) processGovernorPending() {
+	if p.governor == nil {
+		return
+	}
+	toBePublished, err := p.governor.CheckPending()
+	if err != nil {
+		p.logger.Error("failed to check for pending messages on governor", zap.Error(err))
+		return
+	}
+	if len(toBePublished) != 0 {
+		for _, k := range toBePublished {
+			// SECURITY defense-in-depth: Make sure the governor did not generate an unexpected message.
+			if msgIsGoverned, err := p.governor.IsGovernedMsg(k); err != nil {
+				p.logger.Error("cgov: governor failed to determine if message should be governed", zap.String("message_id", k.MessageIDString()), zap.Error(err))
+				continue
+			} else if !msgIsGoverned {
+				p.logger.Error("cgov: governor published a message that should not be governed", zap.String("message_id", k.MessageIDString()))
+				continue
+			}
+			if p.acct != nil {
+				shouldPub, err := p.acct.SubmitObservation(k)
+				if err != nil {
+					p.logger.Error("acct: failed to process message released by governor", zap.String("message_id", k.MessageIDString()), zap.Error(err))
+					continue
+				}
+				if !shouldPub {
+					continue
+				}
+			}
+			gs := p.gst.Get()
+			if gs == nil {
+				p.logger.Warn("received observation before guardian set was known - skipping")
+				continue
+			}
+			p.obsC <- &vaaObservation{
+				MessagePublication: k,
+				gsIndex:            gs.Index,
+			}
+		}
+	}
+}
+
+// checkReobservations checks if any observations have been waiting on consensus for more than 5 minutes and
+// re-requests them.
+func (p *VAAConsensusProcessor) checkReobservations() {
+	p.manager.IterateReactors(func(digest ethcommon.Hash, r *reactor.ConsensusReactor[*vaaObservation]) {
+		if r.State() != reactor.StateObserved || r.HasQuorum() || time.Since(r.LastObservation()) < time.Minute*5 {
+			return
+		}
+
+		observation := r.Observation()
+		if observation.Unreliable {
+			return
+		}
+
+		req := &gossipv1.ObservationRequest{
+			ChainId: uint32(observation.EmitterChain),
+			TxHash:  observation.TxHash.Bytes(),
+		}
+		if err := common.PostObservationRequest(p.obsvReqSendC, req); err != nil {
+			p.logger.Warn("failed to broadcast re-observation request", zap.Error(err))
+		}
+	})
+}
+
+func (p *VAAConsensusProcessor) handleSignedVAA(m *gossipv1.SignedVAAWithQuorum) {
+	v, err := vaa.Unmarshal(m.Vaa)
+	if err != nil {
+		p.logger.Warn("received invalid VAA in SignedVAAWithQuorum message",
+			zap.Error(err), zap.Any("message", m))
+		return
+	}
+
+	// Calculate digest for logging
+	digest := v.SigningDigest()
+	hash := hex.EncodeToString(digest.Bytes())
+
+	gs := p.gst.Get()
+	if gs == nil {
+		p.logger.Warn("dropping SignedVAAWithQuorum message since we haven't initialized our guardian set yet",
+			zap.String("digest", hash),
+			zap.Any("message", m),
+		)
+		return
+	}
+
+	if err := v.Verify(gs.Keys); err != nil {
+		p.logger.Warn("dropping SignedVAAWithQuorum message because it failed verification", zap.Error(err))
+		return
+	}
+
+	// We now established that:
+	//  - all signatures on the VAA are valid
+	//  - the signature's addresses match the node's current guardian set
+	//  - enough signatures are present for the VAA to reach quorum
+
+	// Check if we already store this VAA
+	_, err = p.getSignedVAA(*db.VaaIDFromVAA(v))
+	if err == nil {
+		p.logger.Debug("ignored SignedVAAWithQuorum message for VAA we already store",
+			zap.String("digest", hash),
+		)
+		return
+	} else if err != db.ErrVAANotFound {
+		p.logger.Error("failed to look up VAA in database",
+			zap.String("digest", hash),
+			zap.Error(err),
+		)
+		return
+	}
+
+	// Store signed VAA in database.
+	p.logger.Info("storing inbound signed VAA with quorum",
+		zap.String("digest", hash),
+		zap.Any("vaa", v),
+		zap.String("bytes", hex.EncodeToString(m.Vaa)),
+		zap.String("message_id", v.MessageID()))
+
+	if err := p.storeSignedVAA(v); err != nil {
+		p.logger.Error("failed to store signed VAA", zap.Error(err))
+		return
+	}
+	p.attestationEvents.ReportVAAQuorum(v)
+}
+
+func (p *VAAConsensusProcessor) HandleQuorum(observation *vaaObservation, signatures []*vaa.Signature) {
+	p.logger.Info("reached quorum on VAA", zap.String("message_id", observation.MessageID()), zap.Stringer("digest", observation.SigningDigest()))
+
+	v := observation.VAA()
+	v.Signatures = signatures
+
+	p.broadcastSignedVAA(v)
+	p.attestationEvents.ReportVAAQuorum(v)
+}
+
+func (p *VAAConsensusProcessor) HandleFinalization(observation *vaaObservation, signatures []*vaa.Signature) {
+	p.logger.Info("finalized VAA", zap.String("message_id", observation.MessageID()), zap.Stringer("digest", observation.SigningDigest()), zap.Int("num_signatures", len(signatures)))
+}
+
+func (p *VAAConsensusProcessor) HandleTimeout(previousState reactor.State, digest ethcommon.Hash, observation *vaaObservation, signatures []*vaa.Signature) {
+	p.logger.Info("VAA consensus timed out", zap.String("timeout_state", string(previousState)), zap.Stringer("digest", digest), zap.Bool("observed", observation != nil), zap.Int("num_signatures", len(signatures)))
+}
+
+func (p *VAAConsensusProcessor) StoreSignedObservation(observation *vaaObservation, signatures []*vaa.Signature) error {
+	v := observation.VAA()
+	v.Signatures = signatures
+
+	err := p.storeSignedVAA(v)
+	if err != nil {
+		return fmt.Errorf("failed to store signed observation: %w", err)
+	}
+
+	return nil
+}
+
+func (p *VAAConsensusProcessor) GetSignedObservation(id string) (observation *vaaObservation, signatures []*vaa.Signature, found bool, err error) {
+	vID, err := db.VaaIDFromString(id)
+	if err != nil {
+		return nil, nil, false, fmt.Errorf("failed to parse message id: %w", err)
+	}
+
+	v, err := p.getSignedVAA(*vID)
+	if err != nil {
+		if err == db.ErrVAANotFound {
+			return nil, nil, false, nil
+		}
+		return nil, nil, false, err
+	}
+
+	// This is lossy and loses the txHash and reliability status. This is not an issue at this point because the
+	// data is only used to persist completed VAAs.
+	return &vaaObservation{
+		MessagePublication: &common.MessagePublication{
+			TxHash:           ethcommon.Hash{},
+			Timestamp:        v.Timestamp,
+			Nonce:            v.Nonce,
+			Sequence:         v.Sequence,
+			ConsistencyLevel: v.ConsistencyLevel,
+			EmitterChain:     v.EmitterChain,
+			EmitterAddress:   v.EmitterAddress,
+			Payload:          v.Payload,
+			Unreliable:       false,
+		},
+		gsIndex: v.GuardianSetIndex,
+	}, v.Signatures, true, nil
+}
+
+type PythNetVaaEntry struct {
+	v          *vaa.VAA
+	updateTime time.Time // Used for determining when to delete entries
+}
+
+func (p *VAAConsensusProcessor) storeSignedVAA(v *vaa.VAA) error {
+	if v.EmitterChain == vaa.ChainIDPythNet {
+		key := fmt.Sprintf("%v/%v", v.EmitterAddress, v.Sequence)
+		p.pythnetVAAsLock.Lock()
+		p.pythnetVaas[key] = PythNetVaaEntry{v: v, updateTime: time.Now()}
+		p.pythnetVAAsLock.Unlock()
+		return nil
+	}
+	return p.db.StoreSignedVAA(v)
+}
+
+func (p *VAAConsensusProcessor) getSignedVAA(id db.VAAID) (*vaa.VAA, error) {
+	if id.EmitterChain == vaa.ChainIDPythNet {
+		key := fmt.Sprintf("%v/%v", id.EmitterAddress, id.Sequence)
+		p.pythnetVAAsLock.Lock()
+		ret, exists := p.pythnetVaas[key]
+		p.pythnetVAAsLock.Unlock()
+		if exists {
+			return ret.v, nil
+		}
+
+		return nil, db.ErrVAANotFound
+	}
+
+	vb, err := p.db.GetSignedVAABytes(id)
+	if err != nil {
+		return nil, err
+	}
+
+	v, err := vaa.Unmarshal(vb)
+	if err != nil {
+		panic("failed to unmarshal VAA from db")
+	}
+
+	return v, err
+}
+
+func (p *VAAConsensusProcessor) broadcastSignedVAA(v *vaa.VAA) {
+	b, err := v.Marshal()
+	if err != nil {
+		panic(err)
+	}
+
+	w := gossipv1.GossipMessage{Message: &gossipv1.GossipMessage_SignedVaaWithQuorum{
+		SignedVaaWithQuorum: &gossipv1.SignedVAAWithQuorum{Vaa: b},
+	}}
+
+	msg, err := proto.Marshal(&w)
+	if err != nil {
+		panic(err)
+	}
+
+	p.gossipSendC <- msg
+}
+
+// vaaObservation is used to wrap common.MessagePublication as a reactor.Observation.
+type vaaObservation struct {
+	*common.MessagePublication
+	gsIndex uint32
+}
+
+func (v *vaaObservation) MessageID() string {
+	return v.MessagePublication.MessageIDString()
+}
+
+func (v *vaaObservation) SigningDigest() ethcommon.Hash {
+	return v.CreateVAA(0).SigningDigest()
+}
+
+func (v *vaaObservation) VAA() *vaa.VAA {
+	return v.CreateVAA(v.gsIndex)
+}
+
+func spawnChannelProcessor[K any](ctx context.Context, wg *sync.WaitGroup, c <-chan K, f func(K)) {
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case v := <-c:
+				f(v)
+			}
+		}
+	}()
+}
+
+func spawnTickerRunnable(ctx context.Context, wg *sync.WaitGroup, interval time.Duration, f func()) {
+	ticker := time.NewTicker(interval)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-ctx.Done():
+				ticker.Stop()
+				return
+			case <-ticker.C:
+				f()
+			}
+		}
+	}()
+}

--- a/node/pkg/supervisor/supervisor.go
+++ b/node/pkg/supervisor/supervisor.go
@@ -52,6 +52,10 @@ const (
 	// The runnable is done - it does not need to run any loop. This is useful for Runnables that only set up other
 	// child runnables. This runnable will be restarted if a related failure happens somewhere in the supervision tree.
 	SignalDone
+	// The runnable is ephemeral - once it has signaled SignalDone, it will not be restarted even if the parent is rescheduled.
+	// This is useful for Runnables that are only meant to run once, and then exit.
+	// Only nodes without children can be signaled as ephemeral.
+	SignalEphemeral
 )
 
 // Logger returns a Zap logger that will be named after the Distinguished Name of a the runnable (ie its place in the

--- a/whitepapers/0010_guardian_processor.md
+++ b/whitepapers/0010_guardian_processor.md
@@ -1,0 +1,23 @@
+```mermaid
+stateDiagram-v2
+    [*] --> Observed: Message observation
+    Observed --> Observed: Receive guardian signature
+    Observed --> Quorum: Receive guardian signature [reaching quorum]
+    Quorum --> Finalized: QuorumGracePeriod expired
+    Quorum --> Quorum: Receive guardian signature
+    Observed --> TimedOut: QuorumTimeout expired
+    Observed --> Observed: RetransmitFrequency passed
+    
+    [*] --> Unobserved: Receive guardian signature
+    Unobserved --> Observed: Message observation
+    Unobserved --> Unobserved: Receive guardian signature
+    Unobserved --> QuorumUnobserved: Receive guardian signature [reaching quorum]
+    Unobserved --> TimedOut: UnobservedTimeout
+    QuorumUnobserved --> QuorumUnobserved: Receive guardian signature
+    QuorumUnobserved --> Quorum: Message observation
+    QuorumUnobserved --> TimedOut: UnobservedTimeout
+    
+    Finalized --> [*] 
+    TimedOut --> [*]
+
+```


### PR DESCRIPTION
This is the reincarnation of https://github.com/wormhole-foundation/wormhole/pull/1953, but better: 
* stacked on benchmarking code so we can compare the performance to pre-refactor
* instead of replacing the previous processor package, the refactored version is added as a new package `processor2`. Users can pick the old or new version interchangeably. 

With this refactor, the guardian message throughput is only up to ca. 3 messages/s (less with higher concurrency) vs. the previous ~30 messages/s on my host running 19 guardians. 

Suspected reasons for bad performance: 
* starts lot's of goroutines that are managed by the supervisor. 13% of execution time is spent in supervisor.processGC. 
* Too many goroutines in general 
  * 11.4% of time spent malloc'ing
  * 7.7% of time spent in runtime.schedule
  * 7.7% of time spent in runtime.findRunnable
  * lot's of time spent in golang GC
