### PR TITLE
docs: change link on README to point to docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This monorepo contains the reference implementation of the [Wormhole protocol](https://wormholenetwork.com).
 
-To learn about how to use and build on Wormhole read the [docs](http://book.wormholenetwork.com/).
+To learn about how to use and build on Wormhole read the [docs](https://docs.wormhole.com/).
 
 ----
 


### PR DESCRIPTION
Book is no longer maintained.

This README could probably use a refresh with some more links/resources and a new image