### PR TITLE
solana: pattern match instead of label

### DIFF
--- a/solana/programs/core-bridge/src/error.rs
+++ b/solana/programs/core-bridge/src/error.rs
@@ -91,6 +91,9 @@ pub enum CoreBridgeError {
     #[msg("InstructionAtWrongIndex")]
     InstructionAtWrongIndex = 0x702,
 
+    #[msg("EmptySigVerifyInstruction")]
+    EmptySigVerifyInstruction = 0x703,
+
     #[msg("InvalidSigVerifyInstruction")]
     InvalidSigVerifyInstruction = 0x704,
 


### PR DESCRIPTION
This makes it easier to see which fields of a struct are used. Will follow up with the same refactoring in other places where appropriate