### PR TITLE
clients/js: fix low gas budget in Sui VAA submit.

### DIFF
--- a/clients/js/src/chains/sui/utils.ts
+++ b/clients/js/src/chains/sui/utils.ts
@@ -38,6 +38,7 @@ export const executeTransactionBlock = async (
   const consoleWarnTemp = console.warn;
   console.warn = () => {};
 
+  transactionBlock.setGasBudget(100_000_000);
   // Let caller handle parsing and logging info
   const res = await signer.signAndExecuteTransactionBlock({
     transactionBlock,


### PR DESCRIPTION
The default gas budget for Sui transaction blocks is `1_000_000` which is too low to submit VAAs.