### PR TITLE
Algorand Tests: Specify Indexer branch

### DIFF
--- a/algorand/runPythonUnitTests.sh
+++ b/algorand/runPythonUnitTests.sh
@@ -11,6 +11,7 @@ fi
 sed -i -e 's@export ALGOD_URL=""@export ALGOD_URL="https://github.com/algorand/go-algorand"@' \
        -e 's/export ALGOD_CHANNEL="stable"/export ALGOD_CHANNEL=""/'   \
        -e 's/export ALGOD_BRANCH=""/export ALGOD_BRANCH="v3.16.2-stable"/'   \
+       -e 's/export INDEXER_BRANCH="master"/export INDEXER_BRANCH="2.15.4"/'   \
        -e 's/export INDEXER_ENABLE_ALL_PARAMETERS="false"/export INDEXER_ENABLE_ALL_PARAMETERS="true"/'  _sandbox/config.dev
 
 cd _sandbox


### PR DESCRIPTION
A recent change to the indexer branch name is breaking the Algorand build


Its accounted for here: https://github.com/algorand/sandbox/commit/783d25d37bb6b8e80df73fbad8c4ea5bd459caab#diff-596bbaeef3aec3ae956116372ea7d3862e78f4edb3c628d4c730f9d25507b815

but we've pinned sandbox repo to a much earlier version with a [TODO ](https://github.com/wormhole-foundation/wormhole/issues/3068) to improve