### PR TITLE
Fixed typo in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,7 +125,7 @@ You can enable it in VSCode with the following in your `settings.json`.
 
 ## Testing
 
-We believe automated tests ensure the integrity of all Wormhole components. Anyone can verify or extend them transparently and they fit nicely with our software development lifecycle. This ensures Wormhole components operate as expected in both expected and failure cases.
+We believe automated tests ensure the integrity of all Wormhole components. Anyone can verify or extend them transparently and they fit nicely with our software development life cycle. This ensures Wormhole components operate as expected in both expected and failure cases.
 
 Places to find out more about existing test coverage and how to run those tests:
 


### PR DESCRIPTION
Life cycle is two separate words. 

