### PR TITLE
ethereum: Fix flaky governance replay attack test

### DIFF
--- a/ethereum/forge-test/Governance.t.sol
+++ b/ethereum/forge-test/Governance.t.sol
@@ -290,9 +290,13 @@ contract TestGovernance is TestUtils {
         public
         unchangedStorage(address(proxied), storageSlot)
     {
+        MyImplementation newImpl = new MyImplementation(EVMCHAINID, CHAINID);
+
+        vm.assume(storageSlot != IMPLEMENTATION_SLOT);
+        vm.assume(storageSlot != hashedLocation(address(newImpl), INIT_IMPLEMENTATION_SLOT));
+
         vm.chainId(EVMCHAINID);
 
-        MyImplementation newImpl = new MyImplementation(EVMCHAINID, CHAINID);
         bytes memory payload = payloadSubmitContract(MODULE, CHAINID, address(newImpl));
         (bytes memory _vm, bytes32 hash) = validVm(
             0, timestamp, nonce, 1, governanceContract, sequence, consistencyLevel, payload, testGuardian);


### PR DESCRIPTION
After being baffled by the fact that all the storage slot addresses were being calculated correctly, it turns out that the issue with this test was that not enough slots were being discarded.

The test has been updated to align with other similar tests like `testSubmitContractUpgrade`: https://github.com/wormhole-foundation/wormhole/blob/1152b5bd6449f38e0c96d13345caf51726ba4df9/ethereum/forge-test/Governance.t.sol#L67-L80.