### PR TITLE
Node/GACCT: Drop bogus pending transfers from db

### DIFF
--- a/node/pkg/accountant/accountant.go
+++ b/node/pkg/accountant/accountant.go
@@ -333,6 +333,10 @@ func (acct *Accountant) loadPendingTransfers() error {
 		msgId := msg.MessageIDString()
 		if !acct.IsMessageCoveredByAccountant(msg) {
 			acct.logger.Error("dropping reloaded pending transfer because it is not covered by the accountant", zap.String("msgID", msgId))
+			if err := acct.db.AcctDeletePendingTransfer(msgId); err != nil {
+				acct.logger.Error("failed to delete pending transfer from the db", zap.String("msgId", msgId), zap.Error(err))
+				// Ignore this error and keep going.
+			}
 			continue
 		}
 		acct.logger.Info("reloaded pending transfer", zap.String("msgID", msgId))


### PR DESCRIPTION
A change was made a while ago to drop these bad pending transfers on start up, which fixed a reobservation storm. However, the transfers were left in the DB, so we get an error saying they were dropped on every restart. This PR removes them from the DB so that we can be done with them for good.