### PR TITLE
SDK: fix chain id/name types

### DIFF
--- a/sdk/js/src/utils/consts.ts
+++ b/sdk/js/src/utils/consts.ts
@@ -41,7 +41,7 @@ export type ChainId = typeof CHAINS[ChainName];
  *
  * All the EVM-based chain names that Wormhole supports
  */
-export const EVMChainNames: ReadonlyArray<ChainName> = [
+export const EVMChainNames = [
   "ethereum",
   "bsc",
   "polygon",
@@ -67,13 +67,10 @@ export type EVMChainName = typeof EVMChainNames[number];
  *
  * All the Solana-based chain names that Wormhole supports
  */
-export const SolanaChainNames: ReadonlyArray<ChainName> = [
-  "solana",
-  "pythnet",
-] as const;
+export const SolanaChainNames = ["solana", "pythnet"] as const;
 export type SolanaChainName = typeof SolanaChainNames[number];
 
-export const CosmWasmChainNames: ReadonlyArray<ChainName> = [
+export const CosmWasmChainNames = [
   "terra",
   "terra2",
   "injective",
@@ -83,10 +80,7 @@ export const CosmWasmChainNames: ReadonlyArray<ChainName> = [
 export type CosmWasmChainName = typeof CosmWasmChainNames[number];
 
 // TODO: why? these are dupe of entries in CosmWasm
-export const TerraChainNames: ReadonlyArray<ChainName> = [
-  "terra",
-  "terra2",
-] as const;
+export const TerraChainNames = ["terra", "terra2"] as const;
 export type TerraChainName = typeof TerraChainNames[number];
 
 export type Contracts = {
@@ -815,28 +809,28 @@ export function isEVMChain(
   chain: ChainId | ChainName
 ): chain is EVMChainId | EVMChainName {
   const chainName = coalesceChainName(chain);
-  return EVMChainNames.includes(chainName);
+  return EVMChainNames.includes(chainName as unknown as EVMChainName);
 }
 
 export function isCosmWasmChain(
   chain: ChainId | ChainName
 ): chain is CosmWasmChainId | CosmWasmChainName {
   const chainName = coalesceChainName(chain);
-  return CosmWasmChainNames.includes(chainName);
+  return CosmWasmChainNames.includes(chainName as unknown as CosmWasmChainName);
 }
 
 export function isTerraChain(
   chain: ChainId | ChainName
 ): chain is TerraChainId | TerraChainName {
   const chainName = coalesceChainName(chain);
-  return TerraChainNames.includes(chainName);
+  return TerraChainNames.includes(chainName as unknown as TerraChainName);
 }
 
 export function isSolanaChain(
   chain: ChainId | ChainName
 ): chain is SolanaChainId | SolanaChainName {
   const chainName = coalesceChainName(chain);
-  return SolanaChainNames.includes(chainName);
+  return SolanaChainNames.includes(chainName as unknown as SolanaChainName);
 }
 
 /**


### PR DESCRIPTION
Digging into an [issue ](https://github.com/wormhole-foundation/wormhole/actions/runs/5647923071/job/15299026706?pr=3206)while trying to upgrade the cli tool to the latest SDK I found that the `ChainProvider` was producing the incorrect type given a chain like `solana`

I traced this back to the `utils.ts` file and blame provided the jerk that committed [this change](https://github.com/wormhole-foundation/wormhole/commit/7de46f68b424723522e15d994c3851231748ba97)

Before:
![image](https://github.com/wormhole-foundation/wormhole/assets/520236/da6fcd46-5c6f-4655-a3ae-44ebf85b7642)

After (+npm link the local version):
![image](https://github.com/wormhole-foundation/wormhole/assets/520236/845211fd-f66b-4d76-a777-29f046ad611e)


tbh I'm not crazy about this solution but it illustrates the issue. Happy to field other suggestions
