### PR TITLE
SDK: write to the correct index

### DIFF
--- a/sdk/js/src/solana/utils/secp256k1.ts
+++ b/sdk/js/src/solana/utils/secp256k1.ts
@@ -113,7 +113,7 @@ export class Secp256k1SignatureOffsets {
       serialized.writeUInt8(0, 6 + i * offsetSpan);
       serialized.writeUInt16LE(messageDataOffset, 7 + i * offsetSpan);
       serialized.writeUInt16LE(messageDataSize, 9 + i * offsetSpan);
-      serialized.writeUInt8(0, 10 + i * offsetSpan);
+      serialized.writeUInt8(0, 11 + i * offsetSpan);
 
       serialized.write(signature.toString("hex"), signatureOffset, "hex");
       serialized.write(key.toString("hex"), ethAddressOffset, "hex");


### PR DESCRIPTION
In this case we've gotten away with it because the `messageDataLength` in the previous element is always 32 which is `0200` in LE that we overwrite the second byte with a `00` 

But might as well make it right