### PR TITLE
ethereum: PUSH0 test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
           node-version: "16"
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
-      - run: cd ethereum && make test
+      - run: cd ethereum && make test && make test-push0
 
   ethereum-upgrade:
     runs-on: ubuntu-latest

--- a/ethereum/Makefile
+++ b/ethereum/Makefile
@@ -85,5 +85,10 @@ test-identifiers: dependencies
 test-forge: dependencies
 	forge test --no-match-test .*_KEVM # ignore KEVM tests (see PROOFS.md)
 
+# Verify that the contracts do not include PUSH0 opcodes
+test-push0: dependencies
+	forge build --extra-output evm.bytecode.opcodes
+	@if grep -qr --include \*.json PUSH0 ./build-forge; then echo "Contract uses PUSH0 instruction"; exit 1; fi
+
 clean:
 	rm -rf ganache.log .env node_modules build flattened build-forge ethers-contracts lib/forge-std lib/openzeppelin-contracts

--- a/ethereum/Makefile
+++ b/ethereum/Makefile
@@ -88,7 +88,7 @@ test-forge: dependencies
 # Verify that the contracts do not include PUSH0 opcodes
 test-push0: dependencies
 	forge build --extra-output evm.bytecode.opcodes
-	@if grep -qr --include \*.json PUSH0 ./build-forge; then echo "Contract uses PUSH0 instruction"; exit 1; fi
+	@if grep -qr --include \*.json PUSH0 ./build-forge; then echo "Contract uses PUSH0 instruction" 1>&2; exit 1; fi
 
 clean:
 	rm -rf ganache.log .env node_modules build flattened build-forge ethers-contracts lib/forge-std lib/openzeppelin-contracts


### PR DESCRIPTION
Checks that we don't inadvertently build contracts with compiler versions that support PUSH0 opcodes whilst support is spotty.

It's brittle but it works whilst this is a transient state of play.