### PR TITLE
cosmwasm: accounting: fix unnecessary_fallible_conversion error in rust linter

### DIFF
--- a/cosmwasm/contracts/global-accountant/tests/modify_balance.rs
+++ b/cosmwasm/contracts/global-accountant/tests/modify_balance.rs
@@ -15,7 +15,7 @@ fn simple_modify() {
         token_address: [0x7c; 32].into(),
         kind: Kind::Add,
         amount: Uint256::from(300u128),
-        reason: "test".try_into().unwrap(),
+        reason: "test".into(),
     };
 
     let resp = contract.modify_balance(m.clone(), &wh).unwrap();
@@ -61,7 +61,7 @@ fn duplicate_modify() {
         token_address: [0x7c; 32].into(),
         kind: Kind::Add,
         amount: Uint256::from(300u128),
-        reason: "test".try_into().unwrap(),
+        reason: "test".into(),
     };
 
     contract.modify_balance(m.clone(), &wh).unwrap();
@@ -86,7 +86,7 @@ fn round_trip() {
         token_address: [0x7c; 32].into(),
         kind: Kind::Add,
         amount: Uint256::from(300u128),
-        reason: "test".try_into().unwrap(),
+        reason: "test".into(),
     };
 
     contract.modify_balance(m.clone(), &wh).unwrap();
@@ -97,7 +97,7 @@ fn round_trip() {
     // Now reverse the modification.
     m.sequence += 1;
     m.kind = Kind::Sub;
-    m.reason = "reverse".try_into().unwrap();
+    m.reason = "reverse".into();
 
     contract.modify_balance(m.clone(), &wh).unwrap();
 
@@ -125,7 +125,7 @@ fn missing_guardian_set() {
         token_address: [0x7c; 32].into(),
         kind: Kind::Add,
         amount: Uint256::from(300u128),
-        reason: "test".try_into().unwrap(),
+        reason: "test".into(),
     };
 
     let err = contract
@@ -156,7 +156,7 @@ fn expired_guardian_set() {
         token_address: [0x7c; 32].into(),
         kind: Kind::Add,
         amount: Uint256::from(300u128),
-        reason: "test".try_into().unwrap(),
+        reason: "test".into(),
     };
     let err = contract
         .modify_balance(m, &wh)
@@ -178,7 +178,7 @@ fn no_quorum() {
         token_address: [0x7c; 32].into(),
         kind: Kind::Add,
         amount: Uint256::from(300u128),
-        reason: "test".try_into().unwrap(),
+        reason: "test".into(),
     };
 
     let newlen = wh
@@ -211,7 +211,7 @@ fn repeat() {
         token_address: [0x7c; 32].into(),
         kind: Kind::Add,
         amount: Uint256::from(300u128),
-        reason: "test".try_into().unwrap(),
+        reason: "test".into(),
     };
 
     for _ in 0..ITERATIONS {

--- a/cosmwasm/contracts/global-accountant/tests/query.rs
+++ b/cosmwasm/contracts/global-accountant/tests/query.rs
@@ -24,7 +24,7 @@ fn create_accounts(wh: &fake::WormholeKeeper, contract: &mut Contract, count: us
                 token_address: [i as u8; 32].into(),
                 kind: Kind::Add,
                 amount: Uint256::from(j as u128),
-                reason: "create_accounts".try_into().unwrap(),
+                reason: "create_accounts".into(),
             };
 
             contract.modify_balance(m, wh).unwrap();
@@ -97,7 +97,7 @@ pub fn create_modifications(
             token_address: [i as u8; 32].into(),
             kind: Kind::Add,
             amount: Uint256::from(i as u128),
-            reason: format!("{i}").as_str().try_into().unwrap(),
+            reason: format!("{i}").as_str().into(),
         };
 
         contract.modify_balance(m.clone(), wh).unwrap();

--- a/cosmwasm/contracts/global-accountant/tests/submit_observations.rs
+++ b/cosmwasm/contracts/global-accountant/tests/submit_observations.rs
@@ -538,7 +538,7 @@ fn missing_native_account() {
         token_address: token_address.into(),
         kind: Kind::Add,
         amount: Uint256::new(amount.0),
-        reason: "fake wrapped balance for testing".try_into().unwrap(),
+        reason: "fake wrapped balance for testing".into(),
     };
     contract.modify_balance(m, &wh).unwrap();
 
@@ -657,7 +657,7 @@ fn wrapped_to_wrapped() {
         token_address: token_address.into(),
         kind: Kind::Add,
         amount: Uint256::new(amount.0),
-        reason: "fake wrapped balance for testing".try_into().unwrap(),
+        reason: "fake wrapped balance for testing".into(),
     };
     contract.modify_balance(m, &wh).unwrap();
 


### PR DESCRIPTION
str.into() conversions are infallible. Using str.try_into().unwrap() would be unnecessary, triggering unnecessary-fallible-conversions error.

See below:
- `unnecessary_fallible_conversions`: https://rust-lang.github.io/rust-clippy/master/index.html#/unnecessary_fallible_conversions
- Clippy 1.75 changelong: https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-175 (shoutout to @kcsongor for finding this)
