### PR TITLE
Generalize accountant parsing 

### DIFF
--- a/cosmwasm/contracts/global-accountant/src/msg.rs
+++ b/cosmwasm/contracts/global-accountant/src/msg.rs
@@ -9,7 +9,10 @@ use wormhole_sdk::{
 
 use crate::state::{self, PendingTransfer};
 
-pub const SUBMITTED_OBSERVATIONS_PREFIX: &[u8; 35] = b"acct_sub_obsfig_000000000000000000|";
+// NOTE: this is the original PREFIX for the wrapped asset standard ("acct_sub_obsfig_000000000000000000|")
+// given that a new prefix is required for each new deployment, we can use this as a reference
+// TODO: document a standard for prefix construction
+pub const SUBMITTED_OBSERVATIONS_PREFIX: &[u8; 35] = b"acct_sub_obsfig_000000000000000001|";
 
 #[cw_serde]
 #[derive(Default)]

--- a/cosmwasm/packages/accountant/src/contract.rs
+++ b/cosmwasm/packages/accountant/src/contract.rs
@@ -91,7 +91,7 @@ pub fn validate_transfer<C: CustomQuery>(deps: Deps<C>, t: &Transfer) -> anyhow:
 /// #     };
 /// #
 ///       commit_transfer(deps.as_mut(), tx.clone())?;
-///  
+///
 ///       // Repeating the transfer should return an error.
 ///       let err = commit_transfer(deps.as_mut(), tx)
 ///           .expect_err("successfully committed duplicate transfer");
@@ -229,7 +229,7 @@ pub enum ModifyBalanceError {
 ///           amount: Uint256::from(4u128),
 ///           reason: "test".try_into().unwrap(),
 ///       };
-///  
+///
 ///       let err = modify_balance(deps.as_mut(), m)
 ///           .expect_err("successfully modified account with insufficient balance");
 ///       if let Some(e) = err.downcast_ref::<ModifyBalanceError>() {
@@ -341,6 +341,8 @@ mod tests {
     use std::collections::BTreeMap;
 
     use cosmwasm_std::{testing::mock_dependencies, StdError, Uint256};
+
+    use crate::state::transfer::TokenAddresses;
 
     use super::*;
 
@@ -756,7 +758,7 @@ mod tests {
         const ITERATIONS: usize = 10;
         let mut deps = mock_dependencies();
         let emitter_chain = 3;
-        let emitter_address = [3u8; 32].into();
+        let emitter_addresses: TokenAddresses = [3u8; 32].into();
         let data = transfer::Data {
             amount: Uint256::from(400u128),
             token_chain: 3,
@@ -766,7 +768,7 @@ mod tests {
 
         for i in 0..ITERATIONS {
             let tx = Transfer {
-                key: transfer::Key::new(emitter_chain, emitter_address, i as u64),
+                key: transfer::Key::new(emitter_chain, emitter_addresses.clone(), i as u64),
                 data: data.clone(),
             };
 
@@ -1208,6 +1210,7 @@ mod tests {
             .map(|item| item.map(|acc| (acc.key, acc.data)))
             .collect::<StdResult<BTreeMap<_, _>>>()
             .unwrap();
+        // println!("found: {:?}", found);
         assert_eq!(found.len(), count);
 
         for i in 0..count {

--- a/cosmwasm/packages/accountant/src/state/addr.rs
+++ b/cosmwasm/packages/accountant/src/state/addr.rs
@@ -9,6 +9,8 @@ use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{StdError, StdResult};
 use cw_storage_plus::{Key, KeyDeserialize, Prefixer, PrimaryKey};
 
+use super::transfer::TokenAddresses;
+
 #[cw_serde]
 #[derive(Copy, Default, Eq, Hash, PartialOrd, Ord)]
 #[repr(transparent)]
@@ -27,6 +29,12 @@ impl TokenAddress {
 impl From<[u8; 32]> for TokenAddress {
     fn from(addr: [u8; 32]) -> Self {
         TokenAddress(addr)
+    }
+}
+
+impl From<[u8; 32]> for TokenAddresses {
+    fn from(addr: [u8; 32]) -> Self {
+        TokenAddresses(vec![TokenAddress(addr)])
     }
 }
 

--- a/cosmwasm/packages/accountant/src/state/transfer.rs
+++ b/cosmwasm/packages/accountant/src/state/transfer.rs
@@ -3,7 +3,7 @@ use std::{fmt, str::FromStr};
 use anyhow::{ensure, Context};
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{StdResult, Uint256};
-use cw_storage_plus::{Key as CwKey, KeyDeserialize, PrimaryKey};
+use cw_storage_plus::{Key as CwKey, KeyDeserialize, Prefixer, PrimaryKey};
 
 use crate::state::TokenAddress;
 
@@ -15,22 +15,26 @@ pub struct Transfer {
 
 #[cw_serde]
 #[derive(Eq, PartialOrd, Ord, Default, Hash)]
+pub struct TokenAddresses(pub Vec<TokenAddress>);
+
+#[cw_serde]
+#[derive(Eq, PartialOrd, Ord, Default, Hash)]
 pub struct Key {
     // The chain id of the chain on which this transfer originated.
     emitter_chain: u16,
 
     // The address on the emitter chain that created this transfer.
-    emitter_address: TokenAddress,
+    emitter_addresses: TokenAddresses,
 
     // The sequence number of the transfer.
     sequence: u64,
 }
 
 impl Key {
-    pub fn new(emitter_chain: u16, emitter_address: TokenAddress, sequence: u64) -> Self {
+    pub fn new(emitter_chain: u16, emitter_addresses: TokenAddresses, sequence: u64) -> Self {
         Self {
             emitter_chain,
-            emitter_address,
+            emitter_addresses,
             sequence,
         }
     }
@@ -39,12 +43,27 @@ impl Key {
         self.emitter_chain
     }
 
-    pub fn emitter_address(&self) -> &TokenAddress {
-        &self.emitter_address
+    pub fn emitter_addresses(&self) -> &Vec<TokenAddress> {
+        &self.emitter_addresses.0
     }
 
     pub fn sequence(&self) -> u64 {
         self.sequence
+    }
+}
+
+impl fmt::Display for TokenAddresses {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // write!(f, "/")?;
+
+        for (index, address) in self.0.iter().enumerate() {
+            if index > 0 {
+                write!(f, "/")?;
+            }
+            write!(f, "{}", address)?;
+        }
+
+        write!(f, "")
     }
 }
 
@@ -53,8 +72,23 @@ impl fmt::Display for Key {
         write!(
             f,
             "{:05}/{}/{:016}",
-            self.emitter_chain, self.emitter_address, self.sequence
+            self.emitter_chain, self.emitter_addresses, self.sequence
         )
+    }
+}
+
+impl FromStr for TokenAddresses {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut items = Vec::new();
+
+        for item_str in s.split(',') {
+            let item = item_str.trim().parse()?;
+            items.push(item);
+        }
+
+        Ok(TokenAddresses(items))
     }
 }
 
@@ -69,7 +103,7 @@ impl FromStr for Key {
             .transpose()
             .context("failed to parse emitter chain")?
             .context("emitter chain missing")?;
-        let emitter_address = components
+        let emitter_addresses = components
             .next()
             .map(str::parse)
             .transpose()
@@ -89,9 +123,24 @@ impl FromStr for Key {
 
         Ok(Key {
             emitter_chain,
-            emitter_address,
+            emitter_addresses,
             sequence,
         })
+    }
+}
+
+impl KeyDeserialize for TokenAddresses {
+    type Output = Self;
+
+    fn from_vec(v: Vec<u8>) -> StdResult<Self::Output> {
+        let chunks = v.chunks(32).collect::<Vec<_>>();
+        let mut token_addresses = Vec::new();
+        for chunk in chunks.iter() {
+            let addr = <TokenAddress>::from_vec(chunk.to_vec());
+            token_addresses.push(addr.unwrap())
+        }
+
+        Ok(TokenAddresses(token_addresses))
     }
 }
 
@@ -99,27 +148,39 @@ impl KeyDeserialize for Key {
     type Output = Self;
 
     fn from_vec(v: Vec<u8>) -> StdResult<Self::Output> {
-        <(u16, TokenAddress, u64)>::from_vec(v).map(|(emitter_chain, emitter_address, sequence)| {
-            Key {
+        <(u16, TokenAddresses, u64)>::from_vec(v).map(
+            |(emitter_chain, emitter_addresses, sequence)| Key {
                 emitter_chain,
-                emitter_address,
+                emitter_addresses,
                 sequence,
-            }
-        })
+            },
+        )
+    }
+}
+
+impl<'a> Prefixer<'a> for TokenAddresses {
+    fn prefix(&self) -> Vec<CwKey> {
+        self.0.iter().flat_map(|address| address.prefix()).collect()
     }
 }
 
 impl<'a> PrimaryKey<'a> for Key {
-    type Prefix = (u16, TokenAddress);
+    type Prefix = (u16, TokenAddresses);
     type SubPrefix = u16;
     type Suffix = u64;
-    type SuperSuffix = (TokenAddress, u64);
+    type SuperSuffix = (TokenAddresses, u64);
 
     fn key(&self) -> Vec<CwKey> {
         self.emitter_chain
             .key()
             .into_iter()
-            .chain(self.emitter_address.key())
+            .chain(
+                self.emitter_addresses
+                    .0
+                    .iter()
+                    .flat_map(|a| a.key())
+                    .collect::<Vec<_>>(),
+            )
             .chain(self.sequence.key())
             .collect()
     }
@@ -150,8 +211,15 @@ mod test {
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 62, 225, 139, 34, 20, 175, 249, 112, 0, 217, 116,
             207, 100, 126, 124, 52, 126, 143, 165, 133,
         ]);
-        let k = Key::new(2, addr, 254278);
-        let expected = "00002/0000000000000000000000003ee18b2214aff97000d974cf647e7c347e8fa585/0000000000254278";
+        let addr_1 = TokenAddress::new([
+            0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 62, 225, 139, 34, 20, 175, 249, 112, 0, 217, 116,
+            207, 100, 126, 124, 52, 126, 143, 165, 133,
+        ]);
+        let mut addrs = Vec::new();
+        addrs.push(addr);
+        addrs.push(addr_1);
+        let k = Key::new(2, TokenAddresses(addrs), 254278);
+        let expected = "00002/0000000000000000000000003ee18b2214aff97000d974cf647e7c347e8fa585/0000010000000000000000003ee18b2214aff97000d974cf647e7c347e8fa585/0000000000254278";
         assert_eq!(expected, k.to_string());
     }
 }


### PR DESCRIPTION
Currently, the global accountant supports tracking of balances for the wrapped asset standard. While the logic for tracking balances and checking the relevant invariants is generalizable, the parsing logic is not (e.g relaying transfers that do not go through AR may suffer from a double emitter problem). 