### PR TITLE
CCQ/Node/EVM: Refactor

### DIFF
--- a/node/pkg/p2p/ccq_p2p.go
+++ b/node/pkg/p2p/ccq_p2p.go
@@ -251,14 +251,14 @@ func (ccq *ccqP2p) publisher(ctx context.Context, gk *ecdsa.PrivateKey, queryRes
 			ccqP2pMessagesSent.Inc()
 			if err != nil {
 				ccq.logger.Error("failed to publish query response",
-					zap.String("requestID", msg.RequestID()),
+					zap.String("requestSignature", msg.Signature()),
 					zap.Any("query_response", msg),
 					zap.Any("signature", sig),
 					zap.Error(err),
 				)
 			} else {
 				ccq.logger.Info("published signed query response", //TODO: Change to Debug
-					zap.String("requestID", msg.RequestID()),
+					zap.String("requestSignature", msg.Signature()),
 					zap.Any("query_response", msg),
 					zap.Any("signature", sig),
 				)

--- a/node/pkg/query/query.go
+++ b/node/pkg/query/query.go
@@ -402,7 +402,7 @@ func parseAllowedRequesters(ccqAllowedRequesters string) (map[ethCommon.Address]
 	var nullAddr ethCommon.Address
 	result := make(map[ethCommon.Address]struct{})
 	for _, str := range strings.Split(ccqAllowedRequesters, ",") {
-		addr := ethCommon.BytesToAddress(ethCommon.Hex2Bytes(str))
+		addr := ethCommon.BytesToAddress(ethCommon.Hex2Bytes(strings.TrimPrefix(str, "0x")))
 		if addr == nullAddr {
 			return nil, fmt.Errorf("invalid value in `--ccqAllowedRequesters`: `%s`", str)
 		}

--- a/node/pkg/query/request.go
+++ b/node/pkg/query/request.go
@@ -121,6 +121,10 @@ type PerChainQueryInternal struct {
 	Request    *PerChainQueryRequest
 }
 
+func (pcqi *PerChainQueryInternal) ID() string {
+	return fmt.Sprintf("%s:%d", pcqi.RequestID, pcqi.RequestIdx)
+}
+
 // QueryRequestDigest returns the query signing prefix based on the environment.
 func QueryRequestDigest(env common.Environment, b []byte) ethCommon.Hash {
 	var queryRequestPrefix []byte

--- a/node/pkg/query/response.go
+++ b/node/pkg/query/response.go
@@ -266,7 +266,7 @@ func (left *QueryResponsePublication) Equal(right *QueryResponsePublication) boo
 	return true
 }
 
-func (resp *QueryResponsePublication) RequestID() string {
+func (resp *QueryResponsePublication) Signature() string {
 	if resp == nil || resp.Request == nil {
 		return "nil"
 	}


### PR DESCRIPTION
This code reduces the amount of code that is duplicated between the `eth_call`, `eth_call_by_timestamp` and `eth_call_with_finality`.

This PR also fixes #3539.