### PR TITLE
upgrade to golang 1.20.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.20.7"
+          go-version: "1.20.8"
       - run: make node
 
   algorand:
@@ -276,7 +276,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.20.7"
+          go-version: "1.20.8"
       - run: cd sdk/vaa && go test && go test -v -fuzz FuzzCalculateQuorum -run FuzzCalculateQuorum -fuzztime 15s
 
   # Run Go linters
@@ -293,7 +293,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.20.7"
+          go-version: "1.20.8"
       - name: Install formatter
         run: go install golang.org/x/tools/cmd/goimports@v0.8.0
       - name: Formatting checks
@@ -322,7 +322,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.20.7"
+          go-version: "1.20.8"
       # The go-ethereum and celo-blockchain packages both implement secp256k1 using the exact same header, but that causes duplicate symbols.
       - name: Run golang tests
         run: cd node && go test -v -timeout 5m -race -ldflags '-extldflags "-Wl,--allow-multiple-definition" ' ./...

--- a/Dockerfile.proto
+++ b/Dockerfile.proto
@@ -1,5 +1,5 @@
 # syntax=docker.io/docker/dockerfile:1.3@sha256:42399d4635eddd7a9b8a24be879d2f9a930d0ed040a61324cfdf59ef1357b3b2
-FROM docker.io/golang:1.20.7-bullseye@sha256:74b09b3b6fa5aa542df8ef974cb745eb477be72f6fcf821517fb410aff532b00 AS go-tools
+FROM docker.io/golang:1.20.8-bullseye@sha256:2db41d88870617e0f43e7e1f304649eb4563706e3c4d25a624e43e83299fb822 AS go-tools
 
 # Support additional root CAs
 COPY README.md cert.pem* /certs/
@@ -15,7 +15,7 @@ RUN --mount=type=cache,target=/root/.cache --mount=type=cache,target=/go \
 	cd /app/tools && CGO_ENABLED=0 ./build.sh
 
 # syntax=docker.io/docker/dockerfile:1.3@sha256:42399d4635eddd7a9b8a24be879d2f9a930d0ed040a61324cfdf59ef1357b3b2
-FROM docker.io/golang:1.20.7-bullseye@sha256:74b09b3b6fa5aa542df8ef974cb745eb477be72f6fcf821517fb410aff532b00 AS go-build
+FROM docker.io/golang:1.20.8-bullseye@sha256:2db41d88870617e0f43e7e1f304649eb4563706e3c4d25a624e43e83299fb822 AS go-build
 
 # Support additional root CAs
 COPY README.md cert.pem* /certs/

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker.io/docker/dockerfile:1.3@sha256:42399d4635eddd7a9b8a24be879d2f9a930d0ed040a61324cfdf59ef1357b3b2
-FROM --platform=linux/amd64 docker.io/golang:1.20.7-bullseye@sha256:74b09b3b6fa5aa542df8ef974cb745eb477be72f6fcf821517fb410aff532b00 AS build
+FROM --platform=linux/amd64 docker.io/golang:1.20.8-bullseye@sha256:2db41d88870617e0f43e7e1f304649eb4563706e3c4d25a624e43e83299fb822 AS build
 # libwasmvm.so is not compatible with arm
 
 # Support additional root CAs

--- a/scripts/Dockerfile.lint
+++ b/scripts/Dockerfile.lint
@@ -1,5 +1,5 @@
 # syntax=docker.io/docker/dockerfile:1.3@sha256:42399d4635eddd7a9b8a24be879d2f9a930d0ed040a61324cfdf59ef1357b3b2
-FROM docker.io/golang:1.20.7-bullseye@sha256:74b09b3b6fa5aa542df8ef974cb745eb477be72f6fcf821517fb410aff532b00
+FROM docker.io/golang:1.20.8-bullseye@sha256:2db41d88870617e0f43e7e1f304649eb4563706e3c4d25a624e43e83299fb822
 
 RUN useradd -u 1000 -U -m -d /home/lint lint
 USER 1000

--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -63,7 +63,7 @@ esac
 
 # Install Go
 ARCH=amd64
-GO=1.20.7
+GO=1.20.8
 
 (
   if [[ -d /usr/local/go ]]; then


### PR DESCRIPTION
# For Release Notes: 
Please compile with golang >= 1.20.8. 
