### PR TITLE
Node/EVM: Minor code cleanup

### DIFF
--- a/node/pkg/watchers/evm/config.go
+++ b/node/pkg/watchers/evm/config.go
@@ -17,7 +17,6 @@ type WatcherConfig struct {
 	Rpc                    string             // RPC URL
 	Contract               string             // hex representation of the contract address
 	GuardianSetUpdateChain bool               // if `true`, we will retrieve the GuardianSet from this chain and watch this chain for GuardianSet updates
-	WaitForConfirmations   bool               // (optional)
 	L1FinalizerRequired    watchers.NetworkID // (optional)
 	l1Finalizer            interfaces.L1Finalizer
 }
@@ -56,7 +55,6 @@ func (wc *WatcherConfig) Create(
 	var devMode bool = (env == common.UnsafeDevNet)
 
 	watcher := NewEthWatcher(wc.Rpc, eth_common.HexToAddress(wc.Contract), string(wc.NetworkID), wc.ChainID, msgC, setWriteC, obsvReqC, queryReqC, queryResponseC, devMode)
-	watcher.SetWaitForConfirmations(wc.WaitForConfirmations)
 	watcher.SetL1Finalizer(wc.l1Finalizer)
 	return watcher, watcher.Run, nil
 }


### PR DESCRIPTION
This PR removes some dead code from the EVM watcher in an attempt to make the code more readable.

Since the watcher has been upgraded to use `finalized` for all chains, the `waitForConfirmations` config parameter was always false, so I've removed it. This meant that the `expectedConfirmations` variable was always zero, so I also removed that.

Additionally, the `maxWaitConfirmations` config parameter is always 60, so I made it a constant.