### PR TITLE
Node: Reduce info logging

### DIFF
--- a/node/pkg/processor/cleanup.go
+++ b/node/pkg/processor/cleanup.go
@@ -114,7 +114,7 @@ func (p *Processor) handleCleanup(ctx context.Context) {
 				chain = s.ourObservation.GetEmitterChain()
 			}
 
-			p.logger.Info("observation considered settled",
+			p.logger.Debug("observation considered settled",
 				zap.String("digest", hash),
 				zap.Duration("delta", delta),
 				zap.Int("have_sigs", hasSigs),
@@ -135,7 +135,7 @@ func (p *Processor) handleCleanup(ctx context.Context) {
 			// observation that come in. Therefore, keep it for a reasonable amount of time.
 			// If a very late observation arrives after cleanup, a nil aggregation state will be created
 			// and then expired after a while (as noted in observation.go, this can be abused by a byzantine guardian).
-			p.logger.Info("expiring submitted observation", zap.String("digest", hash), zap.Duration("delta", delta))
+			p.logger.Debug("expiring submitted observation", zap.String("digest", hash), zap.Duration("delta", delta))
 			delete(p.state.signatures, hash)
 			aggregationStateExpiration.Inc()
 		case !s.submitted && ((s.ourMsg != nil && s.retryCount >= 14400 /* 120 hours */) || (s.ourMsg == nil && s.retryCount >= 10 /* 5 minutes */)):

--- a/node/pkg/processor/observation.go
+++ b/node/pkg/processor/observation.go
@@ -195,7 +195,7 @@ func (p *Processor) handleObservation(ctx context.Context, m *gossipv1.SignedObs
 		// 2/3+ majority required for VAA to be valid - wait until we have quorum to submit VAA.
 		quorum := vaa.CalculateQuorum(len(gs.Keys))
 
-		p.logger.Debug("aggregation state for observation", // 1.2M out of 3M info messages / hour / guardian
+		p.logger.Debug("aggregation state for observation", // 1.3M out of 3M info messages / hour / guardian
 			zap.String("digest", hash),
 			zap.Any("set", gs.KeysAsHexStrings()),
 			zap.Uint32("index", gs.Index),

--- a/node/pkg/processor/observation.go
+++ b/node/pkg/processor/observation.go
@@ -195,7 +195,7 @@ func (p *Processor) handleObservation(ctx context.Context, m *gossipv1.SignedObs
 		// 2/3+ majority required for VAA to be valid - wait until we have quorum to submit VAA.
 		quorum := vaa.CalculateQuorum(len(gs.Keys))
 
-		p.logger.Info("aggregation state for observation",
+		p.logger.Debug("aggregation state for observation", // 1.2M out of 3M info messages / hour / guardian
 			zap.String("digest", hash),
 			zap.Any("set", gs.KeysAsHexStrings()),
 			zap.Uint32("index", gs.Index),
@@ -208,11 +208,11 @@ func (p *Processor) handleObservation(ctx context.Context, m *gossipv1.SignedObs
 		if len(sigs) >= quorum && !p.state.signatures[hash].submitted {
 			p.state.signatures[hash].ourObservation.HandleQuorum(sigs, hash, p)
 		} else {
-			p.logger.Info("quorum not met or already submitted, doing nothing",
+			p.logger.Debug("quorum not met or already submitted, doing nothing", // 1.2M out of 3M info messages / hour / guardian
 				zap.String("digest", hash))
 		}
 	} else {
-		p.logger.Info("we have not yet seen this observation - temporarily storing signature",
+		p.logger.Debug("we have not yet seen this observation - temporarily storing signature", // 175K out of 3M info messages / hour / guardian
 			zap.String("digest", hash),
 			zap.Bools("aggregation", agg))
 


### PR DESCRIPTION
Looking at INFO logging for a random hour, for a random guardian (Staking Facilities), we saw about 3 million messages. Of those:

- `aggregation state for observation` occurred 1.3 million times.
- `quorum not met or already submitted, doing nothing` occurred 1.2 million times.
- `we have not yet seen this observation - temporarily storing signature` occurred 175K times.
None of these events are particularly noteworthy, so this PR changes them to debugs.