### PR TITLE
CCQ: Solana mock should support min_context_slot

### DIFF
--- a/node/cmd/ccq/utils.go
+++ b/node/cmd/ccq/utils.go
@@ -163,7 +163,7 @@ func validateSolanaAccountQuery(logger *zap.Logger, permsForUser *permissionEntr
 		if _, exists := permsForUser.allowedCalls[callKey]; !exists {
 			logger.Debug("requested call not authorized", zap.String("userName", permsForUser.userName), zap.String("callKey", callKey))
 			invalidQueryRequestReceived.WithLabelValues("call_not_authorized").Inc()
-			return http.StatusBadRequest, fmt.Errorf(`call "%s" not authorized`, callKey)
+			return http.StatusForbidden, fmt.Errorf(`call "%s" not authorized`, callKey)
 		}
 
 		totalRequestedCallsByChain.WithLabelValues(chainId.String()).Inc()

--- a/node/pkg/query/request.go
+++ b/node/pkg/query/request.go
@@ -121,7 +121,7 @@ const EvmContractAddressLength = 20
 // SolanaAccountQueryRequestType is the type of a Solana sol_account query request.
 const SolanaAccountQueryRequestType ChainSpecificQueryType = 4
 
-// SolanaAccountQueryRequest implements ChainSpecificQuery for an EVM eth_call query request.
+// SolanaAccountQueryRequest implements ChainSpecificQuery for a Solana sol_account query request.
 type SolanaAccountQueryRequest struct {
 	// Commitment identifies the commitment level to be used in the queried. Currently it may only "finalized".
 	// Before we can support "confirmed", we need a way to read the account data and the block information atomically.
@@ -1002,7 +1002,7 @@ func (saq *SolanaAccountQueryRequest) UnmarshalFromReader(reader *bytes.Reader) 
 
 // Validate does basic validation on a Solana sol_account query.
 func (saq *SolanaAccountQueryRequest) Validate() error {
-	if len(saq.Commitment) > math.MaxUint32 {
+	if len(saq.Commitment) > SolanaMaxCommitmentLength {
 		return fmt.Errorf("commitment too long")
 	}
 	if saq.Commitment != "finalized" {
@@ -1017,7 +1017,7 @@ func (saq *SolanaAccountQueryRequest) Validate() error {
 		return fmt.Errorf("does not contain any account entries")
 	}
 	if len(saq.Accounts) > SolanaMaxAccountsPerQuery {
-		return fmt.Errorf("too many account entries, may not be more that %d", SolanaMaxAccountsPerQuery)
+		return fmt.Errorf("too many account entries, may not be more than %d", SolanaMaxAccountsPerQuery)
 	}
 	for _, acct := range saq.Accounts {
 		// The account is fixed length, so don't need to check for nil.

--- a/node/pkg/query/response.go
+++ b/node/pkg/query/response.go
@@ -905,7 +905,7 @@ func (sar *SolanaAccountQueryResponse) Type() ChainSpecificQueryType {
 }
 
 // Marshal serializes the binary representation of a Solana sol_account response.
-// This method calls Validate() and relies on it to range checks lengths, etc.
+// This method calls Validate() and relies on it to range check lengths, etc.
 func (sar *SolanaAccountQueryResponse) Marshal() ([]byte, error) {
 	if err := sar.Validate(); err != nil {
 		return nil, err

--- a/sdk/js-query/src/mock/index.ts
+++ b/sdk/js-query/src/mock/index.ts
@@ -20,6 +20,17 @@ import {
 } from "../query";
 import { BinaryWriter } from "../query/BinaryWriter";
 
+interface SolanaGetMultipleAccountsOpts {
+  commitment: string;
+  minSlotContext?: number;
+  dataSlice?: SolanaDataSlice;
+}
+
+interface SolanaDataSlice {
+  offset: number;
+  length: number;
+}
+
 type SolanaAccountData = {
   data: [string, string];
   executable: boolean;
@@ -399,18 +410,18 @@ export class QueryProxyMock {
           accounts.push(base58.encode(acct));
         });
 
-        let opts =
-          query.dataSliceOffset === BigInt(0)
-            ? {
-                commitment: query.commitment,
-              }
-            : {
-                commitment: query.commitment,
-                dataSlice: {
-                  offset: Number(query.dataSliceOffset),
-                  length: Number(query.dataSliceLength),
-                },
-              };
+        let opts: SolanaGetMultipleAccountsOpts = {
+          commitment: query.commitment,
+        };
+        if (query.minContextSlot != BigInt(0)) {
+          opts.minSlotContext = Number(query.minContextSlot);
+        }
+        if (query.dataSliceOffset !== BigInt(0)) {
+          opts.dataSlice = {
+            offset: Number(query.dataSliceOffset),
+            length: Number(query.dataSliceLength),
+          };
+        }
 
         const response = await axios.post<SolanaGetMultipleAccountsResponse>(
           rpc,

--- a/sdk/js-query/src/mock/mock.test.ts
+++ b/sdk/js-query/src/mock/mock.test.ts
@@ -260,6 +260,29 @@ describe.skip("mocks match testnet", () => {
       "01000000574108aed69daf7e625a361864b1f74d13702f2ca56de9660e566d1d8691848d01000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000"
     );
   });
+  test("SolAccount to devnet with min context slot", async () => {
+    const accounts = [
+      "2WDq7wSs9zYrpx2kbHDA4RUTRch2CCTP6ZWaH4GNfnQQ", // Example token in devnet
+      "BVxyYhm498L79r4HMQ9sxZ5bi41DmJmeWZ7SCS7Cyvna", // Example NFT in devnet
+    ];
+
+    const query = new QueryRequest(42, [
+      new PerChainQueryRequest(
+        1,
+        new SolanaAccountQueryRequest("finalized", accounts, BigInt(7))
+      ),
+    ]);
+    const resp = await mock.mock(query);
+    const queryResponse = QueryResponse.from(resp.bytes);
+    const sar = queryResponse.responses[0]
+      .response as SolanaAccountQueryResponse;
+    expect(Buffer.from(sar.results[0].data).toString("hex")).toEqual(
+      "01000000574108aed69daf7e625a361864b1f74d13702f2ca56de9660e566d1d8691848d0000e8890423c78a0901000000000000000000000000000000000000000000000000000000000000000000000000"
+    );
+    expect(Buffer.from(sar.results[1].data).toString("hex")).toEqual(
+      "01000000574108aed69daf7e625a361864b1f74d13702f2ca56de9660e566d1d8691848d01000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000"
+    );
+  });
   test("SolAccount to devnet with data slice", async () => {
     const accounts = [
       "2WDq7wSs9zYrpx2kbHDA4RUTRch2CCTP6ZWaH4GNfnQQ", // Example token in devnet
@@ -273,6 +296,35 @@ describe.skip("mocks match testnet", () => {
           "finalized",
           accounts,
           BigInt(0),
+          BigInt(1),
+          BigInt(10)
+        )
+      ),
+    ]);
+    const resp = await mock.mock(query);
+    const queryResponse = QueryResponse.from(resp.bytes);
+    const sar = queryResponse.responses[0]
+      .response as SolanaAccountQueryResponse;
+    expect(Buffer.from(sar.results[0].data).toString("hex")).toEqual(
+      "000000574108aed69daf"
+    );
+    expect(Buffer.from(sar.results[1].data).toString("hex")).toEqual(
+      "000000574108aed69daf"
+    );
+  });
+  test("SolAccount to devnet with min context slot and data slice", async () => {
+    const accounts = [
+      "2WDq7wSs9zYrpx2kbHDA4RUTRch2CCTP6ZWaH4GNfnQQ", // Example token in devnet
+      "BVxyYhm498L79r4HMQ9sxZ5bi41DmJmeWZ7SCS7Cyvna", // Example NFT in devnet
+    ];
+
+    const query = new QueryRequest(42, [
+      new PerChainQueryRequest(
+        1,
+        new SolanaAccountQueryRequest(
+          "finalized",
+          accounts,
+          BigInt(7),
           BigInt(1),
           BigInt(10)
         )

--- a/whitepapers/0013_ccq.md
+++ b/whitepapers/0013_ccq.md
@@ -404,7 +404,7 @@ uint32  response_len
    - The `slot_number` is the slot number returned by the query.
    - The `block_time_us` is the timestamp of the block associated with the slot.
    - The `block_hash` is the block hash associated with the slot.
-   - The array of results array returns the data for each account queried.
+   - The `results` array returns the data for each account queried
 
    ```go
    u64         lamports


### PR DESCRIPTION
The Mock for the Solana `sol_account` query does not support the `min_context_slot` parameter. This PR adds that support.

Additionally, this PR includes a few small tweaks that came out of PR #3637.