### PR TITLE
Node/Gateway: Wormconn chainID wrong for testnet

### DIFF
--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -998,6 +998,11 @@ func runNode(cmd *cobra.Command, args []string) {
 	// Redirect ipfs logs to plain zap
 	ipfslog.SetPrimaryCore(logger.Core())
 
+	wormchainId := "wormchain"
+	if *testnetMode {
+		wormchainId = "wormchain-testnet-0"
+	}
+
 	var accountantWormchainConn *wormconn.ClientConn
 	if *accountantContract != "" {
 		// TODO: wormchainKeyPath and wormchainKeyPassPhrase are being replaced by accountantKeyPath and accountantKeyPassPhrase.
@@ -1040,7 +1045,7 @@ func runNode(cmd *cobra.Command, args []string) {
 
 		// Connect to wormchain.
 		logger.Info("Connecting to wormchain", zap.String("wormchainURL", *wormchainURL), zap.String("keyPath", keyPathName), zap.String("component", "gacct"))
-		accountantWormchainConn, err = wormconn.NewConn(rootCtx, *wormchainURL, wormchainKey)
+		accountantWormchainConn, err = wormconn.NewConn(rootCtx, *wormchainURL, wormchainKey, wormchainId)
 		if err != nil {
 			logger.Fatal("failed to connect to wormchain", zap.Error(err), zap.String("component", "gacct"))
 		}
@@ -1074,7 +1079,7 @@ func runNode(cmd *cobra.Command, args []string) {
 		}
 
 		logger.Info("Connecting to wormchain", zap.String("wormchainURL", *wormchainURL), zap.String("keyPath", wormchainKeyPathName), zap.String("component", "gwrelayer"))
-		gatewayRelayerWormchainConn, err = wormconn.NewConn(rootCtx, *wormchainURL, wormchainKey)
+		gatewayRelayerWormchainConn, err = wormconn.NewConn(rootCtx, *wormchainURL, wormchainKey, wormchainId)
 		if err != nil {
 			logger.Fatal("failed to connect to wormchain", zap.Error(err), zap.String("component", "gwrelayer"))
 		}

--- a/node/hack/accountant/send_obs.go
+++ b/node/hack/accountant/send_obs.go
@@ -42,7 +42,7 @@ func main() {
 		logger.Fatal("failed to load devnet wormchain private key", zap.Error(err))
 	}
 
-	wormchainConn, err := wormconn.NewConn(ctx, wormchainURL, wormchainKey)
+	wormchainConn, err := wormconn.NewConn(ctx, wormchainURL, wormchainKey, "wormchain")
 	if err != nil {
 		logger.Fatal("failed to connect to wormchain", zap.Error(err))
 	}

--- a/node/pkg/wormconn/clientconn.go
+++ b/node/pkg/wormconn/clientconn.go
@@ -29,11 +29,12 @@ type ClientConn struct {
 	encCfg        EncodingConfig
 	privateKey    cryptotypes.PrivKey
 	senderAddress string
+	chainId       string
 	mutex         sync.Mutex // Protects the account / sequence number
 }
 
 // NewConn creates a new connection to the wormhole-chain instance at `target`.
-func NewConn(ctx context.Context, target string, privateKey cryptotypes.PrivKey) (*ClientConn, error) {
+func NewConn(ctx context.Context, target string, privateKey cryptotypes.PrivKey, chainId string) (*ClientConn, error) {
 	c, err := grpc.DialContext(
 		ctx,
 		target,
@@ -50,7 +51,7 @@ func NewConn(ctx context.Context, target string, privateKey cryptotypes.PrivKey)
 		return nil, err
 	}
 
-	return &ClientConn{c: c, encCfg: encCfg, privateKey: privateKey, senderAddress: senderAddress}, nil
+	return &ClientConn{c: c, encCfg: encCfg, privateKey: privateKey, senderAddress: senderAddress, chainId: chainId}, nil
 }
 
 func (c *ClientConn) SenderAddress() string {

--- a/node/pkg/wormconn/send_tx.go
+++ b/node/pkg/wormconn/send_tx.go
@@ -53,7 +53,7 @@ func (c *ClientConn) SignAndBroadcastTx(ctx context.Context, msg sdktypes.Msg) (
 	}
 
 	signerData := authsigning.SignerData{
-		ChainID:       "wormchain",
+		ChainID:       c.chainId,
 		AccountNumber: account.GetAccountNumber(),
 		Sequence:      sequence,
 	}


### PR DESCRIPTION
The ChainID parameter on wormchain transactions is hardcoded to be "wormchain". However, in testnet it should be "wormchain-testnet-0".