### PR TITLE
Node: Processor multithreading with dispatcher

### DIFF
--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -206,7 +206,8 @@ var (
 	bigTableTopicName          *string
 	bigTableKeyPath            *string
 
-	chainGovernorEnabled *bool
+	chainGovernorEnabled  *bool
+	processorWorkerFactor *float64
 )
 
 func init() {
@@ -367,6 +368,7 @@ func init() {
 	bigTableKeyPath = NodeCmd.Flags().String("bigTableKeyPath", "", "Path to json Service Account key")
 
 	chainGovernorEnabled = NodeCmd.Flags().Bool("chainGovernorEnabled", false, "Run the chain governor")
+	processorWorkerFactor = NodeCmd.Flags().Float64("processorWorkerFactor", 0.0, "Multiplier used to compute number of processor workers, 0.0 means single threaded")
 }
 
 var (
@@ -1365,7 +1367,7 @@ func runNode(cmd *cobra.Command, args []string) {
 		node.GuardianOptionAdminService(*adminSocketPath, ethRPC, ethContract, rpcMap),
 		node.GuardianOptionP2P(p2pKey, *p2pNetworkID, *p2pBootstrap, *nodeName, *disableHeartbeatVerify, *p2pPort, ibc.GetFeatures),
 		node.GuardianOptionStatusServer(*statusAddr),
-		node.GuardianOptionProcessor(),
+		node.GuardianOptionProcessor(*processorWorkerFactor),
 	}
 
 	if shouldStart(publicGRPCSocketPath) {

--- a/node/pkg/node/node_test.go
+++ b/node/pkg/node/node_test.go
@@ -192,7 +192,7 @@ func mockGuardianRunnable(t testing.TB, gs []*mockGuardian, mockGuardianIndex ui
 			GuardianOptionPublicWeb(cfg.publicWeb, cfg.publicSocket, "", false, ""),
 			GuardianOptionAdminService(cfg.adminSocket, nil, nil, rpcMap),
 			GuardianOptionStatusServer(fmt.Sprintf("[::]:%d", cfg.statusPort)),
-			GuardianOptionProcessor(),
+			GuardianOptionProcessor(0.0),
 		}
 
 		guardianNode := NewGuardianNode(

--- a/node/pkg/node/options.go
+++ b/node/pkg/node/options.go
@@ -446,7 +446,7 @@ func GuardianOptionDatabase(db *db.Database) *GuardianOption {
 
 // GuardianOptionProcessor enables the default processor, which is required to make consensus on messages.
 // Dependencies: db, governor, accountant
-func GuardianOptionProcessor() *GuardianOption {
+func GuardianOptionProcessor(workerFactor float64) *GuardianOption {
 	return &GuardianOption{
 		name: "processor",
 		// governor and accountant may be set to nil, but that choice needs to be made before the processor is configured
@@ -469,6 +469,7 @@ func GuardianOptionProcessor() *GuardianOption {
 				g.gov,
 				g.acct,
 				g.acctC.readC,
+				workerFactor,
 			).Run
 
 			return nil

--- a/node/pkg/processor/broadcast.go
+++ b/node/pkg/processor/broadcast.go
@@ -7,7 +7,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
-	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"google.golang.org/protobuf/proto"
 
@@ -50,20 +49,20 @@ func (p *Processor) broadcastSignature(
 	// Store our VAA in case we're going to submit it to Solana
 	hash := hex.EncodeToString(digest.Bytes())
 
-	if p.state.signatures[hash] == nil {
-		p.state.signatures[hash] = &state{
-			firstObserved: time.Now(),
-			nextRetry:     time.Now().Add(nextRetryDuration(0)),
-			signatures:    map[ethcommon.Address][]byte{},
-			source:        "loopback",
-		}
+	state, created := p.state.getOrCreateState(hash)
+	state.lock.Lock()
+	defer state.lock.Unlock()
+
+	if created {
+		state.source = "loopback"
+		state.nextRetry = time.Now().Add(nextRetryDuration(0))
 	}
 
-	p.state.signatures[hash].ourObservation = o
-	p.state.signatures[hash].ourMsg = msg
-	p.state.signatures[hash].txHash = txhash
-	p.state.signatures[hash].source = o.GetEmitterChain().String()
-	p.state.signatures[hash].gs = p.gs // guaranteed to match ourObservation - there's no concurrent access to p.gs
+	state.ourObservation = o
+	state.ourMsg = msg
+	state.txHash = txhash
+	state.source = o.GetEmitterChain().String()
+	state.gs = p.gs.Load() // guaranteed to match ourObservation - there's no concurrent access to p.gs: TODO: Is this comment a problem??
 
 	// Fast path for our own signature. Put this in a go routine so it can block if the channel is full. That's also why we're not using node_common.PostMsgWithTimestamp.
 	go func() { p.obsvC <- node_common.CreateMsgWithTimestamp[gossipv1.SignedObservation](&obsv) }()

--- a/node/pkg/processor/cleanup.go
+++ b/node/pkg/processor/cleanup.go
@@ -67,152 +67,175 @@ var (
 
 // handleCleanup handles periodic retransmissions and cleanup of observations
 func (p *Processor) handleCleanup(ctx context.Context) {
+	p.cleanupState()
+	p.cleanupPythnetVaas()
+}
+
+// cleanupState walks through the aggregation state map and cleans up entries that are no longer needed. It grabs the state lock.
+func (p *Processor) cleanupState() {
+	p.state.signaturesLock.Lock()
+	defer p.state.signaturesLock.Unlock()
+
 	p.logger.Info("aggregation state summary", zap.Int("cached", len(p.state.signatures)))
 	aggregationStateEntries.Set(float64(len(p.state.signatures)))
 
 	for hash, s := range p.state.signatures {
-		delta := time.Since(s.firstObserved)
-
-		if !s.submitted && s.ourObservation != nil && delta > settlementTime {
-			// Expire pending VAAs post settlement time if we have a stored quorum VAA.
-			//
-			// This occurs when we observed a message after the cluster has already reached
-			// consensus on it, causing us to never achieve quorum.
-			if ourVaa, ok := s.ourObservation.(*VAA); ok {
-				if _, err := p.getSignedVAA(*db.VaaIDFromVAA(&ourVaa.VAA)); err == nil {
-					// If we have a stored quorum VAA, we can safely expire the state.
-					//
-					// This is a rare case, and we can safely expire the state, since we
-					// have a quorum VAA.
-					p.logger.Info("Expiring late VAA", zap.String("digest", hash), zap.Duration("delta", delta))
-					aggregationStateLate.Inc()
-					delete(p.state.signatures, hash)
-					continue
-				} else if err != db.ErrVAANotFound {
-					p.logger.Error("failed to look up VAA in database",
-						zap.String("digest", hash),
-						zap.Error(err),
-					)
-				}
-			}
+		if shouldDelete := p.cleanUpStateEntry(hash, s); shouldDelete {
+			delete(p.state.signatures, hash) // Can't use p.state.delete() because we're holding the lock.
 		}
+	}
+}
 
-		switch {
-		case !s.settled && delta > settlementTime:
-			// After 30 seconds, the observation is considered settled - it's unlikely that more observations will
-			// arrive, barring special circumstances. This is a better time to count misses than submission,
-			// because we submit right when we quorum rather than waiting for all observations to arrive.
-			s.settled = true
+// cleanUpStateEntry cleans up a single aggregation state entry. It grabs the lock for that entry. Returns true if the entry should be deleted.
+func (p *Processor) cleanUpStateEntry(hash string, s *state) bool {
+	s.lock.Lock()
+	defer s.lock.Unlock()
 
-			// Use either the most recent (in case of a observation we haven't seen) or stored gs, if available.
-			var gs *common.GuardianSet
-			if s.gs != nil {
-				gs = s.gs
-			} else {
-				gs = p.gs
-			}
+	delta := time.Since(s.firstObserved)
 
-			hasSigs := len(s.signatures)
-			wantSigs := vaa.CalculateQuorum(len(gs.Keys))
-			quorum := hasSigs >= wantSigs
-
-			var chain vaa.ChainID
-			if s.ourObservation != nil {
-				chain = s.ourObservation.GetEmitterChain()
-			}
-
-			p.logger.Debug("observation considered settled",
-				zap.String("digest", hash),
-				zap.Duration("delta", delta),
-				zap.Int("have_sigs", hasSigs),
-				zap.Int("required_sigs", wantSigs),
-				zap.Bool("quorum", quorum),
-				zap.Stringer("emitter_chain", chain),
-			)
-
-			for _, k := range gs.Keys {
-				if _, ok := s.signatures[k]; ok {
-					aggregationStateFulfillment.WithLabelValues(k.Hex(), s.source, "present").Inc()
-				} else {
-					aggregationStateFulfillment.WithLabelValues(k.Hex(), s.source, "missing").Inc()
-				}
-			}
-		case s.submitted && delta.Hours() >= 1:
-			// We could delete submitted observations right away, but then we'd lose context about additional (late)
-			// observation that come in. Therefore, keep it for a reasonable amount of time.
-			// If a very late observation arrives after cleanup, a nil aggregation state will be created
-			// and then expired after a while (as noted in observation.go, this can be abused by a byzantine guardian).
-			p.logger.Debug("expiring submitted observation", zap.String("digest", hash), zap.Duration("delta", delta))
-			delete(p.state.signatures, hash)
-			aggregationStateExpiration.Inc()
-		case !s.submitted && ((s.ourMsg != nil && delta > retryLimitOurs) || (s.ourMsg == nil && delta > retryLimitNotOurs)):
-			// Clearly, this horse is dead and continued beatings won't bring it closer to quorum.
-			p.logger.Info("expiring unsubmitted observation after exhausting retries", zap.String("digest", hash), zap.Duration("delta", delta), zap.Bool("weObserved", s.ourMsg != nil))
-			delete(p.state.signatures, hash)
-			aggregationStateTimeout.Inc()
-		case !s.submitted && delta >= FirstRetryMinWait && time.Since(s.nextRetry) >= 0:
-			// Poor observation has been unsubmitted for five minutes - clearly, something went wrong.
-			// If we have previously submitted an observation, and it was reliable, we can make another attempt to get
-			// it over the finish line by sending a re-observation request to the network and rebroadcasting our
-			// sig. If we do not have an observation, it means we either never observed it, or it got
-			// revived by a malfunctioning guardian node, in which case, we can't do anything about it
-			// and just delete it to keep our state nice and lean.
-			if s.ourMsg != nil {
-				// Unreliable observations cannot be resubmitted and can be considered failed after 5 minutes
-				if !s.ourObservation.IsReliable() {
-					p.logger.Info("expiring unsubmitted unreliable observation", zap.String("digest", hash), zap.Duration("delta", delta))
-					delete(p.state.signatures, hash)
-					aggregationStateTimeout.Inc()
-					break
-				}
-
-				// If we have already stored this VAA, there is no reason for us to request reobservation.
-				alreadyInDB, err := p.signedVaaAlreadyInDB(hash, s)
-				if err != nil {
-					p.logger.Error("failed to check if observation is already in DB, requesting reobservation", zap.String("hash", hash), zap.Error(err))
-				}
-
-				if alreadyInDB {
-					p.logger.Debug("observation already in DB, not requesting reobservation", zap.String("digest", hash))
-				} else {
-					p.logger.Info("resubmitting observation",
-						zap.String("digest", hash),
-						zap.Duration("delta", delta),
-						zap.String("firstObserved", s.firstObserved.String()),
-					)
-					req := &gossipv1.ObservationRequest{
-						ChainId: uint32(s.ourObservation.GetEmitterChain()),
-						TxHash:  s.txHash,
-					}
-					if err := common.PostObservationRequest(p.obsvReqSendC, req); err != nil {
-						p.logger.Warn("failed to broadcast re-observation request", zap.Error(err))
-					}
-					p.gossipSendC <- s.ourMsg
-					s.retryCtr++
-					s.nextRetry = time.Now().Add(nextRetryDuration(s.retryCtr))
-					aggregationStateRetries.Inc()
-				}
-			} else {
-				// For nil state entries, we log the quorum to determine whether the
-				// network reached consensus without us. We don't know the correct guardian
-				// set, so we simply use the most recent one.
-				hasSigs := len(s.signatures)
-				wantSigs := vaa.CalculateQuorum(len(p.gs.Keys))
-
-				p.logger.Debug("expiring unsubmitted nil observation",
+	if !s.submitted && s.ourObservation != nil && delta > settlementTime {
+		// Expire pending VAAs post settlement time if we have a stored quorum VAA.
+		//
+		// This occurs when we observed a message after the cluster has already reached
+		// consensus on it, causing us to never achieve quorum.
+		if ourVaa, ok := s.ourObservation.(*VAA); ok {
+			if _, err := p.getSignedVAA(*db.VaaIDFromVAA(&ourVaa.VAA)); err == nil {
+				// If we have a stored quorum VAA, we can safely expire the state.
+				//
+				// This is a rare case, and we can safely expire the state, since we
+				// have a quorum VAA.
+				p.logger.Info("Expiring late VAA", zap.String("digest", hash), zap.Duration("delta", delta))
+				aggregationStateLate.Inc()
+				return true
+			} else if err != db.ErrVAANotFound {
+				p.logger.Error("failed to look up VAA in database",
 					zap.String("digest", hash),
-					zap.Duration("delta", delta),
-					zap.Int("have_sigs", hasSigs),
-					zap.Int("required_sigs", wantSigs),
-					zap.Bool("quorum", hasSigs >= wantSigs),
+					zap.Error(err),
 				)
-				delete(p.state.signatures, hash)
-				aggregationStateUnobserved.Inc()
 			}
 		}
 	}
 
-	// Clean up old pythnet VAAs.
+	switch {
+	case !s.settled && delta > settlementTime:
+		// After 30 seconds, the observation is considered settled - it's unlikely that more observations will
+		// arrive, barring special circumstances. This is a better time to count misses than submission,
+		// because we submit right when we quorum rather than waiting for all observations to arrive.
+		s.settled = true
+
+		// Use either the most recent (in case of a observation we haven't seen) or stored gs, if available.
+		var gs *common.GuardianSet
+		if s.gs != nil {
+			gs = s.gs
+		} else {
+			gs = p.gs.Load()
+		}
+
+		hasSigs := len(s.signatures)
+		wantSigs := vaa.CalculateQuorum(len(gs.Keys))
+		quorum := hasSigs >= wantSigs
+
+		var chain vaa.ChainID
+		if s.ourObservation != nil {
+			chain = s.ourObservation.GetEmitterChain()
+		}
+
+		p.logger.Debug("observation considered settled",
+			zap.String("digest", hash),
+			zap.Duration("delta", delta),
+			zap.Int("have_sigs", hasSigs),
+			zap.Int("required_sigs", wantSigs),
+			zap.Bool("quorum", quorum),
+			zap.Stringer("emitter_chain", chain),
+		)
+
+		for _, k := range gs.Keys {
+			if _, ok := s.signatures[k]; ok {
+				aggregationStateFulfillment.WithLabelValues(k.Hex(), s.source, "present").Inc()
+			} else {
+				aggregationStateFulfillment.WithLabelValues(k.Hex(), s.source, "missing").Inc()
+			}
+		}
+	case s.submitted && delta.Hours() >= 1:
+		// We could delete submitted observations right away, but then we'd lose context about additional (late)
+		// observation that come in. Therefore, keep it for a reasonable amount of time.
+		// If a very late observation arrives after cleanup, a nil aggregation state will be created
+		// and then expired after a while (as noted in observation.go, this can be abused by a byzantine guardian).
+		p.logger.Debug("expiring submitted observation", zap.String("digest", hash), zap.Duration("delta", delta))
+		aggregationStateExpiration.Inc()
+		return true
+	case !s.submitted && ((s.ourMsg != nil && delta > retryLimitOurs) || (s.ourMsg == nil && delta > retryLimitNotOurs)):
+		// Clearly, this horse is dead and continued beatings won't bring it closer to quorum.
+		p.logger.Info("expiring unsubmitted observation after exhausting retries", zap.String("digest", hash), zap.Duration("delta", delta))
+		aggregationStateTimeout.Inc()
+		return true
+	case !s.submitted && delta >= FirstRetryMinWait && time.Since(s.nextRetry) >= 0:
+		// Poor observation has been unsubmitted for five minutes - clearly, something went wrong.
+		// If we have previously submitted an observation, and it was reliable, we can make another attempt to get
+		// it over the finish line by sending a re-observation request to the network and rebroadcasting our
+		// sig. If we do not have an observation, it means we either never observed it, or it got
+		// revived by a malfunctioning guardian node, in which case, we can't do anything about it
+		// and just delete it to keep our state nice and lean.
+		if s.ourMsg != nil {
+			// Unreliable observations cannot be resubmitted and can be considered failed after 5 minutes
+			if !s.ourObservation.IsReliable() {
+				p.logger.Info("expiring unsubmitted unreliable observation", zap.String("digest", hash), zap.Duration("delta", delta))
+				aggregationStateTimeout.Inc()
+				return true
+			}
+
+			// If we have already stored this VAA, there is no reason for us to request reobservation.
+			alreadyInDB, err := p.signedVaaAlreadyInDB(hash, s)
+			if err != nil {
+				p.logger.Error("failed to check if observation is already in DB, requesting reobservation", zap.String("hash", hash), zap.Error(err))
+			}
+
+			if alreadyInDB {
+				p.logger.Debug("observation already in DB, not requesting reobservation", zap.String("digest", hash))
+			} else {
+				p.logger.Info("resubmitting observation",
+					zap.String("digest", hash),
+					zap.Duration("delta", delta),
+					zap.String("firstObserved", s.firstObserved.String()),
+				)
+				req := &gossipv1.ObservationRequest{
+					ChainId: uint32(s.ourObservation.GetEmitterChain()),
+					TxHash:  s.txHash,
+				}
+				if err := common.PostObservationRequest(p.obsvReqSendC, req); err != nil {
+					p.logger.Warn("failed to broadcast re-observation request", zap.Error(err))
+				}
+				p.gossipSendC <- s.ourMsg
+				s.retryCtr++
+				s.nextRetry = time.Now().Add(nextRetryDuration(s.retryCtr))
+				aggregationStateRetries.Inc()
+			}
+		} else {
+			// For nil state entries, we log the quorum to determine whether the
+			// network reached consensus without us. We don't know the correct guardian
+			// set, so we simply use the most recent one.
+			hasSigs := len(s.signatures)
+			wantSigs := vaa.CalculateQuorum(len(p.gs.Load().Keys))
+
+			p.logger.Debug("expiring unsubmitted nil observation",
+				zap.String("digest", hash),
+				zap.Duration("delta", delta),
+				zap.Int("have_sigs", hasSigs),
+				zap.Int("required_sigs", wantSigs),
+				zap.Bool("quorum", hasSigs >= wantSigs),
+			)
+			aggregationStateUnobserved.Inc()
+			return true
+		}
+	}
+
+	return false
+}
+
+// cleanupPythnetVaas deletes expired pythnet vaas.
+func (p *Processor) cleanupPythnetVaas() {
+	p.pythnetVaaLock.Lock()
+	defer p.pythnetVaaLock.Unlock()
 	oldestTime := time.Now().Add(-time.Hour)
 	for key, pe := range p.pythnetVaas {
 		if pe.updateTime.Before(oldestTime) {

--- a/node/pkg/processor/dispatcher.go
+++ b/node/pkg/processor/dispatcher.go
@@ -1,0 +1,248 @@
+package processor
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"math"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/certusone/wormhole/node/pkg/common"
+	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
+	"github.com/wormhole-foundation/wormhole/sdk/vaa"
+	"go.uber.org/zap"
+)
+
+// readerChannels is the set of channels read by a single worker.
+type readerChannels struct {
+	setC            <-chan *common.GuardianSet // TODO: Drop this if we get rid of single threaded mode.
+	msgC            <-chan *common.MessagePublication
+	acctReadC       <-chan *common.MessagePublication // TODO: Drop this if we get rid of single threaded mode.
+	injectC         <-chan *vaa.VAA
+	obsvC           <-chan *common.MsgWithTimeStamp[gossipv1.SignedObservation]
+	signedInC       <-chan *gossipv1.SignedVAAWithQuorum // TODO: Drop this if we get rid of single threaded mode.
+	parsedSignedInC <-chan *vaa.VAA
+}
+
+// writerChannels is the set of channels used to write to a single worker.
+type writerChannels struct {
+	setC            chan<- *common.GuardianSet // TODO: Drop this if we get rid of single threaded mode.
+	msgC            chan<- *common.MessagePublication
+	acctReadC       chan<- *common.MessagePublication // TODO: Drop this if we get rid of single threaded mode.
+	injectC         chan<- *vaa.VAA
+	obsvC           chan<- *common.MsgWithTimeStamp[gossipv1.SignedObservation]
+	signedInC       chan<- *gossipv1.SignedVAAWithQuorum // TODO: Drop this if we get rid of single threaded mode.
+	parsedSignedInC chan<- *vaa.VAA
+}
+
+// runDispatcher starts the dispatcher and workers. It creates a readerChannels struct for each worker and an array of writerChannels structs for the dispatcher.
+func (p *Processor) runDispatcher(ctx context.Context) {
+	// Compute the number of workers based on the number of CPUs and the worker factor.
+	numWorkers := int(math.Ceil(float64(runtime.NumCPU()) * p.workerFactor))
+	p.numWorkers = uint64(numWorkers)
+
+	// Compute the size of the message channels based on incoming channel size and the number of workers.
+	msgCSize := p.computeMsgChanSize(cap(p.msgC))
+	signedInCSize := p.computeMsgChanSize(cap(p.signedInC))
+	obsvCSize := p.computeMsgChanSize(cap(p.obsvC))
+	injectCSize := p.computeMsgChanSize(cap(p.injectC))
+	acctCSize := p.computeMsgChanSize(cap(p.acctReadC))
+
+	p.logger.Info("processor configured to use workers",
+		zap.Int("numWorkers", numWorkers),
+		zap.Float64("workerFactor", p.workerFactor),
+		zap.Int("msgCSize", msgCSize),
+		zap.Int("signedInCSize", signedInCSize),
+		zap.Int("obsvCSize", obsvCSize),
+		zap.Int("injectCSize", injectCSize),
+		zap.Int("acctCSize", acctCSize),
+	)
+
+	var w sync.WaitGroup
+	w.Add(numWorkers)
+
+	p.workerChans = make([]*writerChannels, 0)
+
+	for workerIdx := 0; workerIdx < numWorkers; workerIdx++ {
+		setC := makeChannelPair[*common.GuardianSet](1)
+		msgC := makeChannelPair[*common.MessagePublication](msgCSize)
+		signedInC := makeChannelPair[*gossipv1.SignedVAAWithQuorum](signedInCSize)
+		parsedSignedInC := makeChannelPair[*vaa.VAA](signedInCSize)
+		obsvC := makeChannelPair[*common.MsgWithTimeStamp[gossipv1.SignedObservation]](obsvCSize)
+		injectC := makeChannelPair[*vaa.VAA](injectCSize)
+		acctC := makeChannelPair[*common.MessagePublication](acctCSize)
+
+		readerChans := &readerChannels{
+			setC:            setC.readC,
+			msgC:            msgC.readC,
+			acctReadC:       acctC.readC,
+			injectC:         injectC.readC,
+			obsvC:           obsvC.readC,
+			signedInC:       signedInC.readC,
+			parsedSignedInC: parsedSignedInC.readC,
+		}
+
+		writerChans := &writerChannels{
+			setC:            setC.writeC,
+			msgC:            msgC.writeC,
+			acctReadC:       acctC.writeC,
+			injectC:         injectC.writeC,
+			obsvC:           obsvC.writeC,
+			signedInC:       signedInC.writeC,
+			parsedSignedInC: parsedSignedInC.writeC,
+		}
+
+		p.workerChans = append(p.workerChans, writerChans)
+
+		go func(ctx context.Context, workerIdx int, chans *readerChannels) {
+			p.logger.Info("processor worker started", zap.Int("workerIdx", workerIdx))
+			err := p.runWorker(ctx, chans, false)
+			if err != nil {
+				p.logger.Error("processor worker failed", zap.Int("workerIdx", workerIdx), zap.Error(err))
+			}
+			p.logger.Info("processor worker done", zap.Int("workerIdx", workerIdx))
+			w.Done()
+		}(ctx, workerIdx, readerChans)
+	}
+
+	go func() { _ = p.dispatcher(ctx, p.workerChans) }()
+
+	w.Wait()
+}
+
+// computeMsgChanSize computes the size of a per-worker message channel based on the base size and the number of workers.
+func (p *Processor) computeMsgChanSize(baseSize int) int {
+	return int(math.Ceil(float64(baseSize)/float64(p.numWorkers))) * 2
+}
+
+// The dispatcher receives events from outside the processor and dispatches to a deterministic worker based on the VAA digest.
+// It also performs periodic cleanup. This is okay because cleanup locks the entire state map anyway.
+func (p *Processor) dispatcher(ctx context.Context, workerChans []*writerChannels) error {
+	// Always start the timers to avoid nil pointer dereferences below. They will only be rearmed on worker 1.
+	cleanup := time.NewTimer(CleanupInterval)
+	defer cleanup.Stop()
+
+	// Always initialize the timer so don't have a nil pointer in the case below. It won't get rearmed after that.
+	govTimer := time.NewTimer(GovInterval)
+	defer govTimer.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			if p.acct != nil {
+				p.acct.Close()
+			}
+			return ctx.Err()
+		case gs := <-p.setC:
+			p.gs.Store(gs)
+			p.logger.Info("guardian set updated",
+				zap.Strings("set", gs.KeysAsHexStrings()),
+				zap.Uint32("index", gs.Index))
+			p.gst.Set(gs)
+		case k := <-p.msgC:
+			p.dispatchMessage(workerChans, k)
+		case k := <-p.acctReadC:
+			if p.acct == nil {
+				return fmt.Errorf("received an accountant event when accountant is not configured")
+			}
+			// SECURITY defense-in-depth: Make sure the accountant did not generate an unexpected message.
+			if !p.acct.IsMessageCoveredByAccountant(k) {
+				return fmt.Errorf("accountant published a message that is not covered by it: `%s`", k.MessageIDString())
+			}
+			p.dispatchMessage(workerChans, k)
+		case v := <-p.injectC:
+			digest := v.SigningDigest().Bytes()
+			workerIdx := p.workerIdxFromDigest(digest)
+			if workerIdx > len(workerChans) {
+				panic(fmt.Sprintf(`failed to compute worker idx on injected VAA for digest "%v", numWorkers: %d`, hex.EncodeToString(digest), len(workerChans)))
+			}
+			workerChans[workerIdx].injectC <- v
+		case m := <-p.obsvC:
+			workerIdx := p.workerIdxFromDigest(m.Msg.Hash)
+			if workerIdx > len(workerChans) {
+				panic(fmt.Sprintf(`failed to compute worker idx on observation for digest "%v", numWorkers: %d`, hex.EncodeToString(m.Msg.Hash), len(workerChans)))
+			}
+			workerChans[workerIdx].obsvC <- m
+		case m := <-p.signedInC:
+			v, alreadyInDB, err := p.unmarshalSignedVaaWithQuorum(m)
+			if err != nil {
+				p.logger.Error("failed to parse incoming signed VAA with quorum", zap.Error(err))
+				continue
+			}
+			if !alreadyInDB {
+				digest := v.SigningDigest().Bytes()
+				workerIdx := p.workerIdxFromDigest(digest)
+				if workerIdx > len(workerChans) {
+					panic(fmt.Sprintf(`failed to compute worker idx on incoming signed VAA with quorum for digest "%v", numWorkers: %d`, hex.EncodeToString(digest), len(workerChans)))
+				}
+				workerChans[workerIdx].parsedSignedInC <- v
+			}
+		case <-cleanup.C:
+			cleanup.Reset(CleanupInterval)
+			p.handleCleanup(ctx)
+		case <-govTimer.C:
+			if p.governor != nil {
+				toBePublished, err := p.governor.CheckPending()
+				if err != nil {
+					return err
+				}
+				if len(toBePublished) != 0 {
+					for _, k := range toBePublished {
+						// SECURITY defense-in-depth: Make sure the governor did not generate an unexpected message.
+						if msgIsGoverned, err := p.governor.IsGovernedMsg(k); err != nil {
+							return fmt.Errorf("governor failed to determine if message should be governed: `%s`: %w", k.MessageIDString(), err)
+						} else if !msgIsGoverned {
+							return fmt.Errorf("governor published a message that should not be governed: `%s`", k.MessageIDString())
+						}
+						if p.acct != nil {
+							shouldPub, err := p.acct.SubmitObservation(k)
+							if err != nil {
+								return fmt.Errorf("failed to process message released by governor `%s`: %w", k.MessageIDString(), err)
+							}
+							if !shouldPub {
+								continue
+							}
+						}
+						p.dispatchMessage(workerChans, k)
+					}
+				}
+				govTimer.Reset(GovInterval)
+			}
+		}
+	}
+}
+
+// dispatchMessage dispatches a message publication to the appropriate worker.
+func (p *Processor) dispatchMessage(workerChans []*writerChannels, k *common.MessagePublication) {
+	digest := digestFromMsg(k)
+	workerIdx := p.workerIdxFromDigest(digest)
+	if workerIdx >= len(workerChans) {
+		panic(fmt.Sprintf(`failed to compute worker idx for digest "%v", numWorkers: %d`, hex.EncodeToString(digest), len(workerChans)))
+	}
+	workerChans[workerIdx].msgC <- k
+}
+
+// digestFromMsg returns the digest of the message publication by creating a VAA. TODO: We could pass this VAA to handleMessage() so we don't have to create the VAA twice.
+func digestFromMsg(msg *common.MessagePublication) []byte {
+	v := msg.CreateVAA(0) // We can pass zero in as the guardian set index because it is not part of the digest.
+	return v.SigningDigest().Bytes()
+}
+
+// workerIdxFromDigest generates the worker index from the digest by doing a modulo operation.
+func (p *Processor) workerIdxFromDigest(digest []byte) int {
+	return int(binary.BigEndian.Uint64(digest) % p.numWorkers)
+}
+
+// TODO: Move this to common.
+type channelPair[T any] struct {
+	readC  <-chan T
+	writeC chan<- T
+}
+
+func makeChannelPair[T any](cap int) channelPair[T] {
+	out := make(chan T, cap)
+	return channelPair[T]{out, out}
+}

--- a/node/pkg/processor/message.go
+++ b/node/pkg/processor/message.go
@@ -41,7 +41,8 @@ var (
 // handleMessage processes a message received from a chain and instantiates our deterministic copy of the VAA. An
 // event may be received multiple times and must be handled in an idempotent fashion.
 func (p *Processor) handleMessage(ctx context.Context, k *common.MessagePublication) {
-	if p.gs == nil {
+	gs := p.gs.Load()
+	if gs == nil {
 		p.logger.Warn("dropping observation since we haven't initialized our guardian set yet",
 			zap.Stringer("emitter_chain", k.EmitterChain),
 			zap.Stringer("emitter_address", k.EmitterAddress),
@@ -70,7 +71,7 @@ func (p *Processor) handleMessage(ctx context.Context, k *common.MessagePublicat
 	v := &VAA{
 		VAA: vaa.VAA{
 			Version:          vaa.SupportedVAAVersion,
-			GuardianSetIndex: p.gs.Index,
+			GuardianSetIndex: gs.Index,
 			Signatures:       nil,
 			Timestamp:        k.Timestamp,
 			Nonce:            k.Nonce,

--- a/node/pkg/processor/observation.go
+++ b/node/pkg/processor/observation.go
@@ -93,6 +93,14 @@ func (p *Processor) handleObservation(ctx context.Context, obs *node_common.MsgW
 		return
 	}
 
+	state, created := p.state.getOrCreateState(hash)
+	state.lock.Lock()
+	defer state.lock.Unlock()
+	if created {
+		state.source = "unknown"
+		state.nextRetry = time.Now().Add(nextRetryDuration(0))
+	}
+
 	// Determine which guardian set to use. The following cases are possible:
 	//
 	//  - We have already seen the message and generated ourObservation. In this case, use the guardian set valid at the time,
@@ -110,10 +118,10 @@ func (p *Processor) handleObservation(ctx context.Context, obs *node_common.MsgW
 	// During an update, vaaState.signatures can contain signatures from *both* guardian sets.
 	//
 	var gs *node_common.GuardianSet
-	if p.state.signatures[hash] != nil && p.state.signatures[hash].gs != nil {
-		gs = p.state.signatures[hash].gs
+	if state.gs != nil {
+		gs = state.gs
 	} else {
-		gs = p.gs
+		gs = p.gs.Load()
 	}
 
 	// We haven't yet observed the trusted guardian set on Ethereum, and therefore, it's impossible to verify it.
@@ -124,6 +132,9 @@ func (p *Processor) handleObservation(ctx context.Context, obs *node_common.MsgW
 			zap.String("their_addr", their_addr.Hex()),
 		)
 		observationsFailedTotal.WithLabelValues("uninitialized_guardian_set").Inc()
+		if created {
+			p.state.delete(hash)
+		}
 		return
 	}
 
@@ -138,6 +149,9 @@ func (p *Processor) handleObservation(ctx context.Context, obs *node_common.MsgW
 			zap.Any("keys", gs.KeysAsHexStrings()),
 		)
 		observationsFailedTotal.WithLabelValues("unknown_guardian").Inc()
+		if created {
+			p.state.delete(hash)
+		}
 		return
 	}
 
@@ -148,8 +162,7 @@ func (p *Processor) handleObservation(ctx context.Context, obs *node_common.MsgW
 	// We can now count events by guardian without worry about cardinality explosions:
 	observationsReceivedByGuardianAddressTotal.WithLabelValues(their_addr.Hex()).Inc()
 
-	// []byte isn't hashable in a map. Paying a small extra cost for encoding for easier debugging.
-	if p.state.signatures[hash] == nil {
+	if created {
 		// We haven't yet seen this event ourselves, and therefore do not know what the VAA looks like.
 		// However, we have established that a valid guardian has signed it, and therefore we can
 		// already start aggregating signatures for it.
@@ -159,22 +172,15 @@ func (p *Processor) handleObservation(ctx context.Context, obs *node_common.MsgW
 		// signatures - such byzantine behavior would be plainly visible and would be dealt with by kicking them.
 
 		observationsUnknownTotal.Inc()
-
-		p.state.signatures[hash] = &state{
-			firstObserved: time.Now(),
-			nextRetry:     time.Now().Add(nextRetryDuration(0)),
-			signatures:    map[common.Address][]byte{},
-			source:        "unknown",
-		}
 	}
 
-	p.state.signatures[hash].signatures[their_addr] = m.Signature
+	state.signatures[their_addr] = m.Signature
 
 	// Aggregate all valid signatures into a list of vaa.Signature and construct signed VAA.
 	agg := make([]bool, len(gs.Keys))
 	var sigs []*vaa.Signature
 	for i, a := range gs.Keys {
-		s, ok := p.state.signatures[hash].signatures[a]
+		s, ok := state.signatures[a]
 
 		if ok {
 			var bs [65]byte
@@ -191,7 +197,7 @@ func (p *Processor) handleObservation(ctx context.Context, obs *node_common.MsgW
 		agg[i] = ok
 	}
 
-	if p.state.signatures[hash].ourObservation != nil {
+	if state.ourObservation != nil {
 		// We have made this observation on chain!
 
 		// 2/3+ majority required for VAA to be valid - wait until we have quorum to submit VAA.
@@ -207,8 +213,9 @@ func (p *Processor) handleObservation(ctx context.Context, obs *node_common.MsgW
 			zap.Bool("quorum", len(sigs) >= quorum),
 		)
 
-		if len(sigs) >= quorum && !p.state.signatures[hash].submitted {
-			p.state.signatures[hash].ourObservation.HandleQuorum(sigs, hash, p)
+		if len(sigs) >= quorum && !state.submitted {
+			state.ourObservation.HandleQuorum(sigs, hash, p)
+			state.submitted = true
 		} else {
 			p.logger.Debug("quorum not met or already submitted, doing nothing", // 1.2M out of 3M info messages / hour / guardian
 				zap.String("digest", hash))
@@ -250,7 +257,8 @@ func (p *Processor) handleInboundSignedVAAWithQuorum(ctx context.Context, m *gos
 	digest := v.SigningDigest()
 	hash := hex.EncodeToString(digest.Bytes())
 
-	if p.gs == nil {
+	gs := p.gs.Load()
+	if gs == nil {
 		p.logger.Warn("dropping SignedVAAWithQuorum message since we haven't initialized our guardian set yet",
 			zap.String("digest", hash),
 			zap.Any("message", m),
@@ -259,7 +267,7 @@ func (p *Processor) handleInboundSignedVAAWithQuorum(ctx context.Context, m *gos
 	}
 
 	// Check if guardianSet doesn't have any keys
-	if len(p.gs.Keys) == 0 {
+	if len(gs.Keys) == 0 {
 		p.logger.Warn("dropping SignedVAAWithQuorum message since we have a guardian set without keys",
 			zap.String("digest", hash),
 			zap.Any("message", m),
@@ -267,7 +275,7 @@ func (p *Processor) handleInboundSignedVAAWithQuorum(ctx context.Context, m *gos
 		return
 	}
 
-	if err := v.Verify(p.gs.Keys); err != nil {
+	if err := v.Verify(gs.Keys); err != nil {
 		p.logger.Warn("dropping SignedVAAWithQuorum message because it failed verification: " + err.Error())
 		return
 	}

--- a/node/pkg/processor/observation_test.go
+++ b/node/pkg/processor/observation_test.go
@@ -111,7 +111,7 @@ func TestHandleInboundSignedVAAWithQuorum(t *testing.T) {
 			ctx := context.Background()
 			signedVAAWithQuorum := &gossipv1.SignedVAAWithQuorum{Vaa: marshalVAA}
 			processor := Processor{}
-			processor.gs = &guardianSet
+			processor.gs.Store(&guardianSet)
 			processor.logger = observedLogger
 
 			processor.handleInboundSignedVAAWithQuorum(ctx, signedVAAWithQuorum)

--- a/node/pkg/processor/processor.go
+++ b/node/pkg/processor/processor.go
@@ -4,6 +4,10 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"fmt"
+	"math"
+	"runtime"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/certusone/wormhole/node/pkg/db"
@@ -47,6 +51,9 @@ type (
 
 	// state represents the local view of a given observation
 	state struct {
+		// Mutex protecting this particular state entry.
+		lock sync.Mutex
+
 		// First time this digest was seen (possibly even before we observed it ourselves).
 		firstObserved time.Time
 		// A re-observation request shall not be sent before this time.
@@ -76,9 +83,35 @@ type (
 
 	// aggregationState represents the node's aggregation of guardian signatures.
 	aggregationState struct {
-		signatures observationMap
+		// signaturesLock should be held when inserting / deleting / iterating over the map, but not when working with a single entry.
+		signaturesLock sync.Mutex
+		signatures     observationMap
 	}
 )
+
+// getOrCreateState returns the state for a given hash, creating it if it doesn't exist.  It grabs the lock.
+func (s *aggregationState) getOrCreateState(hash string) (*state, bool) {
+	s.signaturesLock.Lock()
+	defer s.signaturesLock.Unlock()
+
+	created := false
+	if _, ok := s.signatures[hash]; !ok {
+		created = true
+		s.signatures[hash] = &state{
+			firstObserved: time.Now(),
+			signatures:    make(map[ethcommon.Address][]byte),
+		}
+	}
+
+	return s.signatures[hash], created
+}
+
+// delete removes a state entry from the map. It grabs the lock.
+func (s *aggregationState) delete(hash string) {
+	s.signaturesLock.Lock()
+	defer s.signaturesLock.Unlock()
+	delete(s.signatures, hash)
+}
 
 type PythNetVaaEntry struct {
 	v          *vaa.VAA
@@ -116,7 +149,7 @@ type Processor struct {
 	// Runtime state
 
 	// gs is the currently valid guardian set
-	gs *common.GuardianSet
+	gs atomic.Pointer[common.GuardianSet]
 	// gst is managed by the processor and allows concurrent access to the
 	// guardian set by other components.
 	gst *common.GuardianSetState
@@ -126,10 +159,13 @@ type Processor struct {
 	// gk pk as eth address
 	ourAddr ethcommon.Address
 
-	governor    *governor.ChainGovernor
-	acct        *accountant.Accountant
-	acctReadC   <-chan *common.MessagePublication
-	pythnetVaas map[string]PythNetVaaEntry
+	governor  *governor.ChainGovernor
+	acct      *accountant.Accountant
+	acctReadC <-chan *common.MessagePublication
+
+	pythnetVaaLock sync.Mutex
+	pythnetVaas    map[string]PythNetVaaEntry
+	workerFactor   float64
 }
 
 var (
@@ -137,14 +173,14 @@ var (
 		prometheus.HistogramOpts{
 			Name:    "wormhole_signed_observation_channel_delay_us",
 			Help:    "Latency histogram for delay of signed observations in channel",
-			Buckets: []float64{10.0, 20.0, 50.0, 100.0, 1000.0, 5000.0, 10000.0},
+			Buckets: []float64{10.0, 20.0, 50.0, 100.0, 250, 500, 750, 1000.0, 5000.0, 10000.0},
 		})
 
 	observationTotalDelay = promauto.NewHistogram(
 		prometheus.HistogramOpts{
 			Name:    "wormhole_signed_observation_total_delay_us",
 			Help:    "Latency histogram for total time to process signed observations",
-			Buckets: []float64{10.0, 20.0, 50.0, 100.0, 1000.0, 5000.0, 10000.0},
+			Buckets: []float64{10.0, 20.0, 50.0, 100.0, 250, 500, 750, 1000.0, 5000.0, 10000.0},
 		})
 )
 
@@ -164,8 +200,8 @@ func NewProcessor(
 	g *governor.ChainGovernor,
 	acct *accountant.Accountant,
 	acctReadC <-chan *common.MessagePublication,
+	workerFactor float64,
 ) *Processor {
-
 	return &Processor{
 		msgC:         msgC,
 		setC:         setC,
@@ -180,21 +216,67 @@ func NewProcessor(
 
 		attestationEvents: attestationEvents,
 
-		logger:      supervisor.Logger(ctx),
-		state:       &aggregationState{observationMap{}},
-		ourAddr:     crypto.PubkeyToAddress(gk.PublicKey),
-		governor:    g,
-		acct:        acct,
-		acctReadC:   acctReadC,
-		pythnetVaas: make(map[string]PythNetVaaEntry),
+		logger:       supervisor.Logger(ctx).With(zap.String("component", "processor")),
+		state:        &aggregationState{signatures: observationMap{}},
+		ourAddr:      crypto.PubkeyToAddress(gk.PublicKey),
+		governor:     g,
+		acct:         acct,
+		acctReadC:    acctReadC,
+		pythnetVaas:  make(map[string]PythNetVaaEntry),
+		workerFactor: workerFactor,
 	}
 }
 
 func (p *Processor) Run(ctx context.Context) error {
-	cleanup := time.NewTicker(CleanupInterval)
+	if p.workerFactor < 0.0 {
+		return fmt.Errorf("workerFactor must be positive or zero")
+	}
+
+	var ret error
+	if p.workerFactor == 0.0 {
+		ret = p.RunOne(ctx, 1)
+	} else {
+
+		numWorkers := int(math.Ceil(float64(runtime.NumCPU()) * p.workerFactor))
+		p.logger.Info("processor configured to use workers", zap.Int("numWorkers", numWorkers), zap.Float64("workerFactor", p.workerFactor))
+
+		var w sync.WaitGroup
+		w.Add(numWorkers)
+
+		for workerId := 1; workerId <= numWorkers; workerId++ {
+			go func(ctx context.Context, workerId int) {
+				p.logger.Info("processor worker started", zap.Int("workerId", workerId))
+				err := p.RunOne(ctx, workerId)
+				if err != nil {
+					p.logger.Error("processor worker failed", zap.Int("workerId", workerId), zap.Error(err))
+				}
+				p.logger.Info("processor worker done", zap.Int("workerId", workerId))
+				w.Done()
+			}(ctx, workerId)
+		}
+
+		w.Wait()
+	}
+
+	// Log these as warnings so they show up in the benchmark logs.
+	metric := &dto.Metric{}
+	_ = observationChanDelay.Write(metric)
+	p.logger.Warn("PROCESSOR_METRICS", zap.Any("observationChannelDelay", metric.String()))
+
+	metric = &dto.Metric{}
+	_ = observationTotalDelay.Write(metric)
+	p.logger.Warn("PROCESSOR_METRICS", zap.Any("observationProcessingDelay", metric.String()))
+	return ret
+}
+
+func (p *Processor) RunOne(ctx context.Context, workerId int) error {
+	// Always start the timers to avoid nil pointer dereferences below. They will only be rearmed on worker 1.
+	cleanup := time.NewTimer(CleanupInterval)
+	defer cleanup.Stop()
 
 	// Always initialize the timer so don't have a nil pointer in the case below. It won't get rearmed after that.
 	govTimer := time.NewTimer(GovInterval)
+	defer govTimer.Stop()
 
 	for {
 		select {
@@ -202,22 +284,13 @@ func (p *Processor) Run(ctx context.Context) error {
 			if p.acct != nil {
 				p.acct.Close()
 			}
-
-			// Log these as warnings so they show up in the benchmark logs.
-			metric := &dto.Metric{}
-			_ = observationChanDelay.Write(metric)
-			p.logger.Warn("PROCESSOR_METRICS", zap.Any("observationChannelDelay", metric.String()))
-
-			metric = &dto.Metric{}
-			_ = observationTotalDelay.Write(metric)
-			p.logger.Warn("PROCESSOR_METRICS", zap.Any("observationProcessingDelay", metric.String()))
-
 			return ctx.Err()
-		case p.gs = <-p.setC:
+		case gs := <-p.setC:
+			p.gs.Store(gs)
 			p.logger.Info("guardian set updated",
-				zap.Strings("set", p.gs.KeysAsHexStrings()),
-				zap.Uint32("index", p.gs.Index))
-			p.gst.Set(p.gs)
+				zap.Strings("set", gs.KeysAsHexStrings()),
+				zap.Uint32("index", gs.Index))
+			p.gst.Set(gs)
 		case k := <-p.msgC:
 			if p.governor != nil {
 				if !p.governor.ProcessMsg(k) {
@@ -252,9 +325,12 @@ func (p *Processor) Run(ctx context.Context) error {
 		case m := <-p.signedInC:
 			p.handleInboundSignedVAAWithQuorum(ctx, m)
 		case <-cleanup.C:
-			p.handleCleanup(ctx)
+			if workerId == 1 {
+				cleanup.Reset(CleanupInterval)
+				p.handleCleanup(ctx)
+			}
 		case <-govTimer.C:
-			if p.governor != nil {
+			if p.governor != nil && workerId == 1 {
 				toBePublished, err := p.governor.CheckPending()
 				if err != nil {
 					return err
@@ -279,8 +355,6 @@ func (p *Processor) Run(ctx context.Context) error {
 						p.handleMessage(ctx, k)
 					}
 				}
-			}
-			if (p.governor != nil) || (p.acct != nil) {
 				govTimer.Reset(GovInterval)
 			}
 		}
@@ -290,6 +364,8 @@ func (p *Processor) Run(ctx context.Context) error {
 func (p *Processor) storeSignedVAA(v *vaa.VAA) error {
 	if v.EmitterChain == vaa.ChainIDPythNet {
 		key := fmt.Sprintf("%v/%v", v.EmitterAddress, v.Sequence)
+		p.pythnetVaaLock.Lock()
+		defer p.pythnetVaaLock.Unlock()
 		p.pythnetVaas[key] = PythNetVaaEntry{v: v, updateTime: time.Now()}
 		return nil
 	}
@@ -297,8 +373,9 @@ func (p *Processor) storeSignedVAA(v *vaa.VAA) error {
 }
 
 func (p *Processor) getSignedVAA(id db.VAAID) (*vaa.VAA, error) {
-
 	if id.EmitterChain == vaa.ChainIDPythNet {
+		p.pythnetVaaLock.Lock()
+		defer p.pythnetVaaLock.Unlock()
 		key := fmt.Sprintf("%v/%v", id.EmitterAddress, id.Sequence)
 		ret, exists := p.pythnetVaas[key]
 		if exists {

--- a/node/pkg/processor/vaa.go
+++ b/node/pkg/processor/vaa.go
@@ -36,7 +36,6 @@ func (v *VAA) HandleQuorum(sigs []*vaa.Signature, hash string, p *Processor) {
 
 	p.broadcastSignedVAA(signed)
 	p.attestationEvents.ReportVAAQuorum(signed)
-	p.state.signatures[hash].submitted = true
 }
 
 func (v *VAA) IsReliable() bool {


### PR DESCRIPTION
This version of processor multithreading builds on PR #3166 by dispatching events to a deterministic worker based on the digest of the VAA. The idea is all events for a single VAA will go to the same worker, reducing lock contention. The dispatching is done using channels between the dispatcher routine and the worker routines.