### PR TITLE
CCQ: Change network ID

### DIFF
--- a/node/cmd/ccq/query_server.go
+++ b/node/cmd/ccq/query_server.go
@@ -68,6 +68,7 @@ var QueryServerCmd = &cobra.Command{
 
 func runQueryServer(cmd *cobra.Command, args []string) {
 	common.SetRestrictiveUmask()
+	networkID := *p2pNetworkID + "/ccq"
 
 	// Setup logging
 	lvl, err := ipfslog.LevelFromString(*logLevel)
@@ -85,7 +86,7 @@ func runQueryServer(cmd *cobra.Command, args []string) {
 			logger.Fatal("if --telemetryLokiURL is specified --telemetryNodeName must be specified")
 		}
 		labels := map[string]string{
-			"network":   *p2pNetworkID,
+			"network":   networkID,
 			"node_name": *telemetryNodeName,
 			"version":   version.Version(),
 		}
@@ -155,7 +156,7 @@ func runQueryServer(cmd *cobra.Command, args []string) {
 
 	// Run p2p
 	pendingResponses := NewPendingResponses()
-	p2p, err := runP2P(ctx, priv, *p2pPort, *p2pNetworkID, *p2pBootstrap, *ethRPC, *ethContract, pendingResponses, logger)
+	p2p, err := runP2P(ctx, priv, *p2pPort, networkID, *p2pBootstrap, *ethRPC, *ethContract, pendingResponses, logger)
 	if err != nil {
 		logger.Fatal("Failed to start p2p", zap.Error(err))
 	}

--- a/node/hack/query/send_req.go
+++ b/node/hack/query/send_req.go
@@ -75,7 +75,7 @@ func main() {
 	components := p2p.DefaultComponents()
 	components.Port = p2pPort
 	bootstrapPeers := p2pBootstrap
-	networkID := p2pNetworkID
+	networkID := p2pNetworkID + "/ccq"
 
 	h, err := p2p.NewHost(logger, ctx, networkID, bootstrapPeers, components, priv)
 	if err != nil {

--- a/node/hack/query/test/query_test.go
+++ b/node/hack/query/test/query_test.go
@@ -78,7 +78,7 @@ func TestCrossChainQuery(t *testing.T) {
 	components := p2p.DefaultComponents()
 	components.Port = p2pPort
 	bootstrapPeers := p2pBootstrap
-	networkID := p2pNetworkID
+	networkID := p2pNetworkID + "/ccq"
 
 	h, err := p2p.NewHost(logger, ctx, networkID, bootstrapPeers, components, priv)
 	if err != nil {

--- a/node/pkg/p2p/ccq_p2p.go
+++ b/node/pkg/p2p/ccq_p2p.go
@@ -69,13 +69,14 @@ func (ccq *ccqP2p) run(
 	ctx context.Context,
 	priv crypto.PrivKey,
 	gk *ecdsa.PrivateKey,
-	networkID string,
+	p2pNetworkID string,
 	bootstrapPeers string,
 	port uint,
 	signedQueryReqC chan<- *gossipv1.SignedQueryRequest,
 	queryResponseReadC <-chan *query.QueryResponsePublication,
 	errC chan error,
 ) error {
+	networkID := p2pNetworkID + "/ccq"
 	var err error
 
 	components := DefaultComponents()


### PR DESCRIPTION
This PR appends "/ccq" to the end of the P2P network ID used for CCQ to separate it out from the main gossip network.