### PR TITLE
Node/CCQ: Unmarshal should check for extra bytes

### DIFF
--- a/node/pkg/query/request.go
+++ b/node/pkg/query/request.go
@@ -212,6 +212,10 @@ func (queryRequest *QueryRequest) UnmarshalFromReader(reader *bytes.Reader) erro
 		queryRequest.PerChainQueries = append(queryRequest.PerChainQueries, &perChainQuery)
 	}
 
+	if reader.Len() != 0 {
+		return fmt.Errorf("excess bytes in unmarshal")
+	}
+
 	return nil
 }
 

--- a/node/pkg/query/request_test.go
+++ b/node/pkg/query/request_test.go
@@ -104,6 +104,17 @@ func TestQueryRequestMarshalUnmarshal(t *testing.T) {
 	assert.True(t, queryRequest.Equal(&queryRequest2))
 }
 
+func TestQueryRequestUnmarshalWithExtraBytesShouldFail(t *testing.T) {
+	queryRequest := createQueryRequestForTesting(t, vaa.ChainIDPolygon)
+	queryRequestBytes, err := queryRequest.Marshal()
+	require.NoError(t, err)
+
+	withExtraBytes := append(queryRequestBytes, []byte("Hello, World!")[:]...)
+	var queryRequest2 QueryRequest
+	err = queryRequest2.Unmarshal(withExtraBytes)
+	assert.EqualError(t, err, "excess bytes in unmarshal")
+}
+
 func TestMarshalOfQueryRequestWithNoPerChainQueriesShouldFail(t *testing.T) {
 	queryRequest := &QueryRequest{
 		Nonce: 1,

--- a/node/pkg/query/response.go
+++ b/node/pkg/query/response.go
@@ -180,24 +180,29 @@ func (msg *QueryResponsePublication) Unmarshal(data []byte) error {
 	}
 	signedQueryRequest.Signature = signature[:]
 
-	// Skip the query length.
+	// Read the serialized request.
 	queryRequestLen := uint32(0)
 	if err := binary.Read(reader, binary.BigEndian, &queryRequestLen); err != nil {
 		return fmt.Errorf("failed to read length of query request: %w", err)
 	}
 
+	queryRequestBytes := make([]byte, queryRequestLen)
+	if n, err := reader.Read(queryRequestBytes[:]); err != nil || n != int(queryRequestLen) {
+		return fmt.Errorf("failed to read query request [%d]: %w", n, err)
+	}
+
 	queryRequest := QueryRequest{}
-	err := queryRequest.UnmarshalFromReader(reader)
+	queryRequestReader := bytes.NewReader(queryRequestBytes[:])
+	err := queryRequest.UnmarshalFromReader(queryRequestReader)
 	if err != nil {
 		return fmt.Errorf("failed to unmarshal query request: %w", err)
 	}
 
-	queryRequestBytes, err := queryRequest.Marshal()
+	queryRequestBytes, err = queryRequest.Marshal()
 	if err != nil {
 		return err
 	}
 	signedQueryRequest.QueryRequest = queryRequestBytes
-
 	msg.Request = signedQueryRequest
 
 	// Responses
@@ -215,6 +220,10 @@ func (msg *QueryResponsePublication) Unmarshal(data []byte) error {
 		msg.PerChainResponses = append(msg.PerChainResponses, &pcr)
 	}
 
+	if reader.Len() != 0 {
+		return fmt.Errorf("excess bytes in unmarshal")
+	}
+
 	return nil
 }
 
@@ -224,7 +233,7 @@ func (msg *QueryResponsePublication) Validate() error {
 	var queryRequest QueryRequest
 	err := queryRequest.Unmarshal(msg.Request.QueryRequest)
 	if err != nil {
-		return fmt.Errorf("failed to unmarshal query request")
+		return fmt.Errorf("failed to unmarshal query request: %w", err)
 	}
 	if err := queryRequest.Validate(); err != nil {
 		return fmt.Errorf("query request is invalid: %w", err)


### PR DESCRIPTION
The CCQ `Unmarshal` methods should fail if someone slips extra bytes at the end of the message. Not sure if this is really an exploitable issue, but it seems like a reasonable safety.