### PR TITLE
tilt: remove additional root CA support

### DIFF
--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -1,11 +1,6 @@
 # syntax=docker.io/docker/dockerfile:1.3@sha256:42399d4635eddd7a9b8a24be879d2f9a930d0ed040a61324cfdf59ef1357b3b2
 FROM node:18-alpine@sha256:44aaf1ccc80eaed6572a0f2ef7d6b5a2982d54481e4255480041ac92221e2f11 as cli-build
 
-# Support additional root CAs
-COPY README.md cert.pem* /certs/
-# Alpine
-RUN if [ -e /certs/cert.pem ]; then cp /certs/cert.pem /etc/ssl/cert.pem; fi
-
 # Copy package.json & package-lock.json by themselves to create a cache layer
 COPY clients/js/package.json clients/js/package-lock.json /clients/js/
 

--- a/Dockerfile.const
+++ b/Dockerfile.const
@@ -5,11 +5,6 @@ FROM node:18-alpine@sha256:44aaf1ccc80eaed6572a0f2ef7d6b5a2982d54481e4255480041a
 # fetch scripts/guardian-set-init.sh deps
 RUN apk update && apk add bash g++ make python3 curl jq findutils
 
-# Support additional root CAs
-COPY README.md cert.pem* /certs/
-# Alpine
-RUN if [ -e /certs/cert.pem ]; then cp /certs/cert.pem /etc/ssl/cert.pem; fi
-
 # Copy and link CLI
 COPY --from=cli-export clients/js /cli
 

--- a/Dockerfile.proto
+++ b/Dockerfile.proto
@@ -1,11 +1,6 @@
 # syntax=docker.io/docker/dockerfile:1.3@sha256:42399d4635eddd7a9b8a24be879d2f9a930d0ed040a61324cfdf59ef1357b3b2
 FROM docker.io/golang:1.20.10-bullseye@sha256:082569b3303b164cc4a7c88ac59b19b69c1a5d662041ac0dca046ac239632442 AS go-tools
 
-# Support additional root CAs
-COPY README.md cert.pem* /certs/
-# Debian
-RUN if [ -e /certs/cert.pem ]; then cp /certs/cert.pem /etc/ssl/certs/ca-certificates.crt; fi
-
 RUN mkdir /app
 
 COPY tools/build.sh /app/tools/
@@ -16,11 +11,6 @@ RUN --mount=type=cache,target=/root/.cache --mount=type=cache,target=/go \
 
 # syntax=docker.io/docker/dockerfile:1.3@sha256:42399d4635eddd7a9b8a24be879d2f9a930d0ed040a61324cfdf59ef1357b3b2
 FROM docker.io/golang:1.20.10-bullseye@sha256:082569b3303b164cc4a7c88ac59b19b69c1a5d662041ac0dca046ac239632442 AS go-build
-
-# Support additional root CAs
-COPY README.md cert.pem* /certs/
-# Debian
-RUN if [ -e /certs/cert.pem ]; then cp /certs/cert.pem /etc/ssl/certs/ca-certificates.crt; fi
 
 COPY --from=go-tools /app /app
 
@@ -33,11 +23,6 @@ RUN --mount=type=cache,target=/root/.cache \
 	tools/bin/buf generate
 
 FROM node:16-alpine@sha256:004dbac84fed48e20f9888a23e32fa7cf83c2995e174a78d41d9a9dd1e051a20 AS node-build
-
-# Support additional root CAs
-COPY README.md cert.pem* /certs/
-# Alpine
-RUN if [ -e /certs/cert.pem ]; then cp /certs/cert.pem /etc/ssl/cert.pem; fi
 
 COPY --from=go-tools /app /app
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -757,7 +757,7 @@ if near:
         ref = "near-node",
         context = "near",
         dockerfile = "near/Dockerfile",
-        only = ["Dockerfile", "node_builder.sh", "start_node.sh", "README.md", "cert.pem"],
+        only = ["Dockerfile", "node_builder.sh", "start_node.sh", "README.md"],
     )
 
     docker_build(

--- a/algorand/Dockerfile
+++ b/algorand/Dockerfile
@@ -2,11 +2,6 @@
 FROM const-gen AS const-export
 FROM docker.io/python:3.10@sha256:eeed7cac682f9274d183f8a7533ee1360a26acb3616aa712b2be7896f80d8c5f
 
-# Support additional root CAs
-COPY README.md cert.pem* /certs/
-# Debian
-RUN if [ -e /certs/cert.pem ]; then cp /certs/cert.pem /etc/ssl/certs/ca-certificates.crt; fi
-
 RUN python3 -m pip install virtualenv
 
 RUN apt-get update

--- a/algorand/sandbox-algorand/images/algod/Dockerfile
+++ b/algorand/sandbox-algorand/images/algod/Dockerfile
@@ -1,13 +1,6 @@
 ARG GO_VERSION=1.18.2
 FROM golang:$GO_VERSION@sha256:04fab5aaf4fc18c40379924674491d988af3d9e97487472e674d0b5fd837dfac as algorand-algod
 
-# Support additional root CAs
-COPY config.dev cert.pem* /certs/
-# Debian
-RUN if [ -e /certs/cert.pem ]; then cp /certs/cert.pem /etc/ssl/certs/ca-certificates.crt; fi
-# git
-RUN if [ -e /certs/cert.pem ]; then git config --global http.sslCAInfo /certs/cert.pem; fi
-
 ARG CHANNEL=master
 ARG URL="https://github.com/algorand/go-algorand"
 ARG BRANCH=master

--- a/algorand/sandbox-algorand/images/indexer/Dockerfile
+++ b/algorand/sandbox-algorand/images/indexer/Dockerfile
@@ -1,13 +1,6 @@
 ARG GO_VERSION=1.18.2
 FROM golang:$GO_VERSION-alpine@sha256:4795c5d21f01e0777707ada02408debe77fe31848be97cf9fa8a1462da78d949
 
-# Support additional root CAs
-COPY config.dev cert.pem* /certs/
-# Debian (for top Go priority)
-RUN if [ -e /certs/cert.pem ]; then cp /certs/cert.pem /etc/ssl/certs/ca-certificates.crt; fi
-# Alpine
-RUN if [ -e /certs/cert.pem ]; then cp /certs/cert.pem /etc/ssl/cert.pem; fi
-
 # Environment variables used by install.sh
 ARG URL=https://github.com/algorand/indexer
 ARG BRANCH=2.15.4
@@ -18,10 +11,6 @@ WORKDIR /opt/indexer
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apk add --no-cache git bzip2 make bash libtool boost-dev autoconf automake g++ postgresql
-
-# Support additional root CAs
-# git
-RUN if [ -e /certs/cert.pem ]; then git config --global http.sslCAInfo /certs/cert.pem; fi
 
 # Copy files to container.
 COPY images/indexer/disabled.go /tmp/disabled.go

--- a/aptos/Dockerfile
+++ b/aptos/Dockerfile
@@ -2,10 +2,6 @@ FROM cli-gen AS cli-export
 FROM const-gen AS const-export
 FROM ghcr.io/wormhole-foundation/aptos:2.0.3@sha256:1e79c5a615b10073a780122abfaaf9b90735912df560b4e7b6a056fe45816392 as aptos
 
-# Support additional root CAs
-COPY cert.pem* /certs/
-RUN if [ -e /certs/cert.pem ]; then cp /certs/cert.pem /etc/ssl/certs/ca-certificates.crt; fi
-
 # Install nodejs
 # todo(aki): move this into base image?
 RUN apt-get update

--- a/cosmwasm/Dockerfile
+++ b/cosmwasm/Dockerfile
@@ -11,11 +11,6 @@ COPY cosmwasm/packages /code/packages
 COPY cosmwasm/artifacts /code/artifacts
 COPY sdk/rust /sdk/rust
 
-# Support additional root CAs
-COPY README.md cert.pem* /certs/
-# Alpine
-RUN if [ -e /certs/cert.pem ]; then cp /certs/cert.pem /etc/ssl/cert.pem; fi
-
 RUN --mount=type=cache,target=/target,id=cosmwasm_target --mount=type=cache,target=/usr/local/cargo/registry optimize_workspace.sh
 
 FROM scratch as artifacts

--- a/cosmwasm/Dockerfile.deploy
+++ b/cosmwasm/Dockerfile.deploy
@@ -9,14 +9,6 @@ FROM cosmwasm_artifacts AS artifacts
 # Contract deployment stage
 FROM node:16-buster-slim@sha256:93c9fc3550f5f7d159f282027228e90e3a7f8bf38544758024f005e82607f546
 
-# Support additional root CAs
-COPY cert.pem* /certs/
-# Node
-ENV NODE_EXTRA_CA_CERTS=/certs/cert.pem
-ENV NODE_OPTIONS=--use-openssl-ca
-# npm
-RUN if [ -e /certs/cert.pem ]; then npm config set cafile /certs/cert.pem; fi
-
 RUN apt update && apt install netcat curl jq -y
 
 WORKDIR /app/tools

--- a/ethereum/Dockerfile
+++ b/ethereum/Dockerfile
@@ -26,17 +26,6 @@ WORKDIR /home/node/app
 # Fix git ssh error
 RUN git config --global url."https://".insteadOf ssh://
 
-# Support additional root CAs
-COPY README.md cert.pem* /certs/
-# Node
-ENV NODE_EXTRA_CA_CERTS=/certs/cert.pem
-ENV NODE_OPTIONS=--use-openssl-ca
-# npm
-RUN if [ -e /certs/cert.pem ]; then npm config set cafile /certs/cert.pem; fi
-# git
-RUN if [ -e /certs/cert.pem ]; then git config --global http.sslCAInfo /certs/cert.pem; fi
-
-
 WORKDIR /home/node/app
 
 # Only invalidate the npm install step if package.json changed

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -2,13 +2,6 @@
 FROM --platform=linux/amd64 docker.io/golang:1.20.10-bullseye@sha256:082569b3303b164cc4a7c88ac59b19b69c1a5d662041ac0dca046ac239632442 AS build
 # libwasmvm.so is not compatible with arm
 
-# Support additional root CAs
-COPY node/go.mod cert.pem* /certs/
-# Debian
-RUN if [ -e /certs/cert.pem ]; then cp /certs/cert.pem /etc/ssl/certs/ca-certificates.crt; fi
-# git
-RUN if [ -e /certs/cert.pem ]; then git config --global http.sslCAInfo /certs/cert.pem; fi
-
 WORKDIR /app
 
 COPY node/tools tools

--- a/relayer/generic_relayer/relayer-engine-v2/Dockerfile
+++ b/relayer/generic_relayer/relayer-engine-v2/Dockerfile
@@ -19,14 +19,6 @@ WORKDIR /home/node/app
 # Fix git ssh error
 RUN git config --global url."https://".insteadOf ssh://
 
-# Node
-ENV NODE_EXTRA_CA_CERTS=/certs/cert.pem
-ENV NODE_OPTIONS=--use-openssl-ca
-# npm
-RUN if [ -e /certs/cert.pem ]; then npm config set cafile /certs/cert.pem; fi
-# git
-RUN if [ -e /certs/cert.pem ]; then git config --global http.sslCAInfo /certs/cert.pem; fi
-
 COPY --chown=node:node ./ethereum/ts-scripts/relayer/config/ ./ethereum/ts-scripts/relayer/config/
 
 #Path matters so as to not break imports

--- a/solana/Dockerfile
+++ b/solana/Dockerfile
@@ -1,11 +1,6 @@
 #syntax=docker/dockerfile:1.2@sha256:e2a8561e419ab1ba6b2fe6cbdf49fd92b95912df1cf7d313c3e2230a333fdbcc
 FROM ghcr.io/wormhole-foundation/solana:1.10.31@sha256:d31e8db926a1d3fbaa9d9211d9979023692614b7b64912651aba0383e8c01bad AS solana
 
-# Support additional root CAs
-COPY cert.pem* /certs/
-# Debian
-RUN if [ -e /certs/cert.pem ]; then cp /certs/cert.pem /etc/ssl/certs/ca-certificates.crt; fi
-
 # Add bridge contract sources
 WORKDIR /usr/src/bridge
 

--- a/solana/Dockerfile.wasm
+++ b/solana/Dockerfile.wasm
@@ -6,11 +6,6 @@ RUN rustup component add rustfmt
 
 WORKDIR /usr/src/bridge
 
-# Support additional root CAs
-COPY cert.pem* /certs/
-# Debian
-RUN if [ -e /certs/cert.pem ]; then cp /certs/cert.pem /etc/ssl/certs/ca-certificates.crt; fi
-
 RUN cargo install wasm-pack --vers 0.9.1
 
 ENV RUST_LOG="solana_runtime::system_instruction_processor=trace,solana_runtime::message_processor=trace,solana_bpf_loader=debug,solana_rbpf=debug"

--- a/sui/Dockerfile
+++ b/sui/Dockerfile
@@ -2,10 +2,6 @@ FROM cli-gen AS cli-export
 FROM const-gen AS const-export
 FROM ghcr.io/wormhole-foundation/sui:1.0.0-testnet_1@sha256:806fc83e7bbd59bca0a1960870d27b041d0b99a286d7eccfcec25beb74c2346c as sui
 
-COPY sui/README.md sui/cert.pem* /certs/
-RUN if [ -e /certs/cert.pem ]; then cp /certs/cert.pem /etc/ssl/certs/ca-certificates.crt; fi
-RUN if [ -e /certs/cert.pem ]; then git config --global http.sslCAInfo /certs/cert.pem; fi
-
 RUN sui genesis -f
 
 COPY sui/devnet/ /root/.sui/sui_config/

--- a/terra/Dockerfile
+++ b/terra/Dockerfile
@@ -7,11 +7,6 @@ COPY Cargo.lock /code/
 COPY Cargo.toml /code/
 COPY contracts /code/contracts
 
-# Support additional root CAs
-COPY README.md cert.pem* /certs/
-# Alpine
-RUN if [ -e /certs/cert.pem ]; then cp /certs/cert.pem /etc/ssl/cert.pem; fi
-
 RUN --mount=type=cache,target=/target,id=terra_classic_target --mount=type=cache,target=/usr/local/cargo/registry optimize_workspace.sh
 
 FROM scratch as artifacts
@@ -19,14 +14,6 @@ COPY --from=builder /code/artifacts /
 
 # Contract deployment stage
 FROM node:16-buster-slim@sha256:93c9fc3550f5f7d159f282027228e90e3a7f8bf38544758024f005e82607f546
-
-# Support additional root CAs
-COPY README.md cert.pem* /certs/
-# Node
-ENV NODE_EXTRA_CA_CERTS=/certs/cert.pem
-ENV NODE_OPTIONS=--use-openssl-ca
-# npm
-RUN if [ -e /certs/cert.pem ]; then npm config set cafile /certs/cert.pem; fi
 
 RUN apt update && apt install netcat curl jq -y
 

--- a/wormchain/Dockerfile.deploy
+++ b/wormchain/Dockerfile.deploy
@@ -9,14 +9,6 @@ FROM cosmwasm_artifacts AS artifacts
 # Contract deployment stage
 FROM node:16-buster-slim@sha256:93c9fc3550f5f7d159f282027228e90e3a7f8bf38544758024f005e82607f546
 
-# Support additional root CAs
-COPY cert.pem* /certs/
-# Node
-ENV NODE_EXTRA_CA_CERTS=/certs/cert.pem
-ENV NODE_OPTIONS=--use-openssl-ca
-# npm
-RUN if [ -e /certs/cert.pem ]; then npm config set cafile /certs/cert.pem; fi
-
 RUN apt update && apt install netcat curl jq -y
 
 WORKDIR /app/tools


### PR DESCRIPTION
I had previously added this code to support contributors behind corporate firewalls which required custom root certificate authorities. I don't think this is needed anymore and is simply spamming logs.