### PR TITLE
CCQ: Server should use base networkID  for logging

### DIFF
--- a/node/cmd/ccq/query_server.go
+++ b/node/cmd/ccq/query_server.go
@@ -86,7 +86,7 @@ func runQueryServer(cmd *cobra.Command, args []string) {
 			logger.Fatal("if --telemetryLokiURL is specified --telemetryNodeName must be specified")
 		}
 		labels := map[string]string{
-			"network":   networkID,
+			"network":   *p2pNetworkID,
 			"node_name": *telemetryNodeName,
 			"version":   version.Version(),
 		}


### PR DESCRIPTION
The last PR changed the network ID for CCQ to add "/ccq" on the end. This is working, but as a side affect, the query server is now using that as the network name in Loki logging, which is confusing. This PR reverts that so the logging will be done using the base network ID.