### PR TITLE
Node: Processor multithreading w/ direct dispatch

### DIFF
--- a/node/pkg/node/options.go
+++ b/node/pkg/node/options.go
@@ -454,7 +454,7 @@ func GuardianOptionProcessor(workerFactor float64) *GuardianOption {
 
 		f: func(ctx context.Context, logger *zap.Logger, g *G) error {
 
-			g.runnables["processor"] = processor.NewProcessor(ctx,
+			p := processor.NewProcessor(ctx,
 				g.db,
 				g.msgC.readC,
 				g.setC.readC,
@@ -470,7 +470,14 @@ func GuardianOptionProcessor(workerFactor float64) *GuardianOption {
 				g.acct,
 				g.acctC.readC,
 				workerFactor,
-			).Run
+			)
+
+			g.runnables["processor"] = p.Run
+
+			// Give P2P a direct link to the processor to avoid a channel hop. TODO: This is ugly!
+			if workerFactor != 0.0 {
+				p2p.Proc = p
+			}
 
 			return nil
 		}}


### PR DESCRIPTION
This PR builds on PR #3240 by allowing the P2P receiver to bypass the dispatcher routine and dispatch observations (only observations so far) directly to a worker routine. This eliminates a channel hop.
