### PR TITLE
node/evm: fix Base safe block support

### DIFF
--- a/node/pkg/watchers/evm/watcher.go
+++ b/node/pkg/watchers/evm/watcher.go
@@ -321,13 +321,15 @@ func (w *Watcher) Run(parentCtx context.Context) error {
 			return fmt.Errorf("failed to create polygon connector: %w", err)
 		}
 	} else if w.chainID == vaa.ChainIDBase && !w.unsafeDevMode {
+		useFinalizedBlocks = true
+		safeBlocksSupported = true
 		baseConnector, err := connectors.NewEthereumConnector(timeout, w.networkName, w.url, w.contract, logger)
 		if err != nil {
 			ethConnectionErrors.WithLabelValues(w.networkName, "dial_error").Inc()
 			p2p.DefaultRegistry.AddErrorCount(w.chainID, 1)
 			return fmt.Errorf("dialing eth client failed: %w", err)
 		}
-		w.ethConn, err = connectors.NewBlockPollConnector(ctx, baseConnector, finalizers.NewDefaultFinalizer(), 250*time.Millisecond, true, true)
+		w.ethConn, err = connectors.NewBlockPollConnector(ctx, baseConnector, finalizers.NewDefaultFinalizer(), 250*time.Millisecond, useFinalizedBlocks, safeBlocksSupported)
 		if err != nil {
 			ethConnectionErrors.WithLabelValues(w.networkName, "dial_error").Inc()
 			p2p.DefaultRegistry.AddErrorCount(w.chainID, 1)


### PR DESCRIPTION
Base safe support may not have been properly working due to not setting the `safeBlocksSupported` in the `Run` scope.