### PR TITLE
Client/JS: Add Holesky support

### DIFF
--- a/clients/js/README.md
+++ b/clients/js/README.md
@@ -257,7 +257,7 @@ Options:
          "osmosis", "sui", "aptos", "arbitrum", "optimism", "gnosis", "pythnet",
      "xpla", "btc", "base", "sei", "rootstock", "scroll", "mantle", "wormchain",
                "cosmoshub", "evmos", "kujira", "neutron", "celestia", "sepolia",
-                         "arbitrum_sepolia", "base_sepolia", "optimism_sepolia"]
+              "arbitrum_sepolia", "base_sepolia", "optimism_sepolia", "holesky"]
   -n, --network           Network
                             [required] [choices: "mainnet", "testnet", "devnet"]
   -a, --contract-address  Contract to submit VAA to (override config)   [string]
@@ -314,7 +314,7 @@ Options:
          "osmosis", "sui", "aptos", "arbitrum", "optimism", "gnosis", "pythnet",
      "xpla", "btc", "base", "sei", "rootstock", "scroll", "mantle", "wormchain",
                "cosmoshub", "evmos", "kujira", "neutron", "celestia", "sepolia",
-                         "arbitrum_sepolia", "base_sepolia", "optimism_sepolia"]
+              "arbitrum_sepolia", "base_sepolia", "optimism_sepolia", "holesky"]
       --dst-chain   destination chain
            [required] [choices: "solana", "ethereum", "terra", "bsc", "polygon",
         "avalanche", "oasis", "algorand", "aurora", "fantom", "karura", "acala",
@@ -322,7 +322,7 @@ Options:
          "osmosis", "sui", "aptos", "arbitrum", "optimism", "gnosis", "pythnet",
      "xpla", "btc", "base", "sei", "rootstock", "scroll", "mantle", "wormchain",
                "cosmoshub", "evmos", "kujira", "neutron", "celestia", "sepolia",
-                         "arbitrum_sepolia", "base_sepolia", "optimism_sepolia"]
+              "arbitrum_sepolia", "base_sepolia", "optimism_sepolia", "holesky"]
       --dst-addr    destination address                      [string] [required]
       --token-addr  token address               [string] [default: native token]
       --amount      token amount                             [string] [required]
@@ -356,7 +356,7 @@ Positionals:
          "osmosis", "sui", "aptos", "arbitrum", "optimism", "gnosis", "pythnet",
      "xpla", "btc", "base", "sei", "rootstock", "scroll", "mantle", "wormchain",
                "cosmoshub", "evmos", "kujira", "neutron", "celestia", "sepolia",
-                         "arbitrum_sepolia", "base_sepolia", "optimism_sepolia"]
+              "arbitrum_sepolia", "base_sepolia", "optimism_sepolia", "holesky"]
   tx       Source transaction hash                                      [string]
 
 Options:

--- a/clients/js/package-lock.json
+++ b/clients/js/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@celo-tools/celo-ethers-wrapper": "^0.1.0",
-        "@certusone/wormhole-sdk": "^0.10.7",
+        "@certusone/wormhole-sdk": "^0.10.8",
         "@cosmjs/encoding": "^0.26.2",
         "@improbable-eng/grpc-web-node-http-transport": "^0.15.0",
         "@injectivelabs/networks": "^1.10.7",
@@ -494,9 +494,9 @@
       }
     },
     "node_modules/@certusone/wormhole-sdk": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk/-/wormhole-sdk-0.10.7.tgz",
-      "integrity": "sha512-1qV/MYM7deFl+/d1kK34PzDsgDaUQrNvrUVCeUw60WQP8ySf/vWiWk5ny6kaad16d+Qv8JxmVRuHMV4GxZR9/g==",
+      "version": "0.10.8",
+      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk/-/wormhole-sdk-0.10.8.tgz",
+      "integrity": "sha512-W2rA8fMdkVFWvy93+51K+8Kv/bpjuFtxCYCQI4YkWe+g4zLkDXw+yYMVPPqc/chFLFNSutPMqUtXAg7+y8lowg==",
       "dependencies": {
         "@certusone/wormhole-sdk-proto-web": "0.0.7",
         "@certusone/wormhole-sdk-wasm": "^0.0.1",
@@ -8367,9 +8367,9 @@
       "requires": {}
     },
     "@certusone/wormhole-sdk": {
-      "version": "0.10.7",
-      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk/-/wormhole-sdk-0.10.7.tgz",
-      "integrity": "sha512-1qV/MYM7deFl+/d1kK34PzDsgDaUQrNvrUVCeUw60WQP8ySf/vWiWk5ny6kaad16d+Qv8JxmVRuHMV4GxZR9/g==",
+      "version": "0.10.8",
+      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk/-/wormhole-sdk-0.10.8.tgz",
+      "integrity": "sha512-W2rA8fMdkVFWvy93+51K+8Kv/bpjuFtxCYCQI4YkWe+g4zLkDXw+yYMVPPqc/chFLFNSutPMqUtXAg7+y8lowg==",
       "requires": {
         "@certusone/wormhole-sdk-proto-web": "0.0.7",
         "@certusone/wormhole-sdk-wasm": "^0.0.1",

--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -30,7 +30,7 @@
   ],
   "dependencies": {
     "@celo-tools/celo-ethers-wrapper": "^0.1.0",
-    "@certusone/wormhole-sdk": "^0.10.7",
+    "@certusone/wormhole-sdk": "^0.10.8",
     "@cosmjs/encoding": "^0.26.2",
     "@improbable-eng/grpc-web-node-http-transport": "^0.15.0",
     "@injectivelabs/networks": "^1.10.7",

--- a/clients/js/src/chains/generic/getOriginalAsset.ts
+++ b/clients/js/src/chains/generic/getOriginalAsset.ts
@@ -65,7 +65,8 @@ export const getOriginalAsset = async (
     case "sepolia":
     case "arbitrum_sepolia":
     case "base_sepolia":
-    case "optimism_sepolia": {
+    case "optimism_sepolia":
+    case "holesky": {
       const provider = getProviderForChain(chainName, network, { rpc });
       return getOriginalAssetEth(
         tokenBridgeAddress,

--- a/clients/js/src/chains/generic/getWrappedAssetAddress.ts
+++ b/clients/js/src/chains/generic/getWrappedAssetAddress.ts
@@ -75,7 +75,8 @@ export const getWrappedAssetAddress = async (
     case "sepolia":
     case "arbitrum_sepolia":
     case "base_sepolia":
-    case "optimism_sepolia": {
+    case "optimism_sepolia":
+    case "holesky": {
       const provider = getProviderForChain(chainName, network, { rpc });
       return getForeignAssetEth(
         tokenBridgeAddress,

--- a/clients/js/src/chains/generic/provider.ts
+++ b/clients/js/src/chains/generic/provider.ts
@@ -103,6 +103,7 @@ export const getProviderForChain = <T extends ChainId | ChainName>(
     case "arbitrum_sepolia":
     case "base_sepolia":
     case "optimism_sepolia":
+    case "holesky":
       return new ethers.providers.JsonRpcProvider(rpc) as ChainProvider<T>;
     case "terra":
     case "terra2":

--- a/clients/js/src/consts/networks.ts
+++ b/clients/js/src/consts/networks.ts
@@ -178,6 +178,11 @@ const MAINNET = {
     key: undefined,
     chain_id: undefined,
   },
+  holesky: {
+    rpc: undefined,
+    key: undefined,
+    chain_id: undefined,
+  },
   cosmoshub: {
     rpc: undefined,
     key: undefined,
@@ -344,6 +349,11 @@ const TESTNET = {
     rpc: "https://rpc.ankr.com/eth_sepolia",
     key: getEnvVar("ETH_KEY_TESTNET"),
     chain_id: 11155111,
+  },
+  holesky: {
+    rpc: "https://rpc.ankr.com/eth_holesky",
+    key: getEnvVar("ETH_KEY_TESTNET"),
+    chain_id: 17000,
   },
   btc: {
     rpc: undefined,
@@ -539,6 +549,10 @@ const DEVNET = {
     key: undefined,
   },
   sepolia: {
+    rpc: undefined,
+    key: undefined,
+  },
+  holesky: {
     rpc: undefined,
     key: undefined,
   },


### PR DESCRIPTION
This PR updates the `worm` command to support the Holesky testnet.