### PR TITLE
Node: Remove unnecessary debug logging

### DIFF
--- a/node/pkg/accountant/accountant.go
+++ b/node/pkg/accountant/accountant.go
@@ -292,12 +292,10 @@ func (acct *Accountant) publishTransferAlreadyLocked(pe *pendingEntry) {
 
 // addPendingTransferAlreadyLocked adds a pending transfer to both the map and the database. It assumes the caller holds the lock.
 func (acct *Accountant) addPendingTransferAlreadyLocked(pe *pendingEntry) error {
-	acct.logger.Info("writing transfer to database", zap.String("msgId", pe.msgId))
 	pe.setUpdTime()
 	if err := acct.db.AcctStorePendingTransfer(pe.msg); err != nil {
 		return err
 	}
-	acct.logger.Info("wrote message to database", zap.String("msgId", pe.msgId))
 
 	acct.pendingTransfers[pe.msgId] = pe
 	transfersOutstanding.Set(float64(len(acct.pendingTransfers)))

--- a/node/pkg/governor/governor.go
+++ b/node/pkg/governor/governor.go
@@ -393,7 +393,6 @@ func (gov *ChainGovernor) ProcessMsgForTime(msg *common.MessagePublication, now 
 
 	if enqueueIt {
 		dbData := db.PendingTransfer{ReleaseTime: releaseTime, Msg: *msg}
-		gov.logger.Info("writing pending transfer to database", zap.String("msgId", msg.MessageIDString()))
 		err = gov.db.StorePendingMsg(&dbData)
 		if err != nil {
 			gov.logger.Error("failed to store pending vaa",
@@ -404,7 +403,6 @@ func (gov *ChainGovernor) ProcessMsgForTime(msg *common.MessagePublication, now 
 			)
 			return false, err
 		}
-		gov.logger.Info("wrote pending transfer to database", zap.String("msgId", msg.MessageIDString()))
 
 		ce.pending = append(ce.pending, &pendingEntry{token: token, amount: payload.Amount, hash: hash, dbData: dbData})
 		gov.msgsSeen[hash] = transferEnqueued


### PR DESCRIPTION
These log messages were added to governor and accountant to help debug a deadlock in mainnet. That problem as been fixed, so these messages should be removed.