### PR TITLE
Node: Observations are incorrectly ignored when marked settled

### DIFF
--- a/node/pkg/processor/observation.go
+++ b/node/pkg/processor/observation.go
@@ -83,8 +83,8 @@ func (p *Processor) handleObservation(ctx context.Context, obs *node_common.MsgW
 	m := obs.Msg
 	hash := hex.EncodeToString(m.Hash)
 	s := p.state.signatures[hash]
-	if s != nil && s.settled {
-		// already settled; ignoring additional signatures for it.
+	if s != nil && s.submitted {
+		// already submitted; ignoring additional signatures for it.
 		return
 	}
 


### PR DESCRIPTION
A recent change to `handleObservation` caused it to ignore additional signatures if the transaction is marked settled. However, the observation gets marked settled after only 30 seconds, and it sometimes (like in the case of consistency level 201, safe blocks) observations can take more than 30 seconds to arrive.

This PR changes it to ignore additional signatures once the transaction is marked submitted, meaning we have submitted / published the VAA.