### PR TITLE
node/ccq: allow guardian peers

### DIFF
--- a/node/pkg/p2p/p2p.go
+++ b/node/pkg/p2p/p2p.go
@@ -356,7 +356,7 @@ func Run(
 
 		if ccqEnabled {
 			ccqErrC := make(chan error)
-			ccq := newCcqRunP2p(logger, ccqAllowedPeers)
+			ccq := newCcqRunP2p(logger, ccqAllowedPeers, components)
 			if err := ccq.run(ctx, priv, gk, networkID, ccqBootstrapPeers, ccqPort, signedQueryReqC, queryResponseReadC, ccqErrC); err != nil {
 				return fmt.Errorf("failed to start p2p for CCQ: %w", err)
 			}


### PR DESCRIPTION
I'm not sure if it matters (local testing didn't seem impacted) if we listen to requests from other guardians. Seems rude to let them retry subscriptions for... seemingly forever every second.