### PR TITLE
node/node_test: Add RSA to crypto benchmark

### DIFF
--- a/node/pkg/node/node_test.go
+++ b/node/pkg/node/node_test.go
@@ -1061,6 +1061,44 @@ func BenchmarkCrypto(b *testing.B) {
 		})
 	})
 
+	/*
+		RSA is an option for libp2p.
+		In an optimized RSA implementation, signature verification in RSA can be faster than with elliptic curves, while signature generation is always slower.
+		Since libp2p is verification-heavy, this might overall still be a faster option.
+		This benchmarks show that the libp2p RSA sigverify seems to be unoptimized and is actually slower than ED25519, as of go-libp2p v0.29.2:
+			libp2p_(Ed25519)/sign-64		36178 ns/op
+			libp2p_(Ed25519)/verify-64		85326 ns/op
+			libp2p_(RSA)/sign-64		  2226550 ns/op
+			libp2p_(RSA)/verify-64		   327945 ns/op
+	*/
+	b.Run("libp2p (RSA)", func(b *testing.B) {
+
+		r := math_rand.New(math_rand.NewSource(0)) //#nosec G404 testnet / devnet keys are public knowledge
+		p2pKey, _, err := libp2p_crypto.GenerateKeyPairWithReader(libp2p_crypto.RSA, 2048, r)
+		if err != nil {
+			panic(err)
+		}
+
+		b.Run("sign", func(b *testing.B) {
+			msgs := signingMsgs(b.N)
+			b.ResetTimer()
+			signMsgsP2p(p2pKey, msgs)
+		})
+
+		b.Run("verify", func(b *testing.B) {
+			msgs := signingMsgs(b.N)
+			signatures := signMsgsP2p(p2pKey, msgs)
+			b.ResetTimer()
+
+			// RSA.Verify
+			for i := 0; i < b.N; i++ {
+				ok, err := p2pKey.GetPublic().Verify(msgs[i], signatures[i])
+				assert.NoError(b, err)
+				assert.True(b, ok)
+			}
+		})
+	})
+
 	b.Run("ethcrypto (secp256k1)", func(b *testing.B) {
 
 		gk := devnet.InsecureDeterministicEcdsaKeyByIndex(ethcrypto.S256(), 0)


### PR DESCRIPTION
I was wondering if it was worthwhile to consider moving from ED25519 in the p2p network to RSA because RSA allows for faster signature verification, albeit larger signature size, and libp2p is verification-heavy. 
The benchmarks show that the libp2p RSA seems to be unoptimized and is actually slower than ED25519.
