### PR TITLE
CI: Solana -- Allow running on x86 with no avx

### DIFF
--- a/solana/Dockerfile
+++ b/solana/Dockerfile
@@ -1,5 +1,5 @@
 #syntax=docker/dockerfile:1.2@sha256:e2a8561e419ab1ba6b2fe6cbdf49fd92b95912df1cf7d313c3e2230a333fdbcc
-FROM ghcr.io/wormhole-foundation/solana:1.10.31@sha256:d31e8db926a1d3fbaa9d9211d9979023692614b7b64912651aba0383e8c01bad AS solana
+FROM ghcr.io/wormhole-foundation/solana-no-avx:1.16.24@sha256:ce400089cca28ac353cc550ee488ea0c6fea2bb07936eca9b113aa487ea1dc56 AS solana
 
 # Add bridge contract sources
 WORKDIR /usr/src/bridge

--- a/solana/Dockerfile.base
+++ b/solana/Dockerfile.base
@@ -1,39 +1,17 @@
 #syntax=docker/dockerfile:1.2@sha256:e2a8561e419ab1ba6b2fe6cbdf49fd92b95912df1cf7d313c3e2230a333fdbcc
-FROM docker.io/library/rust:1.69.0@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a as solana
-RUN apt-get update && apt-get install -y curl \
-    libssl-dev \
-    libudev-dev \
-    pkg-config \
-    zlib1g-dev  \
-    clang \
-    cmake \
-    make \
-    libprotobuf-dev \
-    protobuf-compiler \
-    ninja-build
+FROM docker.io/library/rust:1.60.0@sha256:9fe1f39bec70576e2bd568fafb194b2a532a6f2928bc0b951ac2c0a69a2be9fe as solana
 
-# fetch solana src
-ARG tag=1.16.24
-WORKDIR /
-RUN curl -L -s https://github.com/solana-labs/solana/archive/refs/tags/v${tag}.tar.gz -o solana-${tag}.tar.gz
-RUN tar zxvf solana-${tag}.tar.gz
+RUN sh -c "$(curl -sSfL https://release.solana.com/v1.10.31/install)"
 
-# build solana
-WORKDIR /solana-${tag}
-ENV RUSTFLAGS="-C target-feature=-avx,-avx2"
-RUN /solana-${tag}/scripts/cargo-install-all.sh  --debug .
-ENV PATH="/solana-${tag}/bin:$PATH"
+ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
 
-# RUN /solana-${tag}/bin/solana-install -V ${tag} init
-#RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.24/install)"
-#ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
-
-
+COPY rust-toolchain .
 # Solana does a questionable download at the beginning of a *first* build-bpf call. Trigger and layer-cache it explicitly.
-# RUN cargo init --lib /tmp/decoy-crate && \
-#     cd /tmp/decoy-crate && cargo build-bpf && \
-#     rm -rf /tmp/decoy-crate
-# # The strip shell script downloads criterion the first time it runs so cache it here as well.
-# RUN touch /tmp/foo.so && \
-#     /root/.local/share/solana/install/active_release/bin/sdk/bpf/scripts/strip.sh /tmp/foo.so /tmp/bar.so || \
-#     rm /tmp/foo.so
+RUN cargo init --lib /tmp/decoy-crate && \
+    cd /tmp/decoy-crate && cargo build-bpf && \
+    rm -rf /tmp/decoy-crate
+
+# The strip shell script downloads criterion the first time it runs so cache it here as well.
+RUN touch /tmp/foo.so && \
+    /root/.local/share/solana/install/active_release/bin/sdk/bpf/scripts/strip.sh /tmp/foo.so /tmp/bar.so || \
+    rm /tmp/foo.so

--- a/solana/Dockerfile.base
+++ b/solana/Dockerfile.base
@@ -1,17 +1,39 @@
 #syntax=docker/dockerfile:1.2@sha256:e2a8561e419ab1ba6b2fe6cbdf49fd92b95912df1cf7d313c3e2230a333fdbcc
-FROM docker.io/library/rust:1.60.0@sha256:9fe1f39bec70576e2bd568fafb194b2a532a6f2928bc0b951ac2c0a69a2be9fe as solana
+FROM docker.io/library/rust:1.69.0@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a as solana
+RUN apt-get update && apt-get install -y curl \
+    libssl-dev \
+    libudev-dev \
+    pkg-config \
+    zlib1g-dev  \
+    clang \
+    cmake \
+    make \
+    libprotobuf-dev \
+    protobuf-compiler \
+    ninja-build
 
-RUN sh -c "$(curl -sSfL https://release.solana.com/v1.10.31/install)"
+# fetch solana src
+ARG tag=1.16.24
+WORKDIR /
+RUN curl -L -s https://github.com/solana-labs/solana/archive/refs/tags/v${tag}.tar.gz -o solana-${tag}.tar.gz
+RUN tar zxvf solana-${tag}.tar.gz
 
-ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
+# build solana
+WORKDIR /solana-${tag}
+ENV RUSTFLAGS="-C target-feature=-avx,-avx2"
+RUN /solana-${tag}/scripts/cargo-install-all.sh  --debug .
+ENV PATH="/solana-${tag}/bin:$PATH"
 
-COPY rust-toolchain .
+# RUN /solana-${tag}/bin/solana-install -V ${tag} init
+#RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.24/install)"
+#ENV PATH="/root/.local/share/solana/install/active_release/bin:$PATH"
+
+
 # Solana does a questionable download at the beginning of a *first* build-bpf call. Trigger and layer-cache it explicitly.
-RUN cargo init --lib /tmp/decoy-crate && \
-    cd /tmp/decoy-crate && cargo build-bpf && \
-    rm -rf /tmp/decoy-crate
-
-# The strip shell script downloads criterion the first time it runs so cache it here as well.
-RUN touch /tmp/foo.so && \
-    /root/.local/share/solana/install/active_release/bin/sdk/bpf/scripts/strip.sh /tmp/foo.so /tmp/bar.so || \
-    rm /tmp/foo.so
+# RUN cargo init --lib /tmp/decoy-crate && \
+#     cd /tmp/decoy-crate && cargo build-bpf && \
+#     rm -rf /tmp/decoy-crate
+# # The strip shell script downloads criterion the first time it runs so cache it here as well.
+# RUN touch /tmp/foo.so && \
+#     /root/.local/share/solana/install/active_release/bin/sdk/bpf/scripts/strip.sh /tmp/foo.so /tmp/bar.so || \
+#     rm /tmp/foo.so

--- a/solana/Dockerfile.client
+++ b/solana/Dockerfile.client
@@ -1,7 +1,7 @@
 #syntax=docker/dockerfile:1.2@sha256:e2a8561e419ab1ba6b2fe6cbdf49fd92b95912df1cf7d313c3e2230a333fdbcc
 FROM cli-gen AS cli-export
 FROM const-gen AS const-export
-FROM ghcr.io/wormhole-foundation/solana:1.10.31@sha256:d31e8db926a1d3fbaa9d9211d9979023692614b7b64912651aba0383e8c01bad AS solana
+FROM ghcr.io/wormhole-foundation/solana-no-avx:1.16.24@sha256:ce400089cca28ac353cc550ee488ea0c6fea2bb07936eca9b113aa487ea1dc56 AS solana
 
 RUN apt-get update
 

--- a/solana/Dockerfile.noavx.base
+++ b/solana/Dockerfile.noavx.base
@@ -1,0 +1,53 @@
+#syntax=docker/dockerfile:1.2@sha256:e2a8561e419ab1ba6b2fe6cbdf49fd92b95912df1cf7d313c3e2230a333fdbcc
+FROM docker.io/library/rust:1.69.0@sha256:b7e0e2c6199fb5f309742c5eba637415c25ca2bed47fa5e80e274d4510ddfa3a as solana
+RUN apt-get update && apt-get install -y curl \
+    libssl-dev \
+    libudev-dev \
+    pkg-config \
+    zlib1g-dev  \
+    clang \
+    cmake \
+    make \
+    libprotobuf-dev \
+    protobuf-compiler \
+    ninja-build
+
+# fetch solana src
+ARG tag=1.16.24
+WORKDIR /
+RUN curl -L -s https://github.com/solana-labs/solana/archive/refs/tags/v${tag}.tar.gz -o solana-${tag}.tar.gz
+RUN tar zxvf solana-${tag}.tar.gz
+
+# build solana
+WORKDIR /solana-${tag}
+
+# Set flags to prevent simd/avx usage
+ENV RUST_REED_SOLOMON_ERASURE_ARCH=native
+ENV RUSTFLAGS="-C target-feature=-avx,-avx2"
+
+ENV INSTALL_DIR="/root/.local/share/solana/install/releases/${tag}/solana-release"
+RUN mkdir -p $INSTALL_DIR
+RUN /solana-${tag}/scripts/cargo-install-all.sh $INSTALL_DIR
+
+# Turn off flags
+ENV RUST_REED_SOLOMON_ERASURE_ARCH=
+ENV RUSTFLAGS=
+
+# Link to active releases
+ENV ACTIVE_LINK="/root/.local/share/solana/install/active_release"
+RUN ln -s $INSTALL_DIR $ACTIVE_LINK
+
+# Add bins to path
+ENV PATH="$ACTIVE_LINK/bin:$PATH"
+
+WORKDIR /
+RUN rm -rf /solana-${tag}
+
+# Solana does a questionable download at the beginning of a *first* build-bpf call. Trigger and layer-cache it explicitly.
+RUN cargo init --lib /tmp/decoy-crate && \
+    cd /tmp/decoy-crate && cargo build-bpf && \
+    rm -rf /tmp/decoy-crate
+# The strip shell script downloads criterion the first time it runs so cache it here as well.
+RUN touch /tmp/foo.so && \
+    /root/.local/share/solana/install/active_release/bin/sdk/bpf/scripts/strip.sh /tmp/foo.so /tmp/bar.so || \
+    rm /tmp/foo.so


### PR DESCRIPTION
In order to run Tilt on a M1/M2 architecture, we can rely on Rosetta for virtualization but the binaries must be compiled without support for AVX/AVX2 (and SIMD for Reed Solomon crate).

This is probably slower but I'm not sure by how much or if it will affect CI/testing.

We should also probably make this not the default but add some check during `tilt up` to see if the host is 1) on a mac and 2) has rosetta enabled, then switch to the non-avx base docker image. 


This does build the contracts and run `solana-test-validator` successfully but currently hitting an issue during the setup process: 

![image](https://github.com/wormhole-foundation/wormhole/assets/520236/f38a9ad0-2547-4258-9b91-18e4e6c4d5ad)
