### PR TITLE
node: Fix governor token list script for new chains

### DIFF
--- a/node/hack/governor/src/index.ts
+++ b/node/hack/governor/src/index.ts
@@ -164,7 +164,7 @@ axios
             }
 
             // This is a new token
-            if (!existingTokenPrices[chain][wormholeAddr]) {
+            if (existingTokenPrices[chain] == undefined || existingTokenPrices[chain][wormholeAddr] == undefined) {
               addedTokens.push(chain + "-" + wormholeAddr + "-" + data.Symbol);
             }
             // This is an existing token


### PR DESCRIPTION
This fixes the script if there is a new token on a chain that doesn't already have at least 1 token on the list