### PR TITLE
watcher: add sui logging

### DIFF
--- a/node/pkg/watchers/sui/watcher.go
+++ b/node/pkg/watchers/sui/watcher.go
@@ -475,7 +475,7 @@ func (e *Watcher) Run(ctx context.Context) error {
 				var res SuiTxnQuery
 				err = json.Unmarshal(body, &res)
 				if err != nil {
-					logger.Error("failed to unmarshal event message", zap.Error(err))
+					logger.Error("failed to unmarshal event message", zap.String("body", string(body)), zap.Error(err))
 					p2p.DefaultRegistry.AddErrorCount(vaa.ChainIDSui, 1)
 					return fmt.Errorf("sui__fetch_obvs_req failed to unmarshal: %w", err)
 


### PR DESCRIPTION
Some of the guardians are getting SUI errors:
```
jsonPayload: {
error: "json: cannot unmarshal string into Go struct field FieldsData.result.parsedJson.nonce of type uint64"
logger: "root.suiwatch"
message: "failed to unmarshal event message"
severity: "ERROR"
timestamp: "2023-07-12T17:14:17.588311789Z"
}
```
This PR adds a log message to try and determine what the bad message is.