### PR TITLE
Ccq/p2p with single host

### DIFF
--- a/devnet/query-server.yaml
+++ b/devnet/query-server.yaml
@@ -49,7 +49,7 @@ spec:
             - "0xC89Ce4735882C9F0f0FE26686c53074E09B0D550"
             # Hardcoded devnet bootstrap (generated from deterministic key in guardiand)
             - --bootstrap
-            - /dns4/guardian-0.guardian/udp/8996/quic/p2p/12D3KooWL3XJ9EMCyZvmmGXL2LMiVBtrVa2BuESsJiXkSj7333Jw
+            - /dns4/guardian-0.guardian/udp/8999/quic/p2p/12D3KooWL3XJ9EMCyZvmmGXL2LMiVBtrVa2BuESsJiXkSj7333Jw
             - --logLevel=info
           ports:
             - containerPort: 6069

--- a/node/cmd/ccq/p2p.go
+++ b/node/cmd/ccq/p2p.go
@@ -149,6 +149,7 @@ func runP2P(ctx context.Context, priv crypto.PrivKey, port uint, networkID, boot
 	for len(th_req.ListPeers()) < 1 {
 		time.Sleep(time.Millisecond * 100)
 	}
+	logger.Info("Found peers")
 
 	// Fetch the initial current guardian set
 	guardianSet, err := FetchCurrentGuardianSet(ethRpcUrl, ethCoreAddr)

--- a/node/hack/query/send_req.go
+++ b/node/hack/query/send_req.go
@@ -58,7 +58,7 @@ func main() {
 
 	p2pNetworkID := "/wormhole/dev"
 	var p2pPort uint = 8998 // don't collide with spy so we can run from the same container in tilt
-	p2pBootstrap := "/dns4/guardian-0.guardian/udp/8996/quic/p2p/12D3KooWL3XJ9EMCyZvmmGXL2LMiVBtrVa2BuESsJiXkSj7333Jw"
+	p2pBootstrap := "/dns4/guardian-0.guardian/udp/8999/quic/p2p/12D3KooWL3XJ9EMCyZvmmGXL2LMiVBtrVa2BuESsJiXkSj7333Jw"
 	nodeKeyPath := "./querier.key"
 
 	ctx := context.Background()
@@ -172,6 +172,7 @@ func main() {
 	for len(th_req.ListPeers()) < 1 {
 		time.Sleep(time.Millisecond * 100)
 	}
+	logger.Info("Done listening for peers")
 
 	//
 	// END SETUP

--- a/node/pkg/p2p/ccq_p2p.go
+++ b/node/pkg/p2p/ccq_p2p.go
@@ -17,7 +17,6 @@ import (
 	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
 
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
-	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"go.uber.org/zap"
@@ -66,9 +65,8 @@ func newCcqRunP2p(
 
 func (ccq *ccqP2p) run(
 	ctx context.Context,
-	priv crypto.PrivKey,
 	gk *ecdsa.PrivateKey,
-	h *host.Host,
+	h host.Host,
 	networkID string,
 	signedQueryReqC chan<- *gossipv1.SignedQueryRequest,
 	queryResponseReadC <-chan *query.QueryResponsePublication,
@@ -83,7 +81,7 @@ func (ccq *ccqP2p) run(
 	topic_resp := fmt.Sprintf("%s/%s", networkID, "ccq_resp")
 
 	ccq.logger.Info("Creating pubsub topics", zap.String("request_topic", topic_req), zap.String("response_topic", topic_resp))
-	ps, err := pubsub.NewGossipSub(ctx, *h,
+	ps, err := pubsub.NewGossipSub(ctx, h,
 		// We only want to accept subscribes from peers in the allow list.
 		pubsub.WithPeerFilter(func(peerID peer.ID, topic string) bool {
 			if len(ccq.allowedPeers) == 0 {
@@ -140,7 +138,7 @@ func (ccq *ccqP2p) run(
 		return ccq.publisher(ctx, gk, queryResponseReadC)
 	})
 
-	ccq.logger.Info("Node has been started", zap.String("peer_id", ccq.h.ID().String()), zap.String("addrs", fmt.Sprintf("%v", ccq.h.Addrs())))
+	ccq.logger.Info("Node has been started", zap.String("peer_id", h.ID().String()), zap.String("addrs", fmt.Sprintf("%v", h.Addrs())))
 	return nil
 }
 

--- a/node/pkg/p2p/p2p.go
+++ b/node/pkg/p2p/p2p.go
@@ -330,7 +330,7 @@ func Run(
 		if ccqEnabled {
 			ccqErrC := make(chan error)
 			ccq := newCcqRunP2p(logger, ccqAllowedPeers)
-			if err := ccq.run(ctx, priv, gk, &h, networkID, signedQueryReqC, queryResponseReadC, ccqErrC); err != nil {
+			if err := ccq.run(ctx, gk, h, networkID, signedQueryReqC, queryResponseReadC, ccqErrC); err != nil {
 				return fmt.Errorf("failed to start p2p for CCQ: %w", err)
 			}
 			defer ccq.close()

--- a/node/pkg/p2p/p2p.go
+++ b/node/pkg/p2p/p2p.go
@@ -347,7 +347,7 @@ func Run(
 		if ccqEnabled {
 			ccqErrC := make(chan error)
 			ccq := newCcqRunP2p(logger, ccqAllowedPeers)
-			if err := ccq.run(ctx, priv, gk, networkID, ccqBootstrapPeers, ccqPort, signedQueryReqC, queryResponseReadC, ccqErrC); err != nil {
+			if err := ccq.run(ctx, priv, gk, &h, networkID, signedQueryReqC, queryResponseReadC, ccqErrC); err != nil {
 				return fmt.Errorf("failed to start p2p for CCQ: %w", err)
 			}
 			defer ccq.close()


### PR DESCRIPTION
This PR attempts to switch CCQ to use the same host / bootstrap parameters as regular gossip, but different pub/sub channels.

To test this:
- Bring up tilt with `tilt up -- --manual` (Filter for ccq in the guardian and you should see the ccq server initialializing.)
- Run the test by cd'ing to node/hack/query and doing `kubectl --namespace=wormhole exec -it spy-0 -- sh -c "cd node/hack/query/ && go run send_req.go"`.

You should see the request being received in the guardian and the response being published by the guardian. However, the test will hang waiting on the response (last message in stdout is "Waiting for message").