### PR TITLE
ethereum: ensure forge tests work with new forge

### DIFF
--- a/ethereum/forge-test/TokenImplementation.t.sol
+++ b/ethereum/forge-test/TokenImplementation.t.sol
@@ -78,7 +78,7 @@ contract TestTokenImplementation is TokenImplementation, Test {
         address spender,
         uint256 amount,
         uint256 deadline
-    ) public view returns (SignatureSetup memory output) {
+    ) public returns (SignatureSetup memory output) {
         // prepare signer allowing for tokens to be spent
         uint256 sk = uint256(walletPrivateKey);
         output.allower = vm.addr(sk);

--- a/ethereum/forge-test/relayer/WormholeRelayer.t.sol
+++ b/ethereum/forge-test/relayer/WormholeRelayer.t.sol
@@ -162,7 +162,7 @@ contract WormholeRelayerTests is Test {
         GasParameters memory gasParams,
         FeeParameters memory feeParams,
         uint32 minTargetGasLimit
-    ) public pure {
+    ) public {
         vm.assume(gasParams.evmGasOverhead > 0);
         vm.assume(gasParams.targetGasLimit > 0);
         vm.assume(feeParams.targetNativePrice > 0);

--- a/ethereum/forge-test/relayer/WormholeSimulator.sol
+++ b/ethereum/forge-test/relayer/WormholeSimulator.sol
@@ -322,7 +322,6 @@ contract SigningWormholeSimulator is WormholeSimulator {
      */
     function encodeAndSignMessage(IWormhole.VM memory vm_)
         public
-        view
         override
         returns (bytes memory signedMessage)
     {


### PR DESCRIPTION
Otherwise, you get errors like:

    Compiler run failed:
    Error (8961): Function cannot be declared as view because this expression (potentially) modifies the state.
    --> forge-test/TokenImplementation.t.sol:84:26:
    |
    84 |         output.allower = vm.addr(sk);
    |                          ^^^^^^^^^^^

    Error (8961): Function cannot be declared as view because this expression (potentially) modifies the state.
    --> forge-test/TokenImplementation.t.sol:101:42:
        |
    101 |         (output.v, output.r, output.s) = vm.sign(sk, message);
        |                                          ^^^^^^^^^^^^^^^^^^^^

    Error (8961): Function cannot be declared as view because this expression (potentially) modifies the state.
    --> forge-test/relayer/WormholeSimulator.sol:335:45:
        |
    335 |         (sigs[0].v, sigs[0].r, sigs[0].s) = vm.sign(devnetGuardianPK, vm_.hash);
        |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

    Error (8961): Function cannot be declared as pure because this expression (potentially) modifies the state.
    --> forge-test/relayer/WormholeRelayer.t.sol:166:9:
        |
    166 |         vm.assume(gasParams.evmGasOverhead > 0);
        |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

    Error (8961): Function cannot be declared as pure because this expression (potentially) modifies the state.
    --> forge-test/relayer/WormholeRelayer.t.sol:167:9:
        |
    167 |         vm.assume(gasParams.targetGasLimit > 0);
        |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

    Error (8961): Function cannot be declared as pure because this expression (potentially) modifies the state.
    --> forge-test/relayer/WormholeRelayer.t.sol:168:9:
        |
    168 |         vm.assume(feeParams.targetNativePrice > 0);
        |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

    Error (8961): Function cannot be declared as pure because this expression (potentially) modifies the state.
    --> forge-test/relayer/WormholeRelayer.t.sol:169:9:
        |
    169 |         vm.assume(gasParams.targetGasPrice > 0);
        |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

    Error (8961): Function cannot be declared as pure because this expression (potentially) modifies the state.
    --> forge-test/relayer/WormholeRelayer.t.sol:170:9:
        |
    170 |         vm.assume(gasParams.sourceGasPrice > 0);
        |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^