### PR TITLE
SDK: remove semicolon in event definition

### DIFF
--- a/sdk/js/src/relayer/relayer/helpers.ts
+++ b/sdk/js/src/relayer/relayer/helpers.ts
@@ -49,7 +49,7 @@ export function parseWormholeLog(log: ethers.providers.Log): {
   parsed: DeliveryInstruction | string;
 } {
   const abi = [
-    "event LogMessagePublished(address indexed sender, uint64 sequence, uint32 nonce, bytes payload, uint8 consistencyLevel);",
+    "event LogMessagePublished(address indexed sender, uint64 sequence, uint32 nonce, bytes payload, uint8 consistencyLevel)",
   ];
   const iface = new ethers.utils.Interface(abi);
   const parsed = iface.parseLog(log);


### PR DESCRIPTION
Running the `worm status ...` command causes an error message to be written to the console:

```
unknown modifier: ;
...
```

This seems to be caused by the fragment parser in the ethers library 

Tested with:

```ts
import { ethers } from "ethers";

(async function () {
  const abi = [
    "event LogMessagePublished(address indexed sender, uint64 sequence, uint32 nonce, bytes payload, uint8 consistencyLevel)",
  ];
  const iface = new ethers.utils.Interface(abi);
  console.log(iface.fragments[0].name);
  
  const abix = [
    "event LogMessagePublished(address indexed sender, uint64 sequence, uint32 nonce, bytes payload, uint8 consistencyLevel);",
  ];
  const ifacex = new ethers.utils.Interface(abix);
  console.log(ifacex.fragments[0].name);
})();
```

logging: 
```
LogMessagePublished
unknown modifier: ;
LogMessagePublished
```
