### PR TITLE
SDK: base64 encode payload being sent to injective token bridge

### DIFF
--- a/sdk/js/src/token_bridge/injective.ts
+++ b/sdk/js/src/token_bridge/injective.ts
@@ -247,7 +247,7 @@ export async function transferFromInjective(
           recipient: Buffer.from(recipientAddress).toString("base64"),
           fee: relayerFee,
           nonce,
-          payload,
+          payload: fromUint8Array(payload),
         }
       : {
           asset: {


### PR DESCRIPTION
The injective SDK does not base64 encode Uint8Arrays, passing a payload here will result in a transaction with nonsensical data in the transaction.

Any other places we have Uint8Array as input are treated with `fromUint8Array` or `Buffer.from().toString('base64')`

ex
https://github.com/wormhole-foundation/wormhole/blob/5288d51e152c7a82978ae9cdcfde740c904da5b9/sdk/js/src/token_bridge/injective.ts#L82

------

This code is going on [1.5 years old ](https://github.com/wormhole-foundation/wormhole/pull/1396) but somehow was never run or reported to us

I could not find any existing tests that exercise the payload argument but willing to add if this is a scary change