### PR TITLE
CCQ: Query server metrics

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -924,7 +924,8 @@ if query_server:
         "query-server",
         resource_deps = ["guardian"],
         port_forwards = [
-            port_forward(6069, name = "REST [:6069]", host = webHost)
+            port_forward(6069, name = "REST [:6069]", host = webHost),
+            port_forward(6068, name = "REST [:6068]", host = webHost)
         ],
         labels = ["query-server"],
         trigger_mode = trigger_mode

--- a/Tiltfile
+++ b/Tiltfile
@@ -925,7 +925,7 @@ if query_server:
         resource_deps = ["guardian"],
         port_forwards = [
             port_forward(6069, name = "REST [:6069]", host = webHost),
-            port_forward(6068, name = "REST [:6068]", host = webHost)
+            port_forward(6068, name = "Status [:6068]", host = webHost)
         ],
         labels = ["query-server"],
         trigger_mode = trigger_mode

--- a/devnet/query-server.yaml
+++ b/devnet/query-server.yaml
@@ -62,5 +62,5 @@ spec:
               protocol: TCP
           readinessProbe:
             httpGet:
-              port: 6068
+              port: status
               path: /health

--- a/devnet/query-server.yaml
+++ b/devnet/query-server.yaml
@@ -41,6 +41,8 @@ spec:
             - node/cmd/ccq/devnet.signing.key
             - --listenAddr
             - "[::]:6069"
+            - --statusAddr
+            - "[::]:6068"
             - --permFile
             - "node/cmd/ccq/devnet.permissions.json"
             - --ethRPC
@@ -55,6 +57,10 @@ spec:
             - containerPort: 6069
               name: rest
               protocol: TCP
+            - containerPort: 6068
+              name: status
+              protocol: TCP
           readinessProbe:
-            tcpSocket:
-              port: rest
+            httpGet:
+              port: 6068
+              path: /health

--- a/devnet/query-server.yaml
+++ b/devnet/query-server.yaml
@@ -9,6 +9,9 @@ spec:
     - name: rest
       port: 6069
       protocol: TCP
+    - name: status
+      port: 6068
+      protocol: TCP
   selector:
     app: query-server
 ---

--- a/node/cmd/ccq/metrics.go
+++ b/node/cmd/ccq/metrics.go
@@ -1,0 +1,51 @@
+package ccq
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	allQueryRequestsReceived = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "ccq_server_total_query_requests_received",
+			Help: "Total number of query requests received, valid and invalid",
+		})
+
+	validQueryRequestsReceived = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "ccq_server_total_valid_query_requests_received",
+			Help: "Total number of valid query requests received",
+		})
+
+	invalidQueryRequestReceived = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "ccq_server_invalid_query_requests_received_by_reason",
+			Help: "Total number of invalid query requests received by reason",
+		}, []string{"reason"})
+
+	totalRequestedCallsByChain = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "ccq_server_total_requested_calls_by_chain",
+			Help: "Total number of requested calls by chain",
+		}, []string{"chain_name"})
+
+	queryResponsesReceived = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "ccq_server_total_query_responses_received_by_peer_id",
+			Help: "Total number of query responses received by peer ID",
+		}, []string{"peer_id"})
+
+	inboundP2pError = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "ccq_server_inbound_p2p_errors",
+			Help: "Total number of inbound p2p errors",
+		}, []string{"reason"})
+
+	totalQueryTime = promauto.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "ccq_server_total_query_time_in_ms",
+			Help:    "Time from request to response published in ms",
+			Buckets: []float64{10.0, 100.0, 250.0, 500.0, 1000.0, 5000.0, 10000.0, 30000.0},
+		})
+)

--- a/node/cmd/ccq/status.go
+++ b/node/cmd/ccq/status.go
@@ -1,0 +1,38 @@
+package ccq
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/certusone/wormhole/node/pkg/common"
+	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"go.uber.org/zap"
+)
+
+type statusServer struct {
+	logger *zap.Logger
+	env    common.Environment
+}
+
+func NewStatusServer(addr string, logger *zap.Logger, env common.Environment) *http.Server {
+	s := &statusServer{
+		logger: logger,
+		env:    env,
+	}
+	r := mux.NewRouter()
+	r.HandleFunc("/health", s.handleHealth).Methods("GET")
+	r.Handle("/metrics", promhttp.Handler())
+	return &http.Server{
+		Addr:              addr,
+		Handler:           r,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+}
+
+func (s *statusServer) handleHealth(w http.ResponseWriter, r *http.Request) {
+	s.logger.Debug("health check")
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprintf(w, "ok")
+}

--- a/node/cmd/ccq/utils.go
+++ b/node/cmd/ccq/utils.go
@@ -211,6 +211,7 @@ func validateRequest(logger *zap.Logger, env common.Environment, perms Permissio
 	permsForUser, exists := perms[apiKey]
 	if !exists {
 		logger.Debug("invalid api key", zap.String("apiKey", apiKey))
+		invalidQueryRequestReceived.WithLabelValues("invalid_api_key").Inc()
 		return http.StatusForbidden, fmt.Errorf("invalid api key")
 	}
 
@@ -223,6 +224,7 @@ func validateRequest(logger *zap.Logger, env common.Environment, perms Permissio
 				zap.Bool("allowUnsigned", permsForUser.allowUnsigned),
 				zap.Bool("signerKeyConfigured", signerKey != nil),
 			)
+			invalidQueryRequestReceived.WithLabelValues("request_not_signed").Inc()
 			return http.StatusBadRequest, fmt.Errorf("request not signed")
 		}
 
@@ -232,6 +234,7 @@ func validateRequest(logger *zap.Logger, env common.Environment, perms Permissio
 		qr.Signature, err = ethCrypto.Sign(digest.Bytes(), signerKey)
 		if err != nil {
 			logger.Debug("failed to sign request", zap.String("userName", permsForUser.userName), zap.Error(err))
+			invalidQueryRequestReceived.WithLabelValues("failed_to_sign_request").Inc()
 			return http.StatusInternalServerError, fmt.Errorf("failed to sign request: %w", err)
 		}
 	}
@@ -240,12 +243,14 @@ func validateRequest(logger *zap.Logger, env common.Environment, perms Permissio
 	err := queryRequest.Unmarshal(qr.QueryRequest)
 	if err != nil {
 		logger.Debug("failed to unmarshal request", zap.String("userName", permsForUser.userName), zap.Error(err))
+		invalidQueryRequestReceived.WithLabelValues("failed_to_unmarshal_request").Inc()
 		return http.StatusInternalServerError, fmt.Errorf("failed to unmarshal request: %w", err)
 	}
 
 	// Make sure the overall query request is sane.
 	if err := queryRequest.Validate(); err != nil {
 		logger.Debug("failed to validate request", zap.String("userName", permsForUser.userName), zap.Error(err))
+		invalidQueryRequestReceived.WithLabelValues("failed_to_validate_request").Inc()
 		return http.StatusBadRequest, fmt.Errorf("failed to validate request: %w", err)
 	}
 
@@ -262,10 +267,12 @@ func validateRequest(logger *zap.Logger, env common.Environment, perms Permissio
 			status, err = validateCallData(logger, permsForUser, "ethCallWithFinality", pcq.ChainId, q.CallData)
 		default:
 			logger.Debug("unsupported query type", zap.String("userName", permsForUser.userName), zap.Any("type", pcq.Query))
+			invalidQueryRequestReceived.WithLabelValues("unsupported_query_type").Inc()
 			return http.StatusBadRequest, fmt.Errorf("unsupported query type")
 		}
 
 		if err != nil {
+			// Metric is pegged below.
 			return status, err
 		}
 	}
@@ -280,18 +287,23 @@ func validateCallData(logger *zap.Logger, permsForUser *permissionEntry, callTag
 		contractAddress, err := vaa.BytesToAddress(cd.To)
 		if err != nil {
 			logger.Debug("failed to parse contract address", zap.String("userName", permsForUser.userName), zap.String("contract", hex.EncodeToString(cd.To)), zap.Error(err))
+			invalidQueryRequestReceived.WithLabelValues("invalid_contract_address").Inc()
 			return http.StatusBadRequest, fmt.Errorf("failed to parse contract address: %w", err)
 		}
 		if len(cd.Data) < ETH_CALL_SIG_LENGTH {
 			logger.Debug("eth call data must be at least four bytes", zap.String("userName", permsForUser.userName), zap.String("data", hex.EncodeToString(cd.Data)))
+			invalidQueryRequestReceived.WithLabelValues("bad_call_data").Inc()
 			return http.StatusBadRequest, fmt.Errorf("eth call data must be at least four bytes")
 		}
 		call := hex.EncodeToString(cd.Data[0:ETH_CALL_SIG_LENGTH])
 		callKey := fmt.Sprintf("%s:%d:%s:%s", callTag, chainId, contractAddress, call)
 		if _, exists := permsForUser.allowedCalls[callKey]; !exists {
 			logger.Debug("requested call not authorized", zap.String("userName", permsForUser.userName), zap.String("callKey", callKey))
+			invalidQueryRequestReceived.WithLabelValues("call_not_authorized").Inc()
 			return http.StatusBadRequest, fmt.Errorf(`call "%s" not authorized`, callKey)
 		}
+
+		totalRequestedCallsByChain.WithLabelValues(chainId.String()).Inc()
 	}
 
 	return http.StatusOK, nil

--- a/sdk/js-query/src/query/ethCall.test.ts
+++ b/sdk/js-query/src/query/ethCall.test.ts
@@ -24,11 +24,10 @@ const CI = process.env.CI;
 const ENV = "DEVNET";
 const ETH_NODE_URL = CI ? "ws://eth-devnet:8545" : "ws://localhost:8545";
 
-const CCQ_SERVER_URL = CI
-  ? "http://query-server:6069/v1"
-  : "http://localhost:6069/v1";
+const SERVER_URL = CI ? "http://query-server:" : "http://localhost:";
+const CCQ_SERVER_URL = SERVER_URL + "6069/v1";
 const QUERY_URL = CCQ_SERVER_URL + "/query";
-const HEALTH_URL = CCQ_SERVER_URL + "/health";
+const HEALTH_URL = SERVER_URL + "6068/health";
 const PRIVATE_KEY =
   "cfb12303a19cde580bb4dd771639b0d26bc68353645571a8cff516ab2ee113a0";
 const WETH_ADDRESS = "0xDDb64fE46a91D46ee29420539FC25FD07c5FEa3E";

--- a/testing/querysdk.sh
+++ b/testing/querysdk.sh
@@ -4,5 +4,5 @@ num=${NUM_GUARDIANS:-1} # default value for NUM_GUARDIANS = 1
 for ((i=0; i<num; i++)); do
     while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' guardian-$i.guardian:6060/readyz)" != "200" ]]; do sleep 5; done
 done
-while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' query-server:6069/v1/health)" != "200" ]]; do sleep 5; done
+while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' query-server:6068/health)" != "200" ]]; do sleep 5; done
 CI=true npm --prefix ../sdk/js-query run test-ci


### PR DESCRIPTION
This server adds Prometheus metrics to the CCQ query_server. It adds a new `statusAddr` config parameter which specifies the port on which the query_server should publish metrics and listen for health check requests. This defaults to `localhost:6068`.

In tilt, the following are useful endpoints:

- http://localhost:6068/metrics
- http://localhost:6068/health