### PR TITLE
Node/Gov: Don't enqueue already signed VAAs

### DIFF
--- a/node/pkg/governor/governor_monitoring_test.go
+++ b/node/pkg/governor/governor_monitoring_test.go
@@ -1,6 +1,9 @@
 package governor
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"testing"
 
 	"github.com/certusone/wormhole/node/pkg/common"
@@ -11,7 +14,9 @@ import (
 
 func TestIsVAAEnqueuedNilMessageID(t *testing.T) {
 	logger, _ := zap.NewProduction()
-	gov := NewChainGovernor(logger, nil, common.GoTest)
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	gov := NewChainGovernor(logger, nil, key, common.GoTest)
 	enqueued, err := gov.IsVAAEnqueued(nil)
 	require.EqualError(t, err, "no message ID specified")
 	assert.Equal(t, false, enqueued)

--- a/node/pkg/governor/governor_monitoring_test.go
+++ b/node/pkg/governor/governor_monitoring_test.go
@@ -1,12 +1,12 @@
 package governor
 
 import (
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"testing"
 
 	"github.com/certusone/wormhole/node/pkg/common"
+	"github.com/certusone/wormhole/node/pkg/devnet"
+	ethCommon "github.com/ethereum/go-ethereum/common"
+	ethCrypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -14,9 +14,11 @@ import (
 
 func TestIsVAAEnqueuedNilMessageID(t *testing.T) {
 	logger, _ := zap.NewProduction()
-	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	require.NoError(t, err)
-	gov := NewChainGovernor(logger, nil, key, common.GoTest)
+	gk := devnet.InsecureDeterministicEcdsaKeyByIndex(ethCrypto.S256(), uint64(0))
+	gst := common.NewGuardianSetState(nil)
+	gs := &common.GuardianSet{Keys: []ethCommon.Address{ethCommon.HexToAddress("0xbeFA429d57cD18b7F8A4d91A2da9AB4AF05d0FBe")}}
+	gst.Set(gs)
+	gov := NewChainGovernor(logger, nil, ethCrypto.PubkeyToAddress(gk.PublicKey), gst, common.GoTest)
 	enqueued, err := gov.IsVAAEnqueued(nil)
 	require.EqualError(t, err, "no message ID specified")
 	assert.Equal(t, false, enqueued)

--- a/node/pkg/governor/governor_prices.go
+++ b/node/pkg/governor/governor_prices.go
@@ -8,6 +8,9 @@ package governor
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -280,7 +283,13 @@ func CheckQuery(logger *zap.Logger) error {
 	logger.Info("Instantiating governor.")
 	ctx := context.Background()
 	var db db.MockGovernorDB
-	gov := NewChainGovernor(logger, &db, common.MainNet)
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		panic("failed to generate key")
+	}
+
+	gov := NewChainGovernor(logger, &db, key, common.MainNet)
 
 	if err := gov.initConfig(); err != nil {
 		return err

--- a/node/pkg/governor/governor_prices.go
+++ b/node/pkg/governor/governor_prices.go
@@ -25,6 +25,9 @@ import (
 	"github.com/certusone/wormhole/node/pkg/common"
 	"github.com/certusone/wormhole/node/pkg/db"
 	"github.com/certusone/wormhole/node/pkg/supervisor"
+
+	ethCommon "github.com/ethereum/go-ethereum/common"
+	ethCrypto "github.com/ethereum/go-ethereum/crypto"
 )
 
 // The CoinGecko API is documented here: https://www.coingecko.com/en/api/documentation
@@ -284,12 +287,16 @@ func CheckQuery(logger *zap.Logger) error {
 	ctx := context.Background()
 	var db db.MockGovernorDB
 
-	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	gk, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		panic("failed to generate key")
 	}
 
-	gov := NewChainGovernor(logger, &db, key, common.MainNet)
+	gst := common.NewGuardianSetState(nil)
+	gs := &common.GuardianSet{Keys: []ethCommon.Address{ethCommon.HexToAddress("0xbeFA429d57cD18b7F8A4d91A2da9AB4AF05d0FBe")}}
+	gst.Set(gs)
+
+	gov := NewChainGovernor(logger, &db, ethCrypto.PubkeyToAddress(gk.PublicKey), gst, common.MainNet)
 
 	if err := gov.initConfig(); err != nil {
 		return err

--- a/node/pkg/node/options.go
+++ b/node/pkg/node/options.go
@@ -23,6 +23,7 @@ import (
 	"github.com/certusone/wormhole/node/pkg/watchers/ibc"
 	"github.com/certusone/wormhole/node/pkg/watchers/interfaces"
 	"github.com/certusone/wormhole/node/pkg/wormconn"
+	eth_crypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/gorilla/mux"
 	libp2p_crypto "github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -146,7 +147,7 @@ func GuardianOptionGovernor(governorEnabled bool) *GuardianOption {
 		f: func(ctx context.Context, logger *zap.Logger, g *G) error {
 			if governorEnabled {
 				logger.Info("chain governor is enabled")
-				g.gov = governor.NewChainGovernor(logger, g.db, g.gk, g.env)
+				g.gov = governor.NewChainGovernor(logger, g.db, eth_crypto.PubkeyToAddress(g.gk.PublicKey), g.gst, g.env)
 			} else {
 				logger.Info("chain governor is disabled")
 			}

--- a/node/pkg/node/options.go
+++ b/node/pkg/node/options.go
@@ -146,7 +146,7 @@ func GuardianOptionGovernor(governorEnabled bool) *GuardianOption {
 		f: func(ctx context.Context, logger *zap.Logger, g *G) error {
 			if governorEnabled {
 				logger.Info("chain governor is enabled")
-				g.gov = governor.NewChainGovernor(logger, g.db, g.env)
+				g.gov = governor.NewChainGovernor(logger, g.db, g.gk, g.env)
 			} else {
 				logger.Info("chain governor is disabled")
 			}

--- a/node/pkg/publicrpc/publicrpcserver_test.go
+++ b/node/pkg/publicrpc/publicrpcserver_test.go
@@ -2,12 +2,16 @@ package publicrpc
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"testing"
 
 	"github.com/certusone/wormhole/node/pkg/common"
 	"github.com/certusone/wormhole/node/pkg/governor"
 	publicrpcv1 "github.com/certusone/wormhole/node/pkg/proto/publicrpc/v1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -69,7 +73,9 @@ func TestGetSignedVAABadAddress(t *testing.T) {
 func TestGovernorIsVAAEnqueuedNoMessage(t *testing.T) {
 	ctx := context.Background()
 	logger, _ := zap.NewProduction()
-	gov := governor.NewChainGovernor(logger, nil, common.GoTest)
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	gov := governor.NewChainGovernor(logger, nil, key, common.GoTest)
 	server := &PublicrpcServer{logger: logger, gov: gov}
 
 	// A message without the messageId set should not panic but return an error instead.


### PR DESCRIPTION
There is currently a problem where old Oasis transactions are being reobserved and they are flooding the governor. This is not really necessary because the transactions have most likely previously reached quorum. 

This PR changes the governor to check to see if a transfer has been previously been approved, and if so, allows it to be published immediately, without impacting the notional value of the governor.

The following checks are done to determine if the transfer can be approved immediately:

- The VAA is already in the signed VAA database.
- The current digest matches what is in the database.
- The VAA in the database was signed by this guardian.

If the above conditions are met, the VAA can be approved immediately. Additionally, this check is made when pending transfers are reloaded on start up, which should immediately clean up the backlog when a guardian upgrades.