### PR TITLE
Node: Increase subscription buffer size from 32 to 1024

### DIFF
--- a/node/pkg/p2p/p2p.go
+++ b/node/pkg/p2p/p2p.go
@@ -248,7 +248,9 @@ func Run(
 			return fmt.Errorf("failed to join topic: %w", err)
 		}
 
-		sub, err := th.Subscribe()
+		// Increase the buffer size to prevent failed delivery
+		// to slower subscribers
+		sub, err := th.Subscribe(pubsub.WithBufferSize(1024))
 		if err != nil {
 			return fmt.Errorf("failed to subscribe topic: %w", err)
 		}


### PR DESCRIPTION
The default buffer size for subscriptions is 32 messages.

This is apparently too small and causes issues with message delivery with log messages like:
```
INFO    pubsub  go-libp2p-pubsub@v0.9.3/pubsub.go:981   Can't deliver message to subscription for topic /wormhole/testnet/2/1/broadcast; subscriber too slow
```
which comes from
https://github.com/libp2p/go-libp2p-pubsub/blob/6d73cd4b56bf9d7fdd0c0caaed629a3d51027a75/pubsub.go#L981

The comment on the option provides a hint
https://github.com/libp2p/go-libp2p-pubsub/blob/master/pubsub.go#L1303-L1311

----

The choice of 1024 was somewhat arbitrary but "large enough"

It may be better to make this a package level const or add it to the arguments passed to `Run`, though that is already pretty thicc with arguments.

----

Are there any security concerns with this? If I was malicious, could I potentially cause your node to OOM by making a bunch of connections and process them very slowly to fill the buffer? Or is it capped by the [connection managers high water mark?](https://github.com/wormhole-foundation/wormhole/blob/main/node/pkg/p2p/p2p.go#L128-L136)

