### PR TITLE
[sdk/js] Add cosmoshub and evmos chain ids

### DIFF
--- a/sdk/js/src/cosmwasm/address.ts
+++ b/sdk/js/src/cosmwasm/address.ts
@@ -3,6 +3,9 @@ import { LCDClient as XplaLCDClient } from "@xpla/xpla.js";
 import { keccak256 } from "ethers/lib/utils";
 import { isNativeDenom } from "../terra";
 import {
+  CHAIN_ID_COSMOSHUB,
+  CHAIN_ID_EVMOS,
+  CHAIN_ID_WORMCHAIN,
   CHAIN_ID_INJECTIVE,
   CHAIN_ID_SEI,
   CHAIN_ID_TERRA,
@@ -16,6 +19,9 @@ import {
 export const isNativeDenomInjective = (denom: string) => denom === "inj";
 export const isNativeDenomXpla = (denom: string) => denom === "axpla";
 export const isNativeDenomSei = (denom: string) => denom === "usei";
+export const isNativeDenomWormchain = (denom: string) => denom === "uworm";
+export const isNativeDenomCosmosHub = (denom: string) => denom === "uatom";
+export const isNativeDenomEvmos = (denom: string) => denom === "aevmos";
 
 export function isNativeCosmWasmDenom(
   chainId: CosmWasmChainId,
@@ -25,7 +31,10 @@ export function isNativeCosmWasmDenom(
     (isTerraChain(chainId) && isNativeDenom(address)) ||
     (chainId === CHAIN_ID_INJECTIVE && isNativeDenomInjective(address)) ||
     (chainId === CHAIN_ID_XPLA && isNativeDenomXpla(address)) ||
-    (chainId === CHAIN_ID_SEI && isNativeDenomSei(address))
+    (chainId === CHAIN_ID_SEI && isNativeDenomSei(address)) ||
+    (chainId === CHAIN_ID_WORMCHAIN && isNativeDenomWormchain(address)) ||
+    (chainId === CHAIN_ID_COSMOSHUB && isNativeDenomCosmosHub(address)) ||
+    (chainId === CHAIN_ID_EVMOS && isNativeDenomEvmos(address))
   );
 }
 

--- a/sdk/js/src/utils/array.ts
+++ b/sdk/js/src/utils/array.ts
@@ -32,6 +32,8 @@ import {
   CHAIN_ID_XPLA,
   CHAIN_ID_SEI,
   CHAIN_ID_BTC,
+  CHAIN_ID_COSMOSHUB,
+  CHAIN_ID_EVMOS,
 } from "./consts";
 import { hashLookup } from "./near";
 import { getExternalAddressFromType, isValidAptosType } from "./aptos";
@@ -120,6 +122,10 @@ export const tryUint8ArrayToNative = (
     throw Error("uint8ArrayToNative: Use tryHexToNativeStringNear instead.");
   } else if (chainId === CHAIN_ID_OSMOSIS) {
     throw Error("uint8ArrayToNative: Osmosis not supported yet.");
+  } else if (chainId === CHAIN_ID_COSMOSHUB) {
+    throw Error("uint8ArrayToNative: CosmosHub not supported yet.");
+  } else if (chainId === CHAIN_ID_EVMOS) {
+    throw Error("uint8ArrayToNative: Evmos not supported yet.");
   } else if (chainId === CHAIN_ID_SUI) {
     throw Error("uint8ArrayToNative: Sui not supported yet.");
   } else if (chainId === CHAIN_ID_APTOS) {
@@ -257,6 +263,10 @@ export const tryNativeToHexString = (
     return uint8ArrayToHex(arrayify(sha256(Buffer.from(address))));
   } else if (chainId === CHAIN_ID_OSMOSIS) {
     throw Error("hexToNativeString: Osmosis not supported yet.");
+  } else if (chainId === CHAIN_ID_COSMOSHUB) {
+    throw Error("uint8ArrayToNative: CosmosHub not supported yet.");
+  } else if (chainId === CHAIN_ID_EVMOS) {
+    throw Error("uint8ArrayToNative: Evmos not supported yet.");
   } else if (chainId === CHAIN_ID_SUI) {
     if (!isValidSuiType(address) && isValidSuiAddress(address)) {
       return uint8ArrayToHex(

--- a/sdk/js/src/utils/consts.ts
+++ b/sdk/js/src/utils/consts.ts
@@ -32,6 +32,8 @@ export const CHAINS = {
   sei: 32,
   rootstock: 33,
   wormchain: 3104,
+  cosmoshub: 4000,
+  evmos: 4001,
   sepolia: 10002,
 } as const;
 
@@ -78,6 +80,10 @@ export const CosmWasmChainNames = [
   "injective",
   "xpla",
   "sei",
+  "wormchain",
+  "osmosis",
+  "evmos",
+  "cosmoshub",
 ] as const;
 export type CosmWasmChainName = typeof CosmWasmChainNames[number];
 
@@ -276,6 +282,16 @@ const MAINNET = {
     token_bridge: undefined,
     nft_bridge: undefined,
   },
+  cosmoshub: {
+    core: undefined,
+    token_bridge: undefined,
+    nft_bridge: undefined,
+  },
+  evmos: {
+    core: undefined,
+    token_bridge: undefined,
+    nft_bridge: undefined,
+  },
 };
 
 const TESTNET = {
@@ -455,6 +471,16 @@ const TESTNET = {
     token_bridge: "0xDB5492265f6038831E89f495670FF909aDe94bd9",
     nft_bridge: "0x6a0B52ac198e4870e5F3797d5B403838a5bbFD99",
   },
+  cosmoshub: {
+    core: undefined,
+    token_bridge: undefined,
+    nft_bridge: undefined,
+  },
+  evmos: {
+    core: undefined,
+    token_bridge: undefined,
+    nft_bridge: undefined,
+  },
 };
 
 const DEVNET = {
@@ -633,6 +659,16 @@ const DEVNET = {
     token_bridge: undefined,
     nft_bridge: undefined,
   },
+  cosmoshub: {
+    core: undefined,
+    token_bridge: undefined,
+    nft_bridge: undefined,
+  },
+  evmos: {
+    core: undefined,
+    token_bridge: undefined,
+    nft_bridge: undefined,
+  },
 };
 
 /**
@@ -706,6 +742,9 @@ export const CHAIN_ID_BASE = CHAINS["base"];
 export const CHAIN_ID_SEI = CHAINS["sei"];
 export const CHAIN_ID_ROOTSTOCK = CHAINS["rootstock"];
 export const CHAIN_ID_WORMCHAIN = CHAINS["wormchain"];
+export const CHAIN_ID_GATEWAY = CHAIN_ID_WORMCHAIN;
+export const CHAIN_ID_COSMOSHUB = CHAINS["cosmoshub"];
+export const CHAIN_ID_EVMOS = CHAINS["evmos"];
 export const CHAIN_ID_SEPOLIA = CHAINS["sepolia"];
 
 // This inverts the [[CHAINS]] object so that we can look up a chain by id


### PR DESCRIPTION
Use the new cosmos chain id range (`4000` onwards). Leave previous existing cosmos chains with their current id (e.g. `osmosis` with id `20`)