### PR TITLE
ethereum: remove mention of batched vaas in README

### DIFF
--- a/ethereum/README.md
+++ b/ethereum/README.md
@@ -18,13 +18,13 @@ To build the contracts:
 To deploy the bridge on Ethereum you first need to compile all smart contracts:
 `npx truffle compile`
 
-To deploy you can either use the bytecode from the `build/contracts` folder or the oz cli `oz deploy <Contract>` 
+To deploy you can either use the bytecode from the `build/contracts` folder or the oz cli `oz deploy <Contract>`
 ([Documentation](https://docs.openzeppelin.com/learn/deploying-and-interacting)).
 
 You first need to deploy one `Wrapped Asset` and initialize it using dummy data.
 
 Then deploy the `Wormhole` using the initial guardian key (`key_x,y_parity,0`) and the address of the previously deployed
-`WrappedAsset`. The wrapped asset contract will be used as proxy library to all the creation of cheap proxy wrapped 
+`WrappedAsset`. The wrapped asset contract will be used as proxy library to all the creation of cheap proxy wrapped
 assets.
 
 ### Testing
@@ -62,13 +62,3 @@ wormhole/ethereum $ ../scripts/install-foundry
 ```
 
 The installer script installs foundry and the appropriate solc version to build the contracts.
-
-### Batched VAAs
-
-To send a transaction that will create multiple VAAs, invoke the `sendMultipleMessages` method of [ethereum/contracts/mock/MockBatchedVAASender.sol](./contracts/mock/MockBatchedVAASender.sol) with the truffle script:
-
-    npx truffle exec scripts/send_batched_vaa.js
-
-or invoke the same script in the tilt devnet:
-
-    minikube kubectl -- exec -n wormhole eth-devnet-0 -c tests --  npx truffle exec scripts/send_batched_vaa.js


### PR DESCRIPTION
This PR removes the batch VAA section from the ethereum README.md, since this feature is being deprecated.

Separately, we should start removing the associated contracts and the implementation from the node too.