### PR TITLE
Node/gacct: Don't reobserve if enqueued in gov

### DIFF
--- a/node/pkg/accountant/accountant.go
+++ b/node/pkg/accountant/accountant.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/certusone/wormhole/node/pkg/common"
 	"github.com/certusone/wormhole/node/pkg/db"
+	"github.com/certusone/wormhole/node/pkg/governor"
 	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
 	"github.com/certusone/wormhole/node/pkg/supervisor"
 	sdktypes "github.com/cosmos/cosmos-sdk/types"
@@ -91,6 +92,7 @@ type Accountant struct {
 	pendingTransfers     map[string]*pendingEntry // Key is the message ID (emitterChain/emitterAddr/seqNo)
 	subChan              chan *common.MessagePublication
 	env                  common.Environment
+	gov                  *governor.ChainGovernor
 }
 
 // On startup, there can be a large number of re-submission requests.
@@ -132,8 +134,9 @@ func NewAccountant(
 }
 
 // Run initializes the accountant and starts the watcher runnable.
-func (acct *Accountant) Start(ctx context.Context) error {
+func (acct *Accountant) Start(ctx context.Context, gov *governor.ChainGovernor) error {
 	acct.logger.Debug("entering Start", zap.Bool("enforceFlag", acct.enforceFlag))
+	acct.gov = gov
 	acct.pendingTransfersLock.Lock()
 	defer acct.pendingTransfersLock.Unlock()
 

--- a/node/pkg/accountant/accountant_test.go
+++ b/node/pkg/accountant/accountant_test.go
@@ -127,7 +127,7 @@ func newAccountantForTest(
 		env,
 	)
 
-	err := acct.Start(ctx)
+	err := acct.Start(ctx, nil /*gov*/)
 	require.NoError(t, err)
 	return acct
 }

--- a/node/pkg/governor/governor_monitoring.go
+++ b/node/pkg/governor/governor_monitoring.go
@@ -75,6 +75,7 @@
 package governor
 
 import (
+	"bytes"
 	"crypto/ecdsa"
 	"fmt"
 	"sort"
@@ -600,4 +601,22 @@ func (gov *ChainGovernor) publishStatus(hb *gossipv1.Heartbeat, sendC chan<- []b
 	}
 
 	sendC <- b
+}
+
+func (gov *ChainGovernor) IsTransactionEnqueued(emitterChainId vaa.ChainID, txHash ethCommon.Hash) bool {
+	gov.mutex.Lock()
+	defer gov.mutex.Unlock()
+
+	ce, exists := gov.chains[emitterChainId]
+	if !exists {
+		return false
+	}
+
+	for _, pe := range ce.pending {
+		if bytes.Equal(pe.dbData.Msg.TxHash.Bytes(), txHash.Bytes()) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/node/pkg/governor/governor_monitoring_test.go
+++ b/node/pkg/governor/governor_monitoring_test.go
@@ -1,18 +1,51 @@
 package governor
 
 import (
+	"context"
 	"testing"
 
 	"github.com/certusone/wormhole/node/pkg/common"
+	"github.com/certusone/wormhole/node/pkg/db"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
+	"github.com/wormhole-foundation/wormhole/sdk/vaa"
 )
 
 func TestIsVAAEnqueuedNilMessageID(t *testing.T) {
-	logger, _ := zap.NewProduction()
-	gov := NewChainGovernor(logger, nil, common.GoTest)
+	ctx := context.Background()
+	gov, err := newChainGovernorForTest(ctx)
+	require.NoError(t, err)
+	assert.NotNil(t, gov)
+
 	enqueued, err := gov.IsVAAEnqueued(nil)
 	require.EqualError(t, err, "no message ID specified")
 	assert.Equal(t, false, enqueued)
+}
+
+func TestIsTransactionEnqueued(t *testing.T) {
+	ctx := context.Background()
+	gov, err := newChainGovernorForTest(ctx)
+	require.NoError(t, err)
+	assert.NotNil(t, gov)
+	ce := gov.chains[vaa.ChainIDEthereum]
+	require.NotNil(t, ce)
+
+	txHash1 := hashFromString("06f541f5ecfc43407c31587aa6ac3a689e8960f36dc23c332db5510dfc6a4063")
+	txHash2 := hashFromString("06f541f5ecfc43407c31587aa6ac3a689e8960f36dc23c332db5510dfc6a4064")
+
+	// When the pending map is empty, it should return false.
+	assert.False(t, gov.IsTransactionEnqueued(vaa.ChainIDEthereum, txHash1))
+
+	// When we enqueue the transfer, it should return true.
+	ce.pending = append(ce.pending, &pendingEntry{dbData: db.PendingTransfer{Msg: common.MessagePublication{TxHash: txHash1}}})
+	assert.True(t, gov.IsTransactionEnqueued(vaa.ChainIDEthereum, txHash1))
+
+	// Some other transfer should still return false.
+	assert.False(t, gov.IsTransactionEnqueued(vaa.ChainIDEthereum, txHash2))
+
+	// Looking for the same txHash on a different chain should return false.
+	assert.False(t, gov.IsTransactionEnqueued(vaa.ChainIDPolygon, txHash1))
+
+	// Looking for a non-existent chain should return false.
+	assert.False(t, gov.IsTransactionEnqueued(vaa.ChainIDUnset, txHash1))
 }

--- a/node/pkg/node/node.go
+++ b/node/pkg/node/node.go
@@ -164,7 +164,7 @@ func (g *G) Run(rootCtxCancel context.CancelFunc, options ...*GuardianOption) su
 		// Ideally they should just register a g.runnables["governor"] and g.runnables["accountant"] instead of being treated as special cases.
 		if g.acct != nil {
 			logger.Info("Starting accountant")
-			if err := g.acct.Start(ctx); err != nil {
+			if err := g.acct.Start(ctx, g.gov); err != nil {
 				logger.Fatal("acct: failed to start accountant", zap.Error(err))
 			}
 			defer g.acct.Close()


### PR DESCRIPTION
When a transfer is enqueued in some of the guardians, but not all of them, the accountant contract reports it as missing. When this happens, the accountant code in the guardian requests a reobservation. This works well if a transaction was just missed by this guardian.

However, if the guardian has the transfer enqueued in the governor, this just generates needless reobservations. Additionally, if there are enough transfers enqueued in the governor, it can cause the reobservation channel to overflow with unnecessary requests.

This PR changes the global accountant to check to see if the transfer is enqueued in the governor before submitting it to the reobservation channel.