### PR TITLE
node/pkg/p2p: Prevent potential nil pointer dereference when processi…

### DIFF
--- a/node/pkg/p2p/p2p.go
+++ b/node/pkg/p2p/p2p.go
@@ -607,7 +607,7 @@ func Run(
 									zap.String("from", envelope.GetFrom().String()))
 							} else {
 								guardianAddr := eth_common.BytesToAddress(s.GuardianAddr)
-								if guardianAddr != ethcrypto.PubkeyToAddress(gk.PublicKey) {
+								if gk == nil || guardianAddr != ethcrypto.PubkeyToAddress(gk.PublicKey) {
 									prevPeerId, ok := components.ProtectedHostByGuardianKey[guardianAddr]
 									if ok {
 										if prevPeerId != peerId {


### PR DESCRIPTION
…ng heartbeats

Resolves the problem occurring when dereferencing a nil `gk *ecdsa.PublicKey` during heartbeat processing. This issue arises when non-guardian processes utilizing the p2p package set the key to `nil`.