### PR TITLE
NODE/IBC: Allow for a separate block height URL

### DIFF
--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -139,9 +139,10 @@ var (
 	wormchainKeyPath       *string
 	wormchainKeyPassPhrase *string
 
-	ibcWS       *string
-	ibcLCD      *string
-	ibcContract *string
+	ibcWS             *string
+	ibcLCD            *string
+	ibcBlockHeightURL *string
+	ibcContract       *string
 
 	accountantContract      *string
 	accountantWS            *string
@@ -304,6 +305,7 @@ func init() {
 
 	ibcWS = NodeCmd.Flags().String("ibcWS", "", "Websocket used to listen to the IBC receiver smart contract on wormchain")
 	ibcLCD = NodeCmd.Flags().String("ibcLCD", "", "Path to LCD service root for http calls")
+	ibcBlockHeightURL = NodeCmd.Flags().String("ibcBlockHeightURL", "", "Optional URL to query for the block height (generated from ibcWS if not specified)")
 	ibcContract = NodeCmd.Flags().String("ibcContract", "", "Address of the IBC smart contract on wormchain")
 
 	accountantWS = NodeCmd.Flags().String("accountantWS", "", "Websocket used to listen to the accountant smart contract on wormchain")
@@ -840,6 +842,7 @@ func runNode(cmd *cobra.Command, args []string) {
 	rpcMap["celoRPC"] = *celoRPC
 	rpcMap["ethRPC"] = *ethRPC
 	rpcMap["fantomRPC"] = *fantomRPC
+	rpcMap["ibcBlockHeightURL"] = *ibcBlockHeightURL
 	rpcMap["ibcLCD"] = *ibcLCD
 	rpcMap["ibcWS"] = *ibcWS
 	rpcMap["karuraRPC"] = *karuraRPC
@@ -1370,9 +1373,10 @@ func runNode(cmd *cobra.Command, args []string) {
 	var ibcWatcherConfig *node.IbcWatcherConfig = nil
 	if shouldStart(ibcWS) {
 		ibcWatcherConfig = &node.IbcWatcherConfig{
-			Websocket: *ibcWS,
-			Lcd:       *ibcLCD,
-			Contract:  *ibcContract,
+			Websocket:      *ibcWS,
+			Lcd:            *ibcLCD,
+			BlockHeightURL: *ibcBlockHeightURL,
+			Contract:       *ibcContract,
 		}
 	}
 

--- a/node/pkg/node/options.go
+++ b/node/pkg/node/options.go
@@ -260,9 +260,10 @@ func GuardianOptionStatusServer(statusAddr string) *GuardianOption {
 }
 
 type IbcWatcherConfig struct {
-	Websocket string
-	Lcd       string
-	Contract  string
+	Websocket      string
+	Lcd            string
+	BlockHeightURL string
+	Contract       string
 }
 
 // GuardianOptionWatchers configues all normal watchers and all IBC watchers. They need to be all configured at the same time because they may depend on each other.
@@ -421,7 +422,7 @@ func GuardianOptionWatchers(watcherConfigs []watchers.WatcherConfig, ibcWatcherC
 				if len(chainConfig) > 0 {
 					logger.Info("Starting IBC watcher")
 					readiness.RegisterComponent(common.ReadinessIBCSyncing)
-					g.runnablesWithScissors["ibcwatch"] = ibc.NewWatcher(ibcWatcherConfig.Websocket, ibcWatcherConfig.Lcd, ibcWatcherConfig.Contract, chainConfig).Run
+					g.runnablesWithScissors["ibcwatch"] = ibc.NewWatcher(ibcWatcherConfig.Websocket, ibcWatcherConfig.Lcd, ibcWatcherConfig.BlockHeightURL, ibcWatcherConfig.Contract, chainConfig).Run
 				} else {
 					return errors.New("although IBC is enabled, there are no chains for it to monitor")
 				}

--- a/node/pkg/watchers/ibc/watcher_test.go
+++ b/node/pkg/watchers/ibc/watcher_test.go
@@ -218,6 +218,8 @@ func TestParseIbcAllChannelChainsQueryResults(t *testing.T) {
 func TestConvertingWsUrlToHttpUrl(t *testing.T) {
 	assert.Equal(t, "http://wormchain:26657", convertWsUrlToHttpUrl("ws://wormchain:26657/websocket"))
 	assert.Equal(t, "http://wormchain:26657", convertWsUrlToHttpUrl("ws://wormchain:26657"))
+	assert.Equal(t, "http://wormchain:26657", convertWsUrlToHttpUrl("wss://wormchain:26657/websocket"))
+	assert.Equal(t, "http://wormchain:26657", convertWsUrlToHttpUrl("wss://wormchain:26657"))
 	assert.Equal(t, "http://wormchain:26657", convertWsUrlToHttpUrl("wormchain:26657"))
 }
 


### PR DESCRIPTION
Currently the IBC watcher uses the `ibcWS` guardian config parameter to generate the URL used to read the block height and wormchain version. (This is necessary because the LCD may not be used to read `abci_info`.) This works in most cases (including for all mainnet guardians) but may not work in some situations in testnet.

This PR adds a new optional `ibcBlockHeightURL` config parameter. If it is not specified, the `ibcWS` is converted to be used for the http query (as it always has been). If `ibcBlockHeightURL` is specified, then it is used for the block height query.

Additionally, the existing conversion routine only handled URLs that start with "ws://", not "wss://". This PR fixes that.