### PR TITLE
ci: fix terra2 test

### DIFF
--- a/cosmwasm/deployment/terra2/Makefile
+++ b/cosmwasm/deployment/terra2/Makefile
@@ -35,21 +35,17 @@ deploy/token_bridge: token_bridge-code-id-$(NETWORK).txt
 tools/node_modules: tools/package-lock.json
 	cd tools && npm ci
 
-LocalTerra:
-	git clone --depth 1 https://www.github.com/terra-money/LocalTerra
-
 test/node_modules: test/package-lock.json
 	cd test && npm ci
 
-
 .PHONY: test
 ## Run unit and integration tests
-test: artifacts test/node_modules LocalTerra
+test: artifacts test/node_modules
 	@if pgrep terrad; then echo "Error: terrad already running. Stop it before running tests"; exit 1; fi
-	cd LocalTerra && DOCKER_BUILDKIT=1 docker-compose up --detach
-	sleep 5
-	cd test && npm run test || (cd ../LocalTerra && docker-compose down && exit 1)
-	cd LocalTerra && docker-compose down
+	cd devnet && DOCKER_BUILDKIT=1 docker-compose up --detach
+	sleep 10
+	cd test && npm run test || (cd ../devnet && docker-compose down && exit 1)
+	cd devnet && docker-compose down
 
 .PHONY: clean
 clean:

--- a/cosmwasm/deployment/terra2/devnet/docker-compose.yml
+++ b/cosmwasm/deployment/terra2/devnet/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3.8"
+
+services:
+  terrad:
+    image: ghcr.io/terra-money/localterra:2.0.1@sha256:be788330d9af64ad2dc645e41e543a8df335531a84572f1a0350c3e548977a3d
+    ports:
+      - "1317:1317"
+      - "9090:9090"
+      - "9091:9091"
+      - "26657:26657"


### PR DESCRIPTION
The terra-2 test started failing, likely because it was pulling the latest LocalTerra and something changed. This now uses a defined `docker-compose.yaml` and pinned version. Ideally this could share an image with tilt, but that didn't work immediately with the current devnet config.