### PR TITLE
telemetry: add 204 as success status code

### DIFF
--- a/node/pkg/telemetry/prom_remote_write/scrape.go
+++ b/node/pkg/telemetry/prom_remote_write/scrape.go
@@ -74,8 +74,8 @@ func ScrapeAndSendLocalMetrics(ctx context.Context, info PromTelemetryInfo, logg
 	}
 
 	logger.Debug("Grafana result", zap.Int("status code", res.StatusCode))
-	if res.StatusCode != 200 {
-		logger.Error("Grafana returned non-200 status code", zap.Int("status code", res.StatusCode))
+	if res.StatusCode != 200 && res.StatusCode != 204 {
+		logger.Error("Grafana returned a status code other than 200 or 204", zap.Int("status code", res.StatusCode))
 		return err
 	}
 	return nil


### PR DESCRIPTION
Grafana returns "204 No Content" but was considered an error. PR fixes this