### PR TITLE
CI: run ethereum tests on ubuntu-latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
       - run: cd algorand && make test
 
   ethereum:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -74,7 +74,7 @@ jobs:
       - run: cd ethereum && make test
 
   ethereum-upgrade:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2


### PR DESCRIPTION
ubuntu-20.04 ships with GLIBC-2.31, but the latest foundry nightly (which these CI actions use) link against 2.33+ (perhaps foundry should statically link against something like musl...?)

So instead we run these two tests on ubuntu-latest