### PR TITLE
ci: Fix ordering of forge builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
           node-version: "16"
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
-      - run: cd ethereum && make test && make test-push0
+      - run: cd ethereum && make test-push0 && make test
 
   ethereum-upgrade:
     runs-on: ubuntu-latest


### PR DESCRIPTION
If a forge project has already been built it skips compilation, even if you specify extra flags. So the extra opcode output we needed wasn't being generated and the test would always pass. This reorders the tests to make sure we get the opcodes in our build output.