### PR TITLE
ethereum: Fix flaky tests

### DIFF
--- a/ethereum/forge-test/Governance.t.sol
+++ b/ethereum/forge-test/Governance.t.sol
@@ -792,8 +792,10 @@ contract TestGovernance is TestUtils {
         return
             // Avoid precompiled contracts
             addr <= address(0x9) ||
-            // Wormhole contract does not accept assets
+            // Wormhole implementation contract does not accept assets
             addr == address(impl) ||
+            // Wormhole proxy contract does not accept assets
+            addr == address(proxied) ||
 			// Setup contract
 			addr == address(setup) ||
 			// Test contract


### PR DESCRIPTION
Turns out that the recipient address for the failure cases was the same as the WH proxy, so I've added that as another address to avoid