### PR TITLE
Client/js: Simplify edit-vaa command

### DIFF
--- a/clients/js/README.md
+++ b/clients/js/README.md
@@ -94,8 +94,8 @@ Options:
       --signatures, --sigs         comma separated list of signatures   [string]
       --wormscanurl, --wsu         url to wormscan entry for the vaa that
                                    includes signatures                  [string]
-      --wormscanfile, --wsf        json file containing wormscan entry for the
-                                   vaa that includes signatures         [string]
+      --wormscan, --ws             if specified, will query the wormscan entry
+                                   for the vaa to get the signatures   [boolean]
       --emitter-chain-id, --ec     emitter chain id to be used in the vaa
                                                                         [number]
       --emitter-address, --ea      emitter address to be used in the vaa[string]


### PR DESCRIPTION
This PR changes the `worm edit-vaa` command so that you can tell it to look up the signatures on wormscan without specifying the complete URL.

Instead of doing:

`worm edit-vaa -n mainnet --vaa $VAA --wormscanurl https://api.wormscan.io/api/v1/observations/1/0000000000000000000000000000000000000000000000000000000000000004/651169458827220885`

you can just do:

`worm edit-vaa -n mainnet --vaa $VAA --wormscan`

and it will use the sequence number from the VAA bytes to generate the URL. The old command is still supported.