### PR TITLE
Client/js: adds key and rpc support for submit VAA on Sei mainnet.

### DIFF
--- a/clients/js/src/chains/sei/submit.ts
+++ b/clients/js/src/chains/sei/submit.ts
@@ -2,7 +2,7 @@ import { DirectSecp256k1HdWallet } from "@cosmjs/proto-signing";
 import { calculateFee } from "@cosmjs/stargate";
 import { MsgExecuteContractEncodeObject } from "@cosmjs/cosmwasm-stargate";
 import { toUtf8 } from "@cosmjs/encoding";
-import { MsgExecuteContract } from "cosmjs-types/cosmwasm/wasm/v1/tx"
+import { MsgExecuteContract } from "cosmjs-types/cosmwasm/wasm/v1/tx";
 import { getSigningCosmWasmClient } from "@sei-js/core";
 
 import { CONTRACTS } from "@certusone/wormhole-sdk/lib/esm/utils/consts";
@@ -150,11 +150,15 @@ export const submit = async (
   // For some reason, the simulation only provides the gas used but no events
   // so we can't determine whether it worked unless we do away with cosmjs and query the node ourselves.
   // See https://github.com/cosmos/cosmjs/issues/1148#issuecomment-1129259646
-  const gasUsed = await client.simulate(account.address, [executeContractMsg], undefined);
+  const gasUsed = await client.simulate(
+    account.address,
+    [executeContractMsg],
+    undefined
+  );
   // It looks like the simulation is a bit lacking when it comes to estimating gas.
   // See https://github.com/cosmos/cosmos-sdk/issues/4938
   // That's why we multiply it by a factor of 1.3
-  const estimatedGas = Math.floor(gasUsed * 130 / 100);
+  const estimatedGas = Math.floor((gasUsed * 130) / 100);
 
   const fee = calculateFee(estimatedGas, "0.1usei");
   const result = await client.execute(

--- a/clients/js/src/chains/sei/submit.ts
+++ b/clients/js/src/chains/sei/submit.ts
@@ -1,5 +1,8 @@
 import { DirectSecp256k1HdWallet } from "@cosmjs/proto-signing";
 import { calculateFee } from "@cosmjs/stargate";
+import { MsgExecuteContractEncodeObject } from "@cosmjs/cosmwasm-stargate";
+import { toUtf8 } from "@cosmjs/encoding";
+import { MsgExecuteContract } from "cosmjs-types/cosmwasm/wasm/v1/tx"
 import { getSigningCosmWasmClient } from "@sei-js/core";
 
 import { CONTRACTS } from "@certusone/wormhole-sdk/lib/esm/utils/consts";
@@ -10,10 +13,13 @@ import { impossible, Payload } from "../../vaa";
 export const submit = async (
   payload: Payload,
   vaa: Buffer,
-  network: Network
+  network: Network,
+  rpc?: string
 ) => {
   const contracts = CONTRACTS[network].sei;
-  const { rpc, key } = NETWORKS[network].sei;
+  const networkInfo = NETWORKS[network].sei;
+  rpc = rpc || networkInfo.rpc;
+  const key = networkInfo.key;
   if (!key) {
     throw Error(`No ${network} key defined for Sei`);
   }
@@ -131,7 +137,26 @@ export const submit = async (
   });
   const [account] = await wallet.getAccounts();
   const client = await getSigningCosmWasmClient(rpc, wallet);
-  const fee = calculateFee(300000, "0.1usei");
+
+  const executeContractMsg: MsgExecuteContractEncodeObject = {
+    typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
+    value: MsgExecuteContract.fromPartial({
+      sender: account.address,
+      contract: target_contract,
+      msg: toUtf8(JSON.stringify(execute_msg)),
+      funds: [],
+    }),
+  };
+  // For some reason, the simulation only provides the gas used but no events
+  // so we can't determine whether it worked unless we do away with cosmjs and query the node ourselves.
+  // See https://github.com/cosmos/cosmjs/issues/1148#issuecomment-1129259646
+  const gasUsed = await client.simulate(account.address, [executeContractMsg], undefined);
+  // It looks like the simulation is a bit lacking when it comes to estimating gas.
+  // See https://github.com/cosmos/cosmos-sdk/issues/4938
+  // That's why we multiply it by a factor of 1.3
+  const estimatedGas = Math.floor(gasUsed * 130 / 100);
+
+  const fee = calculateFee(estimatedGas, "0.1usei");
   const result = await client.execute(
     account.address,
     target_contract,

--- a/clients/js/src/cmds/submit.ts
+++ b/clients/js/src/cmds/submit.ts
@@ -173,7 +173,7 @@ async function executeSubmit(
   } else if (chain === "xpla") {
     await execute_xpla(parsedVaa.payload, buf, network);
   } else if (chain === "sei") {
-    await submitSei(parsedVaa.payload, buf, network);
+    await submitSei(parsedVaa.payload, buf, network, rpc);
   } else if (chain === "osmosis") {
     throw Error("OSMOSIS is not supported yet");
   } else if (chain === "sui") {

--- a/clients/js/src/consts/networks.ts
+++ b/clients/js/src/consts/networks.ts
@@ -165,7 +165,7 @@ const MAINNET = {
     chain_id: 8453,
   },
   sei: {
-    rpc: undefined,
+    rpc: "https://sei-rpc.polkachu.com/",
     key: getEnvVar("SEI_KEY"),
   },
   rootstock: {

--- a/clients/js/src/consts/networks.ts
+++ b/clients/js/src/consts/networks.ts
@@ -166,7 +166,7 @@ const MAINNET = {
   },
   sei: {
     rpc: undefined,
-    key: undefined,
+    key: getEnvVar("SEI_KEY"),
   },
   rootstock: {
     rpc: "https://public-node.rsk.co",


### PR DESCRIPTION
This adds the following for VAA submit on Sei:
- Gas estimation.
- Process/accept `rpc` option.
- Defines `SEI_KEY` as the environment variable for mainnet Sei keys.