### PR TITLE
cosmwasm: run cargo fmt using new stable 1.72.0

### DIFF
--- a/cosmwasm/contracts/global-accountant/tests/chain_registration.rs
+++ b/cosmwasm/contracts/global-accountant/tests/chain_registration.rs
@@ -42,7 +42,13 @@ fn any_target() {
         .submit_vaas(vec![data])
         .expect("failed to submit chain registration");
 
-    let Action::RegisterChain { chain, emitter_address } = v.payload.action else { panic!() };
+    let Action::RegisterChain {
+        chain,
+        emitter_address,
+    } = v.payload.action
+    else {
+        panic!()
+    };
 
     resp.assert_event(
         &Event::new("wasm-RegisterChain")
@@ -67,7 +73,13 @@ fn wormchain_target() {
         .submit_vaas(vec![data])
         .expect("failed to submit chain registration");
 
-    let Action::RegisterChain { chain, emitter_address } = v.payload.action else { panic!() };
+    let Action::RegisterChain {
+        chain,
+        emitter_address,
+    } = v.payload.action
+    else {
+        panic!()
+    };
 
     resp.assert_event(
         &Event::new("wasm-RegisterChain")


### PR DESCRIPTION
Context: the CI rust toolchain uses the `stable` channel https://github.com/wormhole-foundation/wormhole/blob/753185e042132ad925257384a9ea714cdef6bff1/.github/workflows/build.yml#L348

https://github.com/rust-lang/rust/releases/tag/1.72.0 was released yesterday, which turns out includes a small change in the `rustfmt` formatting algorithm. I ran the new formatting tool

```shell
$ rustup default stable
$ rustup update
$ cargo fmt --all
```