### PR TITLE
terra: uses `tr` instead of bash 4 feature in `verify` script

### DIFF
--- a/terra/verify
+++ b/terra/verify
@@ -45,8 +45,7 @@ obj_file=$1
 code_id=$2
 
 
-hash1uppercased=`curl "$url"/cosmwasm/wasm/v1/code/"$code_id" --silent | jq '.code_info.data_hash' -r`
-hash1=${hash1uppercased,,}
+hash1=`curl "$url"/cosmwasm/wasm/v1/code/"$code_id" --silent | jq '.code_info.data_hash' -r | tr '[:upper:]' '[:lower:]'`
 hash2=`sha256sum $obj_file | cut -f1 -d' '`
 
 echo "Deployed bytecode hash (on $network):"


### PR DESCRIPTION
This allows running the `verify` script on e.g. some mac installations that come bundled with bash v3.