### PR TITLE
Node: Keygen changes

### DIFF
--- a/node/cmd/guardiand/adminclient.go
+++ b/node/cmd/guardiand/adminclient.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/pflag"
 	"golang.org/x/crypto/sha3"
 
+	"github.com/certusone/wormhole/node/pkg/common"
 	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
 	publicrpcv1 "github.com/certusone/wormhole/node/pkg/proto/publicrpc/v1"
 	"github.com/wormhole-foundation/wormhole/sdk"
@@ -39,6 +40,7 @@ import (
 var (
 	clientSocketPath *string
 	shouldBackfill   *bool
+	unsafeDevnetMode *bool
 )
 
 func init() {
@@ -67,6 +69,10 @@ func init() {
 	PurgePythNetVaasCmd.Flags().AddFlagSet(pf)
 	SignExistingVaaCmd.Flags().AddFlagSet(pf)
 	SignExistingVaasFromCSVCmd.Flags().AddFlagSet(pf)
+
+	adminClientSignWormchainAddressFlags := pflag.NewFlagSet("adminClientSignWormchainAddressFlags", pflag.ContinueOnError)
+	unsafeDevnetMode = adminClientSignWormchainAddressFlags.Bool("unsafeDevMode", false, "Run in unsafe devnet mode")
+	AdminClientSignWormchainAddress.Flags().AddFlagSet(adminClientSignWormchainAddressFlags)
 
 	AdminCmd.AddCommand(AdminClientInjectGuardianSetUpdateCmd)
 	AdminCmd.AddCommand(AdminClientFindMissingMessagesCmd)
@@ -225,7 +231,7 @@ func runSignWormchainValidatorAddress(cmd *cobra.Command, args []string) error {
 	if !strings.HasPrefix(wormchainAddress, "wormhole") || strings.HasPrefix(wormchainAddress, "wormholeval") {
 		return fmt.Errorf("must provide a bech32 address that has 'wormhole' prefix")
 	}
-	gk, err := loadGuardianKey(guardianKeyPath)
+	gk, err := common.LoadGuardianKey(guardianKeyPath, *unsafeDevnetMode)
 	if err != nil {
 		return fmt.Errorf("failed to load guardian key: %w", err)
 	}

--- a/node/cmd/guardiand/keygen.go
+++ b/node/cmd/guardiand/keygen.go
@@ -1,0 +1,44 @@
+package guardiand
+
+import (
+	"crypto/ecdsa"
+	"crypto/rand"
+	"log"
+
+	"github.com/certusone/wormhole/node/pkg/common"
+
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+	"github.com/spf13/cobra"
+)
+
+var keyDescription *string
+var blockType *string
+
+func init() {
+	keyDescription = KeygenCmd.Flags().String("desc", "", "Human-readable key description (optional)")
+	blockType = KeygenCmd.Flags().String("block-type", common.GuardianKeyArmoredBlock, "block type of armored file (optional)")
+}
+
+var KeygenCmd = &cobra.Command{
+	Use:   "keygen [KEYFILE]",
+	Short: "Create guardian key at the specified path",
+	Run:   runKeygen,
+	Args:  cobra.ExactArgs(1),
+}
+
+func runKeygen(cmd *cobra.Command, args []string) {
+	common.LockMemory()
+	common.SetRestrictiveUmask()
+
+	log.Print("Creating new key at ", args[0])
+
+	gk, err := ecdsa.GenerateKey(ethcrypto.S256(), rand.Reader)
+	if err != nil {
+		log.Fatalf("failed to generate key: %v", err)
+	}
+
+	err = common.WriteArmoredKey(gk, *keyDescription, args[0], *blockType, false)
+	if err != nil {
+		log.Fatalf("failed to write key: %v", err)
+	}
+}

--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -781,14 +781,9 @@ func runNode(cmd *cobra.Command, args []string) {
 
 	// In devnet mode, we generate a deterministic guardian key and write it to disk.
 	if *unsafeDevMode {
-		gk, err := generateDevnetGuardianKey()
+		err := devnet.GenerateAndStoreDevnetGuardianKey(*guardianKeyPath)
 		if err != nil {
 			logger.Fatal("failed to generate devnet guardian key", zap.Error(err))
-		}
-
-		err = writeGuardianKey(gk, "auto-generated deterministic devnet key", *guardianKeyPath, true)
-		if err != nil {
-			logger.Fatal("failed to write devnet guardian key", zap.Error(err))
 		}
 	}
 
@@ -797,7 +792,7 @@ func runNode(cmd *cobra.Command, args []string) {
 	defer db.Close()
 
 	// Guardian key
-	gk, err := loadGuardianKey(*guardianKeyPath)
+	gk, err := common.LoadGuardianKey(*guardianKeyPath, *unsafeDevMode)
 	if err != nil {
 		logger.Fatal("failed to load guardian key", zap.Error(err))
 	}

--- a/node/pkg/devnet/guardiankey.go
+++ b/node/pkg/devnet/guardiankey.go
@@ -1,0 +1,28 @@
+package devnet
+
+import (
+	"fmt"
+
+	"github.com/certusone/wormhole/node/pkg/common"
+
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+)
+
+// GenerateAndStoreDevnetGuardianKey returns a deterministic testnet key.
+func GenerateAndStoreDevnetGuardianKey(filename string) error {
+	// Figure out our devnet index
+	idx, err := GetDevnetIndex()
+	if err != nil {
+		return err
+	}
+
+	// Generate the guardian key.
+	gk := InsecureDeterministicEcdsaKeyByIndex(ethcrypto.S256(), uint64(idx))
+
+	// Store it to disk.
+	if err := common.WriteArmoredKey(gk, "auto-generated deterministic devnet key", filename, common.GuardianKeyArmoredBlock, true); err != nil {
+		return fmt.Errorf("failed to store generated guardian key: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This PR restructures the code to generate, save and read guardian key files so that it can be shared with CCQ. Once this PR is merged, the code in the `ccq/integration` branch will be updated to use it, including changing the `ccq_server` to not use the guardian key label.