### PR TITLE
CCQ/Node/EVM: Cache timestamps

### DIFF
--- a/node/pkg/adminrpc/adminserver_test.go
+++ b/node/pkg/adminrpc/adminserver_test.go
@@ -78,6 +78,10 @@ func (c mockEVMConnector) Client() *ethclient.Client {
 	panic("unimplemented")
 }
 
+func (c mockEVMConnector) SubscribeNewHead(ctx context.Context, ch chan<- *types.Header) (ethereum.Subscription, error) {
+	panic("unimplemented")
+}
+
 func generateGS(num int) (keys []*ecdsa.PrivateKey, addrs []common.Address) {
 	for i := 0; i < num; i++ {
 		key, err := ethcrypto.GenerateKey()

--- a/node/pkg/query/query.go
+++ b/node/pkg/query/query.go
@@ -419,3 +419,14 @@ func (pq *pendingQuery) numPendingRequests() int {
 
 	return numPending
 }
+
+func SupportsTimestampCaching(chainID vaa.ChainID) bool {
+	/*
+		- P1: Ethereum, Base, Optimism
+		- P1.5: Arbitrum, Polygon, Avalanche
+		- P2: BNB Chain, Moonbeam
+		- P3: Acala, Celo, Fantom, Karura, Klaytn, Oasis
+	*/
+
+	return chainID == vaa.ChainIDEthereum || chainID == vaa.ChainIDBase || chainID == vaa.ChainIDOptimism
+}

--- a/node/pkg/query/request.go
+++ b/node/pkg/query/request.go
@@ -631,19 +631,16 @@ func (ecd *EthCallByTimestampQueryRequest) Validate() error {
 	if len(ecd.TargetBlockIdHint) > math.MaxUint32 {
 		return fmt.Errorf("target block id hint too long")
 	}
-	if ecd.TargetBlockIdHint == "" {
-		return fmt.Errorf("target block id is required")
+	if (ecd.TargetBlockIdHint == "") != (ecd.FollowingBlockIdHint == "") {
+		return fmt.Errorf("if either the target or following block id is unset, they both must be unset")
 	}
-	if !strings.HasPrefix(ecd.TargetBlockIdHint, "0x") {
+	if ecd.TargetBlockIdHint != "" && !strings.HasPrefix(ecd.TargetBlockIdHint, "0x") {
 		return fmt.Errorf("target block id must be a hex number or hash starting with 0x")
 	}
 	if len(ecd.FollowingBlockIdHint) > math.MaxUint32 {
 		return fmt.Errorf("following block id hint too long")
 	}
-	if ecd.FollowingBlockIdHint == "" {
-		return fmt.Errorf("following block id is required")
-	}
-	if !strings.HasPrefix(ecd.FollowingBlockIdHint, "0x") {
+	if ecd.FollowingBlockIdHint != "" && !strings.HasPrefix(ecd.FollowingBlockIdHint, "0x") {
 		return fmt.Errorf("following block id must be a hex number or hash starting with 0x")
 	}
 	if len(ecd.CallData) <= 0 {

--- a/node/pkg/watchers/evm/blocks_by_timestamp.go
+++ b/node/pkg/watchers/evm/blocks_by_timestamp.go
@@ -1,0 +1,149 @@
+package evm
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+)
+
+const (
+	BTS_MAX_BLOCKS = 10000
+)
+
+type (
+	BlocksByTimestamp struct {
+		// cache is ordered by timestamp, blockNum. There may be multiple entries for the same timestamp, but not the same block.
+		cache Blocks
+
+		// maxCacheSize is used to trim the cache.
+		maxCacheSize int
+
+		// mutex is used to protect the cache.
+		mutex sync.Mutex
+	}
+
+	Blocks []Block
+
+	Block struct {
+		Timestamp uint64
+		BlockNum  uint64
+	}
+)
+
+// NewBlocksByTimestamp creates an empty cache of blocks by timestamp.
+func NewBlocksByTimestamp(maxCacheSize int) *BlocksByTimestamp {
+	return &BlocksByTimestamp{
+		cache:        Blocks{},
+		maxCacheSize: maxCacheSize,
+	}
+}
+
+// AddLatest adds a block to the end of the cache. This is meant to be used in the normal scenario when a new latest block is received. It will return an error if the block should not go at the end.
+func (bts *BlocksByTimestamp) AddLatest(timestamp uint64, blockNum uint64) error {
+	bts.mutex.Lock()
+	defer bts.mutex.Unlock()
+	if len(bts.cache) > 0 {
+		last := &bts.cache[len(bts.cache)-1]
+		if timestamp < last.Timestamp {
+			return fmt.Errorf("timestamp %d must be greater than or equal to the previous latest %d", timestamp, last.Timestamp)
+		}
+		if blockNum <= last.BlockNum {
+			return fmt.Errorf("block number %d must be greater than the previous latest %d", blockNum, last.BlockNum)
+		}
+	}
+
+	bts.cache = append(bts.cache, Block{Timestamp: timestamp, BlockNum: blockNum})
+
+	if len(bts.cache) > bts.maxCacheSize {
+		bts.cache = bts.cache[1:]
+	}
+	return nil
+}
+
+// AddBatch adds a batch of blocks to the cache. This is meant to be used for backfilling the cache. It makes sure there are no duplicate blocks and regenerates the cache in the correct order by timestamp.
+func (bts *BlocksByTimestamp) AddBatch(blocks Blocks) {
+	bts.mutex.Lock()
+	defer bts.mutex.Unlock()
+
+	// First build a map of all the existing blocks so we can avoid duplicates.
+	blockMap := make(map[uint64]uint64)
+	for _, block := range bts.cache {
+		blockMap[block.BlockNum] = block.Timestamp
+	}
+
+	// Now add the new blocks to the map, overwriting any duplicates. (Maybe there was a reorg. . .)
+	for _, block := range blocks {
+		blockMap[block.BlockNum] = block.Timestamp
+	}
+
+	// Now put everything into the cache in random order.
+	cache := Blocks{}
+	for blockNum, timestamp := range blockMap {
+		cache = append(cache, Block{Timestamp: timestamp, BlockNum: blockNum})
+	}
+
+	// Sort the cache into timestamp order.
+	sort.SliceStable(cache, func(i, j int) bool {
+		return cache[i].Cmp(cache[j]) < 0
+	})
+
+	if len(cache) > bts.maxCacheSize {
+		// Trim the cache.
+		trimIdx := len(cache) - bts.maxCacheSize
+		cache = cache[trimIdx:]
+	}
+
+	bts.cache = cache
+}
+
+// LookUp searches the cache for the specified timestamp and returns the blocks surrounding that timestamp. It also returns true if the results are complete or false if they are not.
+// The following rules apply:
+// - If timestamp is less than the first timestamp in the cache, it returns (0, <theFirstBlockInTheCache>, false)
+// - If timestamp is greater than or equal to the last timestamp in the cache, it returns (<theLastBlockInTheCache>, 0, false)
+// - If timestamp exactly matches one in the cache, it returns (<theLastBlockForThatTimestamp>, <theFirstBlockForTheNextTimestamp>, true)
+// - If timestamp is not in the cache, but there are blocks around it, it returns (<theLastBlockForThePreviousTimestamp>, <theFirstBlockForTheNextTimestamp>, false)
+func (bts *BlocksByTimestamp) LookUp(timestamp uint64) (uint64, uint64, bool) {
+	bts.mutex.Lock()
+	defer bts.mutex.Unlock()
+
+	if len(bts.cache) == 0 { // Empty cache.
+		return 0, 0, false
+	}
+
+	if timestamp < bts.cache[0].Timestamp { // Before the start of the cache.
+		return 0, bts.cache[0].BlockNum, false
+	}
+
+	if timestamp >= bts.cache[len(bts.cache)-1].Timestamp { // After the end of the cache (including matching the final timestamp).
+		return bts.cache[len(bts.cache)-1].BlockNum, 0, false
+	}
+
+	// The search returns the first entry where the timestamp is greater than requested.
+	idx := bts.cache.SearchForTimestamp(timestamp)
+
+	// If the two blocks are adjacent, then we found what we are looking for.
+	found := bts.cache[idx-1].BlockNum+1 == bts.cache[idx].BlockNum
+	return bts.cache[idx-1].BlockNum, bts.cache[idx].BlockNum, found
+}
+
+func (blocks Blocks) SearchForTimestamp(timestamp uint64) int {
+	return sort.Search(len(blocks), func(i int) bool { return blocks[i].Timestamp > timestamp })
+}
+
+// Cmp compares two blocks, returning the usual -1, 0, +1.
+func (lhs Block) Cmp(rhs Block) int {
+	if lhs.Timestamp < rhs.Timestamp {
+		return -1
+	}
+	if lhs.Timestamp > rhs.Timestamp {
+		return 1
+	}
+	if lhs.BlockNum < rhs.BlockNum {
+		return -1
+	}
+	if lhs.BlockNum > rhs.BlockNum {
+		return 1
+	}
+
+	return 0
+}

--- a/node/pkg/watchers/evm/blocks_by_timestamp_test.go
+++ b/node/pkg/watchers/evm/blocks_by_timestamp_test.go
@@ -1,0 +1,240 @@
+package evm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func cacheIsValid(t *testing.T, bts *BlocksByTimestamp) bool {
+	t.Helper()
+	prevBlock := Block{}
+	for idx := range bts.cache {
+		// fmt.Println("Compare: prev: ", prevBlock, ", this: ", bts.cache[idx], ": ", prevBlock.Cmp(bts.cache[idx]))
+		if prevBlock.Cmp(bts.cache[idx]) != -1 {
+			return false
+		}
+		prevBlock = bts.cache[idx]
+	}
+
+	return true
+}
+
+func TestBlocksByTimestamp_TestCacheIsValid(t *testing.T) {
+	bts := NewBlocksByTimestamp(BTS_MAX_BLOCKS)
+
+	// Empty cache is valid.
+	assert.True(t, cacheIsValid(t, bts))
+
+	bts.cache = append(bts.cache, Block{Timestamp: 1698621628, BlockNum: 420}) // 0
+	bts.cache = append(bts.cache, Block{Timestamp: 1698621629, BlockNum: 430}) // 1
+	bts.cache = append(bts.cache, Block{Timestamp: 1698621629, BlockNum: 440}) // 2
+	bts.cache = append(bts.cache, Block{Timestamp: 1698621631, BlockNum: 450}) // 3
+	bts.cache = append(bts.cache, Block{Timestamp: 1698621632, BlockNum: 460}) // 4
+
+	// Make sure a valid cache is valid.
+	assert.True(t, cacheIsValid(t, bts))
+
+	// Timestamps match but duplicate block should fail.
+	bts.cache[2] = Block{Timestamp: 1698621629, BlockNum: 430}
+	assert.False(t, cacheIsValid(t, bts))
+
+	// Restore things.
+	bts.cache[2] = Block{Timestamp: 1698621629, BlockNum: 440}
+	assert.True(t, cacheIsValid(t, bts))
+
+	// Timestamps match but block out of order should fail.
+	bts.cache[2] = Block{Timestamp: 1698621629, BlockNum: 425}
+	assert.False(t, cacheIsValid(t, bts))
+
+	// Restore things.
+	bts.cache[2] = Block{Timestamp: 1698621629, BlockNum: 440}
+	assert.True(t, cacheIsValid(t, bts))
+
+	// Timestamps out of order should fail.
+	bts.cache[2] = Block{Timestamp: 1698621620, BlockNum: 440}
+	assert.False(t, cacheIsValid(t, bts))
+}
+
+func TestBlocksByTimestamp_AddLatest(t *testing.T) {
+	bts := NewBlocksByTimestamp(BTS_MAX_BLOCKS)
+
+	assert.NoError(t, bts.AddLatest(1698621628, 420))
+	assert.NoError(t, bts.AddLatest(1698621628, 421))
+	assert.NoError(t, bts.AddLatest(1698621628, 422))
+	assert.Error(t, bts.AddLatest(1698621627, 423)) // The timestamp going down is an error.
+	assert.Error(t, bts.AddLatest(1698621629, 422)) // Even if the timestamp goes up, the block must also go up.
+	assert.NoError(t, bts.AddLatest(1698621629, 423))
+	assert.Equal(t, 4, len(bts.cache))
+	assert.True(t, cacheIsValid(t, bts))
+}
+
+func TestBlocksByTimestamp_AddLatestShouldTrimTheCache(t *testing.T) {
+	bts := NewBlocksByTimestamp(5)
+
+	require.NoError(t, bts.AddLatest(1698621628, 420))
+	require.NoError(t, bts.AddLatest(1698621628, 421))
+	require.NoError(t, bts.AddLatest(1698621628, 422))
+	require.NoError(t, bts.AddLatest(1698621628, 423))
+	require.NoError(t, bts.AddLatest(1698621629, 424))
+	require.Equal(t, 5, len(bts.cache), 5)
+	require.True(t, cacheIsValid(t, bts))
+
+	assert.NoError(t, bts.AddLatest(1698621629, 425))
+	assert.Equal(t, 5, len(bts.cache))
+
+	assert.True(t, cacheIsValid(t, bts))
+	assert.Equal(t, uint64(421), bts.cache[0].BlockNum)
+	assert.Equal(t, uint64(422), bts.cache[1].BlockNum)
+	assert.Equal(t, uint64(423), bts.cache[2].BlockNum)
+	assert.Equal(t, uint64(424), bts.cache[3].BlockNum)
+	assert.Equal(t, uint64(425), bts.cache[4].BlockNum)
+}
+
+func TestBlocksByTimestamp_AddBatch(t *testing.T) {
+	bts := NewBlocksByTimestamp(BTS_MAX_BLOCKS)
+
+	// First create a cache with some gaps in it.
+	require.NoError(t, bts.AddLatest(1698621628, 420))
+	require.NoError(t, bts.AddLatest(1698621628, 430))
+	require.NoError(t, bts.AddLatest(1698621728, 440))
+	require.NoError(t, bts.AddLatest(1698621729, 450))
+	require.NoError(t, bts.AddLatest(1698621828, 460))
+	require.Equal(t, 5, len(bts.cache))
+	require.True(t, cacheIsValid(t, bts))
+
+	batch := []Block{
+		// Add a couple afterwards.
+		{Timestamp: 1698621928, BlockNum: 470},
+		{Timestamp: 1698621929, BlockNum: 480},
+
+		// Add a few in the middle.
+		{Timestamp: 1698621630, BlockNum: 431},
+		{Timestamp: 1698621631, BlockNum: 432},
+
+		// Add one at the front.
+		{Timestamp: 1698621528, BlockNum: 410},
+	}
+
+	bts.AddBatch(batch)
+	assert.Equal(t, 10, len(bts.cache))
+	assert.True(t, cacheIsValid(t, bts))
+}
+
+func TestBlocksByTimestamp_AddBatchShouldTrim(t *testing.T) {
+	bts := NewBlocksByTimestamp(8)
+
+	// First create a cache with some gaps in it.
+	require.NoError(t, bts.AddLatest(1698621628, 420))
+	require.NoError(t, bts.AddLatest(1698621628, 430))
+	require.NoError(t, bts.AddLatest(1698621728, 440))
+	require.NoError(t, bts.AddLatest(1698621729, 450))
+	require.NoError(t, bts.AddLatest(1698621828, 460))
+	require.Equal(t, 5, len(bts.cache))
+	require.True(t, cacheIsValid(t, bts))
+
+	batch := []Block{
+		// Add a couple afterwards.
+		{Timestamp: 1698621928, BlockNum: 470},
+		{Timestamp: 1698621929, BlockNum: 480},
+
+		// Add a few in the middle.
+		{Timestamp: 1698621630, BlockNum: 431},
+		{Timestamp: 1698621631, BlockNum: 432},
+
+		// Add one at the front.
+		{Timestamp: 1698621528, BlockNum: 410},
+	}
+
+	bts.AddBatch(batch)
+	assert.Equal(t, 8, len(bts.cache))
+	assert.True(t, cacheIsValid(t, bts))
+	assert.Equal(t, uint64(430), bts.cache[0].BlockNum)
+	assert.Equal(t, uint64(431), bts.cache[1].BlockNum)
+	assert.Equal(t, uint64(432), bts.cache[2].BlockNum)
+	assert.Equal(t, uint64(440), bts.cache[3].BlockNum)
+	assert.Equal(t, uint64(450), bts.cache[4].BlockNum)
+	assert.Equal(t, uint64(460), bts.cache[5].BlockNum)
+	assert.Equal(t, uint64(470), bts.cache[6].BlockNum)
+	assert.Equal(t, uint64(480), bts.cache[7].BlockNum)
+}
+
+func TestBlocksByTimestamp_SearchForTimestamp(t *testing.T) {
+	blocks := Blocks{
+		{Timestamp: 1698621228, BlockNum: 420}, // 0
+		{Timestamp: 1698621328, BlockNum: 430}, // 1
+		{Timestamp: 1698621428, BlockNum: 440}, // 2
+		{Timestamp: 1698621428, BlockNum: 450}, // 3
+		{Timestamp: 1698621528, BlockNum: 460}, // 4
+	}
+
+	// Returns the first entry where the timestamp is greater than requested.
+	assert.Equal(t, 0, blocks.SearchForTimestamp(1698621128))
+	assert.Equal(t, 1, blocks.SearchForTimestamp(1698621228))
+	assert.Equal(t, 2, blocks.SearchForTimestamp(1698621328))
+	assert.Equal(t, 4, blocks.SearchForTimestamp(1698621428))
+	assert.Equal(t, 5, blocks.SearchForTimestamp(1698621528))
+	assert.Equal(t, 5, blocks.SearchForTimestamp(1698621628))
+}
+
+func TestBlocksByTimestamp_LookUp(t *testing.T) {
+	bts := NewBlocksByTimestamp(BTS_MAX_BLOCKS)
+
+	// Empty cache.
+	prev, next, found := bts.LookUp(1698621627)
+	assert.False(t, found)
+	assert.Equal(t, uint64(0), prev)
+	assert.Equal(t, uint64(0), next)
+
+	require.NoError(t, bts.AddLatest(1698621528, 420))
+	require.NoError(t, bts.AddLatest(1698621528, 421))
+	require.NoError(t, bts.AddLatest(1698621628, 422))
+	require.NoError(t, bts.AddLatest(1698621728, 423))
+	require.NoError(t, bts.AddLatest(1698621728, 424))
+	require.NoError(t, bts.AddLatest(1698621828, 426))
+	require.Equal(t, 6, len(bts.cache))
+	require.True(t, cacheIsValid(t, bts))
+
+	// Before the beginning of the cache.
+	prev, next, found = bts.LookUp(1698621527)
+	assert.False(t, found)
+	assert.Equal(t, uint64(0), prev)
+	assert.Equal(t, uint64(420), next)
+
+	// After the end of the cache.
+	prev, next, found = bts.LookUp(1698621928)
+	assert.False(t, found)
+	assert.Equal(t, uint64(426), prev)
+	assert.Equal(t, uint64(0), next)
+
+	// Last timestamp in the cache.
+	prev, next, found = bts.LookUp(1698621828)
+	assert.False(t, found)
+	assert.Equal(t, uint64(426), prev)
+	assert.Equal(t, uint64(0), next)
+
+	// In the cache, one block for the timestamp.
+	prev, next, found = bts.LookUp(1698621628)
+	assert.True(t, found)
+	assert.Equal(t, uint64(422), prev)
+	assert.Equal(t, uint64(423), next)
+
+	// In the cache, multiple blocks for the same timestamp.
+	prev, next, found = bts.LookUp(1698621528)
+	assert.True(t, found)
+	assert.Equal(t, uint64(421), prev)
+	assert.Equal(t, uint64(422), next)
+
+	// Not in the cache, no gap.
+	prev, next, found = bts.LookUp(1698621600)
+	assert.True(t, found)
+	assert.Equal(t, uint64(421), prev)
+	assert.Equal(t, uint64(422), next)
+
+	// Not in the cache, gap.
+	prev, next, found = bts.LookUp(1698621800)
+	assert.False(t, found)
+	assert.Equal(t, uint64(424), prev)
+	assert.Equal(t, uint64(426), next)
+}

--- a/node/pkg/watchers/evm/ccq.go
+++ b/node/pkg/watchers/evm/ccq.go
@@ -211,6 +211,61 @@ func (w *Watcher) ccqHandleEthCallByTimestampQueryRequest(logger *zap.Logger, ct
 		zap.Int("numRequests", len(req.CallData)),
 	)
 
+	if (block == "") != (nextBlock == "") {
+		logger.Error("invalid block id hints in eth_call_by_timestamp query request, if one is unset they both must be unset",
+			zap.Uint64("timestamp", req.TargetTimestamp),
+			zap.String("block", block),
+			zap.String("nextBlock", nextBlock),
+		)
+		w.ccqSendQueryResponseForError(logger, queryRequest, query.QueryFatalError)
+		return
+	}
+
+	if block == "" {
+		if w.ccqTimestampCache == nil {
+			logger.Error("error in block id hints in eth_call_by_timestamp query request, they are unset and chain does not support timestamp caching")
+			w.ccqSendQueryResponseForError(logger, queryRequest, query.QueryFatalError)
+			return
+		}
+
+		// Look the timestamp up in the cache. Note that the cache uses native EVM time, which is seconds, but CCQ uses milliseconds, so we have to convert.
+		blockNum, nextBlockNum, found := w.ccqTimestampCache.LookUp(req.TargetTimestamp / 1000000)
+		if !found {
+			if blockNum == 0 {
+				logger.Error("block look up failed in eth_call_by_timestamp query request, timestamp is before the cache and that is not supported yet",
+					zap.Uint64("timestamp", req.TargetTimestamp),
+					zap.String("block", block),
+					zap.String("nextBlock", nextBlock),
+					zap.Uint64("blockNum", blockNum),
+					zap.Uint64("nextBlockNum", nextBlockNum),
+				)
+				w.ccqSendQueryResponseForError(logger, queryRequest, query.QueryFatalError)
+				return
+			}
+
+			logger.Error("block look up failed in eth_call_by_timestamp query request, timestamp not in cache, will retry",
+				zap.Uint64("timestamp", req.TargetTimestamp),
+				zap.String("block", block),
+				zap.String("nextBlock", nextBlock),
+				zap.Uint64("blockNum", blockNum),
+				zap.Uint64("nextBlockNum", nextBlockNum),
+			)
+			w.ccqSendQueryResponseForError(logger, queryRequest, query.QueryRetryNeeded)
+			return
+		}
+
+		block = fmt.Sprintf("0x%x", blockNum)
+		nextBlock = fmt.Sprintf("0x%x", nextBlockNum)
+
+		logger.Info("cache look up in eth_call_by_timestamp query request mapped timestamp to blocks",
+			zap.Uint64("timestamp", req.TargetTimestamp),
+			zap.String("block", block),
+			zap.String("nextBlock", nextBlock),
+			zap.Uint64("blockNum", blockNum),
+			zap.Uint64("nextBlockNum", nextBlockNum),
+		)
+	}
+
 	blockMethod, callBlockArg, err := ccqCreateBlockRequest(block)
 	if err != nil {
 		logger.Error("invalid target block id hint in eth_call_by_timestamp query request",
@@ -717,4 +772,12 @@ func ccqBuildBatchFromCallData(req EthCallDataIntf, callBlockArg interface{}) ([
 	}
 
 	return batch, evmCallData
+}
+
+func (w *Watcher) ccqAddLatestBlock(logger *zap.Logger, ev *connectors.NewBlock) {
+	if w.ccqTimestampCache != nil {
+		if err := w.ccqTimestampCache.AddLatest(ev.Time, ev.Number.Uint64()); err != nil {
+			logger.Error("failed to add latest block to cache", zap.Any("event", ev), zap.String("component", "ccqevm"))
+		}
+	}
 }

--- a/node/pkg/watchers/evm/connectors/batch_poller.go
+++ b/node/pkg/watchers/evm/connectors/batch_poller.go
@@ -72,7 +72,9 @@ func (b *BatchPollConnector) SubscribeForBlocks(ctx context.Context, errC chan e
 	innerErrSink := make(chan string, 10)
 	innerErrSub := b.errFeed.Subscribe(innerErrSink)
 
-	// Use the standard geth head sink to get latest blocks.
+	// Use the standard geth head sink to get latest blocks. We do this so that we will be notified of rollbacks. The following document
+	// indicates that the subscription will receive a replay of all blocks affected by a rollback. This is important for latest because the
+	// timestamp cache needs to be updated on a rollback. We can only consider polling for latest if we can guarantee that we won't miss rollbacks.
 	// https://ethereum.org/en/developers/tutorials/using-websockets/#subscription-types
 	headSink := make(chan *ethTypes.Header, 2)
 	_, err := b.Connector.SubscribeNewHead(ctx, headSink)

--- a/node/pkg/watchers/evm/connectors/batch_poller_test.go
+++ b/node/pkg/watchers/evm/connectors/batch_poller_test.go
@@ -17,6 +17,7 @@ import (
 
 	ethereum "github.com/ethereum/go-ethereum"
 	ethCommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
 	ethClient "github.com/ethereum/go-ethereum/ethclient"
 	ethEvent "github.com/ethereum/go-ethereum/event"
@@ -151,6 +152,10 @@ func (e *mockConnectorForBatchPoller) expectedHash() ethCommon.Hash {
 
 func (e *mockConnectorForBatchPoller) Client() *ethClient.Client {
 	return e.client
+}
+
+func (e *mockConnectorForBatchPoller) SubscribeNewHead(ctx context.Context, ch chan<- *types.Header) (ethereum.Subscription, error) {
+	return nil, nil
 }
 
 func batchShouldHaveAllThree(t *testing.T, block []*NewBlock, blockNum uint64, expectedHash ethCommon.Hash) {

--- a/node/pkg/watchers/evm/connectors/celo.go
+++ b/node/pkg/watchers/evm/connectors/celo.go
@@ -15,6 +15,7 @@ import (
 
 	ethereum "github.com/ethereum/go-ethereum"
 	ethCommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
 	ethClient "github.com/ethereum/go-ethereum/ethclient"
 	ethEvent "github.com/ethereum/go-ethereum/event"
@@ -209,6 +210,10 @@ func (c *CeloConnector) RawBatchCallContext(ctx context.Context, b []ethRpc.Batc
 }
 
 func (c *CeloConnector) Client() *ethClient.Client {
+	panic("unimplemented")
+}
+
+func (c *CeloConnector) SubscribeNewHead(ctx context.Context, ch chan<- *types.Header) (ethereum.Subscription, error) {
 	panic("unimplemented")
 }
 

--- a/node/pkg/watchers/evm/connectors/common.go
+++ b/node/pkg/watchers/evm/connectors/common.go
@@ -59,6 +59,7 @@ type Connector interface {
 	RawCallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error
 	RawBatchCallContext(ctx context.Context, b []rpc.BatchElem) error
 	Client() *ethClient.Client
+	SubscribeNewHead(ctx context.Context, ch chan<- *types.Header) (ethereum.Subscription, error)
 }
 
 type PollSubscription struct {

--- a/node/pkg/watchers/evm/connectors/ethereum.go
+++ b/node/pkg/watchers/evm/connectors/ethereum.go
@@ -11,6 +11,7 @@ import (
 	ethereum "github.com/ethereum/go-ethereum"
 	ethBind "github.com/ethereum/go-ethereum/accounts/abi/bind"
 	ethCommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
 	ethClient "github.com/ethereum/go-ethereum/ethclient"
 	ethEvent "github.com/ethereum/go-ethereum/event"
@@ -111,4 +112,8 @@ func (e *EthereumBaseConnector) RawBatchCallContext(ctx context.Context, b []eth
 
 func (e *EthereumBaseConnector) Client() *ethClient.Client {
 	return e.client
+}
+
+func (e *EthereumBaseConnector) SubscribeNewHead(ctx context.Context, ch chan<- *types.Header) (ethereum.Subscription, error) {
+	return e.client.SubscribeNewHead(ctx, ch)
 }

--- a/node/pkg/watchers/evm/connectors/poller_test.go
+++ b/node/pkg/watchers/evm/connectors/poller_test.go
@@ -17,6 +17,7 @@ import (
 
 	ethereum "github.com/ethereum/go-ethereum"
 	ethCommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
 	ethClient "github.com/ethereum/go-ethereum/ethclient"
 	ethEvent "github.com/ethereum/go-ethereum/event"
@@ -137,6 +138,10 @@ func (e *mockConnectorForPoller) expectedHash() ethCommon.Hash {
 
 func (e *mockConnectorForPoller) Client() *ethClient.Client {
 	return e.client
+}
+
+func (e *mockConnectorForPoller) SubscribeNewHead(ctx context.Context, ch chan<- *types.Header) (ethereum.Subscription, error) {
+	return nil, nil
 }
 
 type mockFinalizerForPoller struct {

--- a/sdk/js-query/src/query/ethCall.test.ts
+++ b/sdk/js-query/src/query/ethCall.test.ts
@@ -73,9 +73,10 @@ async function getEthCallByTimestampArgs(): Promise<[bigint, bigint, bigint]> {
   let targetBlockTime = BigInt(0);
   while (targetBlockNumber === BigInt(0)) {
     let followingBlock = await web3.eth.getBlock(followingBlockNumber);
-    while (Number(followingBlock) <= 0) {
+    while (Number(followingBlock.number) <= 0) {
       await sleep(1000);
-      followingBlock = await web3.eth.getBlock(followingBlockNumber);
+      followingBlock = await web3.eth.getBlock(followingBlock.number);
+      followingBlockNumber = followingBlock.number;
     }
     const targetBlock = await web3.eth.getBlock(
       (Number(followingBlockNumber) - 1).toString()
@@ -386,7 +387,7 @@ describe("eth call", () => {
       "0100000001010005020000005b0006079bf7fad4800000000930783238643936333000000009307832386439363331020d500b1d8e8ef31e21c99d1db9a6444d3adf12700000000406fdde030d500b1d8e8ef31e21c99d1db9a6444d3adf12700000000418160ddd"
     );
   });
-  test("successful eth_call_by_timestamp query", async () => {
+  test("successful eth_call_by_timestamp query with block hints", async () => {
     const nameCallData = createTestEthCallData(WETH_ADDRESS, "name", "string");
     const totalSupplyCallData = createTestEthCallData(
       WETH_ADDRESS,
@@ -399,6 +400,38 @@ describe("eth call", () => {
       targetBlockTime,
       targetBlockNumber.toString(16),
       followingBlockNumber.toString(16),
+      [nameCallData, totalSupplyCallData]
+    );
+    const chainId = 2;
+    const ethQuery = new PerChainQueryRequest(chainId, ethCall);
+    const nonce = 1;
+    const request = new QueryRequest(nonce, [ethQuery]);
+    const serialized = request.serialize();
+    const digest = QueryRequest.digest(ENV, serialized);
+    const signature = sign(PRIVATE_KEY, digest);
+    const response = await axios.put(
+      QUERY_URL,
+      {
+        signature,
+        bytes: Buffer.from(serialized).toString("hex"),
+      },
+      { headers: { "X-API-Key": "my_secret_key" } }
+    );
+    expect(response.status).toBe(200);
+  });
+  test("successful eth_call_by_timestamp query without block hints", async () => {
+    const nameCallData = createTestEthCallData(WETH_ADDRESS, "name", "string");
+    const totalSupplyCallData = createTestEthCallData(
+      WETH_ADDRESS,
+      "totalSupply",
+      "uint256"
+    );
+    const [targetBlockTime, targetBlockNumber, followingBlockNumber] =
+      await getEthCallByTimestampArgs();
+    const ethCall = new EthCallByTimestampQueryRequest(
+      targetBlockTime + BigInt(5000),
+      "",
+      "",
       [nameCallData, totalSupplyCallData]
     );
     const chainId = 2;
@@ -462,7 +495,7 @@ describe("eth call", () => {
       });
     expect(err).toBe(true);
   });
-  test("eth_call_by_timestamp query without target hint should fail for now", async () => {
+  test("eth_call_by_timestamp query with following hint but not target hint should fail", async () => {
     const nameCallData = createTestEthCallData(WETH_ADDRESS, "name", "string");
     const totalSupplyCallData = createTestEthCallData(
       WETH_ADDRESS,
@@ -502,12 +535,12 @@ describe("eth call", () => {
         err = true;
         expect(error.response.status).toBe(400);
         expect(error.response.data).toBe(
-          `failed to validate request: failed to validate per chain query 0: chain specific query is invalid: target block id is required\n`
+          `failed to validate request: failed to validate per chain query 0: chain specific query is invalid: if either the target or following block id is unset, they both must be unset\n`
         );
       });
     expect(err).toBe(true);
   });
-  test("eth_call_by_timestamp query without following hint should fail for now", async () => {
+  test("eth_call_by_timestamp query with target hint but not following hint should fail", async () => {
     const nameCallData = createTestEthCallData(WETH_ADDRESS, "name", "string");
     const totalSupplyCallData = createTestEthCallData(
       WETH_ADDRESS,
@@ -546,7 +579,7 @@ describe("eth call", () => {
         err = true;
         expect(error.response.status).toBe(400);
         expect(error.response.data).toBe(
-          `failed to validate request: failed to validate per chain query 0: chain specific query is invalid: following block id is required\n`
+          `failed to validate request: failed to validate per chain query 0: chain specific query is invalid: if either the target or following block id is unset, they both must be unset\n`
         );
       });
     expect(err).toBe(true);


### PR DESCRIPTION
This PR is the first phase of caching the timestamp to block ID mapping in the EVM watcher for use by the CCQ `eth_call_by_timestamp` request.

This first phase only adds latest blocks to the cache, without any back filling of the cache. It also only supports three chains, Ethereum, Base and Optimism.

The next phase after this PR will add the ability to back fill the cache by doing batch queries to read old blocks.

Future phases will add support for more EVM chains, which should really only be a testing effort.