### PR TITLE
node/processor: processor v3 (parallelized)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ bigtable-writer.json
 sui.log.*
 sui/examples/wrapped_coin
 *.prof
+node.test

--- a/node/pkg/common/chainlock_test.go
+++ b/node/pkg/common/chainlock_test.go
@@ -193,30 +193,30 @@ func TestMessageID(t *testing.T) {
 	type test struct {
 		label  string
 		input  MessagePublication
-		output []byte
+		output string
 	}
 
 	tests := []test{
 		{label: "simple",
 			input:  MessagePublication{Sequence: 1, EmitterChain: vaa.ChainIDEthereum, EmitterAddress: addr},
-			output: []byte("2/0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16/1")},
+			output: "2/0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16/1"},
 		{label: "missing sequence",
 			input:  MessagePublication{EmitterChain: vaa.ChainIDEthereum, EmitterAddress: addr},
-			output: []byte("2/0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16/0")},
+			output: "2/0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16/0"},
 		{label: "missing chain id",
 			input:  MessagePublication{Sequence: 1, EmitterAddress: addr},
-			output: []byte("0/0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16/1")},
+			output: "0/0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16/1"},
 		{label: "missing emitter address",
 			input:  MessagePublication{Sequence: 1, EmitterChain: vaa.ChainIDEthereum},
-			output: []byte("2/0000000000000000000000000000000000000000000000000000000000000000/1")},
+			output: "2/0000000000000000000000000000000000000000000000000000000000000000/1"},
 		{label: "empty message",
 			input:  MessagePublication{},
-			output: []byte("0/0000000000000000000000000000000000000000000000000000000000000000/0")},
+			output: "0/0000000000000000000000000000000000000000000000000000000000000000/0"},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.label, func(t *testing.T) {
-			assert.Equal(t, tc.output, tc.input.MessageID())
+			assert.Equal(t, tc.output, tc.input.MessageIDString())
 		})
 	}
 }

--- a/node/pkg/node/node.go
+++ b/node/pkg/node/node.go
@@ -12,6 +12,7 @@ import (
 	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
 	"github.com/certusone/wormhole/node/pkg/reporter"
 	"github.com/certusone/wormhole/node/pkg/supervisor"
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 
 	"github.com/wormhole-foundation/wormhole/sdk/vaa"
 	"go.uber.org/zap"
@@ -99,7 +100,7 @@ func (g *G) initializeBasic(logger *zap.Logger, rootCtxCancel context.CancelFunc
 	g.acctC = makeChannelPair[*common.MessagePublication](accountant.MsgChannelCapacity)
 
 	// Guardian set state managed by processor
-	g.gst = common.NewGuardianSetState(nil)
+	g.gst = common.NewGuardianSetStateForGuardian(ethcrypto.PubkeyToAddress(g.gk.PublicKey), nil)
 
 	// provides methods for reporting progress toward message attestation, and channels for receiving attestation lifecycle events.
 	g.attestationEvents = reporter.EventListener(logger)

--- a/node/pkg/node/node_test.go
+++ b/node/pkg/node/node_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/certusone/wormhole/node/pkg/common"
 	"github.com/certusone/wormhole/node/pkg/db"
 	"github.com/certusone/wormhole/node/pkg/devnet"
+	"github.com/certusone/wormhole/node/pkg/p2p"
 	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
 	publicrpcv1 "github.com/certusone/wormhole/node/pkg/proto/publicrpc/v1"
 	"github.com/certusone/wormhole/node/pkg/readiness"
@@ -1012,10 +1013,16 @@ func BenchmarkConsensus(b *testing.B) {
 	//CONSOLE_LOG_LEVEL = zap.DebugLevel
 	//CONSOLE_LOG_LEVEL = zap.InfoLevel
 	CONSOLE_LOG_LEVEL = zap.WarnLevel
-	PROCESSOR_CPU = 6
 	PROCESSOR_VERSION = 3
+	PROCESSOR_CPU = 10
+
+	// with p2p sigverify
 	//runConsensusBenchmark(b, "1", 19, 1000, 50) // v1: ~7.5s, v3: ~5.7s
-	runConsensusBenchmark(b, "1", 7, 3000, 50) // v1: ~4.8s, v3: ~3.1s
+	//runConsensusBenchmark(b, "1", 7, 3000, 50) // v1: ~4.8s, v3: ~3.1s
+
+	// without p2p sigverify
+	p2p.NoSigVerify = true
+	runConsensusBenchmark(b, "1", 7, 5000, 50) // v1: ~6.4s, v3: ~3.3s
 }
 
 func runConsensusBenchmark(t *testing.B, name string, numGuardians int, numMessages int, maxPendingObs int) {

--- a/node/pkg/node/options.go
+++ b/node/pkg/node/options.go
@@ -14,6 +14,7 @@ import (
 	"github.com/certusone/wormhole/node/pkg/governor"
 	"github.com/certusone/wormhole/node/pkg/p2p"
 	"github.com/certusone/wormhole/node/pkg/processor"
+	"github.com/certusone/wormhole/node/pkg/processor3"
 	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
 	"github.com/certusone/wormhole/node/pkg/readiness"
 	"github.com/certusone/wormhole/node/pkg/reporter"
@@ -454,6 +455,10 @@ func GuardianOptionProcessor() *GuardianOption {
 
 		f: func(ctx context.Context, logger *zap.Logger, g *G) error {
 
+			if _, ok := g.runnables["processor"]; ok {
+				return errors.New("processor already defined")
+			}
+
 			g.runnables["processor"] = processor.NewProcessor(ctx,
 				g.db,
 				g.msgC.readC,
@@ -462,6 +467,55 @@ func GuardianOptionProcessor() *GuardianOption {
 				g.obsvC,
 				g.obsvReqSendC.writeC,
 				g.injectC.readC,
+				g.signedInC.readC,
+				g.gk,
+				g.gst,
+				g.attestationEvents,
+				g.gov,
+				g.acct,
+				g.acctC.readC,
+			).Run
+
+			return nil
+		}}
+}
+
+// GuardianOptionProcessor enables the default processor, which is required to make consensus on messages.
+// Dependencies: db, governor, accountant
+func GuardianOptionProcessor3(numCPU int) *GuardianOption {
+	return &GuardianOption{
+		name: "processor",
+		// governor and accountant may be set to nil, but that choice needs to be made before the processor is configured
+		dependencies: []string{"db", "governor", "accountant"},
+
+		f: func(ctx context.Context, logger *zap.Logger, g *G) error {
+
+			if _, ok := g.runnables["processor"]; ok {
+				return errors.New("processor already defined")
+			}
+
+			// Start routine to update guardian set state
+			go func() {
+				for {
+					select {
+					case <-ctx.Done():
+						return
+					case gs := <-g.setC.readC:
+						g.gst.Set(gs)
+						logger.Info("guardian set updated",
+							zap.Strings("set", gs.KeysAsHexStrings()),
+							zap.Uint32("index", gs.Index))
+					}
+				}
+			}()
+
+			g.runnables["processor"] = processor3.NewProcessor3(
+				numCPU,
+				g.db,
+				g.msgC.readC,
+				g.gossipSendC,
+				g.obsvC,
+				g.obsvReqSendC.writeC,
 				g.signedInC.readC,
 				g.gk,
 				g.gst,

--- a/node/pkg/p2p/p2p.go
+++ b/node/pkg/p2p/p2p.go
@@ -293,7 +293,7 @@ func Run(
 
 		// Increase the buffer size to prevent failed delivery
 		// to slower subscribers
-		sub, err := th.Subscribe(pubsub.WithBufferSize(1024))
+		sub, err := th.Subscribe(pubsub.WithBufferSize(1024 * 10))
 		if err != nil {
 			return fmt.Errorf("failed to subscribe topic: %w", err)
 		}
@@ -498,15 +498,13 @@ func Run(
 			}
 
 			if envelope.GetFrom() == h.ID() {
-				logger.Debug("received message from ourselves, ignoring",
-					zap.Any("payload", msg.Message))
 				p2pMessagesReceived.WithLabelValues("loopback").Inc()
 				continue
 			}
 
 			logger.Debug("received message",
-				zap.Any("payload", msg.Message),
-				zap.Binary("raw", envelope.Data),
+				//zap.Any("payload", msg.Message),
+				//zap.Binary("raw", envelope.Data),
 				zap.String("from", envelope.GetFrom().String()))
 
 			switch m := msg.Message.(type) {

--- a/node/pkg/p2p/p2p.go
+++ b/node/pkg/p2p/p2p.go
@@ -43,6 +43,8 @@ import (
 
 const DefaultPort = 8999
 
+var NoSigVerify = false
+
 var (
 	p2pHeartbeatsSent = promauto.NewCounter(
 		prometheus.CounterOpts{
@@ -275,7 +277,17 @@ func Run(
 		topic := fmt.Sprintf("%s/%s", networkID, "broadcast")
 
 		logger.Info("Subscribing pubsub topic", zap.String("topic", topic))
-		ps, err := pubsub.NewGossipSub(ctx, h)
+		var opts []pubsub.Option
+
+		if NoSigVerify {
+			opts = []pubsub.Option{
+				pubsub.WithStrictSignatureVerification(false),
+				pubsub.WithMessageSigning(false),
+				pubsub.WithMessageSignaturePolicy(pubsub.StrictNoSign),
+			}
+		}
+
+		ps, err := pubsub.NewGossipSub(ctx, h, opts...)
 		if err != nil {
 			panic(err)
 		}

--- a/node/pkg/p2p/p2p_test.go
+++ b/node/pkg/p2p/p2p_test.go
@@ -87,7 +87,7 @@ func TestSignedHeartbeat(t *testing.T) {
 			Index: 1,
 		}
 
-		gst := node_common.NewGuardianSetState(nil)
+		gst := node_common.NewGuardianSetStateForGuardian(addr, nil)
 
 		heartbeatResult, err := processSignedHeartbeat("someone", s, gs, gst, false)
 

--- a/node/pkg/processor3/broadcast.go
+++ b/node/pkg/processor3/broadcast.go
@@ -1,0 +1,66 @@
+package processor3
+
+import (
+	"google.golang.org/protobuf/proto"
+
+	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/wormhole-foundation/wormhole/sdk/vaa"
+)
+
+var (
+	observationsBroadcastTotal = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "wormhole_observations_broadcast_total3",
+			Help: "Total number of signed observations queued for broadcast",
+		})
+)
+
+func (p *ConcurrentProcessor) broadcastSignature(
+	hash []byte,
+	signature []byte,
+	txhash []byte,
+	msgId string,
+) {
+	obsv := gossipv1.SignedObservation{
+		Addr:      p.ourAddr[:],
+		Hash:      hash,
+		Signature: signature,
+		TxHash:    txhash,
+		MessageId: msgId,
+	}
+
+	w := gossipv1.GossipMessage{Message: &gossipv1.GossipMessage_SignedObservation{SignedObservation: &obsv}}
+
+	msg, err := proto.Marshal(&w)
+	if err != nil {
+		panic(err)
+	}
+
+	// send on p2p
+	p.gossipSendC <- msg
+
+	// Fast path for our own signature
+	p.obsvC <- &obsv
+
+	observationsBroadcastTotal.Inc()
+}
+
+func (p *ConcurrentProcessor) broadcastSignedVAA(v *vaa.VAA) {
+	b, err := v.Marshal()
+	if err != nil {
+		panic(err)
+	}
+
+	w := gossipv1.GossipMessage{Message: &gossipv1.GossipMessage_SignedVaaWithQuorum{
+		SignedVaaWithQuorum: &gossipv1.SignedVAAWithQuorum{Vaa: b},
+	}}
+
+	msg, err := proto.Marshal(&w)
+	if err != nil {
+		panic(err)
+	}
+
+	p.gossipSendC <- msg
+}

--- a/node/pkg/processor3/bucket.go
+++ b/node/pkg/processor3/bucket.go
@@ -1,0 +1,32 @@
+package processor3
+
+import "encoding/binary"
+
+var numPriorityBuckets = 8
+var numProcessingBuckets = 10 // must be greater than numPriorityBuckets
+
+func calculateLeaderSetSize(guardianSetSize int) int {
+	return guardianSetSize/3 + 1
+}
+
+func calculateBucket(hash []byte, myGuardianSetIndex int, numGuardians int) (inLeaderSet bool, processingBucket int) {
+	if !EnableLeaderSets {
+		inLeaderSet = true
+	}
+	// determine if this guardian is responsible for this observation
+	hashId := binary.BigEndian.Uint64(hash)
+	targetIdx := int(hashId % uint64(numGuardians)) // TODO support variable size guardian set
+	r := (targetIdx + myGuardianSetIndex) % numGuardians
+	if r < calculateLeaderSetSize(numGuardians) {
+		inLeaderSet = true
+	}
+
+	if r == 0 {
+		// we are the "primary leader" -- assign this to one of the priority buckets
+		processingBucket = int(targetIdx % numPriorityBuckets)
+	} else {
+		processingBucket = int(targetIdx%(numProcessingBuckets-numPriorityBuckets)) + numPriorityBuckets
+	}
+
+	return
+}

--- a/node/pkg/processor3/cleanup.go
+++ b/node/pkg/processor3/cleanup.go
@@ -1,0 +1,146 @@
+// nolint:unparam // this will be refactored in https://github.com/wormhole-foundation/wormhole/pull/1953
+package processor3
+
+import (
+	"context"
+	"time"
+
+	"github.com/certusone/wormhole/node/pkg/common"
+	"github.com/certusone/wormhole/node/pkg/db"
+	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/wormhole-foundation/wormhole/sdk/vaa"
+
+	"go.uber.org/zap"
+)
+
+var (
+	aggregationStateEntries = promauto.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "wormhole_aggregation_state_entries3",
+			Help: "Current number of aggregation state entries (including unexpired succeed ones)",
+		})
+	aggregationStateExpiration = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "wormhole_aggregation_state_expirations_total3",
+			Help: "Total number of expired submitted aggregation states",
+		})
+	aggregationStateLate = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "wormhole_aggregation_state_late_total3",
+			Help: "Total number of late aggregation states (cluster achieved consensus without us)",
+		})
+	aggregationStateTimeout = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "wormhole_aggregation_state_timeout_total3",
+			Help: "Total number of aggregation states expired due to timeout after exhausting retries",
+		})
+	aggregationStateRetries = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "wormhole_aggregation_state_retries_total3",
+			Help: "Total number of aggregation states queued for resubmission",
+		})
+	aggregationStateUnobserved = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "wormhole_aggregation_state_unobserved_total3",
+			Help: "Total number of aggregation states expired due to no matching local message observations",
+		})
+)
+
+const (
+	settlementTime    = time.Second * 30
+	retryTime         = time.Minute * 5
+	retryLimitOurs    = time.Hour * 24
+	retryLimitNotOurs = time.Hour
+)
+
+// handleCleanup handles periodic retransmissions and cleanup of observations
+func (p *Processor) handleCleanup(ctx context.Context, logger *zap.Logger) {
+	logger.Info("aggregation state summary", zap.Int("cached", len(p.state)))
+	aggregationStateEntries.Set(float64(len(p.state)))
+
+	for hash, s := range p.state {
+		delta := time.Since(s.firstObserved)
+
+		if !s.submitted && delta > settlementTime {
+			// Expire pending VAAs post settlement time if we have a stored quorum VAA.
+			//
+			// This occurs when we observed a message after the cluster has already reached
+			// consensus on it, causing us to never achieve quorum.
+			if s.msg != nil {
+				if _, err := p.getSignedVAA(*db.VaaIDFromVAA(s.msg.CreateVAA(0))); err == nil {
+					// If we have a stored quorum VAA, we can safely expire the state.
+					//
+					// This is a rare case, and we can safely expire the state, since we
+					// have a quorum VAA.
+					logger.Debug("Expiring late VAA", zap.String("digest", hash), zap.Duration("delta", delta))
+					aggregationStateLate.Inc()
+					delete(p.state, hash)
+					continue
+				}
+			}
+		}
+
+		switch {
+		case s.submitted:
+			// delete submitted observations from processor state
+			delete(p.state, hash)
+			aggregationStateExpiration.Inc()
+		case !s.submitted && ((s.msg != nil && delta > retryLimitOurs) || (s.msg == nil && delta > retryLimitNotOurs)):
+			// Clearly, this horse is dead and continued beatings won't bring it closer to quorum.
+			logger.Info("expiring unsubmitted observation after exhausting retries", zap.String("digest", hash), zap.Duration("delta", delta), zap.Bool("weObserved", s.msg != nil))
+			delete(p.state, hash)
+			aggregationStateTimeout.Inc()
+		case !s.submitted && delta.Minutes() >= 5 && time.Since(s.lastRetry) >= retryTime:
+			// Poor observation has been unsubmitted for five minutes - clearly, something went wrong.
+			// If we have previously submitted an observation, and it was reliable, we can make another attempt to get
+			// it over the finish line by sending a re-observation request to the network and rebroadcasting our
+			// sig. If we do not have an observation, it means we either never observed it, or it got
+			// revived by a malfunctioning guardian node, in which case, we can't do anything about it
+			// and just delete it to keep our state nice and lean.
+			if s.msg != nil {
+				// Unreliable observations cannot be resubmitted and can be considered failed after 5 minutes
+				if !s.msg.Unreliable {
+					logger.Info("expiring unsubmitted unreliable observation", zap.String("digest", hash), zap.Duration("delta", delta))
+					delete(p.state, hash)
+					aggregationStateTimeout.Inc()
+					break
+				}
+				logger.Info("resubmitting observation",
+					zap.String("digest", hash),
+					zap.Duration("delta", delta),
+					zap.String("firstObserved", s.firstObserved.String()),
+				)
+				req := &gossipv1.ObservationRequest{
+					ChainId: uint32(s.msg.EmitterChain),
+					TxHash:  s.msg.TxHash[:],
+				}
+				if err := common.PostObservationRequest(p.obsvReqSendC, req); err != nil {
+					logger.Warn("failed to broadcast re-observation request", zap.Error(err))
+				}
+				s.lastRetry = time.Now()
+				aggregationStateRetries.Inc()
+			} else {
+				// For nil state entries, we log the quorum to determine whether the
+				// network reached consensus without us. We don't know the correct guardian
+				// set, so we simply use the most recent one.
+				hasSigs := len(s.signatures)
+				wantSigs := vaa.CalculateQuorum(len(p.gst.Get().Keys))
+
+				logger.Info("expiring unsubmitted nil observation",
+					zap.String("digest", hash),
+					zap.Duration("delta", delta),
+					zap.Int("have_sigs", hasSigs),
+					zap.Int("required_sigs", wantSigs),
+					zap.Bool("quorum", hasSigs >= wantSigs),
+				)
+				delete(p.state, hash)
+				aggregationStateUnobserved.Inc()
+			}
+		}
+	}
+
+	// Clean up old pythnet VAAs.
+	p.pythVaas.deleteBefore(time.Now().Add(-time.Hour))
+}

--- a/node/pkg/processor3/message.go
+++ b/node/pkg/processor3/message.go
@@ -1,0 +1,132 @@
+package processor3
+
+import (
+	"context"
+	"encoding/hex"
+
+	"github.com/mr-tron/base58"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/certusone/wormhole/node/pkg/common"
+	"github.com/certusone/wormhole/node/pkg/reporter"
+	"github.com/wormhole-foundation/wormhole/sdk/vaa"
+)
+
+var (
+	// SECURITY: source_chain/target_chain are untrusted uint8 values. An attacker could cause a maximum of 255**2 label
+	// pairs to be created, which is acceptable.
+
+	messagesObservedTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "wormhole_message_observations_total3",
+			Help: "Total number of messages observed",
+		},
+		[]string{"emitter_chain"})
+
+	messagesSignedTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "wormhole_message_observations_signed_total3",
+			Help: "Total number of message observations that were successfully signed",
+		},
+		[]string{"emitter_chain"})
+)
+
+// handleMessage processes a message received from a chain and instantiates our deterministic copy of the VAA. An
+// event may be received multiple times and must be handled in an idempotent fashion.
+func (p *ConcurrentProcessor) handleMessage(_ context.Context, logger *zap.Logger, k *common.MessagePublication) {
+	if p.gst.Get() == nil {
+		logger.Warn("dropping observation since we haven't initialized our guardian set yet", k.ZapFields()...)
+		return
+	}
+
+	logger.Debug("message publication confirmed", k.ZapFields()...)
+
+	messagesObservedTotal.With(prometheus.Labels{
+		"emitter_chain": k.EmitterChain.String(),
+	}).Add(1)
+
+	v := vaa.VAA{
+		Version:          vaa.SupportedVAAVersion,
+		GuardianSetIndex: p.gst.Get().Index,
+		Signatures:       nil,
+		Timestamp:        k.Timestamp,
+		Nonce:            k.Nonce,
+		EmitterChain:     k.EmitterChain,
+		EmitterAddress:   k.EmitterAddress,
+		Payload:          k.Payload,
+		Sequence:         k.Sequence,
+		ConsistencyLevel: k.ConsistencyLevel,
+	}
+
+	// A governance message should never be emitted on-chain
+	if v.EmitterAddress == vaa.GovernanceEmitter && v.EmitterChain == vaa.GovernanceChain {
+		logger.Error(
+			"EMERGENCY: PLEASE REPORT THIS IMMEDIATELY! A Solana message was emitted from the governance emitter. This should never be possible.",
+			zap.Stringer("emitter_chain", k.EmitterChain),
+			zap.Stringer("emitter_address", k.EmitterAddress),
+			zap.Uint32("nonce", k.Nonce),
+			zap.Stringer("txhash", k.TxHash),
+			zap.Time("timestamp", k.Timestamp))
+		return
+	}
+
+	// Generate digest of the unsigned VAA.
+	digest := v.SigningDigest()
+
+	// Sign the digest using our node's guardian key.
+	s, err := crypto.Sign(digest.Bytes(), p.gk)
+	if err != nil {
+		panic(err)
+	}
+
+	if logger.Level().Enabled(zapcore.DebugLevel) { // check if logging is enabled first for better performance
+		logger.Debug("observed and signed confirmed message publication",
+			zap.Stringer("source_chain", k.EmitterChain),
+			zap.Stringer("txhash", k.TxHash),
+			zap.String("txhash_b58", base58.Encode(k.TxHash.Bytes())),
+			zap.String("digest", hex.EncodeToString(digest.Bytes())),
+			zap.Uint32("nonce", k.Nonce),
+			zap.Uint64("sequence", k.Sequence),
+			zap.Stringer("emitter_chain", k.EmitterChain),
+			zap.Stringer("emitter_address", k.EmitterAddress),
+			zap.String("emitter_address_b58", base58.Encode(k.EmitterAddress.Bytes())),
+			zap.Uint8("consistency_level", k.ConsistencyLevel),
+			zap.String("message_id", v.MessageID()),
+			zap.String("signature", hex.EncodeToString(s)))
+	}
+
+	messagesSignedTotal.With(prometheus.Labels{
+		"emitter_chain": k.EmitterChain.String()}).Add(1)
+
+	p.attestationEvents.ReportMessagePublication(&reporter.MessagePublication{VAA: v, InitiatingTxID: k.TxHash})
+
+	p.msgSelfObservedC <- k
+
+	p.broadcastSignature(digest[:], s, k.TxHash.Bytes(), v.MessageID())
+}
+
+func (p *Processor) dispatchSelfObservation(_ context.Context, _ *zap.Logger, k *common.MessagePublication) {
+	hashBytes := k.CreateHash()
+	inLeaderSet, processingBucket := calculateBucket(hashBytes[:], p.gst.MyKeyIndex(), len(p.gst.Get().Keys))
+	if inLeaderSet {
+
+		hash := k.CreateDigest()
+		s, ok := p.state[hash]
+
+		if !ok {
+			s = p.NewStateFromSelfObserved()
+			p.state[hash] = s
+		}
+
+		p.selfObservationChannels[processingBucket] <- selfObservationEvent{
+			m:     k,
+			state: s,
+		}
+	}
+}

--- a/node/pkg/processor3/observation.go
+++ b/node/pkg/processor3/observation.go
@@ -1,0 +1,370 @@
+//nolint:unparam // this will be refactored in https://github.com/wormhole-foundation/wormhole/pull/1953
+package processor3
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/certusone/wormhole/node/pkg/common"
+	"github.com/certusone/wormhole/node/pkg/db"
+	"github.com/mr-tron/base58"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
+	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
+	"github.com/wormhole-foundation/wormhole/sdk/vaa"
+)
+
+var (
+	observationsReceivedTotal = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "wormhole_observations_received_total3",
+			Help: "Total number of raw VAA observations received from gossip",
+		})
+	observationsReceivedByGuardianAddressTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "wormhole_observations_signed_by_guardian_total3",
+			Help: "Total number of signed and verified VAA observations grouped by guardian address",
+		}, []string{"addr"})
+	observationsFailedTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "wormhole_observations_verification_failures_total3",
+			Help: "Total number of observations verification failure, grouped by failure reason",
+		}, []string{"cause"})
+)
+
+func (p *Processor) dispatchObservation(ctx context.Context, logger *zap.Logger, o *gossipv1.SignedObservation) {
+	inLeaderSet, processingBucket := calculateBucket(o.Hash, p.gst.MyKeyIndex(), len(p.gst.Get().Keys))
+	logger.Debug("dispatchObservation", zap.String("msgId", o.MessageId), zap.Bool("leaderset", inLeaderSet))
+	if !inLeaderSet {
+		// we're not going to deal with this one
+		return
+	}
+
+	hash := hex.EncodeToString(o.Hash)
+
+	s, ok := p.state[hash]
+
+	if !ok {
+		s = p.NewStateFromForeignObserved()
+		p.state[hash] = s
+	}
+
+	if s != nil && s.submitted {
+		// already reached quorum; ignoring additional signatures for it.
+		logger.Debug("dispatchObservation: already reached quorum", zap.String("msgId", o.MessageId), zap.Bool("leaderset", inLeaderSet))
+		// TODO this performance optimization is disabled to allow apples-to-apples comparison with other parallelization approaches
+		//return
+	}
+
+	p.observationChannels[processingBucket] <- observationProcessingJob{o: o, state: s}
+}
+
+// handleObservation processes a remote observation, verifies it, checks whether the VAA has met quorum,
+// and assembles and submits a valid VAA if possible.
+func (p *ConcurrentProcessor) handleObservation(ctx context.Context, logger *zap.Logger, job observationProcessingJob) {
+	// SECURITY: at this point, observations received from the p2p network are fully untrusted (all fields!)
+	//
+	// Note that observations are never tied to the (verified) p2p identity key - the p2p network
+	// identity is completely decoupled from the guardian identity, p2p is just transport.
+
+	obs := job.o
+	s := job.state
+	hash := hex.EncodeToString(obs.Hash)
+
+	logger.Debug("handleObservation", zap.String("messageId", obs.MessageId))
+
+	if s.submitted {
+		// already submitted; ignoring additional signatures
+		logger.Debug("already submitted, doing nothing", zap.String("messageId", obs.MessageId))
+		// TODO this performance optimization is disabled to allow apples-to-apples comparison with other parallelization approaches
+		// return
+	}
+
+	// check if we already have a VAA for this observation
+	vaaId, err := db.VaaIDFromString(obs.MessageId)
+	if err != nil {
+		logger.Info("invalid messageID",
+			zap.String("digest", hash),
+			zap.String("messageId", obs.MessageId),
+		)
+		return
+	}
+	if p.haveSignedVAA(*vaaId) {
+		// already have a VAA for it; ignoring additional signatures
+		logger.Debug("already have VAA, doing nothing", zap.String("messageId", obs.MessageId))
+		return
+	}
+
+	their_addr := ethcommon.BytesToAddress(obs.Addr)
+
+	// check if we have a valid signature from this guardian already
+	if _, ok := s.signatures[their_addr]; ok {
+		// already have a valid signature from this guardian
+		logger.Debug("already have signature from this guardian, doing nothing", zap.String("messageId", obs.MessageId))
+		return
+	}
+
+	if logger.Core().Enabled(zapcore.DebugLevel) {
+		logger.Debug("received observation",
+			zap.String("digest", hash),
+			zap.String("signature", hex.EncodeToString(obs.Signature)),
+			zap.String("addr", hex.EncodeToString(obs.Addr)),
+			zap.String("txhash", hex.EncodeToString(obs.TxHash)),
+			zap.String("txhash_b58", base58.Encode(obs.TxHash)),
+			zap.String("message_id", obs.MessageId),
+		)
+	}
+
+	observationsReceivedTotal.Inc()
+
+	// Verify the Guardian's signature. This verifies that m.Signature matches m.Hash and recovers
+	// the public key that was used to sign the payload.
+	pk, err := crypto.Ecrecover(obs.Hash, obs.Signature)
+	if err != nil {
+		logger.Warn("failed to verify signature on observation",
+			zap.String("digest", hash),
+			zap.String("signature", hex.EncodeToString(obs.Signature)),
+			zap.String("addr", hex.EncodeToString(obs.Addr)),
+			zap.String("messageId", obs.MessageId),
+			zap.Error(err))
+		observationsFailedTotal.WithLabelValues("invalid_signature").Inc()
+		return
+	}
+
+	// Verify that m.Addr matches the public key that signed m.Hash.
+	signer_pk := ethcommon.BytesToAddress(crypto.Keccak256(pk[1:])[12:])
+
+	if their_addr != signer_pk {
+		logger.Info("invalid observation - address does not match pubkey",
+			zap.String("digest", hash),
+			zap.String("signature", hex.EncodeToString(obs.Signature)),
+			zap.String("addr", hex.EncodeToString(obs.Addr)),
+			zap.String("messageId", obs.MessageId),
+			zap.String("pk", signer_pk.Hex()))
+		observationsFailedTotal.WithLabelValues("pubkey_mismatch").Inc()
+		return
+	}
+
+	// Determine which guardian set to use. The following cases are possible:
+	//
+	//  - We have already seen the message and generated ourObservation. In this case, use the guardian set valid at the time,
+	//    even if the guardian set was updated. Old guardian sets remain valid for longer than aggregation state,
+	//    and the guardians in the old set stay online and observe and sign messages for the transition period.
+	//
+	//  - We have not yet seen the message. In this case, we assume the latest guardian set because that's what
+	//    we will store once we do see the message.
+	//
+	// This ensures that during a guardian set update, a node which observed a given message with either the old
+	// or the new guardian set can achieve consensus, since both the old and the new set would achieve consensus,
+	// assuming that 2/3+ of the old and the new guardian set have seen the message and will periodically attempt
+	// to retransmit their observations such that nodes who initially dropped the signature will get a 2nd chance.
+	//
+	// During an update, vaaState.signatures can contain signatures from *both* guardian sets.
+	//
+	var gs *common.GuardianSet
+	if s != nil && s.gs != nil {
+		gs = s.gs
+	} else {
+		gs = p.gst.Get()
+	}
+
+	// We haven't yet observed the trusted guardian set on Ethereum, and therefore, it's impossible to verify it.
+	// May as well not have received it/been offline - drop it and wait for the guardian set.
+	if gs == nil {
+		logger.Warn("dropping observations since we haven't initialized our guardian set yet",
+			zap.String("digest", hash),
+			zap.String("their_addr", their_addr.Hex()),
+			zap.String("messageId", obs.MessageId),
+		)
+		observationsFailedTotal.WithLabelValues("uninitialized_guardian_set").Inc()
+		return
+	}
+
+	// Verify that m.Addr is included in the guardian set. If it's not, drop the message. In case it's us
+	// who have the outdated guardian set, we'll just wait for the message to be retransmitted eventually.
+	_, ok := gs.KeyIndex(their_addr)
+	if !ok {
+		logger.Debug("received observation by unknown guardian - is our guardian set outdated?",
+			zap.String("digest", hash),
+			zap.String("their_addr", their_addr.Hex()),
+			zap.Uint32("index", gs.Index),
+			zap.String("messageId", obs.MessageId),
+			//zap.Any("keys", gs.KeysAsHexStrings()),
+		)
+		observationsFailedTotal.WithLabelValues("unknown_guardian").Inc()
+		return
+	}
+
+	// Hooray! Now, we have verified all fields on SignedObservation and know that it includes
+	// a valid signature by an active guardian. We still don't fully trust them, as they may be
+	// byzantine, but now we know who we're dealing with.
+
+	// We can now count events by guardian without worry about cardinality explosions:
+	observationsReceivedByGuardianAddressTotal.WithLabelValues(their_addr.Hex()).Inc()
+
+	s.signatures[their_addr] = obs.Signature
+
+	quorum := vaa.CalculateQuorum(len(gs.Keys))
+
+	if len(s.signatures) < quorum {
+		// no quorum yet, we're done here
+		logger.Debug("quorum not yet met",
+			zap.String("digest", hash),
+			zap.String("messageId", obs.MessageId),
+		)
+		return
+	}
+
+	// We have reached quorum!
+
+	if s.msg == nil {
+		// We have not made this observation ourselves (yet) and therefore cannot create the VAA.
+		// But hopefully we'll make that observation at some point and then we'll still have quorum.
+		logger.Debug("we have not yet seen this observation and therefore can't create the VAA",
+			zap.String("digest", hash),
+			zap.String("messageId", obs.MessageId),
+		)
+		return
+	}
+
+	// Aggregate all valid signatures into a list of vaa.Signature and construct signed VAA.
+	agg := make([]bool, len(gs.Keys))
+	var sigs []*vaa.Signature
+	for i, a := range gs.Keys {
+		sig, ok := s.signatures[a]
+
+		if ok {
+			var bs [65]byte
+			if n := copy(bs[:], sig); n != 65 {
+				panic(fmt.Sprintf("invalid sig len: %d", n))
+			}
+
+			sigs = append(sigs, &vaa.Signature{
+				Index:     uint8(i),
+				Signature: bs,
+			})
+		}
+
+		agg[i] = ok
+	}
+
+	logger.Debug("aggregation state for observation", // 1.3M out of 3M info messages / hour / guardian
+		zap.String("digest", hash),
+		//zap.Any("set", gs.KeysAsHexStrings()),
+		zap.Uint32("index", gs.Index),
+		zap.Bools("aggregation", agg),
+		zap.Int("required_sigs", quorum),
+		zap.Int("have_sigs", len(sigs)),
+		zap.Bool("quorum", len(sigs) >= quorum),
+		zap.String("messageId", obs.MessageId),
+	)
+
+	if len(sigs) < quorum {
+		// no quorum yet, we're done here
+		logger.Debug("quorum not yet met after aggregating signatures -- maybe there is a guardian set change?",
+			zap.String("digest", hash),
+			zap.String("messageId", obs.MessageId),
+		)
+		return
+	}
+
+	signedVaa := s.msg.CreateVAA(s.gs.Index)
+	signedVaa.Signatures = sigs
+
+	// Store signed VAA in database.
+	logger.Info("signed VAA with quorum",
+		zap.String("digest", hash),
+		zap.String("message_id", signedVaa.MessageID()))
+
+	if err := p.storeSignedVAA(signedVaa); err != nil {
+		logger.Error("failed to store signed VAA", zap.Error(err))
+	}
+
+	p.reachedQuorumC <- hash
+	p.broadcastSignedVAA(signedVaa)
+	p.attestationEvents.ReportVAAQuorum(signedVaa)
+	s.submitted = true
+}
+
+func (p *ConcurrentProcessor) dispatchInboundSignedVAAWithQuorum(ctx context.Context, logger *zap.Logger, m *gossipv1.SignedVAAWithQuorum) {
+	v, err := vaa.Unmarshal(m.Vaa)
+	if err != nil {
+		logger.Warn("received invalid VAA in SignedVAAWithQuorum message",
+			zap.Error(err), zap.Any("message", m))
+		return
+	}
+	hash := v.SigningDigest()
+	_, batchId := calculateBucket(hash[:], p.gst.MyKeyIndex(), len(p.gst.Get().Keys))
+	p.inboundVaaChannels[batchId] <- v
+}
+
+func (p *ConcurrentProcessor) handleInboundSignedVAAWithQuorum(ctx context.Context, logger *zap.Logger, v *vaa.VAA) {
+	logger.Debug("handleInboundSignedVAAWithQuorum", zap.String("messageId", v.MessageID()))
+	// Check if we already store this VAA
+	id := *db.VaaIDFromVAA(v)
+	if p.haveSignedVAA(id) {
+		logger.Debug("ignored SignedVAAWithQuorum message for VAA we already stored", zap.String("messageId", v.MessageID()))
+		return
+	}
+
+	// Calculate digest for logging
+	digest := v.SigningDigest()
+	hash := hex.EncodeToString(digest.Bytes())
+
+	gs := p.gst.Get()
+
+	if gs == nil {
+		logger.Warn("dropping SignedVAAWithQuorum message since we haven't initialized our guardian set yet",
+			zap.String("digest", hash),
+			zap.String("messageId", v.MessageID()),
+		)
+		return
+	}
+
+	// Check if guardianSet doesn't have any keys
+	if len(gs.Keys) == 0 {
+		logger.Warn("dropping SignedVAAWithQuorum message since we have a guardian set without keys",
+			zap.String("digest", hash),
+			zap.String("messageId", v.MessageID()),
+		)
+		return
+	}
+
+	if err := v.Verify(gs.Keys); err != nil {
+		logger.Warn("dropping SignedVAAWithQuorum message because it failed verification: ",
+			zap.Error(err),
+			zap.String("messageId", v.MessageID()),
+		)
+		return
+	}
+
+	// We now established that:
+	//  - all signatures on the VAA are valid
+	//  - the signature's addresses match the node's current guardian set
+	//  - enough signatures are present for the VAA to reach quorum
+
+	// Store signed VAA in database.
+	logger.Debug("storing inbound signed VAA with quorum",
+		zap.String("digest", hash),
+		zap.Any("vaa", v),
+		zap.String("message_id", v.MessageID()))
+
+	if err := p.storeSignedVAA(v); err != nil {
+		logger.Error("failed to store signed VAA", zap.Error(err))
+		return
+	}
+	p.reachedQuorumC <- hash
+	p.attestationEvents.ReportVAAQuorum(v)
+}
+
+func (p *ConcurrentProcessor) handleSelfObservation(ctx context.Context, logger *zap.Logger, e selfObservationEvent) {
+	logger.Debug("handleSelfObservation", zap.String("messageId", e.m.MessageIDString()))
+	e.state.SelfObserved(e.m)
+}

--- a/node/pkg/processor3/observation_test.go
+++ b/node/pkg/processor3/observation_test.go
@@ -1,0 +1,111 @@
+package processor3
+
+/*
+
+func getVAA() vaa.VAA {
+	var payload = []byte{97, 97, 97, 97, 97, 97}
+	var governanceEmitter = vaa.Address{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4}
+
+	vaa := vaa.VAA{
+		Version:          uint8(1),
+		GuardianSetIndex: uint32(1),
+		Signatures:       nil,
+		Timestamp:        time.Unix(0, 0),
+		Nonce:            uint32(1),
+		Sequence:         uint64(1),
+		ConsistencyLevel: uint8(32),
+		EmitterChain:     vaa.ChainIDSolana,
+		EmitterAddress:   governanceEmitter,
+		Payload:          payload,
+	}
+
+	return vaa
+}
+
+func TestHandleInboundSignedVAAWithQuorum_NilGuardianSet(t *testing.T) {
+	vaa := getVAA()
+	marshalVAA, _ := vaa.Marshal()
+
+	// Stub out the minimum to get processor to dance
+	observedZapCore, observedLogs := observer.New(zap.InfoLevel)
+	observedLogger := zap.New(observedZapCore)
+
+	ctx := context.Background()
+	signedVAAWithQuorum := &gossipv1.SignedVAAWithQuorum{Vaa: marshalVAA}
+	processor := Processor{}
+	processor.logger = observedLogger
+
+	processor.handleInboundSignedVAAWithQuorum(ctx, signedVAAWithQuorum)
+
+	// Check to see if we got an error, which we should have,
+	// because a `gs` is not defined on processor
+	assert.Equal(t, 1, observedLogs.Len())
+	firstLog := observedLogs.All()[0]
+	errorString := "dropping SignedVAAWithQuorum message since we haven't initialized our guardian set yet"
+	assert.Equal(t, errorString, firstLog.Message)
+}
+
+func TestHandleInboundSignedVAAWithQuorum(t *testing.T) {
+	goodPrivateKey1, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
+	goodAddr1 := crypto.PubkeyToAddress(goodPrivateKey1.PublicKey)
+	badPrivateKey1, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
+
+	tests := []struct {
+		label      string
+		keyOrder   []*ecdsa.PrivateKey
+		indexOrder []uint8
+		addrs      []ethcommon.Address
+		errString  string
+	}{
+		{label: "GuardianSetNoKeys", keyOrder: []*ecdsa.PrivateKey{}, indexOrder: []uint8{}, addrs: []ethcommon.Address{},
+			errString: "dropping SignedVAAWithQuorum message since we have a guardian set without keys"},
+		{label: "VAANoSignatures", keyOrder: []*ecdsa.PrivateKey{}, indexOrder: []uint8{0}, addrs: []ethcommon.Address{goodAddr1},
+			errString: "dropping SignedVAAWithQuorum message because it failed verification: VAA was not signed"},
+		{label: "VAAInvalidSignatures", keyOrder: []*ecdsa.PrivateKey{badPrivateKey1}, indexOrder: []uint8{0}, addrs: []ethcommon.Address{goodAddr1},
+			errString: "dropping SignedVAAWithQuorum message because it failed verification: VAA had bad signatures"},
+		{label: "DuplicateGoodSignaturesNonMonotonic", keyOrder: []*ecdsa.PrivateKey{goodPrivateKey1, goodPrivateKey1, goodPrivateKey1, goodPrivateKey1}, indexOrder: []uint8{0, 0, 0, 0}, addrs: []ethcommon.Address{goodAddr1},
+			errString: "dropping SignedVAAWithQuorum message because it failed verification: VAA had bad signatures"},
+		{label: "DuplicateGoodSignaturesMonotonic", keyOrder: []*ecdsa.PrivateKey{goodPrivateKey1, goodPrivateKey1, goodPrivateKey1, goodPrivateKey1}, indexOrder: []uint8{0, 1, 2, 3}, addrs: []ethcommon.Address{goodAddr1},
+			errString: "dropping SignedVAAWithQuorum message because it failed verification: VAA had bad signatures"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.label, func(t *testing.T) {
+			vaa := getVAA()
+
+			// Define a GuardianSet from test addrs
+			guardianSet := common.GuardianSet{
+				Keys:  tc.addrs,
+				Index: 1,
+			}
+
+			// Sign with the keys at the proper index
+			for i, key := range tc.keyOrder {
+				vaa.AddSignature(key, tc.indexOrder[i])
+			}
+
+			marshalVAA, err := vaa.Marshal()
+			if err != nil {
+				panic(err)
+			}
+
+			// Stub out the minimum to get processor to dance
+			observedZapCore, observedLogs := observer.New(zap.InfoLevel)
+			observedLogger := zap.New(observedZapCore)
+
+			ctx := context.Background()
+			signedVAAWithQuorum := &gossipv1.SignedVAAWithQuorum{Vaa: marshalVAA}
+			processor := Processor{}
+			processor.gs = &guardianSet
+			processor.logger = observedLogger
+
+			processor.handleInboundSignedVAAWithQuorum(ctx, signedVAAWithQuorum)
+
+			// Check to see if we got an error, which we should have
+			assert.Equal(t, 1, observedLogs.Len())
+			firstLog := observedLogs.All()[0]
+			assert.Equal(t, tc.errString, firstLog.Message)
+		})
+	}
+}
+*/

--- a/node/pkg/processor3/processor.go
+++ b/node/pkg/processor3/processor.go
@@ -1,0 +1,334 @@
+package processor3
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"fmt"
+	"time"
+
+	"github.com/certusone/wormhole/node/pkg/db"
+	"github.com/certusone/wormhole/node/pkg/governor"
+	"github.com/certusone/wormhole/node/pkg/supervisor"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"go.uber.org/zap"
+
+	"github.com/certusone/wormhole/node/pkg/accountant"
+	"github.com/certusone/wormhole/node/pkg/common"
+	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
+	"github.com/certusone/wormhole/node/pkg/reporter"
+	"github.com/wormhole-foundation/wormhole/sdk/vaa"
+)
+
+var EnableLeaderSets = false
+
+// observationMap maps the hex-encoded hash of an observation to its accumulation state
+type observationMap map[string]*state
+
+type observationProcessingJob struct {
+	o     *gossipv1.SignedObservation
+	state *state
+}
+
+type selfObservationEvent struct {
+	m     *common.MessagePublication
+	state *state
+}
+
+type ConcurrentProcessor struct {
+
+	// EXTERNALLY SHARED CHANNELS
+	// msgC is a channel of observed emitted messages
+	msgC <-chan *common.MessagePublication
+
+	// gossipSendC is a channel of outbound messages to broadcast on p2p
+	gossipSendC chan<- []byte
+	// obsvC is a channel of inbound decoded observations from p2p
+	obsvC chan *gossipv1.SignedObservation
+
+	// obsvReqSendC is a send-only channel of outbound re-observation requests to broadcast on p2p
+	obsvReqSendC chan<- *gossipv1.ObservationRequest
+
+	// signedInC is a channel of inbound signed VAA observations from p2p
+	signedInC <-chan *gossipv1.SignedVAAWithQuorum
+
+	// INTERNAL CHANNELS
+	// we write our own observations to this channel such that they can populate the local message state
+	msgSelfObservedC chan *common.MessagePublication
+
+	// collections of channels to fan-out. Related events will be in the same channel.
+	selfObservationChannels []chan selfObservationEvent
+	observationChannels     []chan observationProcessingJob
+	inboundVaaChannels      []chan *vaa.VAA
+
+	// once quorum is reached on a message, this channel is notified and the state is subsequently deleted
+	reachedQuorumC chan string
+
+	// gk is the node's guardian private key
+	gk *ecdsa.PrivateKey
+
+	attestationEvents *reporter.AttestationEventReporter
+
+	db       *db.Database
+	pythVaas pythVaaDb // in-memory store of pythnet VAAs to avoid writing to disk too much
+
+	// gk pk as eth address
+	ourAddr ethcommon.Address
+
+	governor  *governor.ChainGovernor
+	acct      *accountant.Accountant
+	acctReadC <-chan *common.MessagePublication
+
+	// gst is managed by the processor and allows concurrent access to the
+	// guardian set by other components.
+	gst *common.GuardianSetState
+}
+
+type Processor struct {
+	*ConcurrentProcessor
+
+	numCPU int
+
+	// Runtime state
+	state observationMap
+}
+
+func NewProcessor3(
+	numCPU int,
+	db *db.Database,
+	msgC <-chan *common.MessagePublication,
+	gossipSendC chan<- []byte,
+	obsvC chan *gossipv1.SignedObservation,
+	obsvReqSendC chan<- *gossipv1.ObservationRequest,
+	signedInC <-chan *gossipv1.SignedVAAWithQuorum,
+	gk *ecdsa.PrivateKey,
+	gst *common.GuardianSetState,
+	attestationEvents *reporter.AttestationEventReporter,
+	g *governor.ChainGovernor,
+	acct *accountant.Accountant,
+	acctReadC <-chan *common.MessagePublication,
+) *Processor {
+
+	numPriorityBuckets = numCPU
+	numProcessingBuckets = numCPU + 2
+
+	cp := &ConcurrentProcessor{
+		msgC:         msgC,
+		gossipSendC:  gossipSendC,
+		obsvC:        obsvC,
+		obsvReqSendC: obsvReqSendC,
+		signedInC:    signedInC,
+		gk:           gk,
+		db:           db,
+		pythVaas:     NewPythVaaDb(),
+
+		attestationEvents: attestationEvents,
+
+		ourAddr:   crypto.PubkeyToAddress(gk.PublicKey),
+		governor:  g,
+		acct:      acct,
+		acctReadC: acctReadC,
+		gst:       gst,
+
+		msgSelfObservedC:        make(chan *common.MessagePublication, 500),
+		selfObservationChannels: make([]chan selfObservationEvent, numProcessingBuckets),
+		observationChannels:     make([]chan observationProcessingJob, numProcessingBuckets),
+		inboundVaaChannels:      make([]chan *vaa.VAA, numProcessingBuckets),
+		reachedQuorumC:          make(chan string, 500),
+	}
+
+	return &Processor{
+		ConcurrentProcessor: cp,
+		state:               make(observationMap),
+		numCPU:              numCPU,
+	}
+}
+
+func (p *ConcurrentProcessor) processMsg(ctx context.Context, logger *zap.Logger, msg *common.MessagePublication) error {
+	if p.governor != nil {
+		if !p.governor.ProcessMsg(msg) {
+			return nil
+		}
+	}
+	if p.acct != nil {
+		shouldPub, err := p.acct.SubmitObservation(msg)
+		if err != nil {
+			return err
+		}
+		if !shouldPub {
+			return nil
+		}
+	}
+	p.handleMessage(ctx, logger, msg)
+	return nil
+}
+
+func (p *Processor) Run(ctx context.Context) error {
+	for i := 0; i < p.numCPU; i++ {
+		go p.RunConcurrently(ctx) //nolint
+	}
+
+	for i := 0; i < numProcessingBuckets; i++ {
+		p.selfObservationChannels[i] = make(chan selfObservationEvent, 500)
+		p.observationChannels[i] = make(chan observationProcessingJob, 500)
+		p.inboundVaaChannels[i] = make(chan *vaa.VAA, 500)
+		go p.RunObservationProcessor(ctx, p.observationChannels[i], p.inboundVaaChannels[i], p.selfObservationChannels[i]) //nolint
+	}
+
+	p.RunSequential(ctx) //nolint
+	return nil
+}
+
+func (p *ConcurrentProcessor) RunObservationProcessor(ctx context.Context, obsJobC <-chan observationProcessingJob, inboundVaaC <-chan *vaa.VAA, msgSelfC chan selfObservationEvent) error {
+	logger := supervisor.Logger(ctx)
+
+	for {
+		select { // this nested select implements a priority selection for the inboundVaaC and msgSelfC channels
+		case <-ctx.Done():
+			return nil
+		case v := <-inboundVaaC:
+			p.handleInboundSignedVAAWithQuorum(ctx, logger, v)
+		case m := <-msgSelfC:
+			p.handleSelfObservation(ctx, logger, m)
+		default:
+			select {
+			case <-ctx.Done():
+				return nil
+			case v := <-inboundVaaC:
+				p.handleInboundSignedVAAWithQuorum(ctx, logger, v)
+			case m := <-msgSelfC:
+				p.handleSelfObservation(ctx, logger, m)
+			case m := <-obsJobC:
+				p.handleObservation(ctx, logger, m)
+			}
+		}
+	}
+}
+
+func (p *ConcurrentProcessor) RunConcurrently(ctx context.Context) error {
+	logger := supervisor.Logger(ctx)
+	for {
+		select {
+		case msg := <-p.msgC:
+			if err := p.processMsg(ctx, logger, msg); err != nil {
+				return fmt.Errorf("failed to process message `%s`: %w", msg.MessageIDString(), err)
+			}
+		case k := <-p.acctReadC:
+			if p.acct == nil {
+				return fmt.Errorf("received an accountant event when accountant is not configured")
+			}
+			// SECURITY defense-in-depth: Make sure the accountant did not generate an unexpected message.
+			if !p.acct.IsMessageCoveredByAccountant(k) {
+				return fmt.Errorf("accountant published a message that is not covered by it: `%s`", k.MessageIDString())
+			}
+			p.handleMessage(ctx, logger, k)
+		case m := <-p.signedInC:
+			p.dispatchInboundSignedVAAWithQuorum(ctx, logger, m)
+		}
+	}
+}
+
+func (p *Processor) RunSequential(ctx context.Context) error {
+	cleanup := time.NewTicker(30 * time.Second)
+
+	// Always initialize the timer so don't have a nil pointer in the case below. It won't get rearmed after that.
+	govTimer := time.NewTimer(time.Minute)
+
+	logger := supervisor.Logger(ctx)
+
+	for {
+		select {
+		case <-ctx.Done():
+			if p.acct != nil {
+				p.acct.Close()
+			}
+			return ctx.Err()
+		case k := <-p.obsvC:
+			p.dispatchObservation(ctx, logger, k)
+		case <-cleanup.C:
+			p.handleCleanup(ctx, logger)
+		case hash := <-p.reachedQuorumC:
+			delete(p.state, hash)
+		case m := <-p.msgSelfObservedC:
+			p.dispatchSelfObservation(ctx, logger, m)
+		case <-govTimer.C:
+			if p.governor != nil {
+				toBePublished, err := p.governor.CheckPending()
+				if err != nil {
+					return err
+				}
+				if len(toBePublished) != 0 {
+					for _, k := range toBePublished {
+						// SECURITY defense-in-depth: Make sure the governor did not generate an unexpected message.
+						if msgIsGoverned, err := p.governor.IsGovernedMsg(k); err != nil {
+							return fmt.Errorf("governor failed to determine if message should be governed: `%s`: %w", k.MessageIDString(), err)
+						} else if !msgIsGoverned {
+							return fmt.Errorf("governor published a message that should not be governed: `%s`", k.MessageIDString())
+						}
+						if p.acct != nil {
+							shouldPub, err := p.acct.SubmitObservation(k)
+							if err != nil {
+								return fmt.Errorf("failed to process message released by governor `%s`: %w", k.MessageIDString(), err)
+							}
+							if !shouldPub {
+								continue
+							}
+						}
+						p.handleMessage(ctx, logger, k)
+					}
+				}
+			}
+			if (p.governor != nil) || (p.acct != nil) {
+				govTimer = time.NewTimer(time.Minute)
+			}
+		}
+	}
+}
+
+func (p *ConcurrentProcessor) storeSignedVAA(v *vaa.VAA) error {
+	if v.EmitterChain == vaa.ChainIDPythNet {
+		key := *db.VaaIDFromVAA(v)
+		p.pythVaas.put(key, v)
+		return nil
+	}
+	return p.db.StoreSignedVAA(v)
+}
+
+// haveSignedVAA returns true if we already have a VAA for the given VAAID
+func (p *ConcurrentProcessor) haveSignedVAA(id db.VAAID) bool {
+	if id.EmitterChain == vaa.ChainIDPythNet {
+		_, exists := p.pythVaas.get(id)
+		return exists
+	}
+
+	return p.db.HasVAA(id)
+}
+
+func (p *ConcurrentProcessor) getSignedVAA(id db.VAAID) (*vaa.VAA, error) {
+
+	if id.EmitterChain == vaa.ChainIDPythNet {
+		ret, exists := p.pythVaas.get(id)
+		if exists {
+			return ret.v, nil
+		}
+
+		return nil, db.ErrVAANotFound
+	}
+
+	if p.db == nil {
+		return nil, db.ErrVAANotFound
+	}
+
+	vb, err := p.db.GetSignedVAABytes(id)
+	if err != nil {
+		return nil, err
+	}
+
+	vaa, err := vaa.Unmarshal(vb)
+	if err != nil {
+		panic("failed to unmarshal VAA from db")
+	}
+
+	return vaa, err
+}

--- a/node/pkg/processor3/pythdb.go
+++ b/node/pkg/processor3/pythdb.go
@@ -1,0 +1,55 @@
+package processor3
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/certusone/wormhole/node/pkg/db"
+	"github.com/wormhole-foundation/wormhole/sdk/vaa"
+)
+
+type pythVaaDb struct {
+	m map[string]*pythVaaEntry
+	l sync.RWMutex
+}
+
+type pythVaaEntry struct {
+	v          *vaa.VAA
+	updateTime time.Time // Used for determining when to delete entries
+}
+
+func NewPythVaaDb() pythVaaDb {
+	return pythVaaDb{
+		m: make(map[string]*pythVaaEntry),
+	}
+}
+
+func (pdb *pythVaaDb) put(id db.VAAID, v *vaa.VAA) {
+	key := fmt.Sprintf("%v/%v", id.EmitterAddress, id.Sequence)
+	value := &pythVaaEntry{v: v, updateTime: time.Now()}
+
+	pdb.l.Lock()
+	defer pdb.l.Unlock()
+	pdb.m[key] = value
+}
+
+func (pdb *pythVaaDb) get(id db.VAAID) (*pythVaaEntry, bool) {
+	key := fmt.Sprintf("%v/%v", id.EmitterAddress, id.Sequence)
+
+	pdb.l.RLock()
+	defer pdb.l.Unlock()
+	v, ok := pdb.m[key]
+	return v, ok
+}
+
+func (pdb *pythVaaDb) deleteBefore(t time.Time) {
+	pdb.l.Lock()
+	defer pdb.l.Unlock()
+
+	for k, v := range pdb.m {
+		if v.updateTime.Before(t) {
+			delete(pdb.m, k)
+		}
+	}
+}

--- a/node/pkg/processor3/state.go
+++ b/node/pkg/processor3/state.go
@@ -1,0 +1,45 @@
+package processor3
+
+import (
+	"time"
+
+	"github.com/certusone/wormhole/node/pkg/common"
+	ethcommon "github.com/ethereum/go-ethereum/common"
+)
+
+// state represents the local view of the accumulation state of observations for forming a VAA
+type state struct {
+	// First time this digest was seen (possibly even before we observed it ourselves).
+	firstObserved time.Time
+	// The most recent time that a re-observation request was sent to the guardian network.
+	lastRetry time.Time
+	// msg is the MessagePublication for which we are collecting observations
+	msg *common.MessagePublication
+	// Map of signatures seen by guardian. During guardian set updates, this may contain signatures belonging
+	// to either the old or new guardian set.
+	signatures map[ethcommon.Address][]byte
+	// Flag set after reaching quorum and submitting the VAA.
+	submitted bool
+	// guardian set valid at observation/injection time.
+	gs *common.GuardianSet
+}
+
+func (p *ConcurrentProcessor) NewStateFromSelfObserved() *state {
+	return &state{
+		firstObserved: time.Now(),
+		gs:            p.gst.Get(),
+		signatures:    make(map[ethcommon.Address][]byte),
+	}
+}
+
+func (p *ConcurrentProcessor) NewStateFromForeignObserved() *state {
+	return &state{
+		firstObserved: time.Now(),
+		gs:            p.gst.Get(),
+		signatures:    make(map[ethcommon.Address][]byte),
+	}
+}
+
+func (s *state) SelfObserved(m *common.MessagePublication) {
+	s.msg = m
+}


### PR DESCRIPTION
DO NOT MERGE -- Just sharing some code to further discuss

* No longer handle observations after VAA with quorum is reached
* Divide observations and inbound VAAs into streams based on hash and process each stream in parallel, but events in each stream in sequence, such that lock contention is minimized
* Prioritize processing of inbound VAAs such that useless work is minimized

All these changes are implemented in a new processor3 package that is a drop-in replacement for the old processor
