### PR TITLE
Node: Processor delay metrics

### DIFF
--- a/node/cmd/spy/spy.go
+++ b/node/cmd/spy/spy.go
@@ -266,7 +266,7 @@ func runSpy(cmd *cobra.Command, args []string) {
 	sendC := make(chan []byte)
 
 	// Inbound observations
-	obsvC := make(chan *gossipv1.SignedObservation, 1024)
+	obsvC := make(chan *common.MsgWithTimeStamp[gossipv1.SignedObservation], 1024)
 
 	// Inbound observation requests
 	obsvReqC := make(chan *gossipv1.ObservationRequest, 1024)

--- a/node/pkg/common/msg_with_timestamp.go
+++ b/node/pkg/common/msg_with_timestamp.go
@@ -1,0 +1,29 @@
+package common
+
+import (
+	"time"
+)
+
+// MsgWithTimeStamp allows us to track the time of receipt of an event.
+type MsgWithTimeStamp[T any] struct {
+	Msg       *T
+	Timestamp time.Time
+}
+
+// CreateMsgWithTimestamp creates a new MsgWithTimeStamp with the current time.
+func CreateMsgWithTimestamp[T any](msg *T) *MsgWithTimeStamp[T] {
+	return &MsgWithTimeStamp[T]{
+		Msg:       msg,
+		Timestamp: time.Now(),
+	}
+}
+
+// PostMsgWithTimestamp sends the message to the specified channel using the current timestamp. Returns ErrChanFull on error.
+func PostMsgWithTimestamp[T any](msg *T, c chan<- *MsgWithTimeStamp[T]) error {
+	select {
+	case c <- CreateMsgWithTimestamp[T](msg):
+		return nil
+	default:
+		return ErrChanFull
+	}
+}

--- a/node/pkg/node/node.go
+++ b/node/pkg/node/node.go
@@ -54,7 +54,7 @@ type G struct {
 	// Outbound gossip message queue (needs to be read/write because p2p needs read/write)
 	gossipSendC chan []byte
 	// Inbound observations. This is read/write because the processor also writes to it as a fast-path when handling locally made observations.
-	obsvC chan *gossipv1.SignedObservation
+	obsvC chan *common.MsgWithTimeStamp[gossipv1.SignedObservation]
 	// Finalized guardian observations aggregated across all chains
 	msgC channelPair[*common.MessagePublication]
 	// Ethereum incoming guardian set updates
@@ -88,7 +88,7 @@ func (g *G) initializeBasic(logger *zap.Logger, rootCtxCancel context.CancelFunc
 
 	// Setup various channels...
 	g.gossipSendC = make(chan []byte)
-	g.obsvC = make(chan *gossipv1.SignedObservation, inboundObservationBufferSize)
+	g.obsvC = make(chan *common.MsgWithTimeStamp[gossipv1.SignedObservation], inboundObservationBufferSize)
 	g.msgC = makeChannelPair[*common.MessagePublication](0)
 	g.setC = makeChannelPair[*common.GuardianSet](1) // This needs to be a buffered channel because of a circular dependency between processor and accountant during startup.
 	g.signedInC = makeChannelPair[*gossipv1.SignedVAAWithQuorum](inboundSignedVaaBufferSize)

--- a/node/pkg/p2p/watermark_test.go
+++ b/node/pkg/p2p/watermark_test.go
@@ -27,7 +27,7 @@ const LOCAL_P2P_PORTRANGE_START = 11000
 
 type G struct {
 	// arguments passed to p2p.New
-	obsvC                  chan *gossipv1.SignedObservation
+	obsvC                  chan *node_common.MsgWithTimeStamp[gossipv1.SignedObservation]
 	obsvReqC               chan *gossipv1.ObservationRequest
 	obsvReqSendC           chan *gossipv1.ObservationRequest
 	sendC                  chan []byte
@@ -62,7 +62,7 @@ func NewG(t *testing.T, nodeName string) *G {
 	}
 
 	g := &G{
-		obsvC:                  make(chan *gossipv1.SignedObservation, cs),
+		obsvC:                  make(chan *node_common.MsgWithTimeStamp[gossipv1.SignedObservation], cs),
 		obsvReqC:               make(chan *gossipv1.ObservationRequest, cs),
 		obsvReqSendC:           make(chan *gossipv1.ObservationRequest, cs),
 		sendC:                  make(chan []byte, cs),

--- a/node/pkg/processor/broadcast.go
+++ b/node/pkg/processor/broadcast.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"google.golang.org/protobuf/proto"
 
+	node_common "github.com/certusone/wormhole/node/pkg/common"
 	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
 	"github.com/wormhole-foundation/wormhole/sdk/vaa"
 )
@@ -64,8 +65,8 @@ func (p *Processor) broadcastSignature(
 	p.state.signatures[hash].source = o.GetEmitterChain().String()
 	p.state.signatures[hash].gs = p.gs // guaranteed to match ourObservation - there's no concurrent access to p.gs
 
-	// Fast path for our own signature
-	go func() { p.obsvC <- &obsv }()
+	// Fast path for our own signature. Put this in a go routine so it can block if the channel is full. That's also why we're not using node_common.PostMsgWithTimestamp.
+	go func() { p.obsvC <- node_common.CreateMsgWithTimestamp[gossipv1.SignedObservation](&obsv) }()
 
 	observationsBroadcastTotal.Inc()
 }

--- a/node/pkg/processor/observation.go
+++ b/node/pkg/processor/observation.go
@@ -46,12 +46,13 @@ var (
 
 // handleObservation processes a remote VAA observation, verifies it, checks whether the VAA has met quorum,
 // and assembles and submits a valid VAA if possible.
-func (p *Processor) handleObservation(ctx context.Context, m *gossipv1.SignedObservation) {
+func (p *Processor) handleObservation(ctx context.Context, obs *node_common.MsgWithTimeStamp[gossipv1.SignedObservation]) {
 	// SECURITY: at this point, observations received from the p2p network are fully untrusted (all fields!)
 	//
 	// Note that observations are never tied to the (verified) p2p identity key - the p2p network
 	// identity is completely decoupled from the guardian identity, p2p is just transport.
 
+	m := obs.Msg
 	hash := hex.EncodeToString(m.Hash)
 
 	p.logger.Debug("received observation",
@@ -218,6 +219,8 @@ func (p *Processor) handleObservation(ctx context.Context, m *gossipv1.SignedObs
 			zap.Bools("aggregation", agg))
 
 	}
+
+	observationTotalDelay.Observe(float64(time.Since(obs.Timestamp).Microseconds()))
 }
 
 func (p *Processor) handleInboundSignedVAAWithQuorum(ctx context.Context, m *gossipv1.SignedVAAWithQuorum) {


### PR DESCRIPTION
This PR adds metrics to track delay on signed observations by adding two histograms.

One measures the delay from when P2P enqueues the observation on the channel until the processor reads it off the channel.

The second measures the total delay from when P2P enqueues the observation until the processor finishes processing it.

Here is sample output from multiple runs. The first three are using the standard single threaded processor. The second three are using `node_processor_multithreading`

`Standard processor:
PROCESSOR_METRICS       {"observationChannelDelay": "histogram:{sample_count:358602  sample_sum:1.020196794e+09  bucket:{cumulative_count:27698  upper_bound:10}  bucket:{cumulative_count:36184  upper_bound:20}  bucket:{cumulative_count:47105  upper_bound:50}  bucket:{cumulative_count:57899  upper_bound:100}  bucket:{cumulative_count:174922  upper_bound:1000}  bucket:{cumulative_count:291719  upper_bound:5000}  bucket:{cumulative_count:336980  upper_bound:10000}}"}
PROCESSOR_METRICS       {"observationProcessingDelay": "histogram:{sample_count:358602  sample_sum:1.081633683e+09  bucket:{cumulative_count:0  upper_bound:10}  bucket:{cumulative_count:0  upper_bound:20}  bucket:{cumulative_count:96  upper_bound:50}  bucket:{cumulative_count:15220  upper_bound:100}  bucket:{cumulative_count:163425  upper_bound:1000}  bucket:{cumulative_count:288749  upper_bound:5000}  bucket:{cumulative_count:335932  upper_bound:10000}}"}

PROCESSOR_METRICS       {"observationChannelDelay": "histogram:{sample_count:358931  sample_sum:1.103924404e+09  bucket:{cumulative_count:27565  upper_bound:10}  bucket:{cumulative_count:36222  upper_bound:20}  bucket:{cumulative_count:47371  upper_bound:50}  bucket:{cumulative_count:58224  upper_bound:100}  bucket:{cumulative_count:174774  upper_bound:1000}  bucket:{cumulative_count:288419  upper_bound:5000}  bucket:{cumulative_count:334865  upper_bound:10000}}"}
PROCESSOR_METRICS       {"observationProcessingDelay": "histogram:{sample_count:358931  sample_sum:1.16831026e+09  bucket:{cumulative_count:0  upper_bound:10}  bucket:{cumulative_count:0  upper_bound:20}  bucket:{cumulative_count:70  upper_bound:50}  bucket:{cumulative_count:14800  upper_bound:100}  bucket:{cumulative_count:163626  upper_bound:1000}  bucket:{cumulative_count:285205  upper_bound:5000}  bucket:{cumulative_count:333718  upper_bound:10000}}"}

PROCESSOR_METRICS       {"observationChannelDelay": "histogram:{sample_count:358437  sample_sum:1.191968659e+09  bucket:{cumulative_count:24392  upper_bound:10}  bucket:{cumulative_count:31901  upper_bound:20}  bucket:{cumulative_count:41596  upper_bound:50}  bucket:{cumulative_count:50516  upper_bound:100}  bucket:{cumulative_count:154493  upper_bound:1000}  bucket:{cumulative_count:275711  upper_bound:5000}  bucket:{cumulative_count:329802  upper_bound:10000}}"}
PROCESSOR_METRICS       {"observationProcessingDelay": "histogram:{sample_count:358437  sample_sum:1.259743954e+09  bucket:{cumulative_count:0  upper_bound:10}  bucket:{cumulative_count:0  upper_bound:20}  bucket:{cumulative_count:54  upper_bound:50}  bucket:{cumulative_count:11994  upper_bound:100}  bucket:{cumulative_count:142594  upper_bound:1000}  bucket:{cumulative_count:271943  upper_bound:5000}  bucket:{cumulative_count:328340  upper_bound:10000}}"}

Multi-threading, factor: 2.0
PROCESSOR_METRICS       {"component": "processor", "observationChannelDelay": "histogram:{sample_count:360953  sample_sum:2.92578642e+08  bucket:{cumulative_count:116444  upper_bound:10}  bucket:{cumulative_count:117506  upper_bound:20}  bucket:{cumulative_count:120136  upper_bound:50}  bucket:{cumulative_count:125837  upper_bound:100}  bucket:{cumulative_count:254072  upper_bound:1000}  bucket:{cumulative_count:357666  upper_bound:5000}  bucket:{cumulative_count:360790  upper_bound:10000}}"}
PROCESSOR_METRICS       {"component": "processor", "observationProcessingDelay": "histogram:{sample_count:360953  sample_sum:4.47866836e+08  bucket:{cumulative_count:0  upper_bound:10}  bucket:{cumulative_count:0  upper_bound:20}  bucket:{cumulative_count:334  upper_bound:50}  bucket:{cumulative_count:51354  upper_bound:100}  bucket:{cumulative_count:227862  upper_bound:1000}  bucket:{cumulative_count:347946  upper_bound:5000}  bucket:{cumulative_count:358499  upper_bound:10000}}"}

PROCESSOR_METRICS       {"component": "processor", "observationChannelDelay": "histogram:{sample_count:360914  sample_sum:3.04105065e+08  bucket:{cumulative_count:114320  upper_bound:10}  bucket:{cumulative_count:115330  upper_bound:20}  bucket:{cumulative_count:117975  upper_bound:50}  bucket:{cumulative_count:123556  upper_bound:100}  bucket:{cumulative_count:251769  upper_bound:1000}  bucket:{cumulative_count:356785  upper_bound:5000}  bucket:{cumulative_count:360551  upper_bound:10000}}"}
PROCESSOR_METRICS       {"component": "processor", "observationProcessingDelay": "histogram:{sample_count:360914  sample_sum:4.51053333e+08  bucket:{cumulative_count:0  upper_bound:10}  bucket:{cumulative_count:0  upper_bound:20}  bucket:{cumulative_count:226  upper_bound:50}  bucket:{cumulative_count:49122  upper_bound:100}  bucket:{cumulative_count:225737  upper_bound:1000}  bucket:{cumulative_count:347549  upper_bound:5000}  bucket:{cumulative_count:358487  upper_bound:10000}}"}

PROCESSOR_METRICS       {"component": "processor", "observationChannelDelay": "histogram:{sample_count:360894  sample_sum:2.94467931e+08  bucket:{cumulative_count:115142  upper_bound:10}  bucket:{cumulative_count:116440  upper_bound:20}  bucket:{cumulative_count:119320  upper_bound:50}  bucket:{cumulative_count:125147  upper_bound:100}  bucket:{cumulative_count:255418  upper_bound:1000}  bucket:{cumulative_count:356952  upper_bound:5000}  bucket:{cumulative_count:360642  upper_bound:10000}}"}
PROCESSOR_METRICS       {"component": "processor", "observationProcessingDelay": "histogram:{sample_count:360894  sample_sum:4.61647111e+08  bucket:{cumulative_count:0  upper_bound:10}  bucket:{cumulative_count:0  upper_bound:20}  bucket:{cumulative_count:340  upper_bound:50}  bucket:{cumulative_count:46750  upper_bound:100}  bucket:{cumulative_count:226356  upper_bound:1000}  bucket:{cumulative_count:346707  upper_bound:5000}  bucket:{cumulative_count:358414  upper_bound:10000}}"}
`