### PR TITLE
Node/CCQServer: Quorum not met

### DIFF
--- a/node/cmd/ccq/http.go
+++ b/node/cmd/ccq/http.go
@@ -206,6 +206,7 @@ func (s *httpServer) handleQuery(w http.ResponseWriter, r *http.Request) {
 	case errEntry := <-pendingResponse.errCh:
 		s.logger.Info("publishing error response to client", zap.String("userId", permEntry.userName), zap.String("requestId", requestId), zap.Int("status", errEntry.status), zap.Error(errEntry.err))
 		http.Error(w, errEntry.err.Error(), errEntry.status)
+		// Metrics have already been pegged.
 		break
 	}
 

--- a/node/cmd/ccq/metrics.go
+++ b/node/cmd/ccq/metrics.go
@@ -36,6 +36,24 @@ var (
 			Help: "Total number of requests by user name",
 		}, []string{"user_name"})
 
+	successfulQueriesByUser = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "ccq_server_successful_queries_by_user",
+			Help: "Total number of successful queries by user name",
+		}, []string{"user_name"})
+
+	failedQueriesByUser = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "ccq_server_failed_queries_by_user",
+			Help: "Total number of failed queries by user name",
+		}, []string{"user_name"})
+
+	queryTimeoutsByUser = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "ccq_server_query_timeouts_by_user",
+			Help: "Total number of query timeouts by user name",
+		}, []string{"user_name"})
+
 	quorumNotMetByUser = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "ccq_server_quorum_not_met_by_user",

--- a/node/cmd/ccq/metrics.go
+++ b/node/cmd/ccq/metrics.go
@@ -72,6 +72,12 @@ var (
 			Help: "Total number of query responses received by peer ID",
 		}, []string{"peer_id"})
 
+	queryResponsesReceivedByChainAndPeerID = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "ccq_server_total_query_responses_received_by_chain_and_peer_id",
+			Help: "Total number of query responses received by chain and peer ID",
+		}, []string{"chain_name", "peer_id"})
+
 	inboundP2pError = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "ccq_server_inbound_p2p_errors",

--- a/node/cmd/ccq/metrics.go
+++ b/node/cmd/ccq/metrics.go
@@ -36,6 +36,12 @@ var (
 			Help: "Total number of requests by user name",
 		}, []string{"user_name"})
 
+	quorumNotMetByUser = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "ccq_server_quorum_not_met_by_user",
+			Help: "Total number of query failures due to quorum not met by user name",
+		}, []string{"user_name"})
+
 	invalidRequestsByUser = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "ccq_server_invalid_requests_by_user",

--- a/node/cmd/ccq/p2p.go
+++ b/node/cmd/ccq/p2p.go
@@ -167,6 +167,9 @@ func runP2P(ctx context.Context, priv crypto.PrivKey, port uint, networkID, boot
 					inboundP2pError.WithLabelValues("failed_to_unmarshal_response").Inc()
 					continue
 				}
+				for _, pcr := range queryResponse.PerChainResponses {
+					queryResponsesReceivedByChainAndPeerID.WithLabelValues(pcr.ChainId.String(), peerId).Inc()
+				}
 				requestSignature := hex.EncodeToString(queryResponse.Request.Signature)
 				logger.Info("query response received from gossip", zap.String("peerId", peerId), zap.Any("requestId", requestSignature))
 				if loggingMap.ShouldLogResponse(requestSignature) {

--- a/node/cmd/ccq/p2p.go
+++ b/node/cmd/ccq/p2p.go
@@ -254,6 +254,7 @@ func runP2P(ctx context.Context, priv crypto.PrivKey, port uint, networkID, boot
 						outstandingResponses := len(guardianSet.Keys) - totalSigners
 						if maxMatchingResponses+outstandingResponses < quorum {
 							quorumNotMetByUser.WithLabelValues(pendingResponse.userName).Inc()
+							failedQueriesByUser.WithLabelValues(pendingResponse.userName).Inc()
 							delete(responses, requestSignature)
 							select {
 							case pendingResponse.errCh <- &ErrorEntry{err: fmt.Errorf("quorum not met"), status: http.StatusBadRequest}:

--- a/node/cmd/ccq/pending_request.go
+++ b/node/cmd/ccq/pending_request.go
@@ -8,14 +8,23 @@ import (
 )
 
 type PendingResponse struct {
-	req *gossipv1.SignedQueryRequest
-	ch  chan *SignedResponse
+	req      *gossipv1.SignedQueryRequest
+	userName string
+	ch       chan *SignedResponse
+	errCh    chan *ErrorEntry
 }
 
-func NewPendingResponse(req *gossipv1.SignedQueryRequest) *PendingResponse {
+type ErrorEntry struct {
+	err    error
+	status int
+}
+
+func NewPendingResponse(req *gossipv1.SignedQueryRequest, userName string) *PendingResponse {
 	return &PendingResponse{
-		req: req,
-		ch:  make(chan *SignedResponse),
+		req:      req,
+		userName: userName,
+		ch:       make(chan *SignedResponse),
+		errCh:    make(chan *ErrorEntry),
 	}
 }
 


### PR DESCRIPTION
This PR changes the CCQ proxy server so that it will give up on a query when the number of matching responses plus the potential number of outstanding responses would not reach quorum. When that happens, it returns a "quorum not met" error to the client.