### PR TITLE
Makefile: set CGO_ENABLED=1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ generate: dirs
 node: $(BIN)/guardiand
 
 .PHONY: $(BIN)/guardiand
+$(BIN)/guardiand: CGO_ENABLED=1
 $(BIN)/guardiand: dirs generate
 	@# The go-ethereum and celo-blockchain packages both implement secp256k1 using the exact same header, but that causes duplicate symbols.
 	cd node && go build -ldflags "-X github.com/certusone/wormhole/node/pkg/version.version=${VERSION} -extldflags -Wl,--allow-multiple-definition" \


### PR DESCRIPTION
This is required for building the guardiand binary.


To verify that it _doesn't_ build without this flag, run

```
CGO_ENABLED=0 make node
```

The above is needed in cases where `go env` is set up such that it supplies this flag by default, masking the issue.