### PR TITLE
Node: Add StartRunnable to scissors

### DIFF
--- a/node/pkg/common/scissors.go
+++ b/node/pkg/common/scissors.go
@@ -24,37 +24,7 @@ var (
 
 // Start a go routine with recovering from any panic by sending an error to a error channel
 func RunWithScissors(ctx context.Context, errC chan error, name string, runnable supervisor.Runnable) {
-	ScissorsErrorsCaught.WithLabelValues(name).Add(0)
-	ScissorsPanicsCaught.WithLabelValues(name).Add(0)
-	go func() {
-		defer func() {
-			if r := recover(); r != nil {
-				var err error
-				switch x := r.(type) {
-				case error:
-					err = fmt.Errorf("%s: %w", name, x)
-				default:
-					err = fmt.Errorf("%s: %v", name, x)
-				}
-				// We don't want this to hang if the listener has already gone away.
-				select {
-				case errC <- err:
-				default:
-				}
-				ScissorsPanicsCaught.WithLabelValues(name).Inc()
-
-			}
-		}()
-		err := runnable(ctx)
-		if err != nil {
-			// We don't want this to hang if the listener has already gone away.
-			select {
-			case errC <- err:
-			default:
-			}
-			ScissorsErrorsCaught.WithLabelValues(name).Inc()
-		}
-	}()
+	StartRunnable(ctx, errC, true, name, runnable)
 }
 
 func WrapWithScissors(runnable supervisor.Runnable, name string) supervisor.Runnable {
@@ -74,5 +44,50 @@ func WrapWithScissors(runnable supervisor.Runnable, name string) supervisor.Runn
 		}()
 
 		return runnable(ctx)
+	}
+}
+
+// StartRunnable starts a go routine with the ability to recover from errors by publishing them to an error channel. If catchPanics is true,
+// it will also catch panics and publish the panic message to the error channel. If catchPanics is false, the panic will be propagated upward.
+func StartRunnable(ctx context.Context, errC chan error, catchPanics bool, name string, runnable supervisor.Runnable) {
+	ScissorsErrorsCaught.WithLabelValues(name).Add(0)
+	if catchPanics {
+		ScissorsPanicsCaught.WithLabelValues(name).Add(0)
+	}
+	go func() {
+		if catchPanics {
+			defer func() {
+				if r := recover(); r != nil {
+					var err error
+					switch x := r.(type) {
+					case error:
+						err = fmt.Errorf("%s: %w", name, x)
+					default:
+						err = fmt.Errorf("%s: %v", name, x)
+					}
+					// We don't want this to hang if the listener has already gone away.
+					select {
+					case errC <- err:
+					default:
+					}
+					ScissorsPanicsCaught.WithLabelValues(name).Inc()
+
+				}
+			}()
+		}
+		startRunnable(ctx, errC, name, runnable)
+	}()
+}
+
+// startRunnable is used by StartRunnable. It is a separate function so we can call it directly from tests.
+func startRunnable(ctx context.Context, errC chan error, name string, runnable supervisor.Runnable) {
+	err := runnable(ctx)
+	if err != nil {
+		// We don't want this to hang if the listener has already gone away.
+		select {
+		case errC <- err:
+		default:
+		}
+		ScissorsErrorsCaught.WithLabelValues(name).Inc()
 	}
 }


### PR DESCRIPTION
This PR adds a `StartRunnable` method to the `RunWithScissors` interface. This method allows you to control if panics should be caught or not, and is intended to eventually replace the `RunWithScissors` calls (which will be done with other PRs).