### PR TITLE
CCQ: Query server environment is hard coded to devnet

### DIFF
--- a/devnet/query-server.yaml
+++ b/devnet/query-server.yaml
@@ -33,6 +33,8 @@ spec:
           command:
             - /guardiand
             - query-server
+            - --env
+            - dev
             - --nodeKey
             - node/cmd/ccq/ccq.p2p.key
             - --signerKey

--- a/node/pkg/common/mode.go
+++ b/node/pkg/common/mode.go
@@ -1,5 +1,10 @@
 package common
 
+import (
+	"fmt"
+	"strings"
+)
+
 type Environment string
 
 const (
@@ -9,3 +14,24 @@ const (
 	GoTest         Environment = "unit-test"
 	AccountantMock Environment = "accountant-mock" // Used for mocking accountant with a Wormchain connection
 )
+
+// ParseEnvironment parses a string into the corresponding Environment value, allowing various reasonable variations.
+func ParseEnvironment(str string) (Environment, error) {
+	str = strings.ToLower(str)
+	if str == "prod" || str == "mainnet" {
+		return MainNet, nil
+	}
+	if str == "test" || str == "testnet" {
+		return TestNet, nil
+	}
+	if str == "dev" || str == "devnet" || str == "unsafedevnet" {
+		return UnsafeDevNet, nil
+	}
+	if str == "unit-test" || str == "gotest" {
+		return GoTest, nil
+	}
+	if str == "accountant-mock" || str == "accountantmock" {
+		return AccountantMock, nil
+	}
+	return UnsafeDevNet, fmt.Errorf("invalid environment string: %s", str)
+}

--- a/node/pkg/common/mode_test.go
+++ b/node/pkg/common/mode_test.go
@@ -1,0 +1,51 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseEnvironment(t *testing.T) {
+	type test struct {
+		input  string
+		output Environment
+		err    bool
+	}
+
+	tests := []test{
+		{input: "MainNet", output: MainNet, err: false},
+		{input: "Prod", output: MainNet, err: false},
+
+		{input: "TestNet", output: TestNet, err: false},
+		{input: "test", output: TestNet, err: false},
+
+		{input: "UnsafeDevNet", output: UnsafeDevNet, err: false},
+		{input: "devnet", output: UnsafeDevNet, err: false},
+		{input: "dev", output: UnsafeDevNet, err: false},
+
+		{input: "GoTest", output: GoTest, err: false},
+		{input: "unit-test", output: GoTest, err: false},
+
+		{input: "AccountantMock", output: AccountantMock, err: false},
+		{input: "accountant-mock", output: AccountantMock, err: false},
+
+		{input: "junk", output: UnsafeDevNet, err: true},
+		{input: "", output: UnsafeDevNet, err: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			output, err := ParseEnvironment(tc.input)
+			if err != nil {
+				if tc.err == false {
+					assert.NoError(t, err)
+				}
+			} else if tc.err {
+				assert.Error(t, err)
+			} else {
+				assert.Equal(t, tc.output, output)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The `ccq_server` was recently updated to allow it to sign requests on behalf of API keys for which the feature is enabled. Unfortunately, that code hard coded the environment to devnet, so the requests are being signed using the wrong prefix for testnet. This PR fixes that. It also adds some more debug logging.