### PR TITLE
CCQ: High level validation helpers + slight refactor

### DIFF
--- a/ethereum/contracts/query/QueryDemo.sol
+++ b/ethereum/contracts/query/QueryDemo.sol
@@ -101,10 +101,10 @@ contract QueryDemo is QueryResponse {
             EthCallQueryResponse memory eqr = parseEthCallQueryResponse(r.responses[i]);
 
             // Validate that update is not obsolete
-            validateBlockNum(eqr.blockNum, chainEntry.blockNum, block.number);
+            validateBlockNum(eqr.blockNum, chainEntry.blockNum);
 
             // Validate that update is not stale
-            validateBlockTime(eqr.blockTime, block.timestamp - 300, block.timestamp);
+            validateBlockTime(eqr.blockTime, block.timestamp - 300);
 
             if (eqr.result.length != 1) {
                 revert UnexpectedResultMismatch();

--- a/ethereum/contracts/query/QueryResponse.sol
+++ b/ethereum/contracts/query/QueryResponse.sol
@@ -364,7 +364,7 @@ abstract contract QueryResponse {
     function validateBlockTime(uint64 _blockTime, uint256 _minBlockTime, uint256 _maxBlockTime) public pure {
         uint256 blockTimeInSeconds = _blockTime / 1_000_000; // Rounds down
         
-        if (blockTimeInSeconds < _minBlockTime || _blockTime > _maxBlockTime) {
+        if (blockTimeInSeconds < _minBlockTime || blockTimeInSeconds > _maxBlockTime) {
             revert InvalidBlockTime();
         }
     }
@@ -378,11 +378,16 @@ abstract contract QueryResponse {
 
     /// @dev validateChainId validates that the parsed chainId is one of an array of chainIds we expect
     function validateChainId(uint16 chainId, uint16[] memory _validChainIds) public pure {
+        bool validChainId = false;
+        
         for (uint256 i = 0; i < _validChainIds.length; ++i) {
             if (chainId == _validChainIds[i]) {
-                revert InvalidChainId();
+                validChainId = true;
+                break;
             }
         }
+
+        if (!validChainId) revert InvalidChainId();
     } 
 
     /// @dev validateMutlipleEthCallData validates that each EthCallData in an array comes from a function signature and contract address we expect
@@ -393,8 +398,8 @@ abstract contract QueryResponse {
     }
 
     /// @dev validateEthCallData validates that EthCallData comes from a function signature and contract address we expect
+    /// @dev An empty array means we accept all addresses/function signatures
     function validateEthCallData(EthCallData memory r, address[] memory _expectedContractAddresses, bytes4[] memory _expectedFunctionSignatures) public pure {
-        // An empty array means we accept all addresses/function signatures
         bool validContractAddress = _expectedContractAddresses.length == 0 ? true : false;
         bool validFunctionSignature = _expectedFunctionSignatures.length == 0 ? true : false;
         

--- a/ethereum/contracts/query/QueryResponse.sol
+++ b/ethereum/contracts/query/QueryResponse.sol
@@ -406,6 +406,13 @@ abstract contract QueryResponse {
 
     /// @dev validateEthCallData validates that EthCallData comes from a function signature and contract address we expect
     /// @dev An empty array means we accept all addresses/function signatures
+    /// @dev Example 1: To accept signatures 0xaaaaaaaa and 0xbbbbbbbb from `address(abcd)` you'd pass in [0xaaaaaaaa, 0xbbbbbbbb], [address(abcd)]
+    /// @dev Example 2: To accept any function signatures from `address(abcd)` or `address(efab)` you'd pass in [], [address(abcd), address(efab)]
+    /// @dev Example 3: To accept function signature 0xaaaaaaaa from any address you'd pass in [0xaaaaaaaa], []
+    /// @dev WARNING Example 4: If you want to accept signature 0xaaaaaaaa from `address(abcd)` and signature 0xbbbbbbbb from `address(efab)` the following input would be incorrect:
+    /// @dev [0xaaaaaaaa, 0xbbbbbbbb], [address(abcd), address(efab)]
+    /// @dev This would accept both 0xaaaaaaaa and 0xbbbbbbbb from `address(abcd)` AND `address(efab)`. Instead you should make 2 calls to this method
+    /// @dev using the pattern in Example 1. [0xaaaaaaaa], [address(abcd)] OR [0xbbbbbbbb], [address(efab)]
     function validateEthCallData(EthCallData memory r, address[] memory _expectedContractAddresses, bytes4[] memory _expectedFunctionSignatures) public pure {
         bool validContractAddress = _expectedContractAddresses.length == 0 ? true : false;
         bool validFunctionSignature = _expectedFunctionSignatures.length == 0 ? true : false;

--- a/ethereum/forge-test/query/QueryResponse.t.sol
+++ b/ethereum/forge-test/query/QueryResponse.t.sol
@@ -481,34 +481,32 @@ contract TestQueryResponse is Test {
         queryResponse.verifyQueryResponseSignatures(resp, signatures);
     }
 
-    function testFuzz_validateBlockTime_success(uint256 _blockTime, uint256 _minBlockTime, uint256 _maxBlockTime) public view {
+    function testFuzz_validateBlockTime_success(uint256 _blockTime, uint256 _minBlockTime) public view {
         _blockTime = bound(_blockTime, 0, type(uint64).max/1_000_000);
         vm.assume(_blockTime >= _minBlockTime);
-        vm.assume(_blockTime <= _maxBlockTime);
 
-        queryResponse.validateBlockTime(uint64(_blockTime * 1_000_000), _minBlockTime, _maxBlockTime);
+        queryResponse.validateBlockTime(uint64(_blockTime * 1_000_000), _minBlockTime);
     }
 
-    function testFuzz_validateBlockTime_fail(uint256 _blockTime, uint256 _minBlockTime, uint256 _maxBlockTime) public {
+    function testFuzz_validateBlockTime_fail(uint256 _blockTime, uint256 _minBlockTime) public {
         _blockTime = bound(_blockTime, 0, type(uint64).max/1_000_000);
-        vm.assume(_blockTime < _minBlockTime || _blockTime > _maxBlockTime);
+        vm.assume(_blockTime < _minBlockTime);
 
-        vm.expectRevert(InvalidBlockTime.selector);
-        queryResponse.validateBlockTime(uint64(_blockTime * 1_000_000), _minBlockTime, _maxBlockTime);
+        vm.expectRevert(StaleBlockTime.selector);
+        queryResponse.validateBlockTime(uint64(_blockTime * 1_000_000), _minBlockTime);
     }
 
-    function testFuzz_validateBlockNum_success(uint64 _blockNum, uint256 _minBlockNum, uint256 _maxBlockNum) public view {
+    function testFuzz_validateBlockNum_success(uint64 _blockNum, uint256 _minBlockNum) public view {
         vm.assume(_blockNum >= _minBlockNum);
-        vm.assume(_blockNum <= _maxBlockNum);
 
-        queryResponse.validateBlockNum(_blockNum, _minBlockNum, _maxBlockNum);
+        queryResponse.validateBlockNum(_blockNum, _minBlockNum);
     }
 
-    function testFuzz_validateBlockNum_fail(uint64 _blockNum, uint256 _minBlockNum, uint256 _maxBlockNum) public {
-        vm.assume(_blockNum < _minBlockNum || _blockNum > _maxBlockNum);
+    function testFuzz_validateBlockNum_fail(uint64 _blockNum, uint256 _minBlockNum) public {
+        vm.assume(_blockNum < _minBlockNum);
 
-        vm.expectRevert(InvalidBlockNum.selector);
-        queryResponse.validateBlockNum(_blockNum, _minBlockNum, _maxBlockNum);
+        vm.expectRevert(StaleBlockNum.selector);
+        queryResponse.validateBlockNum(_blockNum, _minBlockNum);
     }
 
     function testFuzz_validateChainId_success(uint16 _validChainIndex, uint16[] memory _validChainIds) public view {

--- a/ethereum/forge-test/query/QueryResponse.t.sol
+++ b/ethereum/forge-test/query/QueryResponse.t.sol
@@ -11,7 +11,9 @@ import "../../contracts/Wormhole.sol";
 import "forge-std/Test.sol";
 
 // @dev A non-abstract QueryResponse contract
-contract QueryResponseContract is QueryResponse { }
+contract QueryResponseContract is QueryResponse { 
+    constructor(address _wormhole) QueryResponse(_wormhole) {}
+}
 
 contract TestQueryResponse is Test {
     // Some happy case defaults
@@ -35,7 +37,7 @@ contract TestQueryResponse is Test {
 
     function setUp() public {
         wormhole = deployWormholeForTest();
-        queryResponse = new QueryResponseContract();
+        queryResponse = new QueryResponseContract(address(wormhole));
     }
 
     uint16 constant TEST_CHAIN_ID = 2;
@@ -121,7 +123,7 @@ contract TestQueryResponse is Test {
         (uint8 sigV, bytes32 sigR, bytes32 sigS) = getSignature(resp);
         IWormhole.Signature[] memory signatures = new IWormhole.Signature[](1);
         signatures[0] = IWormhole.Signature({r: sigR, s: sigS, v: sigV, guardianIndex: sigGuardianIndex});
-        queryResponse.verifyQueryResponseSignatures(address(wormhole), resp, signatures);
+        queryResponse.verifyQueryResponseSignatures(resp, signatures);
         // TODO: There are no assertions for this test
     }
 
@@ -130,7 +132,7 @@ contract TestQueryResponse is Test {
         (uint8 sigV, bytes32 sigR, bytes32 sigS) = getSignature(resp);
         IWormhole.Signature[] memory signatures = new IWormhole.Signature[](1);
         signatures[0] = IWormhole.Signature({r: sigR, s: sigS, v: sigV, guardianIndex: sigGuardianIndex});
-        ParsedQueryResponse memory r = queryResponse.parseAndVerifyQueryResponse(address(wormhole), resp, signatures);
+        ParsedQueryResponse memory r = queryResponse.parseAndVerifyQueryResponse(resp, signatures);
         assertEq(r.version, 1);
         assertEq(r.senderChainId, 0);
         assertEq(r.requestId, hex"ff0c222dc9e3655ec38e212e9792bf1860356d1277462b6bf747db865caca6fc08e6317b64ee3245264e371146b1d315d38c867fe1f69614368dc4430bb560f200");
@@ -306,7 +308,7 @@ contract TestQueryResponse is Test {
         IWormhole.Signature[] memory signatures = new IWormhole.Signature[](1);
         signatures[0] = IWormhole.Signature({r: sigR, s: sigS, v: sigV, guardianIndex: sigGuardianIndex});
         vm.expectRevert(InvalidResponseVersion.selector);
-        queryResponse.parseAndVerifyQueryResponse(address(wormhole), resp, signatures);
+        queryResponse.parseAndVerifyQueryResponse(resp, signatures);
     }
 
     function testFuzz_parseAndVerifyQueryResponse_fuzzSenderChainId(uint16 _senderChainId) public {
@@ -318,7 +320,7 @@ contract TestQueryResponse is Test {
         signatures[0] = IWormhole.Signature({r: sigR, s: sigS, v: sigV, guardianIndex: sigGuardianIndex});
         // This could revert for multiple reasons. But the checkLength to ensure all the bytes are consumed is the backstop.
         vm.expectRevert();
-        queryResponse.parseAndVerifyQueryResponse(address(wormhole), resp, signatures);
+        queryResponse.parseAndVerifyQueryResponse(resp, signatures);
     }
 
     function testFuzz_parseAndVerifyQueryResponse_fuzzSignatureHappyCase(bytes memory _signature) public {
@@ -329,7 +331,7 @@ contract TestQueryResponse is Test {
         (uint8 sigV, bytes32 sigR, bytes32 sigS) = getSignature(resp);
         IWormhole.Signature[] memory signatures = new IWormhole.Signature[](1);
         signatures[0] = IWormhole.Signature({r: sigR, s: sigS, v: sigV, guardianIndex: sigGuardianIndex});
-        ParsedQueryResponse memory r = queryResponse.parseAndVerifyQueryResponse(address(wormhole), resp, signatures);
+        ParsedQueryResponse memory r = queryResponse.parseAndVerifyQueryResponse(resp, signatures);
 
         assertEq(r.requestId, _signature);
     }
@@ -343,7 +345,7 @@ contract TestQueryResponse is Test {
         IWormhole.Signature[] memory signatures = new IWormhole.Signature[](1);
         signatures[0] = IWormhole.Signature({r: sigR, s: sigS, v: sigV, guardianIndex: sigGuardianIndex});
         vm.expectRevert();
-        queryResponse.parseAndVerifyQueryResponse(address(wormhole), resp, signatures);
+        queryResponse.parseAndVerifyQueryResponse(resp, signatures);
     }
 
     function testFuzz_parseAndVerifyQueryResponse_fuzzQueryRequestLen(uint32 _queryRequestLen, bytes calldata _perChainQueries) public {
@@ -355,7 +357,7 @@ contract TestQueryResponse is Test {
         IWormhole.Signature[] memory signatures = new IWormhole.Signature[](1);
         signatures[0] = IWormhole.Signature({r: sigR, s: sigS, v: sigV, guardianIndex: sigGuardianIndex});
         vm.expectRevert();
-        queryResponse.parseAndVerifyQueryResponse(address(wormhole), resp, signatures);
+        queryResponse.parseAndVerifyQueryResponse(resp, signatures);
     }
 
     function testFuzz_parseAndVerifyQueryResponse_fuzzQueryRequestVersion(uint8 _version, uint8 _queryRequestVersion) public {
@@ -366,7 +368,7 @@ contract TestQueryResponse is Test {
         IWormhole.Signature[] memory signatures = new IWormhole.Signature[](1);
         signatures[0] = IWormhole.Signature({r: sigR, s: sigS, v: sigV, guardianIndex: sigGuardianIndex});
         vm.expectRevert();
-        queryResponse.parseAndVerifyQueryResponse(address(wormhole), resp, signatures);
+        queryResponse.parseAndVerifyQueryResponse(resp, signatures);
     }
 
     function testFuzz_parseAndVerifyQueryResponse_fuzzQueryRequestNonce(uint32 _queryRequestNonce) public {
@@ -374,7 +376,7 @@ contract TestQueryResponse is Test {
         (uint8 sigV, bytes32 sigR, bytes32 sigS) = getSignature(resp);
         IWormhole.Signature[] memory signatures = new IWormhole.Signature[](1);
         signatures[0] = IWormhole.Signature({r: sigR, s: sigS, v: sigV, guardianIndex: sigGuardianIndex});
-        ParsedQueryResponse memory r = queryResponse.parseAndVerifyQueryResponse(address(wormhole), resp, signatures);
+        ParsedQueryResponse memory r = queryResponse.parseAndVerifyQueryResponse(resp, signatures);
         
         assertEq(r.nonce, _queryRequestNonce);
     }
@@ -387,7 +389,7 @@ contract TestQueryResponse is Test {
         IWormhole.Signature[] memory signatures = new IWormhole.Signature[](1);
         signatures[0] = IWormhole.Signature({r: sigR, s: sigS, v: sigV, guardianIndex: sigGuardianIndex});
         vm.expectRevert();
-        queryResponse.parseAndVerifyQueryResponse(address(wormhole), resp, signatures);
+        queryResponse.parseAndVerifyQueryResponse(resp, signatures);
     }
 
     function testFuzz_parseAndVerifyQueryResponse_fuzzChainIds(uint16 _requestChainId, uint16 _responseChainId, uint256 _requestQueryType) public {
@@ -401,7 +403,7 @@ contract TestQueryResponse is Test {
         IWormhole.Signature[] memory signatures = new IWormhole.Signature[](1);
         signatures[0] = IWormhole.Signature({r: sigR, s: sigS, v: sigV, guardianIndex: sigGuardianIndex});
         vm.expectRevert(ChainIdMismatch.selector);
-        queryResponse.parseAndVerifyQueryResponse(address(wormhole), resp, signatures);
+        queryResponse.parseAndVerifyQueryResponse(resp, signatures);
     }
 
     function testFuzz_parseAndVerifyQueryResponse_fuzzMistmatchedRequestType(uint256 _requestQueryType, uint256 _responseQueryType) public {
@@ -416,7 +418,7 @@ contract TestQueryResponse is Test {
         IWormhole.Signature[] memory signatures = new IWormhole.Signature[](1);
         signatures[0] = IWormhole.Signature({r: sigR, s: sigS, v: sigV, guardianIndex: sigGuardianIndex});
         vm.expectRevert(RequestTypeMismatch.selector);
-        queryResponse.parseAndVerifyQueryResponse(address(wormhole), resp, signatures);
+        queryResponse.parseAndVerifyQueryResponse(resp, signatures);
     }
 
     function testFuzz_parseAndVerifyQueryResponse_fuzzUnsupportedRequestType(uint8 _requestQueryType) public {
@@ -429,7 +431,7 @@ contract TestQueryResponse is Test {
         IWormhole.Signature[] memory signatures = new IWormhole.Signature[](1);
         signatures[0] = IWormhole.Signature({r: sigR, s: sigS, v: sigV, guardianIndex: sigGuardianIndex});
         vm.expectRevert(UnsupportedQueryType.selector);
-        queryResponse.parseAndVerifyQueryResponse(address(wormhole), resp, signatures);
+        queryResponse.parseAndVerifyQueryResponse(resp, signatures);
     }
 
     function testFuzz_parseAndVerifyQueryResponse_fuzzQueryBytesLength(uint32 _queryLength) public {
@@ -442,7 +444,7 @@ contract TestQueryResponse is Test {
         IWormhole.Signature[] memory signatures = new IWormhole.Signature[](1);
         signatures[0] = IWormhole.Signature({r: sigR, s: sigS, v: sigV, guardianIndex: sigGuardianIndex});
         vm.expectRevert();
-        queryResponse.parseAndVerifyQueryResponse(address(wormhole), resp, signatures);
+        queryResponse.parseAndVerifyQueryResponse(resp, signatures);
     }
 
     function testFuzz_verifyQueryResponseSignatures_validSignature(bytes calldata resp) public view {
@@ -450,7 +452,7 @@ contract TestQueryResponse is Test {
         (uint8 sigV, bytes32 sigR, bytes32 sigS) = getSignature(resp);
         IWormhole.Signature[] memory signatures = new IWormhole.Signature[](1);
         signatures[0] = IWormhole.Signature({r: sigR, s: sigS, v: sigV, guardianIndex: sigGuardianIndex});
-        queryResponse.verifyQueryResponseSignatures(address(wormhole), resp, signatures);
+        queryResponse.verifyQueryResponseSignatures(resp, signatures);
     }
 
     function testFuzz_verifyQueryResponseSignatures_invalidSignature(bytes calldata resp, uint256 privateKey) public {
@@ -463,7 +465,7 @@ contract TestQueryResponse is Test {
         IWormhole.Signature[] memory signatures = new IWormhole.Signature[](1);
         signatures[0] = IWormhole.Signature({r: sigR, s: sigS, v: sigV, guardianIndex: sigGuardianIndex});
         vm.expectRevert("VM signature invalid");
-        queryResponse.verifyQueryResponseSignatures(address(wormhole), resp, signatures);
+        queryResponse.verifyQueryResponseSignatures(resp, signatures);
     }
 
     function testFuzz_verifyQueryResponseSignatures_validSignatureWrongPrefix(bytes calldata responsePrefix) public {
@@ -476,7 +478,7 @@ contract TestQueryResponse is Test {
         IWormhole.Signature[] memory signatures = new IWormhole.Signature[](1);
         signatures[0] = IWormhole.Signature({r: sigR, s: sigS, v: sigV, guardianIndex: sigGuardianIndex});
         vm.expectRevert("VM signature invalid");
-        queryResponse.verifyQueryResponseSignatures(address(wormhole), resp, signatures);
+        queryResponse.verifyQueryResponseSignatures(resp, signatures);
     }
 
 }


### PR DESCRIPTION
As discussed I've added some high level helpers that should hopefully make validating a parsed response easier for integrators rather than having to write validation logic from scratch every time.

I've also slightly refactored the passing of the wormhole address to avoid the potential for an integrator accidentally allowing the caller to specify this value.