### PR TITLE
node/pkg/guardiand: require pythnetWS argument

### DIFF
--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -737,6 +737,9 @@ func runNode(cmd *cobra.Command, args []string) {
 		if *pythnetRPC == "" {
 			logger.Fatal("Please specify --pythnetRPC")
 		}
+		if *pythnetWS == "" {
+			logger.Fatal("Please specify --pythnetWS")
+		}
 
 		if *injectiveWS == "" {
 			logger.Fatal("Please specify --injectiveWS")


### PR DESCRIPTION
The PythNet watcher now requires a websocket to function, this change makes it a required argument to guard against accidentally misconfigured guardians. We ran into this as the cause for missing signatures. As far as I can tell this is the only change needed, the Tiltfile is already configured with a websocket endpoint.