### PR TITLE
aptos: tooling for mainnet upgrades

### DIFF
--- a/aptos/scripts/deploy
+++ b/aptos/scripts/deploy
@@ -11,21 +11,17 @@ EOF
 exit 1
 }
 
+# cd to script directory so that we can run this script from anywhere
+cd "$(dirname "$0")"
 NETWORK=$1 || usage
 
 if [ "$NETWORK" = mainnet ]; then
-    DEPLOYER_ADDR=0x0108bc32f7de18a5f6e1e7d6ee7aff9f5fc858d0d87ac0da94dd8d2a5d267d6b
-
     GUARDIAN_ADDR=0x58CC3AE5C097b213cE3c81979e1B9f9570746AA5
 
 elif [ "$NETWORK" = testnet ]; then
-    DEPLOYER_ADDR=0x0108bc32f7de18a5f6e1e7d6ee7aff9f5fc858d0d87ac0da94dd8d2a5d267d6b
-
     GUARDIAN_ADDR=0x13947Bd48b18E53fdAeEe77F3473391aC727C638
 
 elif [ "$NETWORK" = devnet ]; then
-    DEPLOYER_ADDR=0x277fa055b6a73c42c0662d5236c65c864ccbf2d4abd21f174a30c8b786eab84b
-
     DOTENV=$(dirname $0)/../.env
     [[ -f "$DOTENV" ]] && . "$DOTENV"
 
@@ -36,28 +32,28 @@ else
     usage
 fi
 
-WORMHOLE_ADDR=$(worm info contract "$NETWORK" aptos Core)
-TOKEN_BRIDGE_ADDR=$(worm info contract "$NETWORK" aptos TokenBridge)
-NFT_BRIDGE_ADDR=$(worm info contract "$NETWORK" aptos NFTBridge)
+NAMED_ADDRS="wormhole=$WORMHOLE_ADDR,deployer=$DEPLOYER_ADDR,token_bridge=$TOKEN_BRIDGE_ADDR"
+NAMED_ADDRS="$(./named_addresses $NETWORK)"
 
-NAMED_ADDRS="wormhole=$WORMHOLE_ADDR,deployer=$DEPLOYER_ADDR,token_bridge=$TOKEN_BRIDGE_ADDR,nft_bridge=$NFT_BRIDGE_ADDR"
+echo "Addresses: $NAMED_ADDRS"
 
+# NOTE: this always succeeds, even if the deployer contact is already deployed
 echo "[1/6] Deploying deployer contract for creating resource accounts..."
 worm aptos deploy --network "$NETWORK" ../deployer --named-addresses "$NAMED_ADDRS"
 
-echo "[2/6] Deploying wormhole contract at $WORMHOLE_ADDR..."
+echo "[2/6] Deploying wormhole contract..."
 worm aptos deploy-resource wormhole --network "$NETWORK" ../wormhole --named-addresses "$NAMED_ADDRS"
 
 echo "[3/6] Initialising wormhole with guardian(s) $GUARDIAN_ADDR..."
 worm aptos init-wormhole --network "$NETWORK" -g $GUARDIAN_ADDR
 
-echo "[4/6] Deploying token bridge contract at $TOKEN_BRIDGE_ADDR..."
+echo "[4/6] Deploying token bridge contract..."
 worm aptos deploy-resource token_bridge --network "$NETWORK" ../token_bridge --named-addresses "$NAMED_ADDRS"
 
 echo "[5/6] Initialising token bridge..."
 worm aptos init-token-bridge --network "$NETWORK"
 
-echo "[6/6] Deploying (& initialising) NFT bridge contract at $NFT_BRIDGE_ADDR..."
+echo "[6/6] Deploying (& initialising) NFT bridge contract..."
 worm aptos deploy-resource nft_bridge --network "$NETWORK" ../nft_bridge --named-addresses "$NAMED_ADDRS"
 
 if [ "$NETWORK" = devnet ]; then

--- a/aptos/scripts/named_addresses
+++ b/aptos/scripts/named_addresses
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -eo pipefail
+
+usage() {
+  cat <<-EOF >&2
+	Usage: ${0##*/} <network>
+
+	Print the named addresses for the given network.
+EOF
+  exit 1
+}
+
+if [ $# -lt 1 ]; then
+  usage
+fi
+
+NETWORK="$1"
+
+case "$NETWORK" in
+  testnet)
+    DEPLOYER=0x0108bc32f7de18a5f6e1e7d6ee7aff9f5fc858d0d87ac0da94dd8d2a5d267d6b
+    ;;
+  devnet)
+    DEPLOYER=0x277fa055b6a73c42c0662d5236c65c864ccbf2d4abd21f174a30c8b786eab84b
+    ;;
+  mainnet)
+    DEPLOYER=0x0108bc32f7de18a5f6e1e7d6ee7aff9f5fc858d0d87ac0da94dd8d2a5d267d6b
+    ;;
+  *)
+    echo "Unknown network $NETWORK" >&2
+    usage
+    ;;
+esac
+
+WORMHOLE=$(worm info contract "$NETWORK" aptos Core)
+TOKEN_BRIDGE=$(worm info contract "$NETWORK" aptos TokenBridge)
+NFT_BRIDGE=$(worm info contract "$NETWORK" aptos NFTBridge)
+
+NAMED_ADDRS="wormhole=$WORMHOLE,deployer=$DEPLOYER,token_bridge=$TOKEN_BRIDGE,nft_bridge=$NFT_BRIDGE"
+
+echo "$NAMED_ADDRS"

--- a/aptos/scripts/upgrade
+++ b/aptos/scripts/upgrade
@@ -1,38 +1,96 @@
 #!/bin/bash
 
+# This is a script for upgrading contracts on the Aptos network.
+# It supports all of devnet (localhost), testnet, and mainnet.
+#
+# A VAA may be provided, in which case the script uses that.
+# Otherwise, in devnet, it generates a VAA using the devnet guardian secret.
+# In testnet, it generates a VAA using the testnet guardian secret as long as
+# it's set in the environment variable GUARDIAN_SECRET.
+# In mainnet, a VAA is required.
+
 set -eo pipefail
 
-function usage() {
-cat <<EOF >&2
-Usage:
+usage() {
+  cat <<-EOF >&2
+	Usage: ${0##*/} <network> <module> [OPTIONS]
 
-  $(basename "$0") <devnet|testnet> <Core|TokenBridge> -- Perform a contract upgrade
+	Perform a contract upgrade.
+
+	Positional arguments:
+	  <network>           Network to deploy to (devnet, testnet, mainnet)
+	  <module>            Module to upgrade (Core, TokenBridge, NFTBridge)
+
+	Options:
+	  --vaa               VAA to submit (required for mainnet)
+	  --yes               Skip confirmation prompt
 EOF
-exit 1
+  exit 1
 }
 
-NETWORK=$1 || usage
-MODULE=$2 || usage
+# cd to script directory so that we can run this script from anywhere
+cd "$(dirname "$0")"
+
+# Check if the jq binary is available.
+if ! command -v jq >/dev/null; then
+  echo "jq not found, please install it"
+  exit 1
+fi
+
+# If positional args are missing, print help message and exit
+if [ $# -lt 2 ]; then
+  usage
+fi
+
+# Get positional arguments
+NETWORK="$1"
+shift
+MODULE="$1"
+shift
+
+yes=false
+
+# Parse options
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --vaa)
+        VAA="$2"
+        shift 2
+        ;;
+    --yes)
+        yes=true
+        shift
+        ;;
+    --) # end of options
+        shift
+        break
+        ;;
+    -*)
+        echo "Error: Unsupported option $1" >&2
+        usage
+        ;;
+    *) # anything else
+        echo "Error: Unsupported argument $1" >&2
+        usage
+        ;;
+  esac
+done
 
 if [ "$NETWORK" = testnet ]; then
-    # This script upgrades the core bridge in local devnet by generating a
-    # governance VAA and submitting it
-
-    DEPLOYER_ADDR=0x0108bc32f7de18a5f6e1e7d6ee7aff9f5fc858d0d87ac0da94dd8d2a5d267d6b
     [ -z "$GUARDIAN_SECRET" ] && echo "GUARDIAN_SECRET unset" >&2 && exit 1
 
 elif [ "$NETWORK" = devnet ]; then
     GUARDIAN_SECRET=cfb12303a19cde580bb4dd771639b0d26bc68353645571a8cff516ab2ee113a0
-    DEPLOYER_ADDR=0x277fa055b6a73c42c0662d5236c65c864ccbf2d4abd21f174a30c8b786eab84b
+
+elif [ "$NETWORK" = mainnet ]; then
+    # VAA is required for mainnet
+    if [ -z "$VAA" ]; then
+        echo "VAA required for mainnet" >&2
+        usage
+    fi
 else
     usage
 fi
-
-WORMHOLE_ADDR=$(worm info contract "$NETWORK" aptos Core)
-TOKEN_BRIDGE_ADDR=$(worm info contract "$NETWORK" aptos TokenBridge)
-NFT_BRIDGE_ADDR=$(worm info contract "$NETWORK" aptos NFTBridge)
-
-NAMED_ADDRS="wormhole=$WORMHOLE_ADDR,deployer=$DEPLOYER_ADDR,token_bridge=$TOKEN_BRIDGE_ADDR,nft_bridge=$NFT_BRIDGE_ADDR"
 
 case "$MODULE" in
     Core)
@@ -49,8 +107,45 @@ case "$MODULE" in
        ;;
 esac
 
+NAMED_ADDRS="$(./named_addresses $NETWORK)"
 HASH=$(worm aptos hash-contracts $DIR --named-addresses "$NAMED_ADDRS")
-VAA=$(worm generate upgrade -c aptos -a "$HASH" -m "$MODULE" -g $GUARDIAN_SECRET)
+
+# if VAA is not set, generate it
+[ -z "$VAA" ] && VAA=$(worm generate upgrade -c aptos -a "$HASH" -m "$MODULE" -g $GUARDIAN_SECRET)
+
+# parse VAA
+VAA_JSON=$(worm parse "$VAA")
+
+# sanity check VAA
+check_payload_value() {
+  key="$1"
+  expected_value="$2"
+
+  payload_value=$(echo "$VAA_JSON" | jq -r ".payload.$key")
+
+  if [ "$payload_value" != "$expected_value" ]; then
+    echo "VAA payload: expected $key $expected_value, got $payload_value" >&2
+    exit 1
+  fi
+}
+
+# here we make sure the VAA is for the hash we expect
+check_payload_value "type" "ContractUpgrade"
+check_payload_value "chain" "$(worm info chain-id aptos)"
+check_payload_value "module" "$MODULE"
+check_payload_value "address" "0x$HASH"
+
+echo "VAA is a valid ContractUpgrade VAA for $MODULE"
+
+# Ask for confirmation
+if [ "$yes" = false ]; then
+    read -p "Upgrade $MODULE to $HASH? [y/N] " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        echo "Aborting"
+        exit 1
+    fi
+fi
 
 echo "Submitting VAA: $VAA"
 
@@ -59,3 +154,8 @@ CONTRACT_ADDR=$(worm info contract "$NETWORK" aptos "$MODULE")
 worm submit --network "$NETWORK" "$VAA" --contract-address "$CONTRACT_ADDR"
 worm aptos upgrade $DIR --network "$NETWORK" --contract-address "$CONTRACT_ADDR" --named-addresses "$NAMED_ADDRS"
 worm aptos migrate --network "$NETWORK" --contract-address "$CONTRACT_ADDR"
+
+echo "Successfully upgraded $MODULE to $HASH"
+# if network is mainnet or testnet, print explorer link
+[ "$NETWORK" = mainnet ] || [ "$NETWORK" = testnet ] &&
+    echo "Check it out at https://explorer.aptoslabs.com/account/$CONTRACT_ADDR?network=$NETWORK"

--- a/aptos/scripts/upgrade
+++ b/aptos/scripts/upgrade
@@ -76,6 +76,27 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+case "$MODULE" in
+    Core)
+        DIR="../wormhole"
+        LOWER_MODULE="wormhole"
+    ;;
+    TokenBridge)
+        DIR="../token_bridge"
+        LOWER_MODULE="token_bridge"
+    ;;
+    NFTBridge)
+        DIR="../nft_bridge"
+        LOWER_MODULE="nft_bridge"
+    ;;
+    *) echo "unsupported module $MODULE" >&2
+       usage
+       ;;
+esac
+
+NAMED_ADDRS="$(./named_addresses $NETWORK)"
+HASH=$(worm aptos hash-contracts $DIR --named-addresses "$NAMED_ADDRS")
+
 if [ "$NETWORK" = testnet ]; then
     [ -z "$GUARDIAN_SECRET" ] && echo "GUARDIAN_SECRET unset" >&2 && exit 1
 
@@ -85,30 +106,14 @@ elif [ "$NETWORK" = devnet ]; then
 elif [ "$NETWORK" = mainnet ]; then
     # VAA is required for mainnet
     if [ -z "$VAA" ]; then
-        echo "VAA required for mainnet" >&2
-        usage
+        echo "VAA required for mainnet. Pass it in with the --vaa flag." >&2
+        echo "To generate a draft governance proposal, run" >&2
+        echo "    ../../scripts/contract-upgrade-governance.sh -c aptos --address $HASH --module $LOWER_MODULE" >&2
+        exit 1
     fi
 else
     usage
 fi
-
-case "$MODULE" in
-    Core)
-        DIR="../wormhole"
-    ;;
-    TokenBridge)
-        DIR="../token_bridge"
-    ;;
-    NFTBridge)
-        DIR="../nft_bridge"
-    ;;
-    *) echo "unsupported module $MODULE" >&2
-       usage
-       ;;
-esac
-
-NAMED_ADDRS="$(./named_addresses $NETWORK)"
-HASH=$(worm aptos hash-contracts $DIR --named-addresses "$NAMED_ADDRS")
 
 # if VAA is not set, generate it
 [ -z "$VAA" ] && VAA=$(worm generate upgrade -c aptos -a "$HASH" -m "$MODULE" -g $GUARDIAN_SECRET)

--- a/sdk/js/src/utils/consts.ts
+++ b/sdk/js/src/utils/consts.ts
@@ -373,7 +373,8 @@ const TESTNET = {
     core: "0x5bc11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625",
     token_bridge:
       "0x576410486a2da45eee6c949c995670112ddf2fbeedab20350d506328eefc9d4f",
-    nft_bridge: undefined,
+    nft_bridge:
+      "0x1bdffae984043833ed7fe223f7af7a3f8902d04129b14f801823e64827da7130",
   },
   sui: {
     core: "0x31358d198147da50db32eda2562951d53973a0c0ad5ed738e9b17d88b213d790",


### PR DESCRIPTION
This PR adds support for mainnet aptos upgrades in the aptos upgrade script and the governance proposal generator.
Also added the missing testnet NFT bridge address.

Changed the default behaviour of the governance proposal generator script to fail if the directory is dirty. This can be overridden with the `—force` flag.