### PR TITLE
EVM Watcher: Fix shadowed variable in Optimism case

### DIFF
--- a/node/pkg/watchers/evm/watcher.go
+++ b/node/pkg/watchers/evm/watcher.go
@@ -631,7 +631,6 @@ func (w *Watcher) Run(parentCtx context.Context) error {
 					zap.Stringer("current_blockhash", currentHash),
 					zap.Bool("is_safe_block", ev.Safe),
 					zap.String("eth_network", w.networkName))
-				currentEthHeight.WithLabelValues(w.networkName).Set(float64(ev.Number.Int64()))
 				readiness.SetReady(w.readinessSync)
 				p2p.DefaultRegistry.SetNetworkStats(w.chainID, &gossipv1.Heartbeat_Network{
 					Height:          ev.Number.Int64(),
@@ -646,6 +645,7 @@ func (w *Watcher) Run(parentCtx context.Context) error {
 				} else {
 					atomic.StoreUint64(&currentBlockNumber, blockNumberU)
 					atomic.StoreUint64(&w.latestFinalizedBlockNumber, blockNumberU)
+					currentEthHeight.WithLabelValues(w.networkName).Set(float64(ev.Number.Int64()))
 				}
 
 				for key, pLock := range w.pending {

--- a/node/pkg/watchers/evm/watcher.go
+++ b/node/pkg/watchers/evm/watcher.go
@@ -289,7 +289,7 @@ func (w *Watcher) Run(parentCtx context.Context) error {
 	} else if w.chainID == vaa.ChainIDOptimism && !w.unsafeDevMode {
 		// This only supports Bedrock mode
 		useFinalizedBlocks = true
-		safeBlocksSupported := true
+		safeBlocksSupported = true
 		logger.Info("using finalized blocks, will publish safe blocks")
 		baseConnector, err := connectors.NewEthereumConnector(timeout, w.networkName, w.url, w.contract, logger)
 		if err != nil {


### PR DESCRIPTION
Other cases set the variable to the scope outside the if/else cases so this _seems_ like a mistake.

Also moves a metric set call found during debug session