### PR TITLE
Node/CCQ: Server auto reconnect

### DIFF
--- a/node/cmd/ccq/metrics.go
+++ b/node/cmd/ccq/metrics.go
@@ -72,4 +72,10 @@ var (
 			Name: "ccq_server_perm_file_reload_failure",
 			Help: "Total number of times the permissions file failed to reload",
 		})
+
+	successfulReconnects = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "ccq_server_total_number_of_successful_reconnects",
+			Help: "Total number of successful reconnects to bootstrap peers",
+		})
 )

--- a/node/cmd/ccq/query_server.go
+++ b/node/cmd/ccq/query_server.go
@@ -44,6 +44,7 @@ var (
 	promRemoteURL     *string
 	shutdownDelay1    *uint
 	shutdownDelay2    *uint
+	monitorPeers      *bool
 )
 
 const DEV_NETWORK_ID = "/wormhole/dev"
@@ -64,6 +65,7 @@ func init() {
 	telemetryNodeName = QueryServerCmd.Flags().String("telemetryNodeName", "", "Node name used in telemetry")
 	statusAddr = QueryServerCmd.Flags().String("statusAddr", "[::]:6060", "Listen address for status server (disabled if blank)")
 	promRemoteURL = QueryServerCmd.Flags().String("promRemoteURL", "", "Prometheus remote write URL (Grafana)")
+	monitorPeers = QueryServerCmd.Flags().Bool("monitorPeers", false, "Should monitor bootstrap peers and attempt to reconnect")
 
 	// The default health check monitoring is every five seconds, with a five second timeout, and you have to miss two, for 20 seconds total.
 	shutdownDelay1 = QueryServerCmd.Flags().Uint("shutdownDelay1", 25, "Seconds to delay after disabling health check on shutdown")
@@ -168,7 +170,7 @@ func runQueryServer(cmd *cobra.Command, args []string) {
 
 	// Run p2p
 	pendingResponses := NewPendingResponses()
-	p2p, err := runP2P(ctx, priv, *p2pPort, networkID, *p2pBootstrap, *ethRPC, *ethContract, pendingResponses, logger)
+	p2p, err := runP2P(ctx, priv, *p2pPort, networkID, *p2pBootstrap, *ethRPC, *ethContract, pendingResponses, logger, *monitorPeers)
 	if err != nil {
 		logger.Fatal("Failed to start p2p", zap.Error(err))
 	}

--- a/node/pkg/query/query.go
+++ b/node/pkg/query/query.go
@@ -200,7 +200,7 @@ func handleQueryRequestsImpl(
 			signerAddress := ethCommon.BytesToAddress(ethCrypto.Keccak256(signerBytes[1:])[12:])
 
 			if _, exists := allowedRequestors[signerAddress]; !exists {
-				qLogger.Error("invalid requestor", zap.String("requestor", signerAddress.Hex()), zap.String("requestID", requestID))
+				qLogger.Debug("invalid requestor", zap.String("requestor", signerAddress.Hex()), zap.String("requestID", requestID))
 				invalidQueryRequestReceived.WithLabelValues("invalid_requestor").Inc()
 				continue
 			}
@@ -235,7 +235,7 @@ func handleQueryRequestsImpl(
 			for requestIdx, pcq := range queryRequest.PerChainQueries {
 				chainID := vaa.ChainID(pcq.ChainId)
 				if _, exists := supportedChains[chainID]; !exists {
-					qLogger.Error("chain does not support cross chain queries", zap.String("requestID", requestID), zap.Stringer("chainID", chainID))
+					qLogger.Debug("chain does not support cross chain queries", zap.String("requestID", requestID), zap.Stringer("chainID", chainID))
 					invalidQueryRequestReceived.WithLabelValues("chain_does_not_support_ccq").Inc()
 					errorFound = true
 					break
@@ -243,7 +243,7 @@ func handleQueryRequestsImpl(
 
 				channel, channelExists := chainQueryReqC[chainID]
 				if !channelExists {
-					qLogger.Error("unknown chain ID for query request, dropping it", zap.String("requestID", requestID), zap.Stringer("chain_id", chainID))
+					qLogger.Debug("unknown chain ID for query request, dropping it", zap.String("requestID", requestID), zap.Stringer("chain_id", chainID))
 					invalidQueryRequestReceived.WithLabelValues("failed_to_look_up_channel").Inc()
 					errorFound = true
 					break
@@ -363,7 +363,7 @@ func handleQueryRequestsImpl(
 				timeout := pq.receiveTime.Add(requestTimeoutImpl)
 				qLogger.Debug("audit", zap.String("requestId", reqId), zap.Stringer("receiveTime", pq.receiveTime), zap.Stringer("timeout", timeout))
 				if timeout.Before(now) {
-					qLogger.Error("query request timed out, dropping it", zap.String("requestId", reqId), zap.Stringer("receiveTime", pq.receiveTime))
+					qLogger.Debug("query request timed out, dropping it", zap.String("requestId", reqId), zap.Stringer("receiveTime", pq.receiveTime))
 					queryRequestsTimedOut.Inc()
 					delete(pendingQueries, reqId)
 				} else {

--- a/node/pkg/watchers/evm/ccq.go
+++ b/node/pkg/watchers/evm/ccq.go
@@ -134,7 +134,7 @@ func (w *Watcher) ccqHandleEthCallQueryRequest(ctx context.Context, queryRequest
 
 	// Verify that the block read was successful.
 	if err := w.ccqVerifyBlockResult(blockError, blockResult); err != nil {
-		w.ccqLogger.Error("failed to verify block for eth_call query",
+		w.ccqLogger.Debug("failed to verify block for eth_call query",
 			zap.String("requestId", requestId),
 			zap.String("block", block),
 			zap.Any("batch", batch),
@@ -156,7 +156,7 @@ func (w *Watcher) ccqHandleEthCallQueryRequest(ctx context.Context, queryRequest
 	// Verify all the call results and build the batch of results.
 	results, err := w.ccqVerifyAndExtractQueryResults(requestId, evmCallData)
 	if err != nil {
-		w.ccqLogger.Error("failed to process eth_call query call request",
+		w.ccqLogger.Debug("failed to process eth_call query call request",
 			zap.String("requestId", requestId),
 			zap.String("block", block),
 			zap.Any("batch", batch),
@@ -311,7 +311,7 @@ func (w *Watcher) ccqHandleEthCallByTimestampQueryRequest(ctx context.Context, q
 
 	// Verify the target block read was successful.
 	if err := w.ccqVerifyBlockResult(blockError, blockResult); err != nil {
-		w.ccqLogger.Error("failed to process eth_call_by_timestamp query target block request",
+		w.ccqLogger.Debug("failed to verify target block for eth_call_by_timestamp query",
 			zap.String("requestId", requestId),
 			zap.String("block", block),
 			zap.String("nextBlock", nextBlock),
@@ -324,7 +324,7 @@ func (w *Watcher) ccqHandleEthCallByTimestampQueryRequest(ctx context.Context, q
 
 	// Verify the following block read was successful.
 	if err := w.ccqVerifyBlockResult(nextBlockError, nextBlockResult); err != nil {
-		w.ccqLogger.Error("failed to process eth_call_by_timestamp query following block request",
+		w.ccqLogger.Debug("failed to verify next block for eth_call_by_timestamp query",
 			zap.String("requestId", requestId),
 			zap.String("block", block),
 			zap.String("nextBlock", nextBlock),
@@ -399,7 +399,7 @@ func (w *Watcher) ccqHandleEthCallByTimestampQueryRequest(ctx context.Context, q
 	// Verify all the call results and build the batch of results.
 	results, err := w.ccqVerifyAndExtractQueryResults(requestId, evmCallData)
 	if err != nil {
-		w.ccqLogger.Error("failed to process eth_call_by_timestamp query call request",
+		w.ccqLogger.Debug("failed to process eth_call_by_timestamp query call request",
 			zap.String("requestId", requestId),
 			zap.String("block", block),
 			zap.String("nextBlock", nextBlock),
@@ -493,7 +493,7 @@ func (w *Watcher) ccqHandleEthCallWithFinalityQueryRequest(ctx context.Context, 
 
 	// Verify that the block read was successful.
 	if err := w.ccqVerifyBlockResult(blockError, blockResult); err != nil {
-		w.ccqLogger.Error("failed to process eth_call_with_finality query block request",
+		w.ccqLogger.Debug("failed to verify block for eth_call_with_finality query",
 			zap.String("requestId", requestId),
 			zap.String("block", block),
 			zap.Any("batch", batch),
@@ -539,7 +539,7 @@ func (w *Watcher) ccqHandleEthCallWithFinalityQueryRequest(ctx context.Context, 
 	// Verify all the call results and build the batch of results.
 	results, err := w.ccqVerifyAndExtractQueryResults(requestId, evmCallData)
 	if err != nil {
-		w.ccqLogger.Error("failed to process eth_call_with_finality query call request",
+		w.ccqLogger.Debug("failed to process eth_call_with_finality query call request",
 			zap.String("requestId", requestId),
 			zap.String("finality", req.Finality),
 			zap.Uint64("requestedBlockNumber", blockNumber),


### PR DESCRIPTION
In testnet, the CCQ proxy server is not detecting when a guardian restarts. As a work around, this PR adds the ability for the server to attempt to automatically reconnect when it detects that a bootstrap peer has gone away.

This feature is only intended to be used in testnet, and is controlled by a config parameter, `monitorPeers`.

This PR also changes some CCQ log messages from error to debug so that routine conditions (like block not available yet) don't flood the logs.