### PR TITLE
node/processor: exponential backoff for reobservation requests

### DIFF
--- a/node/pkg/processor/backoff.go
+++ b/node/pkg/processor/backoff.go
@@ -1,0 +1,16 @@
+package processor
+
+import (
+	mathrand "math/rand"
+	"time"
+)
+
+func initRetryTime() time.Time {
+	// return some time between firstRetryMinWait and firstRetryMinWait*2.
+	return time.Now().Add(firstRetryMinWait).Add(time.Duration(mathrand.Int63n(int64(firstRetryMinWait)))) // nolint:gosec
+}
+
+func nextRetryDuration(ctr uint) time.Duration {
+	m := 1 << ctr
+	return firstRetryMinWait * time.Duration(m)
+}

--- a/node/pkg/processor/backoff_test.go
+++ b/node/pkg/processor/backoff_test.go
@@ -1,0 +1,19 @@
+package processor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBackoff(t *testing.T) {
+	assert.Equal(t, firstRetryMinWait, nextRetryDuration(0))
+	assert.Equal(t, firstRetryMinWait*2, nextRetryDuration(1))
+	assert.Equal(t, firstRetryMinWait*4, nextRetryDuration(2))
+
+	for i := 0; i < 10; i++ {
+		assert.Greater(t, time.Now().Add(firstRetryMinWait*2+time.Second), initRetryTime())
+		assert.Less(t, time.Now().Add(firstRetryMinWait-time.Second), initRetryTime())
+	}
+}

--- a/node/pkg/processor/broadcast.go
+++ b/node/pkg/processor/broadcast.go
@@ -52,6 +52,7 @@ func (p *Processor) broadcastSignature(
 	if p.state.signatures[hash] == nil {
 		p.state.signatures[hash] = &state{
 			firstObserved: time.Now(),
+			nextRetry:     initRetryTime(),
 			signatures:    map[ethcommon.Address][]byte{},
 			source:        "loopback",
 		}

--- a/node/pkg/processor/cleanup.go
+++ b/node/pkg/processor/cleanup.go
@@ -58,6 +58,7 @@ const (
 	retryTime         = time.Minute * 5
 	retryLimitOurs    = time.Hour * 24
 	retryLimitNotOurs = time.Hour
+	firstRetryMinWait = time.Minute * 5
 )
 
 // handleCleanup handles periodic retransmissions and cleanup of observations
@@ -145,7 +146,7 @@ func (p *Processor) handleCleanup(ctx context.Context) {
 			p.logger.Info("expiring unsubmitted observation after exhausting retries", zap.String("digest", hash), zap.Duration("delta", delta), zap.Bool("weObserved", s.ourMsg != nil))
 			delete(p.state.signatures, hash)
 			aggregationStateTimeout.Inc()
-		case !s.submitted && delta.Minutes() >= 5 && time.Since(s.lastRetry) >= retryTime:
+		case !s.submitted && delta >= firstRetryMinWait && time.Since(s.nextRetry) >= 0:
 			// Poor observation has been unsubmitted for five minutes - clearly, something went wrong.
 			// If we have previously submitted an observation, and it was reliable, we can make another attempt to get
 			// it over the finish line by sending a re-observation request to the network and rebroadcasting our
@@ -173,7 +174,8 @@ func (p *Processor) handleCleanup(ctx context.Context) {
 					p.logger.Warn("failed to broadcast re-observation request", zap.Error(err))
 				}
 				p.gossipSendC <- s.ourMsg
-				s.lastRetry = time.Now()
+				s.retryCtr++
+				s.nextRetry = time.Now().Add(nextRetryDuration(s.retryCtr))
 				aggregationStateRetries.Inc()
 			} else {
 				// For nil state entries, we log the quorum to determine whether the

--- a/node/pkg/processor/observation.go
+++ b/node/pkg/processor/observation.go
@@ -161,8 +161,10 @@ func (p *Processor) handleObservation(ctx context.Context, m *gossipv1.SignedObs
 
 		p.state.signatures[hash] = &state{
 			firstObserved: time.Now(),
-			signatures:    map[common.Address][]byte{},
-			source:        "unknown",
+			// add some jitter between 0 and 5 minutes for the first retry because there are likely other guardians who will also send a retry.
+			nextRetry:  initRetryTime(),
+			signatures: map[common.Address][]byte{},
+			source:     "unknown",
 		}
 	}
 

--- a/node/pkg/processor/processor.go
+++ b/node/pkg/processor/processor.go
@@ -42,8 +42,10 @@ type (
 	state struct {
 		// First time this digest was seen (possibly even before we observed it ourselves).
 		firstObserved time.Time
-		// The most recent time that a re-observation request was sent to the guardian network.
-		lastRetry time.Time
+		// A re-observation request shall not be sent before this time.
+		nextRetry time.Time
+		// Number of times we sent a re-observation request
+		retryCtr uint
 		// Copy of our observation.
 		ourObservation Observation
 		// Map of signatures seen by guardian. During guardian set updates, this may contain signatures belonging


### PR DESCRIPTION
This change adds jitter and exponential backoff to automated re-observation requests. 
The time before the first request will be randomly between 5 and 10 minutes. 
The wait for the second one will be 10 minutes
The third will be 20 minutes
The fourth will be 40 minutes
...and so on
