### PR TITLE
tilt: eth relayer pin tsx

### DIFF
--- a/ethereum/ts-scripts/relayer/shell/deployInContainer.sh
+++ b/ethereum/ts-scripts/relayer/shell/deployInContainer.sh
@@ -1,7 +1,7 @@
  echo "deploying generic relayer contracts" \ 
-  npx tsx ./ts-scripts/relayer/create2Factory/deployCreate2Factory.ts \
-  && npx tsx ./ts-scripts/relayer/deliveryProvider/deployDeliveryProvider.ts \
-  && npx tsx ./ts-scripts/relayer/wormholeRelayer/deployWormholeRelayer.ts \
-  && npx tsx ./ts-scripts/relayer/mockIntegration/deployMockIntegration.ts \
-  && npx tsx ./ts-scripts/relayer/wormholeRelayer/registerChainsWormholeRelayerSelfSign.ts \
-  && npx tsx ./ts-scripts/relayer/deliveryProvider/configureDeliveryProvider.ts \
+  npx tsx@4.5.1 ./ts-scripts/relayer/create2Factory/deployCreate2Factory.ts \
+  && npx tsx@4.5.1 ./ts-scripts/relayer/deliveryProvider/deployDeliveryProvider.ts \
+  && npx tsx@4.5.1 ./ts-scripts/relayer/wormholeRelayer/deployWormholeRelayer.ts \
+  && npx tsx@4.5.1 ./ts-scripts/relayer/mockIntegration/deployMockIntegration.ts \
+  && npx tsx@4.5.1 ./ts-scripts/relayer/wormholeRelayer/registerChainsWormholeRelayerSelfSign.ts \
+  && npx tsx@4.5.1 ./ts-scripts/relayer/deliveryProvider/configureDeliveryProvider.ts \


### PR DESCRIPTION
The latest version of `tsx` throws a nasty error with the version of node used in the eth tests container.