### PR TITLE
CCQ/Node/EVM: Logger cleanup

### DIFF
--- a/node/pkg/watchers/evm/watcher.go
+++ b/node/pkg/watchers/evm/watcher.go
@@ -485,16 +485,12 @@ func (w *Watcher) Run(parentCtx context.Context) error {
 	})
 
 	common.RunWithScissors(ctx, errC, "evm_fetch_query_req", func(ctx context.Context) error {
-		ccqLogger := logger.With(
-			zap.String("eth_network", w.networkName),
-			zap.String("component", "ccqevm"),
-		)
 		for {
 			select {
 			case <-ctx.Done():
 				return nil
 			case queryRequest := <-w.queryReqC:
-				w.ccqHandleQuery(ccqLogger, ctx, queryRequest)
+				w.ccqHandleQuery(ctx, queryRequest)
 			}
 		}
 	})


### PR DESCRIPTION
This looks like a fairly big PR, but it is really quite simple. A previous PR added a separate `ccqLogger` to the watcher object to avoid having to constantly add the "ccqevm" component. This PR just changes the code to use that every where, rather passing the logger into all the CCQ functions.