### PR TITLE
CLI: Fix bug in doc generator

### DIFF
--- a/clients/js/README.md
+++ b/clients/js/README.md
@@ -84,30 +84,6 @@ Options:
 <summary> edit-vaa </summary>
 
 ```sh
-worm edit-vaa <command>
-
-Commands:
-  worm edit-vaa init-token-bridge           Init token bridge contract
-  worm edit-vaa init-wormhole               Init Wormhole core contract
-  worm edit-vaa deploy <package-dir>        Deploy an Aptos package
-  worm edit-vaa deploy-resource <seed>      Deploy an Aptos package using a
-  <package-dir>                             resource account
-  worm edit-vaa send-example-message        Send example message
-  <message>
-  worm edit-vaa derive-resource-account     Derive resource account address
-  <account> <seed>
-  worm edit-vaa derive-wrapped-address      Derive wrapped coin type
-  <chain> <origin-address>
-  worm edit-vaa hash-contracts              Hash contract bytecodes for upgrade
-  <package-dir>
-  worm edit-vaa upgrade <package-dir>       Perform upgrade after VAA has been
-                                            submitted
-  worm edit-vaa migrate                     Perform migration after contract
-                                            upgrade
-  worm edit-vaa faucet                      Request money from the faucet for a
-                                            given account
-  worm edit-vaa start-validator             Start a local aptos validator
-
 Options:
       --help                       Show help                           [boolean]
       --version                    Show version number                 [boolean]
@@ -141,60 +117,22 @@ Options:
 worm evm <command>
 
 Commands:
-  worm evm init-token-bridge                Init token bridge contract
-  worm evm init-wormhole                    Init Wormhole core contract
-  worm evm deploy <package-dir>             Deploy an Aptos package
-  worm evm deploy-resource <seed>           Deploy an Aptos package using a
-  <package-dir>                             resource account
-  worm evm send-example-message <message>   Send example message
-  worm evm derive-resource-account          Derive resource account address
-  <account> <seed>
-  worm evm derive-wrapped-address <chain>   Derive wrapped coin type
-  <origin-address>
-  worm evm hash-contracts <package-dir>     Hash contract bytecodes for upgrade
-  worm evm upgrade <package-dir>            Perform upgrade after VAA has been
-                                            submitted
-  worm evm migrate                          Perform migration after contract
-                                            upgrade
-  worm evm faucet                           Request money from the faucet for a
-                                            given account
-  worm evm start-validator                  Start a local aptos validator
-  worm evm address-from-secret <secret>     Compute a 20 byte eth address from a
-                                            32 byte private key
-  worm evm storage-update                   Update a storage slot on an EVM fork
-                                            during testing (anvil or hardhat)
-  worm evm chains                           Return all EVM chains
-  worm evm info                             Query info about the on-chain state
-                                            of the contract
-  worm evm hijack                           Override the guardian set of the
-                                            core bridge contract during testing
-                                            (anvil or hardhat)
-  worm evm start-validator                  Start a local EVM validator
+  worm evm address-from-secret <secret>  Compute a 20 byte eth address from a 32
+                                         byte private key
+  worm evm storage-update                Update a storage slot on an EVM fork
+                                         during testing (anvil or hardhat)
+  worm evm chains                        Return all EVM chains
+  worm evm info                          Query info about the on-chain state of
+                                         the contract
+  worm evm hijack                        Override the guardian set of the core
+                                         bridge contract during testing (anvil
+                                         or hardhat)
+  worm evm start-validator               Start a local EVM validator
 
 Options:
-      --help                       Show help                           [boolean]
-      --version                    Show version number                 [boolean]
-  -v, --vaa                        vaa in hex format         [string] [required]
-  -n, --network                    Network
-                            [required] [choices: "mainnet", "testnet", "devnet"]
-      --guardian-set-index, --gsi  guardian set index                   [number]
-      --signatures, --sigs         comma separated list of signatures   [string]
-      --wormscanurl, --wsu         url to wormscan entry for the vaa that
-                                   includes signatures                  [string]
-      --wormscanfile, --wsf        json file containing wormscan entry for the
-                                   vaa that includes signatures         [string]
-      --emitter-chain-id, --ec     emitter chain id to be used in the vaa
-                                                                        [number]
-      --emitter-address, --ea      emitter address to be used in the vaa[string]
-      --nonce, --no                nonce to be used in the vaa          [number]
-      --sequence, --seq            sequence number to be used in the vaa[string]
-      --consistency-level, --cl    consistency level to be used in the vaa
-                                                                        [number]
-      --timestamp, --ts            timestamp to be used in the vaa in unix
-                                   seconds                              [number]
-  -p, --payload                    payload in hex format                [string]
-      --guardian-secret, --gs      Guardian's secret key                [string]
-      --rpc                        RPC endpoint                         [string]
+  --help     Show help                                                 [boolean]
+  --version  Show version number                                       [boolean]
+  --rpc      RPC endpoint                                               [string]
 ```
 </details>
 
@@ -202,40 +140,9 @@ Options:
 <summary> generate </summary>
 
 ```sh
-worm generate <command>
+worm generate [command]
 
 Commands:
-  worm generate init-token-bridge           Init token bridge contract
-  worm generate init-wormhole               Init Wormhole core contract
-  worm generate deploy <package-dir>        Deploy an Aptos package
-  worm generate deploy-resource <seed>      Deploy an Aptos package using a
-  <package-dir>                             resource account
-  worm generate send-example-message        Send example message
-  <message>
-  worm generate derive-resource-account     Derive resource account address
-  <account> <seed>
-  worm generate derive-wrapped-address      Derive wrapped coin type
-  <chain> <origin-address>
-  worm generate hash-contracts              Hash contract bytecodes for upgrade
-  <package-dir>
-  worm generate upgrade <package-dir>       Perform upgrade after VAA has been
-                                            submitted
-  worm generate migrate                     Perform migration after contract
-                                            upgrade
-  worm generate faucet                      Request money from the faucet for a
-                                            given account
-  worm generate start-validator             Start a local aptos validator
-  worm generate address-from-secret         Compute a 20 byte eth address from a
-  <secret>                                  32 byte private key
-  worm generate storage-update              Update a storage slot on an EVM fork
-                                            during testing (anvil or hardhat)
-  worm generate chains                      Return all EVM chains
-  worm generate info                        Query info about the on-chain state
-                                            of the contract
-  worm generate hijack                      Override the guardian set of the
-                                            core bridge contract during testing
-                                            (anvil or hardhat)
-  worm generate start-validator             Start a local EVM validator
   worm generate registration                Generate registration VAA
   worm generate upgrade                     Generate contract upgrade VAA
   worm generate attestation                 Generate a token attestation VAA
@@ -244,30 +151,9 @@ Commands:
   set-default-delivery-provider             for the Wormhole Relayer contract
 
 Options:
-      --help                       Show help                           [boolean]
-      --version                    Show version number                 [boolean]
-  -v, --vaa                        vaa in hex format         [string] [required]
-  -n, --network                    Network
-                            [required] [choices: "mainnet", "testnet", "devnet"]
-      --guardian-set-index, --gsi  guardian set index                   [number]
-      --signatures, --sigs         comma separated list of signatures   [string]
-      --wormscanurl, --wsu         url to wormscan entry for the vaa that
-                                   includes signatures                  [string]
-      --wormscanfile, --wsf        json file containing wormscan entry for the
-                                   vaa that includes signatures         [string]
-      --emitter-chain-id, --ec     emitter chain id to be used in the vaa
-                                                                        [number]
-      --emitter-address, --ea      emitter address to be used in the vaa[string]
-      --nonce, --no                nonce to be used in the vaa          [number]
-      --sequence, --seq            sequence number to be used in the vaa[string]
-      --consistency-level, --cl    consistency level to be used in the vaa
-                                                                        [number]
-      --timestamp, --ts            timestamp to be used in the vaa in unix
-                                   seconds                              [number]
-  -p, --payload                    payload in hex format                [string]
-  -g, --guardian-secret, --gs      Guardians' secret keys (CSV)
-                                                             [string] [required]
-      --rpc                        RPC endpoint                         [string]
+      --help             Show help                                     [boolean]
+      --version          Show version number                           [boolean]
+  -g, --guardian-secret  Guardians' secret keys (CSV)        [string] [required]
 ```
 </details>
 
@@ -275,44 +161,9 @@ Options:
 <summary> info </summary>
 
 ```sh
-worm info <command>
+worm info [command]
 
 Commands:
-  worm info init-token-bridge               Init token bridge contract
-  worm info init-wormhole                   Init Wormhole core contract
-  worm info deploy <package-dir>            Deploy an Aptos package
-  worm info deploy-resource <seed>          Deploy an Aptos package using a
-  <package-dir>                             resource account
-  worm info send-example-message <message>  Send example message
-  worm info derive-resource-account         Derive resource account address
-  <account> <seed>
-  worm info derive-wrapped-address <chain>  Derive wrapped coin type
-  <origin-address>
-  worm info hash-contracts <package-dir>    Hash contract bytecodes for upgrade
-  worm info upgrade <package-dir>           Perform upgrade after VAA has been
-                                            submitted
-  worm info migrate                         Perform migration after contract
-                                            upgrade
-  worm info faucet                          Request money from the faucet for a
-                                            given account
-  worm info start-validator                 Start a local aptos validator
-  worm info address-from-secret <secret>    Compute a 20 byte eth address from a
-                                            32 byte private key
-  worm info storage-update                  Update a storage slot on an EVM fork
-                                            during testing (anvil or hardhat)
-  worm info chains                          Return all EVM chains
-  worm info info                            Query info about the on-chain state
-                                            of the contract
-  worm info hijack                          Override the guardian set of the
-                                            core bridge contract during testing
-                                            (anvil or hardhat)
-  worm info start-validator                 Start a local EVM validator
-  worm info registration                    Generate registration VAA
-  worm info upgrade                         Generate contract upgrade VAA
-  worm info attestation                     Generate a token attestation VAA
-  worm info recover-chain-id                Generate a recover chain ID VAA
-  worm info set-default-delivery-provider   Sets the default delivery provider
-                                            for the Wormhole Relayer contract
   worm info chain-id <chain>                Print the wormhole chain ID integer
                                             associated with the specified chain
                                             name
@@ -332,30 +183,8 @@ Commands:
                                             address.
 
 Options:
-      --help                       Show help                           [boolean]
-      --version                    Show version number                 [boolean]
-  -v, --vaa                        vaa in hex format         [string] [required]
-  -n, --network                    Network
-                            [required] [choices: "mainnet", "testnet", "devnet"]
-      --guardian-set-index, --gsi  guardian set index                   [number]
-      --signatures, --sigs         comma separated list of signatures   [string]
-      --wormscanurl, --wsu         url to wormscan entry for the vaa that
-                                   includes signatures                  [string]
-      --wormscanfile, --wsf        json file containing wormscan entry for the
-                                   vaa that includes signatures         [string]
-      --emitter-chain-id, --ec     emitter chain id to be used in the vaa
-                                                                        [number]
-      --emitter-address, --ea      emitter address to be used in the vaa[string]
-      --nonce, --no                nonce to be used in the vaa          [number]
-      --sequence, --seq            sequence number to be used in the vaa[string]
-      --consistency-level, --cl    consistency level to be used in the vaa
-                                                                        [number]
-      --timestamp, --ts            timestamp to be used in the vaa in unix
-                                   seconds                              [number]
-  -p, --payload                    payload in hex format                [string]
-  -g, --guardian-secret, --gs      Guardians' secret keys (CSV)
-                                                             [string] [required]
-      --rpc                        RPC endpoint                         [string]
+  --help     Show help                                                 [boolean]
+  --version  Show version number                                       [boolean]
 ```
 </details>
 
@@ -363,99 +192,24 @@ Options:
 <summary> near </summary>
 
 ```sh
-worm near <command>
+worm near [command]
 
 Commands:
-  worm near init-token-bridge               Init token bridge contract
-  worm near init-wormhole                   Init Wormhole core contract
-  worm near deploy <package-dir>            Deploy an Aptos package
-  worm near deploy-resource <seed>          Deploy an Aptos package using a
-  <package-dir>                             resource account
-  worm near send-example-message <message>  Send example message
-  worm near derive-resource-account         Derive resource account address
-  <account> <seed>
-  worm near derive-wrapped-address <chain>  Derive wrapped coin type
-  <origin-address>
-  worm near hash-contracts <package-dir>    Hash contract bytecodes for upgrade
-  worm near upgrade <package-dir>           Perform upgrade after VAA has been
-                                            submitted
-  worm near migrate                         Perform migration after contract
-                                            upgrade
-  worm near faucet                          Request money from the faucet for a
-                                            given account
-  worm near start-validator                 Start a local aptos validator
-  worm near address-from-secret <secret>    Compute a 20 byte eth address from a
-                                            32 byte private key
-  worm near storage-update                  Update a storage slot on an EVM fork
-                                            during testing (anvil or hardhat)
-  worm near chains                          Return all EVM chains
-  worm near info                            Query info about the on-chain state
-                                            of the contract
-  worm near hijack                          Override the guardian set of the
-                                            core bridge contract during testing
-                                            (anvil or hardhat)
-  worm near start-validator                 Start a local EVM validator
-  worm near registration                    Generate registration VAA
-  worm near upgrade                         Generate contract upgrade VAA
-  worm near attestation                     Generate a token attestation VAA
-  worm near recover-chain-id                Generate a recover chain ID VAA
-  worm near set-default-delivery-provider   Sets the default delivery provider
-                                            for the Wormhole Relayer contract
-  worm near chain-id <chain>                Print the wormhole chain ID integer
-                                            associated with the specified chain
-                                            name
-  worm near contract <network> <chain>      Print contract address
-  <module>
-  worm near emitter <chain> <address>       Print address in emitter address
-                                            format
-  worm near origin <chain> <address>        Print the origin chain and address
-                                            of the asset that corresponds to the
-                                            given chain and address.
-  worm near registrations <network>         Print chain registrations
-  <chain> <module>
-  worm near rpc <network> <chain>           Print RPC address
-  worm near wrapped <origin-chain>          Print the wrapped address on the
-  <origin-address> <target-chain>           target chain that corresponds with
-                                            the specified origin chain and
-                                            address.
-  worm near contract-update <file>          Submit a contract update using our
-                                            specific APIs
-  worm near deploy <file>                   Submit a contract update using near
-                                            APIs
+  worm near contract-update <file>  Submit a contract update using our specific
+                                    APIs
+  worm near deploy <file>           Submit a contract update using near APIs
 
 Options:
-      --help                       Show help                           [boolean]
-      --version                    Show version number                 [boolean]
-  -v, --vaa                        vaa in hex format         [string] [required]
-  -n, -n, --network                Network
-      [required] [choices: "mainnet", "testnet", "devnet", "mainnet", "testnet",
-                                                                       "devnet"]
-      --guardian-set-index, --gsi  guardian set index                   [number]
-      --signatures, --sigs         comma separated list of signatures   [string]
-      --wormscanurl, --wsu         url to wormscan entry for the vaa that
-                                   includes signatures                  [string]
-      --wormscanfile, --wsf        json file containing wormscan entry for the
-                                   vaa that includes signatures         [string]
-      --emitter-chain-id, --ec     emitter chain id to be used in the vaa
-                                                                        [number]
-      --emitter-address, --ea      emitter address to be used in the vaa[string]
-      --nonce, --no                nonce to be used in the vaa          [number]
-      --sequence, --seq            sequence number to be used in the vaa[string]
-      --consistency-level, --cl    consistency level to be used in the vaa
-                                                                        [number]
-      --timestamp, --ts            timestamp to be used in the vaa in unix
-                                   seconds                              [number]
-  -p, --payload                    payload in hex format                [string]
-  -g, --guardian-secret, --gs      Guardians' secret keys (CSV)
-                                                             [string] [required]
-  -r, --rpc                        Override default rpc endpoint url    [string]
-  -m, --module                     Module to query
-                                   [choices: "Core", "NFTBridge", "TokenBridge"]
-      --account                    Near deployment account   [string] [required]
-      --attach                     Attach some near                     [string]
-      --target                     Near account to upgrade              [string]
-      --mnemonic                   Near private keys                    [string]
-      --key                        Near private key                     [string]
+      --help      Show help                                            [boolean]
+      --version   Show version number                                  [boolean]
+  -m, --module    Module to query  [choices: "Core", "NFTBridge", "TokenBridge"]
+  -n, --network   Network   [required] [choices: "mainnet", "testnet", "devnet"]
+      --account   Near deployment account                    [string] [required]
+      --attach    Attach some near                                      [string]
+      --target    Near account to upgrade                               [string]
+      --mnemonic  Near private keys                                     [string]
+      --key       Near private key                                      [string]
+  -r, --rpc       Override default rpc endpoint url                     [string]
 ```
 </details>
 
@@ -463,103 +217,12 @@ Options:
 <summary> parse <vaa> </summary>
 
 ```sh
-worm parse <vaa> <command>
-
-Commands:
-  worm parse <vaa> init-token-bridge        Init token bridge contract
-  worm parse <vaa> init-wormhole            Init Wormhole core contract
-  worm parse <vaa> deploy <package-dir>     Deploy an Aptos package
-  worm parse <vaa> deploy-resource <seed>   Deploy an Aptos package using a
-  <package-dir>                             resource account
-  worm parse <vaa> send-example-message     Send example message
-  <message>
-  worm parse <vaa> derive-resource-account  Derive resource account address
-  <account> <seed>
-  worm parse <vaa> derive-wrapped-address   Derive wrapped coin type
-  <chain> <origin-address>
-  worm parse <vaa> hash-contracts           Hash contract bytecodes for upgrade
-  <package-dir>
-  worm parse <vaa> upgrade <package-dir>    Perform upgrade after VAA has been
-                                            submitted
-  worm parse <vaa> migrate                  Perform migration after contract
-                                            upgrade
-  worm parse <vaa> faucet                   Request money from the faucet for a
-                                            given account
-  worm parse <vaa> start-validator          Start a local aptos validator
-  worm parse <vaa> address-from-secret      Compute a 20 byte eth address from a
-  <secret>                                  32 byte private key
-  worm parse <vaa> storage-update           Update a storage slot on an EVM fork
-                                            during testing (anvil or hardhat)
-  worm parse <vaa> chains                   Return all EVM chains
-  worm parse <vaa> info                     Query info about the on-chain state
-                                            of the contract
-  worm parse <vaa> hijack                   Override the guardian set of the
-                                            core bridge contract during testing
-                                            (anvil or hardhat)
-  worm parse <vaa> start-validator          Start a local EVM validator
-  worm parse <vaa> registration             Generate registration VAA
-  worm parse <vaa> upgrade                  Generate contract upgrade VAA
-  worm parse <vaa> attestation              Generate a token attestation VAA
-  worm parse <vaa> recover-chain-id         Generate a recover chain ID VAA
-  worm parse <vaa>                          Sets the default delivery provider
-  set-default-delivery-provider             for the Wormhole Relayer contract
-  worm parse <vaa> chain-id <chain>         Print the wormhole chain ID integer
-                                            associated with the specified chain
-                                            name
-  worm parse <vaa> contract <network>       Print contract address
-  <chain> <module>
-  worm parse <vaa> emitter <chain>          Print address in emitter address
-  <address>                                 format
-  worm parse <vaa> origin <chain>           Print the origin chain and address
-  <address>                                 of the asset that corresponds to the
-                                            given chain and address.
-  worm parse <vaa> registrations <network>  Print chain registrations
-  <chain> <module>
-  worm parse <vaa> rpc <network> <chain>    Print RPC address
-  worm parse <vaa> wrapped <origin-chain>   Print the wrapped address on the
-  <origin-address> <target-chain>           target chain that corresponds with
-                                            the specified origin chain and
-                                            address.
-  worm parse <vaa> contract-update <file>   Submit a contract update using our
-                                            specific APIs
-  worm parse <vaa> deploy <file>            Submit a contract update using near
-                                            APIs
-
 Positionals:
-  vaa, v  vaa                                                [string] [required]
+  vaa  vaa                                                              [string]
 
 Options:
-      --help                       Show help                           [boolean]
-      --version                    Show version number                 [boolean]
-  -n, -n, --network                Network
-      [required] [choices: "mainnet", "testnet", "devnet", "mainnet", "testnet",
-                                                                       "devnet"]
-      --guardian-set-index, --gsi  guardian set index                   [number]
-      --signatures, --sigs         comma separated list of signatures   [string]
-      --wormscanurl, --wsu         url to wormscan entry for the vaa that
-                                   includes signatures                  [string]
-      --wormscanfile, --wsf        json file containing wormscan entry for the
-                                   vaa that includes signatures         [string]
-      --emitter-chain-id, --ec     emitter chain id to be used in the vaa
-                                                                        [number]
-      --emitter-address, --ea      emitter address to be used in the vaa[string]
-      --nonce, --no                nonce to be used in the vaa          [number]
-      --sequence, --seq            sequence number to be used in the vaa[string]
-      --consistency-level, --cl    consistency level to be used in the vaa
-                                                                        [number]
-      --timestamp, --ts            timestamp to be used in the vaa in unix
-                                   seconds                              [number]
-  -p, --payload                    payload in hex format                [string]
-  -g, --guardian-secret, --gs      Guardians' secret keys (CSV)
-                                                             [string] [required]
-  -r, --rpc                        Override default rpc endpoint url    [string]
-  -m, --module                     Module to query
-                                   [choices: "Core", "NFTBridge", "TokenBridge"]
-      --account                    Near deployment account   [string] [required]
-      --attach                     Attach some near                     [string]
-      --target                     Near account to upgrade              [string]
-      --mnemonic                   Near private keys                    [string]
-      --key                        Near private key                     [string]
+  --help     Show help                                                 [boolean]
+  --version  Show version number                                       [boolean]
 ```
 </details>
 
@@ -567,116 +230,13 @@ Options:
 <summary> recover <digest> <signature> </summary>
 
 ```sh
-worm recover <digest> <signature> <command>
-
-Commands:
-  worm recover <digest> <signature>         Init token bridge contract
-  init-token-bridge
-  worm recover <digest> <signature>         Init Wormhole core contract
-  init-wormhole
-  worm recover <digest> <signature> deploy  Deploy an Aptos package
-  <package-dir>
-  worm recover <digest> <signature>         Deploy an Aptos package using a
-  deploy-resource <seed> <package-dir>      resource account
-  worm recover <digest> <signature>         Send example message
-  send-example-message <message>
-  worm recover <digest> <signature>         Derive resource account address
-  derive-resource-account <account> <seed>
-  worm recover <digest> <signature>         Derive wrapped coin type
-  derive-wrapped-address <chain>
-  <origin-address>
-  worm recover <digest> <signature>         Hash contract bytecodes for upgrade
-  hash-contracts <package-dir>
-  worm recover <digest> <signature>         Perform upgrade after VAA has been
-  upgrade <package-dir>                     submitted
-  worm recover <digest> <signature>         Perform migration after contract
-  migrate                                   upgrade
-  worm recover <digest> <signature> faucet  Request money from the faucet for a
-                                            given account
-  worm recover <digest> <signature>         Start a local aptos validator
-  start-validator
-  worm recover <digest> <signature>         Compute a 20 byte eth address from a
-  address-from-secret <secret>              32 byte private key
-  worm recover <digest> <signature>         Update a storage slot on an EVM fork
-  storage-update                            during testing (anvil or hardhat)
-  worm recover <digest> <signature> chains  Return all EVM chains
-  worm recover <digest> <signature> info    Query info about the on-chain state
-                                            of the contract
-  worm recover <digest> <signature> hijack  Override the guardian set of the
-                                            core bridge contract during testing
-                                            (anvil or hardhat)
-  worm recover <digest> <signature>         Start a local EVM validator
-  start-validator
-  worm recover <digest> <signature>         Generate registration VAA
-  registration
-  worm recover <digest> <signature>         Generate contract upgrade VAA
-  upgrade
-  worm recover <digest> <signature>         Generate a token attestation VAA
-  attestation
-  worm recover <digest> <signature>         Generate a recover chain ID VAA
-  recover-chain-id
-  worm recover <digest> <signature>         Sets the default delivery provider
-  set-default-delivery-provider             for the Wormhole Relayer contract
-  worm recover <digest> <signature>         Print the wormhole chain ID integer
-  chain-id <chain>                          associated with the specified chain
-                                            name
-  worm recover <digest> <signature>         Print contract address
-  contract <network> <chain> <module>
-  worm recover <digest> <signature>         Print address in emitter address
-  emitter <chain> <address>                 format
-  worm recover <digest> <signature> origin  Print the origin chain and address
-  <chain> <address>                         of the asset that corresponds to the
-                                            given chain and address.
-  worm recover <digest> <signature>         Print chain registrations
-  registrations <network> <chain> <module>
-  worm recover <digest> <signature> rpc     Print RPC address
-  <network> <chain>
-  worm recover <digest> <signature>         Print the wrapped address on the
-  wrapped <origin-chain> <origin-address>   target chain that corresponds with
-  <target-chain>                            the specified origin chain and
-                                            address.
-  worm recover <digest> <signature>         Submit a contract update using our
-  contract-update <file>                    specific APIs
-  worm recover <digest> <signature> deploy  Submit a contract update using near
-  <file>                                    APIs
-
 Positionals:
-  vaa, v     vaa                                             [string] [required]
   digest     digest                                                     [string]
   signature  signature                                                  [string]
 
 Options:
-      --help                       Show help                           [boolean]
-      --version                    Show version number                 [boolean]
-  -n, -n, --network                Network
-      [required] [choices: "mainnet", "testnet", "devnet", "mainnet", "testnet",
-                                                                       "devnet"]
-      --guardian-set-index, --gsi  guardian set index                   [number]
-      --signatures, --sigs         comma separated list of signatures   [string]
-      --wormscanurl, --wsu         url to wormscan entry for the vaa that
-                                   includes signatures                  [string]
-      --wormscanfile, --wsf        json file containing wormscan entry for the
-                                   vaa that includes signatures         [string]
-      --emitter-chain-id, --ec     emitter chain id to be used in the vaa
-                                                                        [number]
-      --emitter-address, --ea      emitter address to be used in the vaa[string]
-      --nonce, --no                nonce to be used in the vaa          [number]
-      --sequence, --seq            sequence number to be used in the vaa[string]
-      --consistency-level, --cl    consistency level to be used in the vaa
-                                                                        [number]
-      --timestamp, --ts            timestamp to be used in the vaa in unix
-                                   seconds                              [number]
-  -p, --payload                    payload in hex format                [string]
-  -g, --guardian-secret, --gs      Guardians' secret keys (CSV)
-                                                             [string] [required]
-  -r, --rpc                        Override default rpc endpoint url    [string]
-  -m, --module                     Module to query
-                                   [choices: "Core", "NFTBridge", "TokenBridge"]
-      --account                    Near deployment account   [string] [required]
-      --attach                     Attach some near                     [string]
-      --target                     Near account to upgrade              [string]
-      --mnemonic                   Near private keys                    [string]
-      --key                        Near private key                     [string]
+  --help     Show help                                                 [boolean]
+  --version  Show version number                                       [boolean]
 ```
 </details>
 
@@ -684,115 +244,24 @@ Options:
 <summary> submit <vaa> </summary>
 
 ```sh
-worm submit <vaa> <command>
-
-Commands:
-  worm submit <vaa> init-token-bridge       Init token bridge contract
-  worm submit <vaa> init-wormhole           Init Wormhole core contract
-  worm submit <vaa> deploy <package-dir>    Deploy an Aptos package
-  worm submit <vaa> deploy-resource <seed>  Deploy an Aptos package using a
-  <package-dir>                             resource account
-  worm submit <vaa> send-example-message    Send example message
-  <message>
-  worm submit <vaa>                         Derive resource account address
-  derive-resource-account <account> <seed>
-  worm submit <vaa> derive-wrapped-address  Derive wrapped coin type
-  <chain> <origin-address>
-  worm submit <vaa> hash-contracts          Hash contract bytecodes for upgrade
-  <package-dir>
-  worm submit <vaa> upgrade <package-dir>   Perform upgrade after VAA has been
-                                            submitted
-  worm submit <vaa> migrate                 Perform migration after contract
-                                            upgrade
-  worm submit <vaa> faucet                  Request money from the faucet for a
-                                            given account
-  worm submit <vaa> start-validator         Start a local aptos validator
-  worm submit <vaa> address-from-secret     Compute a 20 byte eth address from a
-  <secret>                                  32 byte private key
-  worm submit <vaa> storage-update          Update a storage slot on an EVM fork
-                                            during testing (anvil or hardhat)
-  worm submit <vaa> chains                  Return all EVM chains
-  worm submit <vaa> info                    Query info about the on-chain state
-                                            of the contract
-  worm submit <vaa> hijack                  Override the guardian set of the
-                                            core bridge contract during testing
-                                            (anvil or hardhat)
-  worm submit <vaa> start-validator         Start a local EVM validator
-  worm submit <vaa> registration            Generate registration VAA
-  worm submit <vaa> upgrade                 Generate contract upgrade VAA
-  worm submit <vaa> attestation             Generate a token attestation VAA
-  worm submit <vaa> recover-chain-id        Generate a recover chain ID VAA
-  worm submit <vaa>                         Sets the default delivery provider
-  set-default-delivery-provider             for the Wormhole Relayer contract
-  worm submit <vaa> chain-id <chain>        Print the wormhole chain ID integer
-                                            associated with the specified chain
-                                            name
-  worm submit <vaa> contract <network>      Print contract address
-  <chain> <module>
-  worm submit <vaa> emitter <chain>         Print address in emitter address
-  <address>                                 format
-  worm submit <vaa> origin <chain>          Print the origin chain and address
-  <address>                                 of the asset that corresponds to the
-                                            given chain and address.
-  worm submit <vaa> registrations           Print chain registrations
-  <network> <chain> <module>
-  worm submit <vaa> rpc <network> <chain>   Print RPC address
-  worm submit <vaa> wrapped <origin-chain>  Print the wrapped address on the
-  <origin-address> <target-chain>           target chain that corresponds with
-                                            the specified origin chain and
-                                            address.
-  worm submit <vaa> contract-update <file>  Submit a contract update using our
-                                            specific APIs
-  worm submit <vaa> deploy <file>           Submit a contract update using near
-                                            APIs
-
 Positionals:
-  vaa, v     vaa                                             [string] [required]
-  digest     digest                                                     [string]
-  signature  signature                                                  [string]
+  vaa  vaa                                                              [string]
 
 Options:
-      --help                       Show help                           [boolean]
-      --version                    Show version number                 [boolean]
-  -n, -n, -n, --network            Network
-      [required] [choices: "mainnet", "testnet", "devnet", "mainnet", "testnet",
-                                       "devnet", "mainnet", "testnet", "devnet"]
-      --guardian-set-index, --gsi  guardian set index                   [number]
-      --signatures, --sigs         comma separated list of signatures   [string]
-      --wormscanurl, --wsu         url to wormscan entry for the vaa that
-                                   includes signatures                  [string]
-      --wormscanfile, --wsf        json file containing wormscan entry for the
-                                   vaa that includes signatures         [string]
-      --emitter-chain-id, --ec     emitter chain id to be used in the vaa
-                                                                        [number]
-      --emitter-address, --ea      emitter address to be used in the vaa[string]
-      --nonce, --no                nonce to be used in the vaa          [number]
-      --sequence, --seq            sequence number to be used in the vaa[string]
-      --consistency-level, --cl    consistency level to be used in the vaa
-                                                                        [number]
-      --timestamp, --ts            timestamp to be used in the vaa in unix
-                                   seconds                              [number]
-  -p, --payload                    payload in hex format                [string]
-  -g, --guardian-secret, --gs      Guardians' secret keys (CSV)
-                                                             [string] [required]
-  -r, --rpc                        RPC endpoint                         [string]
-  -m, --module                     Module to query
-                                   [choices: "Core", "NFTBridge", "TokenBridge"]
-      --account                    Near deployment account   [string] [required]
-      --attach                     Attach some near                     [string]
-      --target                     Near account to upgrade              [string]
-      --mnemonic                   Near private keys                    [string]
-      --key                        Near private key                     [string]
-  -c, --chain                      chain name
+      --help              Show help                                    [boolean]
+      --version           Show version number                          [boolean]
+  -c, --chain             chain name
              [choices: "unset", "solana", "ethereum", "terra", "bsc", "polygon",
         "avalanche", "oasis", "algorand", "aurora", "fantom", "karura", "acala",
             "klaytn", "celo", "near", "moonbeam", "neon", "terra2", "injective",
          "osmosis", "sui", "aptos", "arbitrum", "optimism", "gnosis", "pythnet",
                            "xpla", "btc", "base", "sei", "wormchain", "sepolia"]
-  -a, --contract-address           Contract to submit VAA to (override config)
-                                                                        [string]
-      --all-chains, --ac           Submit the VAA to all chains except for the
-                                   origin chain specified in the payload
+  -n, --network           Network
+                            [required] [choices: "mainnet", "testnet", "devnet"]
+  -a, --contract-address  Contract to submit VAA to (override config)   [string]
+      --rpc               RPC endpoint                                  [string]
+      --all-chains, --ac  Submit the VAA to all chains except for the origin
+                          chain specified in the payload
                                                       [boolean] [default: false]
 ```
 </details>
@@ -804,130 +273,28 @@ Options:
 worm sui <command>
 
 Commands:
-  worm sui init-token-bridge                Init token bridge contract
-  worm sui init-wormhole                    Init Wormhole core contract
-  worm sui deploy <package-dir>             Deploy an Aptos package
-  worm sui deploy-resource <seed>           Deploy an Aptos package using a
-  <package-dir>                             resource account
-  worm sui send-example-message <message>   Send example message
-  worm sui derive-resource-account          Derive resource account address
-  <account> <seed>
-  worm sui derive-wrapped-address <chain>   Derive wrapped coin type
-  <origin-address>
-  worm sui hash-contracts <package-dir>     Hash contract bytecodes for upgrade
-  worm sui upgrade <package-dir>            Perform upgrade after VAA has been
-                                            submitted
-  worm sui migrate                          Perform migration after contract
-                                            upgrade
-  worm sui faucet                           Request money from the faucet for a
-                                            given account
-  worm sui start-validator                  Start a local aptos validator
-  worm sui address-from-secret <secret>     Compute a 20 byte eth address from a
-                                            32 byte private key
-  worm sui storage-update                   Update a storage slot on an EVM fork
-                                            during testing (anvil or hardhat)
-  worm sui chains                           Return all EVM chains
-  worm sui info                             Query info about the on-chain state
-                                            of the contract
-  worm sui hijack                           Override the guardian set of the
-                                            core bridge contract during testing
-                                            (anvil or hardhat)
-  worm sui start-validator                  Start a local EVM validator
-  worm sui registration                     Generate registration VAA
-  worm sui upgrade                          Generate contract upgrade VAA
-  worm sui attestation                      Generate a token attestation VAA
-  worm sui recover-chain-id                 Generate a recover chain ID VAA
-  worm sui set-default-delivery-provider    Sets the default delivery provider
-                                            for the Wormhole Relayer contract
-  worm sui chain-id <chain>                 Print the wormhole chain ID integer
-                                            associated with the specified chain
-                                            name
-  worm sui contract <network> <chain>       Print contract address
-  <module>
-  worm sui emitter <chain> <address>        Print address in emitter address
-                                            format
-  worm sui origin <chain> <address>         Print the origin chain and address
-                                            of the asset that corresponds to the
-                                            given chain and address.
-  worm sui registrations <network> <chain>  Print chain registrations
-  <module>
-  worm sui rpc <network> <chain>            Print RPC address
-  worm sui wrapped <origin-chain>           Print the wrapped address on the
-  <origin-address> <target-chain>           target chain that corresponds with
-                                            the specified origin chain and
-                                            address.
-  worm sui contract-update <file>           Submit a contract update using our
-                                            specific APIs
-  worm sui deploy <file>                    Submit a contract update using near
-                                            APIs
-  worm sui build-coin                       Build wrapped coin and dump
-                                            bytecode.
+  worm sui build-coin                    Build wrapped coin and dump bytecode.
 
-                                            Example:
-                                            worm sui build-coin -d 8 -v V__0_1_1
-                                            -n testnet -r "https://fullnode.test
-                                            net.sui.io:443"
-  worm sui deploy <package-dir>             Deploy a Sui package
-  worm sui init-example-message-app         Initialize example core message app
-  worm sui init-token-bridge                Initialize token bridge contract
-  worm sui init-wormhole                    Initialize wormhole core contract
-  worm sui publish-example-message          Publish message from example app via
-                                            core bridge
-  worm sui setup-devnet                     Setup devnet by deploying and
-                                            initializing core and token bridges
-                                            and submitting chain registrations.
-  worm sui objects <owner>                  Get owned objects by owner
-  worm sui package-id <state-object-id>     Get package ID from State object ID
-  worm sui tx <transaction-digest>          Get transaction details
-
-Positionals:
-  vaa, v     vaa                                             [string] [required]
-  digest     digest                                                     [string]
-  signature  signature                                                  [string]
+                                         Example:
+                                         worm sui build-coin -d 8 -v V__0_1_1 -n
+                                         testnet -r
+                                         "https://fullnode.testnet.sui.io:443"
+  worm sui deploy <package-dir>          Deploy a Sui package
+  worm sui init-example-message-app      Initialize example core message app
+  worm sui init-token-bridge             Initialize token bridge contract
+  worm sui init-wormhole                 Initialize wormhole core contract
+  worm sui publish-example-message       Publish message from example app via
+                                         core bridge
+  worm sui setup-devnet                  Setup devnet by deploying and
+                                         initializing core and token bridges and
+                                         submitting chain registrations.
+  worm sui objects <owner>               Get owned objects by owner
+  worm sui package-id <state-object-id>  Get package ID from State object ID
+  worm sui tx <transaction-digest>       Get transaction details
 
 Options:
-      --help                       Show help                           [boolean]
-      --version                    Show version number                 [boolean]
-  -n, -n, -n, --network            Network
-      [required] [choices: "mainnet", "testnet", "devnet", "mainnet", "testnet",
-                                       "devnet", "mainnet", "testnet", "devnet"]
-      --guardian-set-index, --gsi  guardian set index                   [number]
-      --signatures, --sigs         comma separated list of signatures   [string]
-      --wormscanurl, --wsu         url to wormscan entry for the vaa that
-                                   includes signatures                  [string]
-      --wormscanfile, --wsf        json file containing wormscan entry for the
-                                   vaa that includes signatures         [string]
-      --emitter-chain-id, --ec     emitter chain id to be used in the vaa
-                                                                        [number]
-      --emitter-address, --ea      emitter address to be used in the vaa[string]
-      --nonce, --no                nonce to be used in the vaa          [number]
-      --sequence, --seq            sequence number to be used in the vaa[string]
-      --consistency-level, --cl    consistency level to be used in the vaa
-                                                                        [number]
-      --timestamp, --ts            timestamp to be used in the vaa in unix
-                                   seconds                              [number]
-  -p, --payload                    payload in hex format                [string]
-  -g, --guardian-secret, --gs      Guardians' secret keys (CSV)
-                                                             [string] [required]
-  -r, --rpc                        RPC endpoint                         [string]
-  -m, --module                     Module to query
-                                   [choices: "Core", "NFTBridge", "TokenBridge"]
-      --account                    Near deployment account   [string] [required]
-      --attach                     Attach some near                     [string]
-      --target                     Near account to upgrade              [string]
-      --mnemonic                   Near private keys                    [string]
-      --key                        Near private key                     [string]
-  -c, --chain                      chain name
-             [choices: "unset", "solana", "ethereum", "terra", "bsc", "polygon",
-        "avalanche", "oasis", "algorand", "aurora", "fantom", "karura", "acala",
-            "klaytn", "celo", "near", "moonbeam", "neon", "terra2", "injective",
-         "osmosis", "sui", "aptos", "arbitrum", "optimism", "gnosis", "pythnet",
-                           "xpla", "btc", "base", "sei", "wormchain", "sepolia"]
-  -a, --contract-address           Contract to submit VAA to (override config)
-                                                                        [string]
-      --all-chains, --ac           Submit the VAA to all chains except for the
-                                   origin chain specified in the payload
-                                                      [boolean] [default: false]
+  --help     Show help                                                 [boolean]
+  --version  Show version number                                       [boolean]
 ```
 </details>
 
@@ -935,136 +302,11 @@ Options:
 <summary> verify-vaa </summary>
 
 ```sh
-worm verify-vaa <command>
-
-Commands:
-  worm verify-vaa init-token-bridge         Init token bridge contract
-  worm verify-vaa init-wormhole             Init Wormhole core contract
-  worm verify-vaa deploy <package-dir>      Deploy an Aptos package
-  worm verify-vaa deploy-resource <seed>    Deploy an Aptos package using a
-  <package-dir>                             resource account
-  worm verify-vaa send-example-message      Send example message
-  <message>
-  worm verify-vaa derive-resource-account   Derive resource account address
-  <account> <seed>
-  worm verify-vaa derive-wrapped-address    Derive wrapped coin type
-  <chain> <origin-address>
-  worm verify-vaa hash-contracts            Hash contract bytecodes for upgrade
-  <package-dir>
-  worm verify-vaa upgrade <package-dir>     Perform upgrade after VAA has been
-                                            submitted
-  worm verify-vaa migrate                   Perform migration after contract
-                                            upgrade
-  worm verify-vaa faucet                    Request money from the faucet for a
-                                            given account
-  worm verify-vaa start-validator           Start a local aptos validator
-  worm verify-vaa address-from-secret       Compute a 20 byte eth address from a
-  <secret>                                  32 byte private key
-  worm verify-vaa storage-update            Update a storage slot on an EVM fork
-                                            during testing (anvil or hardhat)
-  worm verify-vaa chains                    Return all EVM chains
-  worm verify-vaa info                      Query info about the on-chain state
-                                            of the contract
-  worm verify-vaa hijack                    Override the guardian set of the
-                                            core bridge contract during testing
-                                            (anvil or hardhat)
-  worm verify-vaa start-validator           Start a local EVM validator
-  worm verify-vaa registration              Generate registration VAA
-  worm verify-vaa upgrade                   Generate contract upgrade VAA
-  worm verify-vaa attestation               Generate a token attestation VAA
-  worm verify-vaa recover-chain-id          Generate a recover chain ID VAA
-  worm verify-vaa                           Sets the default delivery provider
-  set-default-delivery-provider             for the Wormhole Relayer contract
-  worm verify-vaa chain-id <chain>          Print the wormhole chain ID integer
-                                            associated with the specified chain
-                                            name
-  worm verify-vaa contract <network>        Print contract address
-  <chain> <module>
-  worm verify-vaa emitter <chain>           Print address in emitter address
-  <address>                                 format
-  worm verify-vaa origin <chain> <address>  Print the origin chain and address
-                                            of the asset that corresponds to the
-                                            given chain and address.
-  worm verify-vaa registrations <network>   Print chain registrations
-  <chain> <module>
-  worm verify-vaa rpc <network> <chain>     Print RPC address
-  worm verify-vaa wrapped <origin-chain>    Print the wrapped address on the
-  <origin-address> <target-chain>           target chain that corresponds with
-                                            the specified origin chain and
-                                            address.
-  worm verify-vaa contract-update <file>    Submit a contract update using our
-                                            specific APIs
-  worm verify-vaa deploy <file>             Submit a contract update using near
-                                            APIs
-  worm verify-vaa build-coin                Build wrapped coin and dump
-                                            bytecode.
-
-                                            Example:
-                                            worm sui build-coin -d 8 -v V__0_1_1
-                                            -n testnet -r "https://fullnode.test
-                                            net.sui.io:443"
-  worm verify-vaa deploy <package-dir>      Deploy a Sui package
-  worm verify-vaa init-example-message-app  Initialize example core message app
-  worm verify-vaa init-token-bridge         Initialize token bridge contract
-  worm verify-vaa init-wormhole             Initialize wormhole core contract
-  worm verify-vaa publish-example-message   Publish message from example app via
-                                            core bridge
-  worm verify-vaa setup-devnet              Setup devnet by deploying and
-                                            initializing core and token bridges
-                                            and submitting chain registrations.
-  worm verify-vaa objects <owner>           Get owned objects by owner
-  worm verify-vaa package-id                Get package ID from State object ID
-  <state-object-id>
-  worm verify-vaa tx <transaction-digest>   Get transaction details
-
-Positionals:
-  vaa, v, v  vaa in hex format                               [string] [required]
-  digest     digest                                                     [string]
-  signature  signature                                                  [string]
-
 Options:
-      --help                       Show help                           [boolean]
-      --version                    Show version number                 [boolean]
-  -n, -n, -n, -n, --network        Network
-      [required] [choices: "mainnet", "testnet", "devnet", "mainnet", "testnet",
-       "devnet", "mainnet", "testnet", "devnet", "mainnet", "testnet", "devnet"]
-      --guardian-set-index, --gsi  guardian set index                   [number]
-      --signatures, --sigs         comma separated list of signatures   [string]
-      --wormscanurl, --wsu         url to wormscan entry for the vaa that
-                                   includes signatures                  [string]
-      --wormscanfile, --wsf        json file containing wormscan entry for the
-                                   vaa that includes signatures         [string]
-      --emitter-chain-id, --ec     emitter chain id to be used in the vaa
-                                                                        [number]
-      --emitter-address, --ea      emitter address to be used in the vaa[string]
-      --nonce, --no                nonce to be used in the vaa          [number]
-      --sequence, --seq            sequence number to be used in the vaa[string]
-      --consistency-level, --cl    consistency level to be used in the vaa
-                                                                        [number]
-      --timestamp, --ts            timestamp to be used in the vaa in unix
-                                   seconds                              [number]
-  -p, --payload                    payload in hex format                [string]
-  -g, --guardian-secret, --gs      Guardians' secret keys (CSV)
-                                                             [string] [required]
-  -r, --rpc                        RPC endpoint                         [string]
-  -m, --module                     Module to query
-                                   [choices: "Core", "NFTBridge", "TokenBridge"]
-      --account                    Near deployment account   [string] [required]
-      --attach                     Attach some near                     [string]
-      --target                     Near account to upgrade              [string]
-      --mnemonic                   Near private keys                    [string]
-      --key                        Near private key                     [string]
-  -c, --chain                      chain name
-             [choices: "unset", "solana", "ethereum", "terra", "bsc", "polygon",
-        "avalanche", "oasis", "algorand", "aurora", "fantom", "karura", "acala",
-            "klaytn", "celo", "near", "moonbeam", "neon", "terra2", "injective",
-         "osmosis", "sui", "aptos", "arbitrum", "optimism", "gnosis", "pythnet",
-                           "xpla", "btc", "base", "sei", "wormchain", "sepolia"]
-  -a, --contract-address           Contract to submit VAA to (override config)
-                                                                        [string]
-      --all-chains, --ac           Submit the VAA to all chains except for the
-                                   origin chain specified in the payload
-                                                      [boolean] [default: false]
+      --help     Show help                                             [boolean]
+      --version  Show version number                                   [boolean]
+  -v, --vaa      vaa in hex format                           [string] [required]
+  -n, --network  Network    [required] [choices: "mainnet", "testnet", "devnet"]
 ```
 </details>
 <!--CLI_USAGE-->

--- a/clients/js/src/doc.ts
+++ b/clients/js/src/doc.ts
@@ -17,10 +17,14 @@ import * as submit from "./cmds/submit";
 import * as sui from "./cmds/sui";
 import * as verifyVaa from "./cmds/verifyVaa";
 
+
 const MD_TAG = "<!--CLI_USAGE-->";
 
-async function getHelpText(name: string, cmd: any): Promise<string> {
-  return await cmd.builder(yargs).scriptName(`worm ${cmd.command}`).getHelp();
+async function getHelpText(cmd: any): Promise<string> {
+  // Note that `yargs` is called as a function to produce a fresh copy.
+  // Otherwise the imported module is effectively a singleton where state from 
+  // other commands is accumulated from repeat calls.
+  return await cmd.builder(yargs()).scriptName(`worm ${cmd.command}`).getHelp();
 }
 
 (async function () {
@@ -39,8 +43,8 @@ async function getHelpText(name: string, cmd: any): Promise<string> {
   ];
 
   const helpOutputs: Buffer[] = [];
-  for (const [name, cmd] of Object.entries(cmds)) {
-    const helpText = await getHelpText(name, cmd);
+  for (const cmd of cmds) {
+    const helpText = await getHelpText(cmd);
 
     helpOutputs.push(Buffer.from(`
 <details>

--- a/clients/js/src/main.ts
+++ b/clients/js/src/main.ts
@@ -18,6 +18,8 @@ import * as sui from "./cmds/sui";
 import * as transfer from "./cmds/transfer";
 import * as verifyVaa from "./cmds/verifyVaa";
 
+// Note: When adding another subcommand here, please be sure to also include it
+// in the `cmds` array in `docs.ts` so it is properly documented.
 yargs(hideBin(process.argv))
   // https://github.com/yargs/yargs/blob/main/docs/advanced.md#commanddirdirectory-opts
   // can't use `.commandDir` because bundling + tree-shaking


### PR DESCRIPTION
As reported in https://github.com/wormhole-foundation/wormhole/issues/3152 the `docs.ts` script meant to produce documentation for the CLI tool was producing incorrect subcommands. 

This was caused by re-using the `yargs` singleton that had state built up from other commands.

The fix here is to create a fresh copy for every invocation of `builder`