### PR TITLE
Node/EVM: Add timestamp to block

### DIFF
--- a/node/pkg/watchers/evm/connectors/batch_poller.go
+++ b/node/pkg/watchers/evm/connectors/batch_poller.go
@@ -219,6 +219,7 @@ func (b *BatchPollConnector) getBlocks(ctx context.Context, logger *zap.Logger) 
 
 		ret[idx] = &NewBlock{
 			Number:        &n,
+			Time:          uint64(m.Time),
 			Hash:          m.Hash,
 			L1BlockNumber: l1bn,
 			Finality:      finality,
@@ -276,6 +277,7 @@ func (b *BatchPollConnector) getBlockRange(ctx context.Context, logger *zap.Logg
 
 		ret[idx] = &NewBlock{
 			Number:        &n,
+			Time:          uint64(m.Time),
 			Hash:          m.Hash,
 			L1BlockNumber: l1bn,
 			Finality:      finality,

--- a/node/pkg/watchers/evm/connectors/common.go
+++ b/node/pkg/watchers/evm/connectors/common.go
@@ -30,6 +30,7 @@ type BlockMarshaller struct {
 type NewBlock struct {
 	Number        *big.Int
 	Hash          common.Hash
+	Time          uint64
 	L1BlockNumber *big.Int // This is only populated on some chains (Arbitrum)
 	Finality      FinalityLevel
 }
@@ -38,6 +39,7 @@ func (b *NewBlock) Copy(f FinalityLevel) *NewBlock {
 	return &NewBlock{
 		Number:        b.Number,
 		Hash:          b.Hash,
+		Time:          b.Time,
 		L1BlockNumber: b.L1BlockNumber,
 		Finality:      f,
 	}

--- a/node/pkg/watchers/evm/connectors/instant_finality.go
+++ b/node/pkg/watchers/evm/connectors/instant_finality.go
@@ -47,21 +47,15 @@ func (c *InstantFinalityConnector) SubscribeForBlocks(ctx context.Context, errC 
 					c.logger.Error("new header block number is nil")
 					continue
 				}
-				sink <- &NewBlock{
+				block := &NewBlock{
 					Number:   ev.Number,
+					Time:     ev.Time,
 					Hash:     ev.Hash(),
 					Finality: Finalized,
 				}
-				sink <- &NewBlock{
-					Number:   ev.Number,
-					Hash:     ev.Hash(),
-					Finality: Safe,
-				}
-				sink <- &NewBlock{
-					Number:   ev.Number,
-					Hash:     ev.Hash(),
-					Finality: Latest,
-				}
+				sink <- block
+				sink <- block.Copy(Safe)
+				sink <- block.Copy(Latest)
 			}
 		}
 	})

--- a/node/pkg/watchers/evm/connectors/poller.go
+++ b/node/pkg/watchers/evm/connectors/poller.go
@@ -232,6 +232,7 @@ func getBlock(ctx context.Context, logger *zap.Logger, conn Connector, str strin
 
 	return &NewBlock{
 		Number:        &n,
+		Time:          uint64(m.Time),
 		Hash:          m.Hash,
 		L1BlockNumber: l1bn,
 		Finality:      blockFinality,

--- a/node/pkg/watchers/evm/connectors/polygon.go
+++ b/node/pkg/watchers/evm/connectors/polygon.go
@@ -147,6 +147,7 @@ func (c *PolygonConnector) SubscribeForBlocks(ctx context.Context, errC chan err
 				}
 				sink <- &NewBlock{
 					Number:   ev.Number,
+					Time:     ev.Time,
 					Hash:     ev.Hash(),
 					Finality: Latest,
 				}

--- a/node/pkg/watchers/evm/watcher.go
+++ b/node/pkg/watchers/evm/watcher.go
@@ -604,6 +604,7 @@ func (w *Watcher) Run(parentCtx context.Context) error {
 				currentHash := ev.Hash
 				logger.Debug("processing new header",
 					zap.Stringer("current_block", ev.Number),
+					zap.Uint64("block_time", ev.Time),
 					zap.Stringer("current_blockhash", currentHash),
 					zap.Stringer("finality", ev.Finality),
 					zap.String("eth_network", w.networkName))


### PR DESCRIPTION
The CCQ timestamp to block number feature needs to have access to the timestamp of the latest blocks. This PR adds that for all the various block pollers.