### PR TITLE
Node/EVM: Another blocktime query retry reason

### DIFF
--- a/node/pkg/watchers/evm/connectors/batch_poller.go
+++ b/node/pkg/watchers/evm/connectors/batch_poller.go
@@ -323,7 +323,7 @@ func (b *BatchPollConnector) getBlockRange(ctx context.Context, logger *zap.Logg
 		var n big.Int
 		m := &result.result
 		if m.Number == nil {
-			logger.Debug("number is nil, treating as zero", zap.Stringer("finality", finality), zap.String("tag", b.batchData[idx].tag))
+			logger.Debug("number is nil, treating as zero", zap.Stringer("finality", finality))
 		} else {
 			n = big.Int(*m.Number)
 		}


### PR DESCRIPTION
While testing in testnet, I saw the blocktime query fail on avalanche for another reason. This is another case where a retry works. I was able to verify the fix in testnet.

Also while testing I stumbled across a watcher restart due to an index out of bounds error in batch_poller. The fix for that is also in this PR.