### PR TITLE
Node/CCQ: Solana min context slot support

### DIFF
--- a/node/pkg/query/query.go
+++ b/node/pkg/query/query.go
@@ -25,6 +25,9 @@ const (
 	// RetryInterval specifies how long we will wait between retry intervals. This is the interval of our ticker.
 	RetryInterval = 10 * time.Second
 
+	// AuditInterval specifies how often to audit the list of pending queries.
+	AuditInterval = time.Second
+
 	// SignedQueryRequestChannelSize is the buffer size of the incoming query request channel.
 	SignedQueryRequestChannelSize = 50
 
@@ -105,7 +108,7 @@ func (qh *QueryHandler) Start(ctx context.Context) error {
 
 // handleQueryRequests multiplexes observation requests to the appropriate chain
 func (qh *QueryHandler) handleQueryRequests(ctx context.Context) error {
-	return handleQueryRequestsImpl(ctx, qh.logger, qh.signedQueryReqC, qh.chainQueryReqC, qh.allowedRequestors, qh.queryResponseReadC, qh.queryResponseWriteC, qh.env, RequestTimeout, RetryInterval)
+	return handleQueryRequestsImpl(ctx, qh.logger, qh.signedQueryReqC, qh.chainQueryReqC, qh.allowedRequestors, qh.queryResponseReadC, qh.queryResponseWriteC, qh.env, RequestTimeout, RetryInterval, AuditInterval)
 }
 
 // handleQueryRequestsImpl allows instantiating the handler in the test environment with shorter timeout and retry parameters.
@@ -120,6 +123,7 @@ func handleQueryRequestsImpl(
 	env common.Environment,
 	requestTimeoutImpl time.Duration,
 	retryIntervalImpl time.Duration,
+	auditIntervalImpl time.Duration,
 ) error {
 	qLogger := logger.With(zap.String("component", "ccqhandler"))
 	qLogger.Info("cross chain queries are enabled", zap.Any("allowedRequestors", allowedRequestors), zap.String("env", string(env)))
@@ -165,7 +169,7 @@ func handleQueryRequestsImpl(
 		}
 	}
 
-	ticker := time.NewTicker(retryIntervalImpl)
+	ticker := time.NewTicker(auditIntervalImpl)
 	defer ticker.Stop()
 
 	for {

--- a/node/pkg/query/query.go
+++ b/node/pkg/query/query.go
@@ -22,7 +22,7 @@ const (
 	// RequestTimeout indicates how long before a request is considered to have timed out.
 	RequestTimeout = 1 * time.Minute
 
-	// RetryInterval specifies how long we will wait between retry intervals. This is the interval of our ticker.
+	// RetryInterval specifies how long we will wait between retry intervals.
 	RetryInterval = 10 * time.Second
 
 	// AuditInterval specifies how often to audit the list of pending queries.

--- a/node/pkg/query/query_test.go
+++ b/node/pkg/query/query_test.go
@@ -36,6 +36,7 @@ const (
 	// Speed things up for testing purposes.
 	requestTimeoutForTest = 100 * time.Millisecond
 	retryIntervalForTest  = 10 * time.Millisecond
+	auditIntervalForTest  = 10 * time.Millisecond
 	pollIntervalForTest   = 5 * time.Millisecond
 )
 
@@ -436,7 +437,7 @@ func createQueryHandlerForTestWithoutPublisher(t *testing.T, ctx context.Context
 
 	go func() {
 		err := handleQueryRequestsImpl(ctx, logger, md.signedQueryReqReadC, md.chainQueryReqC, ccqAllowedRequestersList,
-			md.queryResponseReadC, md.queryResponsePublicationWriteC, common.GoTest, requestTimeoutForTest, retryIntervalForTest)
+			md.queryResponseReadC, md.queryResponsePublicationWriteC, common.GoTest, requestTimeoutForTest, retryIntervalForTest, auditIntervalForTest)
 		assert.NoError(t, err)
 	}()
 

--- a/node/pkg/watchers/solana/ccq_test.go
+++ b/node/pkg/watchers/solana/ccq_test.go
@@ -6,11 +6,16 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/certusone/wormhole/node/pkg/query"
 	"github.com/gagliardetto/solana-go/rpc/jsonrpc"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestRetrySlopIsValid(t *testing.T) {
+	assert.Less(t, CCQ_RETRY_SLOP, query.RetryInterval)
+}
 
 func TestCcqIsMinContextSlotErrorSuccess(t *testing.T) {
 	myErr := &jsonrpc.RPCError{

--- a/node/pkg/watchers/solana/ccq_test.go
+++ b/node/pkg/watchers/solana/ccq_test.go
@@ -1,0 +1,98 @@
+package solana
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/gagliardetto/solana-go/rpc/jsonrpc"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCcqIsMinContextSlotErrorSuccess(t *testing.T) {
+	myErr := &jsonrpc.RPCError{
+		Code:    -32016,
+		Message: "Minimum context slot has not been reached",
+		Data: map[string]interface{}{
+			"contextSlot": json.Number("13526"),
+		},
+	}
+
+	isMinContext, currentSlot, err := ccqIsMinContextSlotError(error(myErr))
+	require.NoError(t, err)
+	require.True(t, isMinContext)
+	assert.Equal(t, uint64(13526), currentSlot)
+}
+
+func TestCcqIsMinContextSlotErrorSomeOtherError(t *testing.T) {
+	myErr := fmt.Errorf("Some other error")
+	isMinContext, _, err := ccqIsMinContextSlotError(error(myErr))
+	require.NoError(t, err)
+	require.False(t, isMinContext)
+}
+
+func TestCcqIsMinContextSlotErrorSomeOtherRPCError(t *testing.T) {
+	myErr := &jsonrpc.RPCError{
+		Code:    -32000,
+		Message: "Some other RPC error",
+		Data: map[string]interface{}{
+			"contextSlot": json.Number("13526"),
+		},
+	}
+
+	isMinContext, _, err := ccqIsMinContextSlotError(error(myErr))
+	require.NoError(t, err)
+	require.False(t, isMinContext)
+}
+
+func TestCcqIsMinContextSlotErrorNoData(t *testing.T) {
+	myErr := &jsonrpc.RPCError{
+		Code:    -32016,
+		Message: "Minimum context slot has not been reached",
+	}
+
+	_, _, err := ccqIsMinContextSlotError(error(myErr))
+	assert.EqualError(t, err, `failed to extract data from min context slot error`)
+}
+
+func TestCcqIsMinContextSlotErrorContextSlotMissing(t *testing.T) {
+	myErr := &jsonrpc.RPCError{
+		Code:    -32016,
+		Message: "Minimum context slot has not been reached",
+		Data: map[string]interface{}{
+			"someOtherField": json.Number("13526"),
+		},
+	}
+
+	_, _, err := ccqIsMinContextSlotError(error(myErr))
+	assert.EqualError(t, err, `min context slot error does not contain "contextSlot"`)
+}
+
+func TestCcqIsMinContextSlotErrorContextSlotIsNotAJsonNumber(t *testing.T) {
+	myErr := &jsonrpc.RPCError{
+		Code:    -32016,
+		Message: "Minimum context slot has not been reached",
+		Data: map[string]interface{}{
+			"contextSlot": "13526",
+		},
+	}
+
+	_, _, err := ccqIsMinContextSlotError(error(myErr))
+	assert.EqualError(t, err, `min context slot error "contextSlot" is not json.Number`)
+}
+
+func TestCcqIsMinContextSlotErrorContextSlotIsNotUint64(t *testing.T) {
+	myErr := &jsonrpc.RPCError{
+		Code:    -32016,
+		Message: "Minimum context slot has not been reached",
+		Data: map[string]interface{}{
+			"contextSlot": json.Number("HelloWorld"),
+		},
+	}
+
+	_, _, err := ccqIsMinContextSlotError(error(myErr))
+	assert.True(t, strings.Contains(err.Error(), `min context slot error "contextSlot" is not uint64`))
+}

--- a/sdk/js-query/src/query/solana.test.ts
+++ b/sdk/js-query/src/query/solana.test.ts
@@ -27,6 +27,7 @@ const ENV = "DEVNET";
 const SERVER_URL = CI ? "http://query-server:" : "http://localhost:";
 const CCQ_SERVER_URL = SERVER_URL + "6069/v1";
 const QUERY_URL = CCQ_SERVER_URL + "/query";
+const SOLANA_NODE_URL = CI ? "http://solana-devnet" : "http://localhost:8899";
 
 const PRIVATE_KEY =
   "cfb12303a19cde580bb4dd771639b0d26bc68353645571a8cff516ab2ee113a0";
@@ -35,6 +36,17 @@ const ACCOUNTS = [
   "2WDq7wSs9zYrpx2kbHDA4RUTRch2CCTP6ZWaH4GNfnQQ", // Example token in devnet
   "BVxyYhm498L79r4HMQ9sxZ5bi41DmJmeWZ7SCS7Cyvna", // Example NFT in devnet
 ];
+
+async function getSolanaSlot(comm: string): Promise<bigint> {
+  const response = await axios.post(SOLANA_NODE_URL, {
+    jsonrpc: "2.0",
+    id: 1,
+    method: "getSlot",
+    params: [{ commitment: comm, transactionDetails: "none" }],
+  });
+
+  return response.data.result;
+}
 
 describe("solana", () => {
   test("serialize and deserialize sol_account request with defaults", () => {
@@ -162,6 +174,66 @@ describe("solana", () => {
     const sar = queryResponse.responses[0]
       .response as SolanaAccountQueryResponse;
     expect(sar.slotNumber).not.toEqual(BigInt(0));
+    expect(sar.blockTime).not.toEqual(BigInt(0));
+    expect(sar.results.length).toEqual(2);
+
+    expect(sar.results[0].lamports).toEqual(BigInt(1461600));
+    expect(sar.results[0].rentEpoch).toEqual(BigInt(0));
+    expect(sar.results[0].executable).toEqual(false);
+    expect(base58.encode(Buffer.from(sar.results[0].owner))).toEqual(
+      "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+    );
+    expect(Buffer.from(sar.results[0].data).toString("hex")).toEqual(
+      "01000000574108aed69daf7e625a361864b1f74d13702f2ca56de9660e566d1d8691848d0000e8890423c78a0901000000000000000000000000000000000000000000000000000000000000000000000000"
+    );
+
+    expect(sar.results[1].lamports).toEqual(BigInt(1461600));
+    expect(sar.results[1].rentEpoch).toEqual(BigInt(0));
+    expect(sar.results[1].executable).toEqual(false);
+    expect(base58.encode(Buffer.from(sar.results[1].owner))).toEqual(
+      "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+    );
+    expect(Buffer.from(sar.results[1].data).toString("hex")).toEqual(
+      "01000000574108aed69daf7e625a361864b1f74d13702f2ca56de9660e566d1d8691848d01000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000"
+    );
+  });
+  test("sol_account query with future min context slot", async () => {
+    const currSlot = await getSolanaSlot("finalized");
+    const minContextSlot = BigInt(currSlot) + BigInt(10);
+    const solAccountReq = new SolanaAccountQueryRequest(
+      "finalized",
+      ACCOUNTS,
+      minContextSlot
+    );
+    const nonce = 42;
+    const query = new PerChainQueryRequest(1, solAccountReq);
+    const request = new QueryRequest(nonce, [query]);
+    const serialized = request.serialize();
+    const digest = QueryRequest.digest(ENV, serialized);
+    const signature = sign(PRIVATE_KEY, digest);
+    const response = await axios.put(
+      QUERY_URL,
+      {
+        signature,
+        bytes: Buffer.from(serialized).toString("hex"),
+      },
+      { headers: { "X-API-Key": "my_secret_key" } }
+    );
+    expect(response.status).toBe(200);
+
+    const queryResponse = QueryResponse.from(response.data.bytes);
+    expect(queryResponse.version).toEqual(1);
+    expect(queryResponse.requestChainId).toEqual(0);
+    expect(queryResponse.request.version).toEqual(1);
+    expect(queryResponse.request.requests.length).toEqual(1);
+    expect(queryResponse.request.requests[0].chainId).toEqual(1);
+    expect(queryResponse.request.requests[0].query.type()).toEqual(
+      ChainQueryType.SolanaAccount
+    );
+
+    const sar = queryResponse.responses[0]
+      .response as SolanaAccountQueryResponse;
+    expect(sar.slotNumber).toEqual(minContextSlot);
     expect(sar.blockTime).not.toEqual(BigInt(0));
     expect(sar.results.length).toEqual(2);
 

--- a/sdk/js-query/src/query/solana.test.ts
+++ b/sdk/js-query/src/query/solana.test.ts
@@ -27,7 +27,7 @@ const ENV = "DEVNET";
 const SERVER_URL = CI ? "http://query-server:" : "http://localhost:";
 const CCQ_SERVER_URL = SERVER_URL + "6069/v1";
 const QUERY_URL = CCQ_SERVER_URL + "/query";
-const SOLANA_NODE_URL = CI ? "http://solana-devnet" : "http://localhost:8899";
+const SOLANA_NODE_URL = CI ? "http://solana-devnet:8899" : "http://localhost:8899";
 
 const PRIVATE_KEY =
   "cfb12303a19cde580bb4dd771639b0d26bc68353645571a8cff516ab2ee113a0";


### PR DESCRIPTION
This PR adds a fast retry mechanism to the Solana query handler when the RPC call fails due to the `MinContextSlot` not being met. In that case, we retry every 200 milliseconds, attempting to hit the desired slot.

This PR also changes the query audit interval to once per second from every ten seconds so that we will be more likely to retry a query every ten seconds.