### PR TITLE
wormchain and others: upgrade to golang 1.20.7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -262,7 +262,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.19.9"
+          go-version: "1.20.7"
       - run: |
           cd wormchain
           make proto -B

--- a/bitcoin/Dockerfile
+++ b/bitcoin/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/golang:1.19.9@sha256:86901bd215ca2b33bdef68f70b999140252169bb55883bb29347334fa00b5b62 AS bitcoin-build
+FROM docker.io/golang:1.20.7-bullseye@sha256:74b09b3b6fa5aa542df8ef974cb745eb477be72f6fcf821517fb410aff532b00 AS bitcoin-build
 
 ARG ARCH=amd64
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -99,7 +99,7 @@ frequency). Light clients have much lower hardware requirements.
 For security reasons, we do not provide a pre-built binary. You need to check out the repo and build the
 guardiand binary from source. A Git repo is much harder to tamper with than release binaries.
 
-To build the Wormhole node, you need [Go](https://golang.org/dl/) >= 1.19.0
+To build the Wormhole node, you need [Go](https://golang.org/dl/) >= 1.20.0
 
 First, check out the version of the Wormhole repo that you want to deploy:
 

--- a/near/test/go.mod
+++ b/near/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/certusone/wormhole/near
 
-go 1.19
+go 1.20
 
 require (
 	github.com/tidwall/gjson v1.14.1 // indirect

--- a/wormchain/Dockerfile
+++ b/wormchain/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/golang:1.19.9@sha256:86901bd215ca2b33bdef68f70b999140252169bb55883bb29347334fa00b5b62
+FROM docker.io/golang:1.20.7-bullseye@sha256:74b09b3b6fa5aa542df8ef974cb745eb477be72f6fcf821517fb410aff532b00
 
 #used for a readiness probe
 RUN apt-get update

--- a/wormchain/go.mod
+++ b/wormchain/go.mod
@@ -1,6 +1,6 @@
 module github.com/wormhole-foundation/wormchain
 
-go 1.19
+go 1.20
 
 require (
 	github.com/CosmWasm/wasmd v0.30.0

--- a/wormchain/ibc-relayer/Dockerfile
+++ b/wormchain/ibc-relayer/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/golang:1.19.9@sha256:86901bd215ca2b33bdef68f70b999140252169bb55883bb29347334fa00b5b62
+FROM docker.io/golang:1.20.7-bullseye@sha256:74b09b3b6fa5aa542df8ef974cb745eb477be72f6fcf821517fb410aff532b00
 
 #used for a readiness probe
 RUN apt-get update


### PR DESCRIPTION
First attempt to upgrade wormchain golang version. 

There may be dependencies that need upgrading as well. 

Not sure what's needed for validation other than Tilt test passing. 
Not sure what's needed for upgrading Guardians in prod. 
