### PR TITLE
evm: sets optimism WETH in token bridge initializer

### DIFF
--- a/ethereum/contracts/bridge/BridgeImplementation.sol
+++ b/ethereum/contracts/bridge/BridgeImplementation.sol
@@ -17,6 +17,10 @@ contract BridgeImplementation is Bridge {
 
     function initialize() initializer public virtual {
         // this function needs to be exposed for an upgrade to pass
+        if (evmChainId() == 10) { // optimism
+            address weth = 0x4200000000000000000000000000000000000006;
+            setWETH(weth);
+        }
     }
 
     modifier initializer() {


### PR DESCRIPTION
the canonical WETH on optimism:
https://help.optimism.io/hc/en-us/articles/4417948883611-What-is-ETH-WETH-How-do-they-interact
https://optimistic.etherscan.io/address/0x4200000000000000000000000000000000000006#code
https://github.com/ethereum-optimism/optimism/blob/d48b45954c381f75a13e61312da68d84e9b41418/op-bindings/predeploys/addresses.go#L11