### PR TITLE
solana: make SigVerifyParameters canonical

### DIFF
--- a/solana/programs/core-bridge/src/error.rs
+++ b/solana/programs/core-bridge/src/error.rs
@@ -91,6 +91,9 @@ pub enum CoreBridgeError {
     #[msg("InstructionAtWrongIndex")]
     InstructionAtWrongIndex = 0x702,
 
+    #[msg("EmptySigVerifyInstruction")]
+    EmptySigVerifyInstruction = 0x703,
+
     #[msg("InvalidSigVerifyInstruction")]
     InvalidSigVerifyInstruction = 0x704,
 


### PR DESCRIPTION
all messages are checked to be the same, so we just store one of them