### PR TITLE
ci: Update tilt timeout to 60m

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
           kubectl config use-context ci
 
       # temporarily set --guardiand_loglevel=info to debug https://github.com/wormhole-foundation/wormhole/issues/3052
-      - run: tilt ci -- --ci --namespace=$DEPLOY_NS --num=2 --guardiand_loglevel=info
+      - run: tilt ci --timeout=60m -- --ci --namespace=$DEPLOY_NS --num=2 --guardiand_loglevel=info
         timeout-minutes: 60
 
       # Clean up k8s resources


### PR DESCRIPTION
Tilt CI has a default timeout of 30m, so it times out before the github action step. This change should fix the intermittent build failures.