### PR TITLE
Node: Update QUIC cutover time for testnet

### DIFF
--- a/node/pkg/p2p/cutover.go
+++ b/node/pkg/p2p/cutover.go
@@ -10,7 +10,7 @@ import (
 
 // The format of this time is very picky. Please use the exact format specified by cutOverFmtStr!
 const mainnetCutOverTimeStr = ""
-const testnetCutOverTimeStr = "2024-12-31T23:59:59-0000"
+const testnetCutOverTimeStr = "2023-11-07T14:00:00-0000"
 const devnetCutOverTimeStr = "2022-12-31T23:59:59-0000"
 const cutOverFmtStr = "2006-01-02T15:04:05-0700"
 


### PR DESCRIPTION
This PR sets the time to cut over the gossip network on testnet from QUIC to QUIC-V1. 