### PR TITLE
Node/EVM: Celo not setting timestamp in blocks

### DIFF
--- a/node/pkg/watchers/evm/connectors/celo.go
+++ b/node/pkg/watchers/evm/connectors/celo.go
@@ -173,16 +173,19 @@ func (c *CeloConnector) SubscribeForBlocks(ctx context.Context, errC chan error,
 				sink <- &NewBlock{
 					Number:   ev.Number,
 					Hash:     hash,
+					Time:     ev.Time,
 					Finality: Finalized,
 				}
 				sink <- &NewBlock{
 					Number:   ev.Number,
 					Hash:     hash,
+					Time:     ev.Time,
 					Finality: Safe,
 				}
 				sink <- &NewBlock{
 					Number:   ev.Number,
 					Hash:     hash,
+					Time:     ev.Time,
 					Finality: Latest,
 				}
 			}


### PR DESCRIPTION
When the `Time` attributed was added to the `NewBlock` struct for the timestamp cache feature, Celo was missed. This PR updates the Celo block poller to populate the timestamp.