### PR TITLE
codeowners: add jeff to governor owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -59,7 +59,7 @@
 
 ## Governor
 
-/node/pkg/governor/ @bruce-riley @claudijd @tbjump
+/node/pkg/governor/ @bruce-riley @claudijd @tbjump @SEJeff
 
 ## Gateway Relayer
 


### PR DESCRIPTION
Proposing that we add @SEJeff to the governor CODEOWNER list.  This should add one person of redundancy when a code owner on governor is the proposer and cannot review their own code.