### PR TITLE
ethereum: Add verifyCurrentQuorum method to core bridge

### DIFF
--- a/ethereum/Makefile
+++ b/ethereum/Makefile
@@ -41,7 +41,7 @@ lib/openzeppelin-contracts:
 	forge install openzeppelin/openzeppelin-contracts@0457042d93d9dfd760dbaa06a4d2f1216fdbe297 --no-git --no-commit
 
 lib/wormhole-solidity-sdk:
-	forge install wormhole-foundation/wormhole-solidity-sdk@b9e129e65d34827d92fceeed8c87d3ecdfc801d0 --no-git --no-commit
+	forge install djb15/wormhole-solidity-sdk@78f4b5e1d1ce4c36e43522c9205eb1e92fde7106 --no-git --no-commit
 
 dependencies: node_modules forge_dependencies
 

--- a/ethereum/Makefile
+++ b/ethereum/Makefile
@@ -32,13 +32,16 @@ node_modules: package-lock.json
 # When adding a new dependency, make sure to specify the exact commit hash, and
 # the --no-git and --no-commit flags (see lib/forge-std below)
 .PHONY: forge_dependencies
-forge_dependencies: lib/forge-std lib/openzeppelin-contracts
+forge_dependencies: lib/forge-std lib/openzeppelin-contracts lib/wormhole-solidity-sdk
 
 lib/forge-std:
 	forge install foundry-rs/forge-std@v1.6.1 --no-git --no-commit
 
 lib/openzeppelin-contracts:
 	forge install openzeppelin/openzeppelin-contracts@0457042d93d9dfd760dbaa06a4d2f1216fdbe297 --no-git --no-commit
+
+lib/wormhole-solidity-sdk:
+	forge install wormhole-foundation/wormhole-solidity-sdk@b9e129e65d34827d92fceeed8c87d3ecdfc801d0 --no-git --no-commit
 
 dependencies: node_modules forge_dependencies
 
@@ -87,4 +90,4 @@ test-push0: dependencies
 	@if grep -qr --include \*.json PUSH0 ./build-forge; then echo "Contract uses PUSH0 instruction" 1>&2; exit 1; fi
 
 clean:
-	rm -rf ganache.log .env node_modules build flattened build-forge ethers-contracts lib/forge-std lib/openzeppelin-contracts
+	rm -rf ganache.log .env node_modules build flattened build-forge ethers-contracts lib/forge-std lib/openzeppelin-contracts lib/wormhole-solidity-sdk

--- a/ethereum/contracts/Messages.sol
+++ b/ethereum/contracts/Messages.sol
@@ -192,7 +192,7 @@ contract Messages is Getters {
     /**
      * @dev verifyCurrentQuorum serves to validate arbitrary signatures and check quorum against the current guardianSet
      */
-    function verifyCurrentQuorum(bytes32 hash, Structs.Signature[] memory signatures) public view returns (bool valid, string memory response) {
+    function verifyCurrentQuorum(bytes32 hash, Structs.Signature[] memory signatures) public view returns (bool, string memory) {
         uint32 gsi = getCurrentGuardianSetIndex();
         Structs.GuardianSet memory guardianSet = getGuardianSet(gsi);
         uint256 guardianCount = guardianSet.keys.length;

--- a/ethereum/contracts/Messages.sol
+++ b/ethereum/contracts/Messages.sol
@@ -6,10 +6,12 @@ pragma experimental ABIEncoderV2;
 
 import "./Getters.sol";
 import "./Structs.sol";
-import "./libraries/relayer/BytesParsing.sol";
+import "./libraries/external/BytesLib.sol";
+import "wormhole-solidity-sdk/libraries/BytesParsing.sol";
 
 
 contract Messages is Getters {
+    using BytesLib for bytes;
     using BytesParsing for bytes;
 
     uint8 private constant ADDRESS_SIZE = 20; // in bytes

--- a/ethereum/contracts/Messages.sol
+++ b/ethereum/contracts/Messages.sol
@@ -6,12 +6,10 @@ pragma experimental ABIEncoderV2;
 
 import "./Getters.sol";
 import "./Structs.sol";
-import "./libraries/external/BytesLib.sol";
-import "wormhole-solidity-sdk/libraries/BytesParsing.sol";
+import "wormhole-sdk/libraries/BytesParsing.sol";
 
 
 contract Messages is Getters {
-    using BytesLib for bytes;
     using BytesParsing for bytes;
 
     uint8 private constant ADDRESS_SIZE = 20; // in bytes
@@ -219,13 +217,7 @@ contract Messages is Getters {
         }
 
         /// @dev Verify the proposed vm.signatures against the guardianSet
-        (bool signaturesValid, string memory invalidReason) = verifySignatures(hash, signatures, guardianSet);
-        if(!signaturesValid){
-            return (false, invalidReason);
-        }
-
-        /// If we are here, we've validated the VM is a valid multi-sig that matches the current guardianSet.
-        return (true, "");
+        return verifySignatures(hash, signatures, guardianSet);
     }
 
     /**

--- a/ethereum/contracts/Messages.sol
+++ b/ethereum/contracts/Messages.sol
@@ -195,6 +195,7 @@ contract Messages is Getters {
     function verifyCurrentQuorum(bytes32 hash, Structs.Signature[] memory signatures) public view returns (bool valid, string memory response) {
         uint32 gsi = getCurrentGuardianSetIndex();
         Structs.GuardianSet memory guardianSet = getGuardianSet(gsi);
+        uint256 guardianCount = guardianSet.keys.length;
 
        /**
         * @dev Checks whether the guardianSet has zero keys
@@ -203,7 +204,7 @@ contract Messages is Getters {
         * key length is 0 and vm.signatures length is 0, this could compromise the integrity of both vm and
         * signature verification.
         */
-        if(guardianSet.keys.length == 0){
+        if(guardianCount == 0){
             return (false, "invalid guardian set");
         }
 
@@ -213,7 +214,7 @@ contract Messages is Getters {
         *   if making any changes to this, obtain additional peer review. If guardianSet key length is 0 and
         *   vm.signatures length is 0, this could compromise the integrity of both vm and signature verification.
         */
-        if (signatures.length < quorum(guardianSet.keys.length)){
+        if (signatures.length < quorum(guardianCount)){
             return (false, "no quorum");
         }
 

--- a/ethereum/contracts/interfaces/IWormhole.sol
+++ b/ethereum/contracts/interfaces/IWormhole.sol
@@ -100,6 +100,8 @@ interface IWormhole {
 
     function verifySignatures(bytes32 hash, Signature[] memory signatures, GuardianSet memory guardianSet) external pure returns (bool valid, string memory reason);
 
+    function verifyCurrentQuorum(bytes32 hash, Signature[] memory signatures) external view returns (bool valid, string memory response);
+
     function parseVM(bytes memory encodedVM) external pure returns (VM memory vm);
 
     function quorum(uint numGuardians) external pure returns (uint numSignaturesRequiredForQuorum);

--- a/ethereum/foundry.toml
+++ b/ethereum/foundry.toml
@@ -1,5 +1,5 @@
 [profile.default]
-solc_version = "0.8.4"
+solc_version = "0.8.13"
 optimizer = true
 optimizer_runs = 200
 via_ir = false

--- a/ethereum/foundry.toml
+++ b/ethereum/foundry.toml
@@ -1,5 +1,5 @@
 [profile.default]
-solc_version = "0.8.13"
+solc_version = "0.8.4"
 optimizer = true
 optimizer_runs = 200
 via_ir = false
@@ -17,6 +17,7 @@ remappings = [
     'ds-test/=lib/forge-std/lib/ds-test/src/',
     'forge-std/=lib/forge-std/src/',
     'truffle/=node_modules/truffle/',
+    'wormhole-sdk/=lib/wormhole-solidity-sdk/src/'
 ]
 
 [fmt]

--- a/relayer/ethereum/forge-test/relayer/MockWormhole.sol
+++ b/relayer/ethereum/forge-test/relayer/MockWormhole.sol
@@ -223,6 +223,13 @@ contract MockWormhole is IWormhole {
         revert("unsupported verifySignatures in wormhole mock");
     }
 
+    function verifyCurrentQuorum(
+        bytes32, /*hash*/
+        Signature[] memory /*signatures*/
+    ) external pure returns (bool /*valid*/, string memory /*reason*/) {
+        revert("unsupported verifyCurrentQuorum in wormhole mock");
+    }
+
     function parseContractUpgrade(bytes memory /*encodedUpgrade*/ )
         external
         pure


### PR DESCRIPTION
TODO:
- [ ] Update commit hash for solidity sdk to point to commit on main repo, not on fork. Once https://github.com/wormhole-foundation/wormhole-solidity-sdk/pull/45 lands
- [ ] Fix truffle tests. Will need a new release of the Wormhole solidity SDK with the BytesParsing compiler version decrease as truffle requires dependency management via NPM

# Summary

Added a new method to the core bridge that makes it easier to verify the validity of a message against the current guardian set. This is useful for cases like CCQ since using this new method will reduce the number of external calls from `QueryResponse.sol` from 4 to 1 which will save gas and therefore make an even stronger case for the message pull pattern.

# Gas analysis

## Previous
The current verification looks like it does in https://github.com/wormhole-foundation/wormhole-solidity-sdk/blob/b9e129e65d34827d92fceeed8c87d3ecdfc801d0/src/QueryResponse.sol#L631-L663, with 4 unique external calls into the core bridge. This gas usage for this was tested with a sample test case:

```solidity
  function testFuzz_verifyCurrentQuorumWithoutHelper(bytes memory encoded) public {
    vm.assume(encoded.length > 0);

    // Set the initial guardian set
    address[] memory initialGuardians = new address[](1);
    initialGuardians[0] = testGuardianPub;

    // Create a guardian set
    Structs.GuardianSet memory initialGuardianSet = Structs.GuardianSet({
      keys: initialGuardians,
      expirationTime: 0
    });

    messages.storeGuardianSetPub(initialGuardianSet, uint32(0));

    bytes32 message = keccak256(encoded);

    // Generate legitimate signature.
    Structs.Signature memory goodSignature;
    (goodSignature.v, goodSignature.r, goodSignature.s) = vm.sign(testGuardian, message);
    assertEq(ecrecover(message, goodSignature.v, goodSignature.r, goodSignature.s), vm.addr(testGuardian));
    goodSignature.guardianIndex = 0;

    // Attempt to verify signatures.
    Structs.Signature[] memory sigs = new Structs.Signature[](1);
    sigs[0] = goodSignature;

        // It might be worth adding a verifyCurrentQuorum call on the core bridge so that there is only 1 cross call instead of 4.
    uint32 gsi = messages.getCurrentGuardianSetIndex();
    Structs.GuardianSet memory fetchedGuardianSet = messages.getGuardianSet(gsi);

    /**
    * @dev Checks whether the guardianSet has zero keys
    * WARNING: This keys check is critical to ensure the guardianSet has keys present AND to ensure
    * that guardianSet key size doesn't fall to zero and negatively impact quorum assessment.  If guardianSet
    * key length is 0 and vm.signatures length is 0, this could compromise the integrity of both vm and
    * signature verification.
    */
    if(fetchedGuardianSet.keys.length == 0){
        revert("invalid guardian set");
    }

    /**
    * @dev We're using a fixed point number transformation with 1 decimal to deal with rounding.
    *   WARNING: This quorum check is critical to assessing whether we have enough Guardian signatures to validate a VM
    *   if making any changes to this, obtain additional peer review. If guardianSet key length is 0 and
    *   vm.signatures length is 0, this could compromise the integrity of both vm and signature verification.
    */
    if (sigs.length < messages.quorum(fetchedGuardianSet.keys.length)){
        revert("no quorum");
    }

    /// @dev Verify the proposed vm.signatures against the guardianSet
    (bool valid, string memory reason) = messages.verifySignatures(message, sigs, fetchedGuardianSet);

    assertEq(valid, true);
    assertEq(bytes(reason).length, 0);
  }
```

```
❯ forge test --match-test testFuzz_verifyCurrentQuorumWithoutHelper --gas-report
[⠊] Compiling...
No files changed, compilation skipped

Ran 1 test for forge-test/Messages.t.sol:TestMessages
[PASS] testFuzz_verifyCurrentQuorumWithoutHelper(bytes) (runs: 256, μ: 106115, ~: 106107)
Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 131.91ms (130.80ms CPU time)
| forge-test/Messages.t.sol:ExportedMessages contract |                 |       |        |       |         |
|-----------------------------------------------------|-----------------|-------|--------|-------|---------|
| Deployment Cost                                     | Deployment Size |       |        |       |         |
| 1668761                                             | 7513            |       |        |       |         |
| Function Name                                       | min             | avg   | median | max   | # calls |
| getCurrentGuardianSetIndex                          | 1042            | 1042  | 1042   | 1042  | 256     |
| getGuardianSet                                      | 3612            | 3612  | 3612   | 3612  | 256     |
| quorum                                              | 594             | 594   | 594    | 594   | 257     |
| storeGuardianSetPub                                 | 67461           | 67461 | 67461  | 67461 | 256     |
| verifySignatures                                    | 7046            | 7046  | 7046   | 7046  | 256     |




Ran 1 test suite in 144.28ms (131.91ms CPU time): 1 tests passed, 0 failed, 0 skipped (1 total tests)
```

We exclude the call to `storeGuardianSetPub`, and the total gas for this sums to 12,284.

## New verifyCurrentQuorum method
```
❯ forge test --match-test "testFuzz_verifyCurrentQuorum\\b" --gas-report
[⠊] Compiling...
No files changed, compilation skipped

Ran 1 test for forge-test/Messages.t.sol:TestMessages
[PASS] testFuzz_verifyCurrentQuorum(bytes) (runs: 256, μ: 95136, ~: 95129)
Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 136.61ms (129.51ms CPU time)
| forge-test/Messages.t.sol:ExportedMessages contract |                 |       |        |       |         |
|-----------------------------------------------------|-----------------|-------|--------|-------|---------|
| Deployment Cost                                     | Deployment Size |       |        |       |         |
| 1668761                                             | 7513            |       |        |       |         |
| Function Name                                       | min             | avg   | median | max   | # calls |
| quorum                                              | 594             | 594   | 594    | 594   | 1       |
| storeGuardianSetPub                                 | 67461           | 67461 | 67461  | 67461 | 256     |
| verifyCurrentQuorum                                 | 10313           | 10313 | 10313  | 10313 | 256     |




Ran 1 test suite in 154.74ms (136.61ms CPU time): 1 tests passed, 0 failed, 0 skipped (1 total tests)
```

The gas to call this new method is 10,313.

## Summary
This helper method saves 12,284 - 10,313 = 1971 gas