### PR TITLE
sdk/js: Refactor WrappedMeta class constructor to include lastUpdatedSequence

### DIFF
--- a/sdk/js/CHANGELOG.md
+++ b/sdk/js/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.10.6
+
+### Added
+
+Celestia support
+
+Scroll testnet support
+
+### Changes
+
+Solana WrappedMeta deserialization fix
+
 ## 0.10.5
 
 ### Changes

--- a/sdk/js/src/solana/tokenBridge/accounts/wrapped.ts
+++ b/sdk/js/src/solana/tokenBridge/accounts/wrapped.ts
@@ -68,20 +68,34 @@ export class WrappedMeta {
   chain: number;
   tokenAddress: Buffer;
   originalDecimals: number;
+  lastUpdatedSequence?: bigint;
 
-  constructor(chain: number, tokenAddress: Buffer, originalDecimals: number) {
+  constructor(
+    chain: number,
+    tokenAddress: Buffer,
+    originalDecimals: number,
+    lastUpdatedSequence?: bigint
+  ) {
     this.chain = chain;
     this.tokenAddress = tokenAddress;
     this.originalDecimals = originalDecimals;
+    this.lastUpdatedSequence = lastUpdatedSequence;
   }
 
   static deserialize(data: Buffer): WrappedMeta {
-    if (data.length != 35) {
-      throw new Error("data.length != 35");
+    if (data.length !== 35 && data.length !== 43) {
+      throw new Error(`invalid wrapped meta length: ${data.length}`);
     }
     const chain = data.readUInt16LE(0);
     const tokenAddress = data.subarray(2, 34);
     const originalDecimals = data.readUInt8(34);
-    return new WrappedMeta(chain, tokenAddress, originalDecimals);
+    const lastUpdatedSequence =
+      data.length === 43 ? data.readBigUInt64LE(35) : undefined;
+    return new WrappedMeta(
+      chain,
+      tokenAddress,
+      originalDecimals,
+      lastUpdatedSequence
+    );
   }
 }


### PR DESCRIPTION
The `last_updated_sequence` variable was added to the new `WrappedAsset` struct which is currently deployed in devnet. When I created a new wrapped token or updated an existing one the data length of the wrapped asset changed from 35 to 43 bytes. This PR supports deserializing both the legacy (35 bytes) and new (43 bytes) wrapped asset data. https://github.com/wormhole-foundation/wormhole/blob/cf74cd22ba74f019861066e734ecb058d8d3fdfe/solana/programs/token-bridge/src/legacy/state/wrapped_asset.rs#L48