### PR TITLE
evm: add TransferRedeemed event to Bridge.sol

### DIFF
--- a/ethereum/contracts/bridge/Bridge.sol
+++ b/ethereum/contracts/bridge/Bridge.sol
@@ -20,6 +20,18 @@ import "./token/TokenImplementation.sol";
 contract Bridge is BridgeGovernance, ReentrancyGuard {
     using BytesLib for bytes;
 
+    /**
+     * @notice Emitted when a transfer is completed by the token bridge.
+     * @param emitterChainId Wormhole chain ID of emitter on the source chain.
+     * @param emitterAddress Address (bytes32 zero-left-padded) of emitter on the source chain.
+     * @param sequence Sequence of the Wormhole message.
+     */
+    event TransferRedeemed(
+        uint16 indexed emitterChainId,
+        bytes32 indexed emitterAddress,
+        uint64 indexed sequence
+    );
+
     /*
      *  @dev Produce a AssetMeta message for a given token
      */
@@ -496,6 +508,9 @@ contract Bridge is BridgeGovernance, ReentrancyGuard {
 
         require(!isTransferCompleted(vm.hash), "transfer already completed");
         setTransferCompleted(vm.hash);
+
+        // emit `TransferRedeemed` event
+        emit TransferRedeemed(vm.emitterChainId, vm.emitterAddress, vm.sequence);
 
         require(transfer.toChain == chainId(), "invalid target chain");
 

--- a/ethereum/contracts/bridge/interfaces/ITokenBridge.sol
+++ b/ethereum/contracts/bridge/interfaces/ITokenBridge.sol
@@ -64,6 +64,8 @@ interface ITokenBridge {
 
     event ContractUpgraded(address indexed oldContract, address indexed newContract);
 
+    event TransferRedeemed(uint16 indexed emitterChainId, bytes32 indexed emitterAddress, uint64 indexed sequence);
+
     function _parseTransferCommon(bytes memory encoded) external pure returns (Transfer memory transfer);
 
     function attestToken(address tokenAddress, uint32 nonce) external payable returns (uint64 sequence);

--- a/ethereum/test/bridge.js
+++ b/ethereum/test/bridge.js
@@ -581,6 +581,7 @@ contract("Bridge", function () {
     it("should transfer out locked assets for a valid transfer vm", async function () {
         const accounts = await web3.eth.getAccounts();
         const amount = "1000000000000000000";
+        const sequence = 1697;
 
         const token = new web3.eth.Contract(TokenImplementation.abi, TokenImplementation.address);
         const initialized = new web3.eth.Contract(BridgeImplementationFullABI, TokenBridge.address);
@@ -612,7 +613,7 @@ contract("Bridge", function () {
             0,
             testForeignChainId,
             testForeignBridgeContract,
-            0,
+            sequence,
             data,
             [
                 testSigner1PK
@@ -621,7 +622,7 @@ contract("Bridge", function () {
             0
         );
 
-        await initialized.methods.completeTransfer("0x" + vm).send({
+        const tx = await initialized.methods.completeTransfer("0x" + vm).send({
             value: 0,
             from: accounts[0],
             gasLimit: 2000000
@@ -632,6 +633,14 @@ contract("Bridge", function () {
 
         assert.equal(accountBalanceAfter.toString(10), amount);
         assert.equal(bridgeBalanceAfter.toString(10), "0");
+
+        // verify the `TransferRedeemed` event
+        const event = tx.events.TransferRedeemed;
+
+        assert.equal(event !== undefined, true);
+        assert.equal(event.returnValues.emitterChainId, testForeignChainId);
+        assert.equal(event.returnValues.emitterAddress, testForeignBridgeContract);
+        assert.equal(event.returnValues.sequence, sequence);
     })
 
     it("should deposit and log transfer with payload correctly", async function () {
@@ -719,6 +728,7 @@ contract("Bridge", function () {
     it("should transfer out locked assets for a valid transfer with payload vm", async function () {
         const accounts = await web3.eth.getAccounts();
         const amount = "1000000000000000000";
+        const sequence = 1111;
 
         const token = new web3.eth.Contract(TokenImplementation.abi, TokenImplementation.address);
         const initialized = new web3.eth.Contract(BridgeImplementationFullABI, TokenBridge.address);
@@ -751,7 +761,7 @@ contract("Bridge", function () {
             0,
             testForeignChainId,
             testForeignBridgeContract,
-            0,
+            sequence,
             data,
             [
                 testSigner1PK
@@ -760,7 +770,7 @@ contract("Bridge", function () {
             0
         );
 
-        await initialized.methods.completeTransferWithPayload("0x" + vm).send({
+        const tx = await initialized.methods.completeTransferWithPayload("0x" + vm).send({
             value: 0,
             from: accounts[0],
             gasLimit: 2000000
@@ -771,6 +781,14 @@ contract("Bridge", function () {
 
         assert.equal(accountBalanceAfter.toString(10), new BigNumber(accountBalanceBefore).plus(amount).toString(10));
         assert.equal(bridgeBalanceAfter.toString(10), "0");
+
+        // verify the `TransferRedeemed` event
+        const event = tx.events.TransferRedeemed;
+
+        assert.equal(event !== undefined, true);
+        assert.equal(event.returnValues.emitterChainId, testForeignChainId);
+        assert.equal(event.returnValues.emitterAddress, testForeignBridgeContract);
+        assert.equal(event.returnValues.sequence, sequence);
     })
 
     it("should mint bridged assets wrappers on transfer from another chain and handle fees correctly", async function () {


### PR DESCRIPTION
The purpose of this PR is to add the event `TransferRedeemed` to the token bridge. This will allow off-chain processes to track when a transfer has been redeemed. 