### PR TITLE
Node/Gateway: Relayer not detecting error

### DIFF
--- a/node/pkg/gwrelayer/gwrelayer.go
+++ b/node/pkg/gwrelayer/gwrelayer.go
@@ -264,7 +264,7 @@ func SubmitVAAToContract(
 		return txResp, fmt.Errorf("out of gas: %s", txResp.TxResponse.RawLog)
 	}
 
-	if strings.Contains(txResp.TxResponse.RawLog, "failed to execute message") {
+	if strings.Contains(txResp.TxResponse.RawLog, "failed") {
 		return txResp, fmt.Errorf("submit failed: %s", txResp.TxResponse.RawLog)
 	}
 


### PR DESCRIPTION
The gateway relayer is not detecting this error on a submit VAA:

"signature verification failed; please verify account number (35) and chain-id (wormchain-testnet-0): unauthorized"