### PR TITLE
Ethereum: add optimized verification endpoint to the core bridge

### DIFF
--- a/ethereum/Makefile
+++ b/ethereum/Makefile
@@ -35,7 +35,7 @@ node_modules: package-lock.json
 forge_dependencies: lib/forge-std lib/openzeppelin-contracts
 
 lib/forge-std:
-	forge install foundry-rs/forge-std@v1.5.5 --no-git --no-commit
+	forge install foundry-rs/forge-std@v1.6.1 --no-git --no-commit
 
 lib/openzeppelin-contracts:
 	forge install openzeppelin/openzeppelin-contracts@0457042d93d9dfd760dbaa06a4d2f1216fdbe297 --no-git --no-commit

--- a/ethereum/contracts/Getters.sol
+++ b/ethereum/contracts/Getters.sol
@@ -53,4 +53,8 @@ contract Getters is State {
     function nextSequence(address emitter) public view returns (uint64) {
         return _state.sequences[emitter];
     }
+
+    function getGuardianSetHash(uint32 index) public view returns (bytes32) {
+        return _state.guardianSetHashes[index];
+    }
 }

--- a/ethereum/contracts/Getters.sol
+++ b/ethereum/contracts/Getters.sol
@@ -65,7 +65,7 @@ contract Getters is State {
         uint256 guardianCount = guardianSet.keys.length;
         for (uint256 i = 0; i < guardianCount;) {
             encodedGuardianSet = abi.encodePacked(encodedGuardianSet, guardianSet.keys[i]);
-            unchecked { i += 1; }
+            unchecked { ++i; }
         }
         encodedGuardianSet = abi.encodePacked(encodedGuardianSet, guardianSet.expirationTime);
     }

--- a/ethereum/contracts/Getters.sol
+++ b/ethereum/contracts/Getters.sol
@@ -57,4 +57,16 @@ contract Getters is State {
     function getGuardianSetHash(uint32 index) public view returns (bytes32) {
         return _state.guardianSetHashes[index];
     }
+
+    function getEncodedGuardianSet(uint32 index) public view returns (bytes memory encodedGuardianSet) {
+        Structs.GuardianSet memory guardianSet = getGuardianSet(index);
+
+        // Encode the guardian set.
+        uint256 guardianCount = guardianSet.keys.length;
+        for (uint256 i = 0; i < guardianCount;) {
+            encodedGuardianSet = abi.encodePacked(encodedGuardianSet, guardianSet.keys[i]);
+            unchecked { i += 1; }
+        }
+        encodedGuardianSet = abi.encodePacked(encodedGuardianSet, guardianSet.expirationTime);
+    }
 }

--- a/ethereum/contracts/Governance.sol
+++ b/ethereum/contracts/Governance.sol
@@ -104,6 +104,9 @@ abstract contract Governance is GovernanceStructs, Messages, Setters, ERC1967Upg
         // Trigger a time-based expiry of current guardianSet
         expireGuardianSet(getCurrentGuardianSetIndex());
 
+        // Update the hash of the expiring guardian set
+        setGuardianSetHash(getCurrentGuardianSetIndex());
+
         // Add the new guardianSet to guardianSets
         storeGuardianSet(upgrade.newGuardianSet, upgrade.newGuardianSetIndex);
 

--- a/ethereum/contracts/Governance.sol
+++ b/ethereum/contracts/Governance.sol
@@ -107,6 +107,9 @@ abstract contract Governance is GovernanceStructs, Messages, Setters, ERC1967Upg
         // Add the new guardianSet to guardianSets
         storeGuardianSet(upgrade.newGuardianSet, upgrade.newGuardianSetIndex);
 
+        // Store the guardian set hash 
+        setGuardianSetHash(upgrade.newGuardianSetIndex, upgrade.newGuardianSetHash);
+
         // Makes the new guardianSet effective
         updateGuardianSetIndex(upgrade.newGuardianSetIndex);
     }

--- a/ethereum/contracts/Governance.sol
+++ b/ethereum/contracts/Governance.sol
@@ -108,7 +108,7 @@ abstract contract Governance is GovernanceStructs, Messages, Setters, ERC1967Upg
         storeGuardianSet(upgrade.newGuardianSet, upgrade.newGuardianSetIndex);
 
         // Store the guardian set hash 
-        setGuardianSetHash(upgrade.newGuardianSetIndex, upgrade.newGuardianSetHash);
+        setGuardianSetHash(upgrade.newGuardianSetIndex);
 
         // Makes the new guardianSet effective
         updateGuardianSetIndex(upgrade.newGuardianSetIndex);

--- a/ethereum/contracts/GovernanceStructs.sol
+++ b/ethereum/contracts/GovernanceStructs.sol
@@ -31,7 +31,8 @@ contract GovernanceStructs {
         uint8 action;
         uint16 chain;
 
-        Structs.GuardianSet newGuardianSet;
+        bytes32 newGuardianSetHash;
+        Structs.GuardianSet newGuardianSet; 
         uint32 newGuardianSetIndex;
     }
 
@@ -101,6 +102,9 @@ contract GovernanceStructs {
 
         uint8 guardianLength = encodedUpgrade.toUint8(index);
         index += 1;
+
+        // Guardian set hash. 
+        gsu.newGuardianSetHash = keccak256(encodedUpgrade.slice(index, guardianLength * 20 + 4));
 
         gsu.newGuardianSet = Structs.GuardianSet({
             keys : new address[](guardianLength),

--- a/ethereum/contracts/GovernanceStructs.sol
+++ b/ethereum/contracts/GovernanceStructs.sol
@@ -31,7 +31,7 @@ contract GovernanceStructs {
         uint8 action;
         uint16 chain;
 
-        Structs.GuardianSet newGuardianSet; 
+        Structs.GuardianSet newGuardianSet;
         uint32 newGuardianSetIndex;
     }
 

--- a/ethereum/contracts/GovernanceStructs.sol
+++ b/ethereum/contracts/GovernanceStructs.sol
@@ -31,7 +31,6 @@ contract GovernanceStructs {
         uint8 action;
         uint16 chain;
 
-        bytes32 newGuardianSetHash;
         Structs.GuardianSet newGuardianSet; 
         uint32 newGuardianSetIndex;
     }
@@ -102,9 +101,6 @@ contract GovernanceStructs {
 
         uint8 guardianLength = encodedUpgrade.toUint8(index);
         index += 1;
-
-        // Guardian set hash. 
-        gsu.newGuardianSetHash = keccak256(encodedUpgrade.slice(index, guardianLength * 20 + 4));
 
         gsu.newGuardianSet = Structs.GuardianSet({
             keys : new address[](guardianLength),

--- a/ethereum/contracts/Messages.sol
+++ b/ethereum/contracts/Messages.sol
@@ -12,15 +12,23 @@ import "./libraries/external/BytesLib.sol";
 contract Messages is Getters {
     using BytesLib for bytes;
 
-    function parseAndVerifyVMOptimized(bytes calldata encodedVM, bytes calldata guardianSet) public view returns (Structs.VM memory vm, bool valid, string memory reason) {
+    function parseAndVerifyVMOptimized(
+        bytes calldata encodedVM, 
+        bytes calldata guardianSet, 
+        uint32 guardianSetIndex
+    ) public view returns (Structs.VM memory vm, bool valid, string memory reason) {
         // Verify that the specified guardian set is the current guardian set. 
         require(
-            getGuardianSetHash(getCurrentGuardianSetIndex()) == keccak256(guardianSet), 
+            getGuardianSetHash(guardianSetIndex) == keccak256(guardianSet), 
             "invalid guardian set"
         );
 
         // TODO: Optimize parsing function. 
         vm = parseVM(encodedVM);
+
+        // Verify that the VM is signed with the same guardian set that was specified.
+        require(vm.guardianSetIndex == guardianSetIndex, "mismatched guardian set index");
+
         (valid, reason) = verifyVMInternal(vm, parseGuardianSetOptimized(guardianSet), false);
     }
 

--- a/ethereum/contracts/Messages.sol
+++ b/ethereum/contracts/Messages.sol
@@ -17,7 +17,7 @@ contract Messages is Getters {
         bytes calldata guardianSet, 
         uint32 guardianSetIndex
     ) public view returns (Structs.VM memory vm, bool valid, string memory reason) {
-        // Verify that the specified guardian set is the current guardian set. 
+        // Verify that the specified guardian set is a valid. 
         require(
             getGuardianSetHash(guardianSetIndex) == keccak256(guardianSet), 
             "invalid guardian set"

--- a/ethereum/contracts/Setters.sol
+++ b/ethereum/contracts/Setters.sol
@@ -56,7 +56,20 @@ contract Setters is State {
         _state.evmChainId = evmChainId;
     }
 
-    function setGuardianSetHash(uint32 index, bytes32 hash) internal {
-        _state.guardianSetHashes[index] = hash;
+    function setGuardianSetHash(uint32 index) public {
+        // Fetch the guardian set at the specified index. 
+        Structs.GuardianSet memory guardianSet = _state.guardianSets[index];
+        
+        uint256 guardianCount = guardianSet.keys.length;
+        bytes memory encodedGuardianSet;
+        for (uint256 i = 0; i < guardianCount;) {
+            encodedGuardianSet = abi.encodePacked(encodedGuardianSet, guardianSet.keys[i]);
+            unchecked { i += 1; }
+        }
+
+        // Store the hash. 
+        _state.guardianSetHashes[index] = keccak256(
+            abi.encodePacked(encodedGuardianSet, guardianSet.expirationTime)
+        );
     }
 }

--- a/ethereum/contracts/Setters.sol
+++ b/ethereum/contracts/Setters.sol
@@ -16,10 +16,11 @@ contract Setters is State {
 
     function storeGuardianSet(Structs.GuardianSet memory set, uint32 index) internal {
         uint setLength = set.keys.length;
-        for (uint i = 0; i < setLength; i++) {
+        for (uint i = 0; i < setLength;) {
             require(set.keys[i] != address(0), "Invalid key");
+            unchecked { i += 1; }
         }
-        _state.guardianSets[index] = set;
+        _state.guardianSets[index] = set;    
     }
 
     function setInitialized(address implementatiom) internal {
@@ -53,5 +54,9 @@ contract Setters is State {
     function setEvmChainId(uint256 evmChainId) internal {
         require(evmChainId == block.chainid, "invalid evmChainId");
         _state.evmChainId = evmChainId;
+    }
+
+    function setGuardianSetHash(uint32 index, bytes32 hash) internal {
+        _state.guardianSetHashes[index] = hash;
     }
 }

--- a/ethereum/contracts/Setters.sol
+++ b/ethereum/contracts/Setters.sol
@@ -20,7 +20,7 @@ contract Setters is State {
             require(set.keys[i] != address(0), "Invalid key");
             unchecked { ++i; }
         }
-        _state.guardianSets[index] = set;   
+        _state.guardianSets[index] = set;
     }
 
     function setInitialized(address implementatiom) internal {
@@ -61,6 +61,11 @@ contract Setters is State {
         Structs.GuardianSet memory guardianSet = _state.guardianSets[index];
         
         uint256 guardianCount = guardianSet.keys.length;
+        
+        // Only allow setting the hash for a valid guardian set index
+        // Governance guards against updating to an empty guardian set
+        require(guardianCount > 0, "non-existent guardian set");
+
         bytes memory encodedGuardianSet;
         for (uint256 i = 0; i < guardianCount;) {
             encodedGuardianSet = abi.encodePacked(encodedGuardianSet, guardianSet.keys[i]);

--- a/ethereum/contracts/Setters.sol
+++ b/ethereum/contracts/Setters.sol
@@ -18,9 +18,9 @@ contract Setters is State {
         uint setLength = set.keys.length;
         for (uint i = 0; i < setLength;) {
             require(set.keys[i] != address(0), "Invalid key");
-            unchecked { i += 1; }
+            unchecked { ++i; }
         }
-        _state.guardianSets[index] = set;    
+        _state.guardianSets[index] = set;   
     }
 
     function setInitialized(address implementatiom) internal {

--- a/ethereum/contracts/State.sol
+++ b/ethereum/contracts/State.sol
@@ -44,6 +44,9 @@ contract Storage {
 
         // EIP-155 Chain ID
         uint256 evmChainId;
+
+        // Guardian set hashes. 
+        mapping(uint32 => bytes32) guardianSetHashes;
     }
 }
 

--- a/ethereum/contracts/interfaces/IWormhole.sol
+++ b/ethereum/contracts/interfaces/IWormhole.sol
@@ -88,6 +88,14 @@ interface IWormhole {
 
     function parseAndVerifyVM(bytes calldata encodedVM) external view returns (VM memory vm, bool valid, string memory reason);
 
+    function parseAndVerifyVMOptimized(
+        bytes calldata encodedVM,
+        bytes calldata guardianSet,
+        uint32 guardianSetIndex
+    ) external view returns (VM memory vm, bool valid, string memory reason);
+
+    function parseGuardianSet(bytes calldata guardianSetData) external pure returns (GuardianSet memory guardianSet);
+
     function verifyVM(VM memory vm) external view returns (bool valid, string memory reason);
 
     function verifySignatures(bytes32 hash, Signature[] memory signatures, GuardianSet memory guardianSet) external pure returns (bool valid, string memory reason);
@@ -101,6 +109,10 @@ interface IWormhole {
     function getCurrentGuardianSetIndex() external view returns (uint32);
 
     function getGuardianSetExpiry() external view returns (uint32);
+
+    function getGuardianSetHash(uint32 index) external view returns (bytes32);
+
+    function getEncodedGuardianSet(uint32 index) external view returns (bytes memory encodedGuardianSet);
 
     function governanceActionIsConsumed(bytes32 hash) external view returns (bool);
 
@@ -139,4 +151,6 @@ interface IWormhole {
     function submitTransferFees(bytes memory _vm) external;
 
     function submitRecoverChainId(bytes memory _vm) external;
+
+    function setGuardianSetHash(uint32 index) external;
 }

--- a/ethereum/forge-test/Getters.t.sol
+++ b/ethereum/forge-test/Getters.t.sol
@@ -217,4 +217,17 @@ contract TestGetters is TestUtils {
     {
         testEvmChainId(newEvmChainId, storageSlot);
     }
+
+    function testGuardianSetHash(uint32 guardianSetIndex, bytes32 newGuardianSetHash, bytes32 storageSlot)
+        public
+        unchangedStorage(address(getters), storageSlot)
+    {
+        bytes32 storageLocation = hashedLocation(guardianSetIndex, GUARDIANSETHASHES_STORAGE_INDEX);
+        vm.assume(storageSlot != storageLocation);
+
+        vm.store(address(getters), storageLocation, newGuardianSetHash);
+
+        assertEq(getters.getGuardianSetHash(guardianSetIndex), newGuardianSetHash);
+        assertEq(newGuardianSetHash, vm.load(address(getters), storageLocation));
+    }
 }

--- a/ethereum/forge-test/Messages.t.sol
+++ b/ethereum/forge-test/Messages.t.sol
@@ -11,15 +11,15 @@ import "forge-std/Test.sol";
 import "forge-std/Vm.sol";
 
 contract WormholeSigner is Test {
-  // Signer wallet. 
+  // Signer wallet.
   struct Wallet {
     address addr;
     uint256 key;
   }
 
   function encodeAndSignMessage(
-    Structs.VM memory vm_, 
-    uint256[] memory guardianKeys, 
+    Structs.VM memory vm_,
+    uint256[] memory guardianKeys,
     uint32 guardianSetIndex
   ) public pure returns (bytes memory signedMessage) {
     // Compute the hash of the body
@@ -48,7 +48,7 @@ contract WormholeSigner is Test {
       signatures,
       body
     );
-  } 
+  }
 }
 
 contract ExportedMessages is Messages, Setters {
@@ -66,11 +66,11 @@ contract TestMessages is Test {
   uint256 constant testGuardian = 93941733246223705020089879371323733820373732307041878556247502674739205313440;
 
   ExportedMessages messages;
-  WormholeSigner wormholeSimulator; 
+  WormholeSigner wormholeSimulator;
 
   Structs.GuardianSet guardianSet;
 
-  // Guardian set with 19 guardians and wallets with each signing key. 
+  // Guardian set with 19 guardians and wallets with each signing key.
   Structs.GuardianSet guardianSetOpt;
   uint256[] guardianKeys = new uint256[](19);
 
@@ -83,16 +83,16 @@ contract TestMessages is Test {
   }
 
   function setupMultiGuardian() internal {
-    // initialize guardian set with 19 guardians 
+    // initialize guardian set with 19 guardians
     address[] memory keys = new address[](19);
     for (uint256 i = 0; i < 19; ++i) {
-      // create a keypair for each guardian 
+      // create a keypair for each guardian
       VmSafe.Wallet memory wallet = vm.createWallet(string(abi.encodePacked("guardian", i)));
-      keys[i] = wallet.addr; 
-      guardianKeys[i] = wallet.privateKey; 
+      keys[i] = wallet.addr;
+      guardianKeys[i] = wallet.privateKey;
     }
-    guardianSetOpt = Structs.GuardianSet(keys, 0); 
-    require(messages.quorum(guardianSetOpt.keys.length) == 13, "Quorum should be 13"); 
+    guardianSetOpt = Structs.GuardianSet(keys, 0);
+    require(messages.quorum(guardianSetOpt.keys.length) == 13, "Quorum should be 13");
   }
 
   function setUp() public {
@@ -102,7 +102,7 @@ contract TestMessages is Test {
     wormholeSimulator = new WormholeSigner();
     setupSingleGuardian();
     setupMultiGuardian();
-  } 
+  }
 
   function getSignedVM(
     bytes memory payload,
@@ -269,13 +269,13 @@ contract TestMessages is Test {
     }
     encodedGuardianSet = abi.encodePacked(encodedGuardianSet, guardianSetOpt.expirationTime);
 
-    // Parse the guardian set. 
-    Structs.GuardianSet memory parsedSet = messages.parseGuardianSetOptimized(encodedGuardianSet);
+    // Parse the guardian set.
+    Structs.GuardianSet memory parsedSet = messages.parseGuardianSet(encodedGuardianSet);
 
     // Validate the results by comparing the parsed set to the original set.
     for (uint256 i = 0; i < guardianCount; ++i) {
       assert(parsedSet.keys[i] == guardianSetOpt.keys[i]);
-    } 
+    }
     assert(parsedSet.expirationTime == guardianSetOpt.expirationTime);
   }
 
@@ -290,7 +290,7 @@ contract TestMessages is Test {
     messages.storeGuardianSetPub(guardianSetOpt, currentSetIndex);
     messages.setGuardianSetHash(currentSetIndex);
 
-    // Create a message with an arbitrary payload. 
+    // Create a message with an arbitrary payload.
     bytes memory signedMessage = getSignedVM(
       payload,
       emitterAddress,
@@ -299,14 +299,14 @@ contract TestMessages is Test {
       currentSetIndex
     );
 
-    // Parse and verify the VM. 
+    // Parse and verify the VM.
     (Structs.VM memory vm_, bool valid,) = messages.parseAndVerifyVM(signedMessage);
     assertEq(valid, true);
 
-    // Parse and verify the VM using the optimized endpoint. 
+    // Parse and verify the VM using the optimized endpoint.
     (Structs.VM memory vmOptimized, bool valid_,) = messages.parseAndVerifyVMOptimized(
-      signedMessage, 
-      messages.getEncodedGuardianSet(currentSetIndex), 
+      signedMessage,
+      messages.getEncodedGuardianSet(currentSetIndex),
       currentSetIndex
     );
     assertEq(valid_, true);
@@ -328,6 +328,6 @@ contract TestMessages is Test {
       assertEq(vm_.signatures[i].r, vmOptimized.signatures[i].r);
       assertEq(vm_.signatures[i].s, vmOptimized.signatures[i].s);
       assertEq(vm_.signatures[i].v, vmOptimized.signatures[i].v);
-    }    
+    }
   }
 }

--- a/ethereum/forge-test/Messages.t.sol
+++ b/ethereum/forge-test/Messages.t.sol
@@ -96,7 +96,9 @@ contract TestMessages is Test {
   }
 
   function setUp() public {
+    console.log("here?");
     messages = new ExportedMessages();
+    console.log("or?");
     wormholeSimulator = new WormholeSigner();
     setupSingleGuardian();
     setupMultiGuardian();
@@ -320,5 +322,12 @@ contract TestMessages is Test {
     assertEq(vm_.payload, vmOptimized.payload);
     assertEq(vm_.guardianSetIndex, vmOptimized.guardianSetIndex);
     assertEq(vm_.signatures.length, vmOptimized.signatures.length);
+
+    for (uint256 i = 0; i < vm_.signatures.length; ++i) {
+      assertEq(vm_.signatures[i].guardianIndex, vmOptimized.signatures[i].guardianIndex);
+      assertEq(vm_.signatures[i].r, vmOptimized.signatures[i].r);
+      assertEq(vm_.signatures[i].s, vmOptimized.signatures[i].s);
+      assertEq(vm_.signatures[i].v, vmOptimized.signatures[i].v);
+    }    
   }
 }

--- a/ethereum/forge-test/Messages.t.sol
+++ b/ethereum/forge-test/Messages.t.sol
@@ -112,22 +112,22 @@ contract TestMessages is Test {
     uint32 guardianSetIndex
   ) internal view returns (bytes memory signedTransfer) {
     // construct `TransferWithPayload` Wormhole message
-    Structs.VM memory vm;
+    Structs.VM memory vm_;
 
     // set the vm values inline
-    vm.version = uint8(1);
-    vm.timestamp = uint32(block.timestamp);
-    vm.emitterChainId = emitterChainId;
-    vm.emitterAddress = emitterAddress;
-    vm.sequence = messages.nextSequence(
+    vm_.version = uint8(1);
+    vm_.timestamp = uint32(block.timestamp);
+    vm_.emitterChainId = emitterChainId;
+    vm_.emitterAddress = emitterAddress;
+    vm_.sequence = messages.nextSequence(
         address(uint160(uint256(emitterAddress)))
     );
-    vm.consistencyLevel = 15;
-    vm.payload = payload;
+    vm_.consistencyLevel = 15;
+    vm_.payload = payload;
 
-    // encode the bservation
+    // encode the observation
     signedTransfer = wormholeSimulator.encodeAndSignMessage(
-      vm,
+      vm_,
       _guardianKeys,
       guardianSetIndex
     );
@@ -259,8 +259,8 @@ contract TestMessages is Test {
     assertEq(reason, "vm.hash doesn't match body");
   }
 
-  function testParseGuardianSetOptimized(uint8 guardianCount) public view {
-    vm.assume(guardianCount > 0 && guardianCount <= 19);
+  function testParseGuardianSetOptimized(uint256 guardianCount) public view {
+    guardianCount = bound(guardianCount, 1, 19);
 
     // Encode the guardian set.
     bytes memory encodedGuardianSet;

--- a/ethereum/forge-test/MessagesRV.t.sol
+++ b/ethereum/forge-test/MessagesRV.t.sol
@@ -7,6 +7,7 @@ import "../contracts/Messages.sol";
 import "../contracts/Setters.sol";
 import "../contracts/Structs.sol";
 import "forge-test/rv-helpers/TestUtils.sol";
+import "../contracts/libraries/external/BytesLib.sol";
 
 contract TestMessagesRV is TestUtils {
     using BytesLib for bytes;

--- a/ethereum/forge-test/rv-helpers/MySetters.sol
+++ b/ethereum/forge-test/rv-helpers/MySetters.sol
@@ -44,4 +44,8 @@ contract MySetters is Setters {
     function setEvmChainId_external(uint256 evmChainId) external {
         setEvmChainId(evmChainId);
     }
+
+    function storeGuardianSet_external(Structs.GuardianSet memory set, uint32 index) external {
+        storeGuardianSet(set, index);
+    }
 }

--- a/ethereum/forge-test/rv-helpers/TestUtils.sol
+++ b/ethereum/forge-test/rv-helpers/TestUtils.sol
@@ -19,6 +19,7 @@ bytes32 constant CONSUMEDGOVACTIONS_STORAGE_INDEX = bytes32(uint256(5));
 bytes32 constant INITIALIZEDIMPLEMENTATIONS_STORAGE_INDEX = bytes32(uint256(6));
 bytes32 constant MESSAGEFEE_STORAGE_INDEX = bytes32(uint256(7));
 bytes32 constant EVMCHAINID_STORAGE_INDEX = bytes32(uint256(8));
+bytes32 constant GUARDIANSETHASHES_STORAGE_INDEX = bytes32(uint256(9));
 
 uint256 constant SECP256K1_CURVE_ORDER =
     115792089237316195423570985008687907852837564279074904382605163141518161494337;
@@ -33,6 +34,12 @@ contract TestUtils is Test, KEVMCheats {
 
     // Returns the index hash of the storage slot of a map at location `index` and the key `_key`.
     function hashedLocation(bytes32 _key, bytes32 _index) public pure returns(bytes32) {
+        // returns `keccak(#buf(32,_key) +Bytes #buf(32, index))
+        return keccak256(abi.encode(_key, _index));
+    }
+
+    // Returns the index hash of the storage slot of a map at location `index` and the key `_key`.
+    function hashedLocation(uint256 _key, bytes32 _index) public pure returns(bytes32) {
         // returns `keccak(#buf(32,_key) +Bytes #buf(32, index))
         return keccak256(abi.encode(_key, _index));
     }


### PR DESCRIPTION
The purpose of this PR is to add an optimized `parseAndVerify` endpoint to `Messages.sol` along with various other optimizations. See the following table for the estimated gas savings:

call | before | after | savings
-----|--------|-------|--------
parseAndVerify | 129k | 83k | 46k
parseVM | 26.5k | 16.2k | 10.3k