### PR TITLE
sdk/js: version bump to resolve conflict

### DIFF
--- a/sdk/js/CHANGELOG.md
+++ b/sdk/js/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.10.0
+## 0.10.2
 
 ### Added
 
@@ -14,7 +14,7 @@ transferFromAptos payload type changed from string to Uint8Array
 
 ### Changes
 
-Transfer from Sui with payload uses oldest EmitterCap *or* creates a new one if none exist
+Transfer from Sui with payload uses oldest EmitterCap _or_ creates a new one if none exist
 
 ## 0.9.23
 

--- a/sdk/js/package.json
+++ b/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@certusone/wormhole-sdk",
-  "version": "0.10.0",
+  "version": "0.10.2",
   "description": "SDK for interacting with Wormhole",
   "homepage": "https://wormhole.com",
   "main": "./lib/cjs/index.js",


### PR DESCRIPTION
`0.10.0` and `0.10.1` were published with a `test` tag.