### PR TITLE
Client/JS: Add new chains

### DIFF
--- a/clients/js/README.md
+++ b/clients/js/README.md
@@ -255,8 +255,9 @@ Options:
         "avalanche", "oasis", "algorand", "aurora", "fantom", "karura", "acala",
             "klaytn", "celo", "near", "moonbeam", "neon", "terra2", "injective",
          "osmosis", "sui", "aptos", "arbitrum", "optimism", "gnosis", "pythnet",
-   "xpla", "btc", "base", "sei", "rootstock", "wormchain", "cosmoshub", "evmos",
-                                                            "kujira", "sepolia"]
+     "xpla", "btc", "base", "sei", "rootstock", "scroll", "mantle", "wormchain",
+               "cosmoshub", "evmos", "kujira", "neutron", "celestia", "sepolia",
+                         "arbitrum_sepolia", "base_sepolia", "optimism_sepolia"]
   -n, --network           Network
                             [required] [choices: "mainnet", "testnet", "devnet"]
   -a, --contract-address  Contract to submit VAA to (override config)   [string]
@@ -311,15 +312,17 @@ Options:
         "avalanche", "oasis", "algorand", "aurora", "fantom", "karura", "acala",
             "klaytn", "celo", "near", "moonbeam", "neon", "terra2", "injective",
          "osmosis", "sui", "aptos", "arbitrum", "optimism", "gnosis", "pythnet",
-   "xpla", "btc", "base", "sei", "rootstock", "wormchain", "cosmoshub", "evmos",
-                                                            "kujira", "sepolia"]
+     "xpla", "btc", "base", "sei", "rootstock", "scroll", "mantle", "wormchain",
+               "cosmoshub", "evmos", "kujira", "neutron", "celestia", "sepolia",
+                         "arbitrum_sepolia", "base_sepolia", "optimism_sepolia"]
       --dst-chain   destination chain
            [required] [choices: "solana", "ethereum", "terra", "bsc", "polygon",
         "avalanche", "oasis", "algorand", "aurora", "fantom", "karura", "acala",
             "klaytn", "celo", "near", "moonbeam", "neon", "terra2", "injective",
          "osmosis", "sui", "aptos", "arbitrum", "optimism", "gnosis", "pythnet",
-   "xpla", "btc", "base", "sei", "rootstock", "wormchain", "cosmoshub", "evmos",
-                                                            "kujira", "sepolia"]
+     "xpla", "btc", "base", "sei", "rootstock", "scroll", "mantle", "wormchain",
+               "cosmoshub", "evmos", "kujira", "neutron", "celestia", "sepolia",
+                         "arbitrum_sepolia", "base_sepolia", "optimism_sepolia"]
       --dst-addr    destination address                      [string] [required]
       --token-addr  token address               [string] [default: native token]
       --amount      token amount                             [string] [required]
@@ -351,8 +354,9 @@ Positionals:
         "avalanche", "oasis", "algorand", "aurora", "fantom", "karura", "acala",
             "klaytn", "celo", "near", "moonbeam", "neon", "terra2", "injective",
          "osmosis", "sui", "aptos", "arbitrum", "optimism", "gnosis", "pythnet",
-   "xpla", "btc", "base", "sei", "rootstock", "wormchain", "cosmoshub", "evmos",
-                                                            "kujira", "sepolia"]
+     "xpla", "btc", "base", "sei", "rootstock", "scroll", "mantle", "wormchain",
+               "cosmoshub", "evmos", "kujira", "neutron", "celestia", "sepolia",
+                         "arbitrum_sepolia", "base_sepolia", "optimism_sepolia"]
   tx       Source transaction hash                                      [string]
 
 Options:

--- a/clients/js/package-lock.json
+++ b/clients/js/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@celo-tools/celo-ethers-wrapper": "^0.1.0",
-        "@certusone/wormhole-sdk": "^0.10.5-beta.3",
+        "@certusone/wormhole-sdk": "^0.10.7",
         "@cosmjs/encoding": "^0.26.2",
         "@improbable-eng/grpc-web-node-http-transport": "^0.15.0",
         "@injectivelabs/networks": "^1.10.7",
@@ -494,11 +494,11 @@
       }
     },
     "node_modules/@certusone/wormhole-sdk": {
-      "version": "0.10.5-beta.3",
-      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk/-/wormhole-sdk-0.10.5-beta.3.tgz",
-      "integrity": "sha512-Q1IrWYQ/NPpLcuPs3J8MbUeRwBxBOTZFwLs3jahohgUFCQhGuBwhgpv02CdEYBR/iZpgaDrj2Eo3HOe3uNlYVA==",
+      "version": "0.10.7",
+      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk/-/wormhole-sdk-0.10.7.tgz",
+      "integrity": "sha512-1qV/MYM7deFl+/d1kK34PzDsgDaUQrNvrUVCeUw60WQP8ySf/vWiWk5ny6kaad16d+Qv8JxmVRuHMV4GxZR9/g==",
       "dependencies": {
-        "@certusone/wormhole-sdk-proto-web": "0.0.6",
+        "@certusone/wormhole-sdk-proto-web": "0.0.7",
         "@certusone/wormhole-sdk-wasm": "^0.0.1",
         "@coral-xyz/borsh": "0.2.6",
         "@mysten/sui.js": "0.32.2",
@@ -524,9 +524,9 @@
       }
     },
     "node_modules/@certusone/wormhole-sdk-proto-web": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk-proto-web/-/wormhole-sdk-proto-web-0.0.6.tgz",
-      "integrity": "sha512-LTyjsrWryefx5WmkoBP6FQ2EjLxhMExAGxLkloHUhufVQZdrbGh0htBBUviP+HaDSJBCMPMtulNFwkBJV6muqQ==",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk-proto-web/-/wormhole-sdk-proto-web-0.0.7.tgz",
+      "integrity": "sha512-GCe1/bcqMS0Mt+hsWp4SE4NLL59pWmK0lhQXO0oqAKl0G9AuuTdudySMDF/sLc7z5H2w34bSuSrIEKvPuuSC+w==",
       "dependencies": {
         "@improbable-eng/grpc-web": "^0.15.0",
         "protobufjs": "^7.0.0",
@@ -8367,11 +8367,11 @@
       "requires": {}
     },
     "@certusone/wormhole-sdk": {
-      "version": "0.10.5-beta.3",
-      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk/-/wormhole-sdk-0.10.5-beta.3.tgz",
-      "integrity": "sha512-Q1IrWYQ/NPpLcuPs3J8MbUeRwBxBOTZFwLs3jahohgUFCQhGuBwhgpv02CdEYBR/iZpgaDrj2Eo3HOe3uNlYVA==",
+      "version": "0.10.7",
+      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk/-/wormhole-sdk-0.10.7.tgz",
+      "integrity": "sha512-1qV/MYM7deFl+/d1kK34PzDsgDaUQrNvrUVCeUw60WQP8ySf/vWiWk5ny6kaad16d+Qv8JxmVRuHMV4GxZR9/g==",
       "requires": {
-        "@certusone/wormhole-sdk-proto-web": "0.0.6",
+        "@certusone/wormhole-sdk-proto-web": "0.0.7",
         "@certusone/wormhole-sdk-wasm": "^0.0.1",
         "@coral-xyz/borsh": "0.2.6",
         "@injectivelabs/networks": "1.10.12",
@@ -8402,9 +8402,9 @@
       }
     },
     "@certusone/wormhole-sdk-proto-web": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk-proto-web/-/wormhole-sdk-proto-web-0.0.6.tgz",
-      "integrity": "sha512-LTyjsrWryefx5WmkoBP6FQ2EjLxhMExAGxLkloHUhufVQZdrbGh0htBBUviP+HaDSJBCMPMtulNFwkBJV6muqQ==",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk-proto-web/-/wormhole-sdk-proto-web-0.0.7.tgz",
+      "integrity": "sha512-GCe1/bcqMS0Mt+hsWp4SE4NLL59pWmK0lhQXO0oqAKl0G9AuuTdudySMDF/sLc7z5H2w34bSuSrIEKvPuuSC+w==",
       "requires": {
         "@improbable-eng/grpc-web": "^0.15.0",
         "protobufjs": "^7.0.0",

--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -30,7 +30,7 @@
   ],
   "dependencies": {
     "@celo-tools/celo-ethers-wrapper": "^0.1.0",
-    "@certusone/wormhole-sdk": "^0.10.5-beta.3",
+    "@certusone/wormhole-sdk": "^0.10.7",
     "@cosmjs/encoding": "^0.26.2",
     "@improbable-eng/grpc-web-node-http-transport": "^0.15.0",
     "@injectivelabs/networks": "^1.10.7",

--- a/clients/js/src/chains/generic/getOriginalAsset.ts
+++ b/clients/js/src/chains/generic/getOriginalAsset.ts
@@ -60,7 +60,12 @@ export const getOriginalAsset = async (
     case "optimism":
     case "polygon":
     // case "rootstock":
-    case "sepolia": {
+    case "scroll":
+    case "mantle":
+    case "sepolia":
+    case "arbitrum_sepolia":
+    case "base_sepolia":
+    case "optimism_sepolia": {
       const provider = getProviderForChain(chainName, network, { rpc });
       return getOriginalAssetEth(
         tokenBridgeAddress,
@@ -113,6 +118,8 @@ export const getOriginalAsset = async (
     case "cosmoshub":
     case "evmos":
     case "kujira":
+    case "neutron":
+    case "celestia":
     case "rootstock":
       throw new Error(`${chainName} not supported`);
     default:

--- a/clients/js/src/chains/generic/getWrappedAssetAddress.ts
+++ b/clients/js/src/chains/generic/getWrappedAssetAddress.ts
@@ -70,7 +70,12 @@ export const getWrappedAssetAddress = async (
     case "optimism":
     case "polygon":
     // case "rootstock":
-    case "sepolia": {
+    case "scroll":
+    case "mantle":
+    case "sepolia":
+    case "arbitrum_sepolia":
+    case "base_sepolia":
+    case "optimism_sepolia": {
       const provider = getProviderForChain(chainName, network, { rpc });
       return getForeignAssetEth(
         tokenBridgeAddress,
@@ -159,6 +164,8 @@ export const getWrappedAssetAddress = async (
     case "cosmoshub":
     case "evmos":
     case "kujira":
+    case "neutron":
+    case "celestia":
     case "rootstock":
       throw new Error(`${chainName} not supported`);
     default:

--- a/clients/js/src/chains/generic/provider.ts
+++ b/clients/js/src/chains/generic/provider.ts
@@ -97,7 +97,12 @@ export const getProviderForChain = <T extends ChainId | ChainName>(
     case "optimism":
     case "polygon":
     // case "rootstock":
+    case "scroll":
+    case "mantle":
     case "sepolia":
+    case "arbitrum_sepolia":
+    case "base_sepolia":
+    case "optimism_sepolia":
       return new ethers.providers.JsonRpcProvider(rpc) as ChainProvider<T>;
     case "terra":
     case "terra2":
@@ -157,6 +162,8 @@ export const getProviderForChain = <T extends ChainId | ChainName>(
     case "cosmoshub":
     case "evmos":
     case "kujira":
+    case "neutron":
+    case "celestia":
     case "rootstock":
       throw new Error(`${chainName} not supported`);
     default:

--- a/clients/js/src/cmds/submit.ts
+++ b/clients/js/src/cmds/submit.ts
@@ -190,6 +190,10 @@ async function executeSubmit(
     throw Error("Evmos is not supported yet");
   } else if (chain === "kujira") {
     throw Error("kujira is not supported yet");
+  } else if (chain === "neutron") {
+    throw Error("neutron is not supported yet");
+  } else if (chain === "celestia") {
+    throw Error("celestia is not supported yet");
   } else if (chain === "rootstock") {
     throw Error("rootstock is not supported yet");
   } else {

--- a/clients/js/src/cmds/transfer.ts
+++ b/clients/js/src/cmds/transfer.ts
@@ -144,6 +144,10 @@ export const handler = async (
     throw Error("evmos is not supported yet");
   } else if (srcChain === "kujira") {
     throw Error("kujira is not supported yet");
+  } else if (srcChain === "neutron") {
+    throw Error("neutron is not supported yet");
+  } else if (srcChain === "celestia") {
+    throw Error("celestia is not supported yet");
   } else if (srcChain === "rootstock") {
     throw Error("rootstock is not supported yet");
   } else {

--- a/clients/js/src/consts/networks.ts
+++ b/clients/js/src/consts/networks.ts
@@ -193,6 +193,41 @@ const MAINNET = {
     key: undefined,
     chain_id: undefined,
   },
+  neutron: {
+    rpc: undefined,
+    key: undefined,
+    chain_id: undefined,
+  },
+  celestia: {
+    rpc: undefined,
+    key: undefined,
+    chain_id: undefined,
+  },
+  scroll: {
+    rpc: undefined,
+    key: undefined,
+    chain_id: undefined,
+  },
+  mantle: {
+    rpc: undefined,
+    key: undefined,
+    chain_id: undefined,
+  },
+  arbitrum_sepolia: {
+    rpc: undefined,
+    key: undefined,
+    chain_id: undefined,
+  },
+  base_sepolia: {
+    rpc: undefined,
+    key: undefined,
+    chain_id: undefined,
+  },
+  optimism_sepolia: {
+    rpc: undefined,
+    key: undefined,
+    chain_id: undefined,
+  },
 };
 
 const TESTNET = {
@@ -373,6 +408,41 @@ const TESTNET = {
     key: undefined,
     chain_id: undefined,
   },
+  neutron: {
+    rpc: undefined,
+    key: undefined,
+    chain_id: undefined,
+  },
+  celestia: {
+    rpc: undefined,
+    key: undefined,
+    chain_id: undefined,
+  },
+  scroll: {
+    rpc: "https://rpc.ankr.com/scroll_sepolia_testnet",
+    key: getEnvVar("ETH_KEY_TESTNET"),
+    chain_id: 534353,
+  },
+  mantle: {
+    rpc: "https://rpc.ankr.com/mantle_testnet",
+    key: getEnvVar("ETH_KEY_TESTNET"),
+    chain_id: 5001,
+  },
+  arbitrum_sepolia: {
+    rpc: "https://arbitrum-sepolia.publicnode.com",
+    key: getEnvVar("ETH_KEY_TESTNET"),
+    chain_id: 421614,
+  },
+  base_sepolia: {
+    rpc: "https://sepolia.base.org",
+    key: getEnvVar("ETH_KEY_TESTNET"),
+    chain_id: 84532,
+  },
+  optimism_sepolia: {
+    rpc: "https://rpc.ankr.com/optimism_sepolia",
+    key: getEnvVar("ETH_KEY_TESTNET"),
+    chain_id: 11155420,
+  },
 };
 
 const DEVNET = {
@@ -529,6 +599,41 @@ const DEVNET = {
   kujira: {
     rpc: undefined,
     key: undefined,
+  },
+  neutron: {
+    rpc: undefined,
+    key: undefined,
+    chain_id: undefined,
+  },
+  celestia: {
+    rpc: undefined,
+    key: undefined,
+    chain_id: undefined,
+  },
+  scroll: {
+    rpc: undefined,
+    key: undefined,
+    chain_id: undefined,
+  },
+  mantle: {
+    rpc: undefined,
+    key: undefined,
+    chain_id: undefined,
+  },
+  arbitrum_sepolia: {
+    rpc: undefined,
+    key: undefined,
+    chain_id: undefined,
+  },
+  base_sepolia: {
+    rpc: undefined,
+    key: undefined,
+    chain_id: undefined,
+  },
+  optimism_sepolia: {
+    rpc: undefined,
+    key: undefined,
+    chain_id: undefined,
   },
 };
 


### PR DESCRIPTION
This PR adds testnet support to the `worm` client for the following chains:

1. Scroll
2. Mantle
3. Arbitrum Sepolia
4. Base Sepolia
5. Optimism Sepolia
