### PR TITLE
Node: Drop inbound signed vaas with quorum faster

### DIFF
--- a/node/pkg/processor/processor.go
+++ b/node/pkg/processor/processor.go
@@ -265,6 +265,7 @@ func (p *Processor) storeSignedVAA(v *vaa.VAA) error {
 }
 
 func (p *Processor) getSignedVAA(id db.VAAID) (*vaa.VAA, error) {
+
 	if id.EmitterChain == vaa.ChainIDPythNet {
 		key := fmt.Sprintf("%v/%v", id.EmitterAddress, id.Sequence)
 		ret, exists := p.pythnetVaas[key]
@@ -272,6 +273,10 @@ func (p *Processor) getSignedVAA(id db.VAAID) (*vaa.VAA, error) {
 			return ret.v, nil
 		}
 
+		return nil, db.ErrVAANotFound
+	}
+
+	if p.db == nil {
 		return nil, db.ErrVAANotFound
 	}
 


### PR DESCRIPTION
When handling inbound signed VAAs with quorum, the processor looks to see if they are already in the database, and if so, it just returns without doing anything. It currently doesn't do that until after it verifies the signatures, which is wasted compute. This change moves the DB check ahead of that verification.