### PR TITLE
Node/Gov: Add target to db

### DIFF
--- a/node/pkg/db/governor.go
+++ b/node/pkg/db/governor.go
@@ -95,12 +95,12 @@ func UnmarshalTransfer(data []byte) (*Transfer, error) {
 	}
 
 	if err := binary.Read(reader, binary.BigEndian, &t.OriginChain); err != nil {
-		return nil, fmt.Errorf("failed to read token chain id: %w", err)
+		return nil, fmt.Errorf("failed to read origin chain id: %w", err)
 	}
 
 	originAddress := vaa.Address{}
 	if n, err := reader.Read(originAddress[:]); err != nil || n != 32 {
-		return nil, fmt.Errorf("failed to read emitter address [%d]: %w", n, err)
+		return nil, fmt.Errorf("failed to read origin address [%d]: %w", n, err)
 	}
 	t.OriginAddress = originAddress
 
@@ -122,8 +122,8 @@ func UnmarshalTransfer(data []byte) (*Transfer, error) {
 	if msgIdLen > 0 {
 		msgID := make([]byte, msgIdLen)
 		n, err := reader.Read(msgID)
-		if err != nil || n == 0 {
-			return nil, fmt.Errorf("failed to read vaa id [%d]: %w", n, err)
+		if err != nil || n != int(msgIdLen) {
+			return nil, fmt.Errorf("failed to read msg id [%d]: %w", n, err)
 		}
 		t.MsgID = string(msgID[:n])
 	}
@@ -136,7 +136,7 @@ func UnmarshalTransfer(data []byte) (*Transfer, error) {
 	if hashLen > 0 {
 		hash := make([]byte, hashLen)
 		n, err := reader.Read(hash)
-		if err != nil || n == 0 {
+		if err != nil || n != int(hashLen) {
 			return nil, fmt.Errorf("failed to read hash [%d]: %w", n, err)
 		}
 		t.Hash = string(hash[:n])
@@ -171,7 +171,7 @@ func unmarshalOldTransfer(data []byte) (*Transfer, error) {
 	}
 
 	if err := binary.Read(reader, binary.BigEndian, &t.OriginChain); err != nil {
-		return nil, fmt.Errorf("failed to read token chain id: %w", err)
+		return nil, fmt.Errorf("failed to read origin chain id: %w", err)
 	}
 
 	originAddress := vaa.Address{}

--- a/node/pkg/db/governor_test.go
+++ b/node/pkg/db/governor_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"sort"
-	"strings"
 	"testing"
 	"time"
 
@@ -489,63 +488,51 @@ func TestUnmarshalTransferFailures(t *testing.T) {
 
 	// Truncate the timestamp.
 	_, err = UnmarshalTransfer(bytes[0 : 4-1])
-	require.Error(t, err)
-	assert.True(t, strings.HasPrefix(err.Error(), "failed to read timestamp: "))
+	assert.ErrorContains(t, err, "failed to read timestamp: ")
 
 	// Truncate the value.
 	_, err = UnmarshalTransfer(bytes[0 : 4+8-1])
-	require.Error(t, err)
-	assert.True(t, strings.HasPrefix(err.Error(), "failed to read value: "))
+	assert.ErrorContains(t, err, "failed to read value: ")
 
 	// Truncate the origin chain.
 	_, err = UnmarshalTransfer(bytes[0 : 4+8+2-1])
-	require.Error(t, err)
-	assert.True(t, strings.HasPrefix(err.Error(), "failed to read origin chain id: "))
+	assert.ErrorContains(t, err, "failed to read origin chain id: ")
 
 	// Truncate the origin address.
 	_, err = UnmarshalTransfer(bytes[0 : 4+8+2+32-1])
-	require.Error(t, err)
-	assert.True(t, strings.HasPrefix(err.Error(), "failed to read origin address"))
+	assert.ErrorContains(t, err, "failed to read origin address")
 
 	// Truncate the emitter chain.
 	_, err = UnmarshalTransfer(bytes[0 : 4+8+2+32+2-1])
-	require.Error(t, err)
-	assert.True(t, strings.HasPrefix(err.Error(), "failed to read emitter chain id: "))
+	assert.ErrorContains(t, err, "failed to read emitter chain id: ")
 
 	// Truncate the emitter address.
 	_, err = UnmarshalTransfer(bytes[0 : 4+8+2+32+2+32-1])
-	require.Error(t, err)
-	assert.True(t, strings.HasPrefix(err.Error(), "failed to read emitter address"))
+	assert.ErrorContains(t, err, "failed to read emitter address")
 
 	// Truncate the message ID length.
 	_, err = UnmarshalTransfer(bytes[0 : 4+8+2+32+2+32+2-1])
-	require.Error(t, err)
-	assert.True(t, strings.HasPrefix(err.Error(), "failed to read msgID length: "))
+	assert.ErrorContains(t, err, "failed to read msgID length: ")
 
 	// Truncate the message ID data.
 	_, err = UnmarshalTransfer(bytes[0 : 4+8+2+32+2+32+2+3])
-	require.Error(t, err)
-	assert.True(t, strings.HasPrefix(err.Error(), "failed to read msg id"))
+	assert.ErrorContains(t, err, "failed to read msg id")
 
 	// Truncate the hash length.
 	_, err = UnmarshalTransfer(bytes[0 : 4+8+2+32+2+32+2+82+2-1])
-	require.Error(t, err)
-	assert.True(t, strings.HasPrefix(err.Error(), "failed to read hash length: "))
+	assert.ErrorContains(t, err, "failed to read hash length: ")
 
 	// Truncate the hash data.
 	_, err = UnmarshalTransfer(bytes[0 : 4+8+2+32+2+32+2+82+2+3])
-	require.Error(t, err)
-	assert.True(t, strings.HasPrefix(err.Error(), "failed to read hash"))
+	assert.ErrorContains(t, err, "failed to read hash")
 
 	// Truncate the target chain.
 	_, err = UnmarshalTransfer(bytes[0 : 4+8+2+32+2+32+2+82+2+5+2-1])
-	require.Error(t, err)
-	assert.True(t, strings.HasPrefix(err.Error(), "failed to read target chain id: "))
+	assert.ErrorContains(t, err, "failed to read target chain id: ")
 
 	// Truncate the target address.
 	_, err = UnmarshalTransfer(bytes[0 : 4+8+2+32+2+32+2+82+2+5+2+32-1])
-	require.Error(t, err)
-	assert.True(t, strings.HasPrefix(err.Error(), "failed to read target address"))
+	assert.ErrorContains(t, err, "failed to read target address")
 }
 
 // Note that PendingTransfer.Marshal can't fail, so there are no negative tests for that.
@@ -581,20 +568,17 @@ func TestUnmarshalPendingTransferFailures(t *testing.T) {
 
 	// Truncate the release time.
 	_, err = UnmarshalPendingTransfer(bytes[0:4-1], false)
-	require.Error(t, err)
-	assert.True(t, strings.HasPrefix(err.Error(), "failed to read pending transfer release time: "))
+	assert.ErrorContains(t, err, "failed to read pending transfer release time: ")
 
 	// The remainder is the marshaled message publication as a single buffer.
 
 	// Truncate the entire serialized message.
 	_, err = UnmarshalPendingTransfer(bytes[0:4], false)
-	require.Error(t, err)
-	assert.True(t, strings.HasPrefix(err.Error(), "failed to read pending transfer msg"))
+	assert.ErrorContains(t, err, "failed to read pending transfer msg")
 
 	// Truncate some of the serialized message.
 	_, err = UnmarshalPendingTransfer(bytes[0:len(bytes)-10], false)
-	require.Error(t, err)
-	assert.True(t, strings.HasPrefix(err.Error(), "failed to unmarshal pending transfer msg"))
+	assert.ErrorContains(t, err, "failed to unmarshal pending transfer msg")
 }
 
 func (d *Database) storeOldPendingMsg(t *testing.T, p *PendingTransfer) {

--- a/node/pkg/db/governor_test.go
+++ b/node/pkg/db/governor_test.go
@@ -29,7 +29,10 @@ func TestSerializeAndDeserializeOfTransfer(t *testing.T) {
 	tokenAddr, err := vaa.StringToAddress("0x707f9118e33a9b8998bea41dd0d46f38bb963fc8")
 	require.NoError(t, err)
 
-	tokenBridgeAddr, _ := vaa.StringToAddress("0x0290fb167208af455bb137780163b7b7a9a10c16")
+	ethereumTokenBridgeAddr, _ := vaa.StringToAddress("0x0290fb167208af455bb137780163b7b7a9a10c16")
+	require.NoError(t, err)
+
+	bscTokenBridgeAddr, _ := vaa.StringToAddress("0x26b4afb60d6c903165150c6f0aa14f8016be4aec")
 	require.NoError(t, err)
 
 	xfer1 := &Transfer{
@@ -38,7 +41,9 @@ func TestSerializeAndDeserializeOfTransfer(t *testing.T) {
 		OriginChain:    vaa.ChainIDEthereum,
 		OriginAddress:  tokenAddr,
 		EmitterChain:   vaa.ChainIDEthereum,
-		EmitterAddress: tokenBridgeAddr,
+		EmitterAddress: ethereumTokenBridgeAddr,
+		TargetChain:    vaa.ChainIDBSC,
+		TargetAddress:  bscTokenBridgeAddr,
 		MsgID:          "2/0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16/789101112131415",
 		Hash:           "Hash1",
 	}
@@ -51,12 +56,12 @@ func TestSerializeAndDeserializeOfTransfer(t *testing.T) {
 
 	assert.Equal(t, xfer1, xfer2)
 
-	expectedTransferKey := "GOV:XFER2:2/0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16/789101112131415"
+	expectedTransferKey := "GOV:XFER3:2/0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16/789101112131415"
 	assert.Equal(t, expectedTransferKey, string(TransferMsgID(xfer2)))
 }
 
 func TestPendingMsgID(t *testing.T) {
-	tokenBridgeAddr, err := vaa.StringToAddress("0x0290fb167208af455bb137780163b7b7a9a10c16")
+	ethereumTokenBridgeAddr, err := vaa.StringToAddress("0x0290fb167208af455bb137780163b7b7a9a10c16")
 	require.NoError(t, err)
 
 	msg1 := &common.MessagePublication{
@@ -65,7 +70,7 @@ func TestPendingMsgID(t *testing.T) {
 		Nonce:            123456,
 		Sequence:         789101112131415,
 		EmitterChain:     vaa.ChainIDEthereum,
-		EmitterAddress:   tokenBridgeAddr,
+		EmitterAddress:   ethereumTokenBridgeAddr,
 		Payload:          []byte{},
 		ConsistencyLevel: 16,
 	}
@@ -77,7 +82,10 @@ func TestTransferMsgID(t *testing.T) {
 	tokenAddr, err := vaa.StringToAddress("0x707f9118e33a9b8998bea41dd0d46f38bb963fc8")
 	require.NoError(t, err)
 
-	tokenBridgeAddr, _ := vaa.StringToAddress("0x0290fb167208af455bb137780163b7b7a9a10c16")
+	ethereumTokenBridgeAddr, _ := vaa.StringToAddress("0x0290fb167208af455bb137780163b7b7a9a10c16")
+	require.NoError(t, err)
+
+	bscTokenBridgeAddr, _ := vaa.StringToAddress("0x26b4afb60d6c903165150c6f0aa14f8016be4aec")
 	require.NoError(t, err)
 
 	xfer := &Transfer{
@@ -86,32 +94,34 @@ func TestTransferMsgID(t *testing.T) {
 		OriginChain:    vaa.ChainIDEthereum,
 		OriginAddress:  tokenAddr,
 		EmitterChain:   vaa.ChainIDEthereum,
-		EmitterAddress: tokenBridgeAddr,
+		EmitterAddress: ethereumTokenBridgeAddr,
+		TargetChain:    vaa.ChainIDBSC,
+		TargetAddress:  bscTokenBridgeAddr,
 		MsgID:          "2/0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16/789101112131415",
 		Hash:           "Hash1",
 	}
 
-	assert.Equal(t, []byte("GOV:XFER2:"+"2/0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16/789101112131415"), TransferMsgID(xfer))
+	assert.Equal(t, []byte("GOV:XFER3:"+"2/0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16/789101112131415"), TransferMsgID(xfer))
 }
 
 func TestIsTransfer(t *testing.T) {
-	assert.Equal(t, true, IsTransfer([]byte("GOV:XFER2:"+"2/0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16/789101112131415")))
-	assert.Equal(t, false, IsTransfer([]byte("GOV:XFER2:")))
-	assert.Equal(t, false, IsTransfer([]byte("GOV:XFER2:1")))
-	assert.Equal(t, false, IsTransfer([]byte("GOV:XFER2:1/1/1")))
-	assert.Equal(t, false, IsTransfer([]byte("GOV:XFER2:"+"1/0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16/")))
-	assert.Equal(t, true, IsTransfer([]byte("GOV:XFER2:"+"1/0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16/0")))
+	assert.Equal(t, true, IsTransfer([]byte("GOV:XFER3:"+"2/0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16/789101112131415")))
+	assert.Equal(t, false, IsTransfer([]byte("GOV:XFER3:")))
+	assert.Equal(t, false, IsTransfer([]byte("GOV:XFER3:1")))
+	assert.Equal(t, false, IsTransfer([]byte("GOV:XFER3:1/1/1")))
+	assert.Equal(t, false, IsTransfer([]byte("GOV:XFER3:"+"1/0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16/")))
+	assert.Equal(t, true, IsTransfer([]byte("GOV:XFER3:"+"1/0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16/0")))
 	assert.Equal(t, false, IsTransfer([]byte("GOV:PENDING:"+"2/0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16/789101112131415")))
 	assert.Equal(t, false, IsTransfer([]byte{0x01, 0x02, 0x03, 0x04}))
 	assert.Equal(t, false, IsTransfer([]byte{}))
-	assert.Equal(t, true, isOldTransfer([]byte("GOV:XFER:"+"2/0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16/789101112131415")))
-	assert.Equal(t, false, isOldTransfer([]byte("GOV:XFER2:"+"2/0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16/789101112131415")))
+	assert.Equal(t, true, isOldTransfer([]byte("GOV:XFER2:"+"2/0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16/789101112131415")))
+	assert.Equal(t, false, isOldTransfer([]byte("GOV:XFER3:"+"2/0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16/789101112131415")))
 
 }
 
 func TestIsPendingMsg(t *testing.T) {
 	assert.Equal(t, true, IsPendingMsg([]byte("GOV:PENDING3:"+"2/0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16/789101112131415")))
-	assert.Equal(t, false, IsPendingMsg([]byte("GOV:XFER2:"+"2/0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16/789101112131415")))
+	assert.Equal(t, false, IsPendingMsg([]byte("GOV:XFER3:"+"2/0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16/789101112131415")))
 	assert.Equal(t, false, IsPendingMsg([]byte("GOV:PENDING3:")))
 	assert.Equal(t, false, IsPendingMsg([]byte("GOV:PENDING3:"+"1")))
 	assert.Equal(t, false, IsPendingMsg([]byte("GOV:PENDING3:"+"1/1/1")))
@@ -152,7 +162,10 @@ func TestStoreTransfer(t *testing.T) {
 	tokenAddr, err := vaa.StringToAddress("0x707f9118e33a9b8998bea41dd0d46f38bb963fc8")
 	require.NoError(t, err)
 
-	tokenBridgeAddr, _ := vaa.StringToAddress("0x0290fb167208af455bb137780163b7b7a9a10c16")
+	ethereumTokenBridgeAddr, _ := vaa.StringToAddress("0x0290fb167208af455bb137780163b7b7a9a10c16")
+	require.NoError(t, err)
+
+	bscTokenBridgeAddr, _ := vaa.StringToAddress("0x26b4afb60d6c903165150c6f0aa14f8016be4aec")
 	require.NoError(t, err)
 
 	xfer1 := &Transfer{
@@ -161,7 +174,9 @@ func TestStoreTransfer(t *testing.T) {
 		OriginChain:    vaa.ChainIDEthereum,
 		OriginAddress:  tokenAddr,
 		EmitterChain:   vaa.ChainIDEthereum,
-		EmitterAddress: tokenBridgeAddr,
+		EmitterAddress: ethereumTokenBridgeAddr,
+		TargetChain:    vaa.ChainIDBSC,
+		TargetAddress:  bscTokenBridgeAddr,
 		MsgID:          "2/0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16/789101112131415",
 		Hash:           "Hash1",
 	}
@@ -181,7 +196,10 @@ func TestDeleteTransfer(t *testing.T) {
 	tokenAddr, err := vaa.StringToAddress("0x707f9118e33a9b8998bea41dd0d46f38bb963fc8")
 	require.NoError(t, err)
 
-	tokenBridgeAddr, _ := vaa.StringToAddress("0x0290fb167208af455bb137780163b7b7a9a10c16")
+	ethereumTokenBridgeAddr, _ := vaa.StringToAddress("0x0290fb167208af455bb137780163b7b7a9a10c16")
+	require.NoError(t, err)
+
+	bscTokenBridgeAddr, _ := vaa.StringToAddress("0x26b4afb60d6c903165150c6f0aa14f8016be4aec")
 	require.NoError(t, err)
 
 	xfer1 := &Transfer{
@@ -190,7 +208,9 @@ func TestDeleteTransfer(t *testing.T) {
 		OriginChain:    vaa.ChainIDEthereum,
 		OriginAddress:  tokenAddr,
 		EmitterChain:   vaa.ChainIDEthereum,
-		EmitterAddress: tokenBridgeAddr,
+		EmitterAddress: ethereumTokenBridgeAddr,
+		TargetChain:    vaa.ChainIDBSC,
+		TargetAddress:  bscTokenBridgeAddr,
 		MsgID:          "2/0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16/789101112131415",
 		Hash:           "Hash1",
 	}
@@ -315,7 +335,10 @@ func TestStoreAndReloadTransfers(t *testing.T) {
 	defer db.Close()
 	defer os.Remove(dbPath)
 
-	tokenBridgeAddr, err := vaa.StringToAddress("0x0290fb167208af455bb137780163b7b7a9a10c16")
+	ethereumTokenBridgeAddr, err := vaa.StringToAddress("0x0290fb167208af455bb137780163b7b7a9a10c16")
+	require.NoError(t, err)
+
+	bscTokenBridgeAddr, _ := vaa.StringToAddress("0x26b4afb60d6c903165150c6f0aa14f8016be4aec")
 	require.NoError(t, err)
 
 	tokenAddr, err := vaa.StringToAddress("0x707f9118e33a9b8998bea41dd0d46f38bb963fc8")
@@ -327,7 +350,9 @@ func TestStoreAndReloadTransfers(t *testing.T) {
 		OriginChain:    vaa.ChainIDEthereum,
 		OriginAddress:  tokenAddr,
 		EmitterChain:   vaa.ChainIDEthereum,
-		EmitterAddress: tokenBridgeAddr,
+		EmitterAddress: ethereumTokenBridgeAddr,
+		TargetChain:    vaa.ChainIDBSC,
+		TargetAddress:  bscTokenBridgeAddr,
 		MsgID:          "2/0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16/789101112131415",
 		Hash:           "Hash1",
 	}
@@ -341,7 +366,9 @@ func TestStoreAndReloadTransfers(t *testing.T) {
 		OriginChain:    vaa.ChainIDEthereum,
 		OriginAddress:  tokenAddr,
 		EmitterChain:   vaa.ChainIDEthereum,
-		EmitterAddress: tokenBridgeAddr,
+		EmitterAddress: ethereumTokenBridgeAddr,
+		TargetChain:    vaa.ChainIDBSC,
+		TargetAddress:  bscTokenBridgeAddr,
 		MsgID:          "2/0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16/789101112131416",
 		Hash:           "Hash2",
 	}
@@ -357,7 +384,7 @@ func TestStoreAndReloadTransfers(t *testing.T) {
 			Nonce:            123456,
 			Sequence:         789101112131417,
 			EmitterChain:     vaa.ChainIDEthereum,
-			EmitterAddress:   tokenBridgeAddr,
+			EmitterAddress:   ethereumTokenBridgeAddr,
 			Payload:          []byte{4, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 			ConsistencyLevel: 16,
 		},
@@ -374,7 +401,7 @@ func TestStoreAndReloadTransfers(t *testing.T) {
 			Nonce:            123456,
 			Sequence:         789101112131418,
 			EmitterChain:     vaa.ChainIDEthereum,
-			EmitterAddress:   tokenBridgeAddr,
+			EmitterAddress:   ethereumTokenBridgeAddr,
 			Payload:          []byte{4, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 			ConsistencyLevel: 16,
 		},
@@ -439,38 +466,75 @@ func TestLoadingOldPendingTransfers(t *testing.T) {
 	defer db.Close()
 	defer os.Remove(dbPath)
 
-	tokenBridgeAddr, err := vaa.StringToAddress("0x0290fb167208af455bb137780163b7b7a9a10c16")
+	ethereumTokenBridgeAddr, err := vaa.StringToAddress("0x0290fb167208af455bb137780163b7b7a9a10c16")
+	require.NoError(t, err)
+
+	bscTokenBridgeAddr, _ := vaa.StringToAddress("0x26b4afb60d6c903165150c6f0aa14f8016be4aec")
 	require.NoError(t, err)
 
 	tokenAddr, err := vaa.StringToAddress("0x707f9118e33a9b8998bea41dd0d46f38bb963fc8")
 	require.NoError(t, err)
 
-	xfer1 := &Transfer{
+	oldXfer1 := &Transfer{
 		Timestamp:      time.Unix(int64(1654516425), 0),
 		Value:          125000,
 		OriginChain:    vaa.ChainIDEthereum,
 		OriginAddress:  tokenAddr,
 		EmitterChain:   vaa.ChainIDEthereum,
-		EmitterAddress: tokenBridgeAddr,
-		MsgID:          "2/0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16/789101112131415",
-		Hash:           "Hash1",
+		EmitterAddress: ethereumTokenBridgeAddr,
+		// Don't set TargetChain or TargetAddress.
+		MsgID: "2/0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16/789101112131415",
+		Hash:  "Hash1",
 	}
 
-	err = db.StoreTransfer(xfer1)
+	err = db.storeOldTransfer(oldXfer1)
 	require.Nil(t, err)
 
-	xfer2 := &Transfer{
-		Timestamp:      time.Unix(int64(1654516430), 0),
+	newXfer1 := &Transfer{
+		Timestamp:      time.Unix(int64(1654516426), 0),
 		Value:          125000,
 		OriginChain:    vaa.ChainIDEthereum,
 		OriginAddress:  tokenAddr,
 		EmitterChain:   vaa.ChainIDEthereum,
-		EmitterAddress: tokenBridgeAddr,
+		EmitterAddress: ethereumTokenBridgeAddr,
+		TargetChain:    vaa.ChainIDBSC,
+		TargetAddress:  bscTokenBridgeAddr,
 		MsgID:          "2/0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16/789101112131416",
+		Hash:           "Hash1",
+	}
+
+	err = db.StoreTransfer(newXfer1)
+	require.Nil(t, err)
+
+	oldXfer2 := &Transfer{
+		Timestamp:      time.Unix(int64(1654516427), 0),
+		Value:          125000,
+		OriginChain:    vaa.ChainIDEthereum,
+		OriginAddress:  tokenAddr,
+		EmitterChain:   vaa.ChainIDEthereum,
+		EmitterAddress: ethereumTokenBridgeAddr,
+		// Don't set TargetChain or TargetAddress.
+		MsgID: "2/0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16/789101112131417",
+		Hash:  "Hash2",
+	}
+
+	err = db.storeOldTransfer(oldXfer2)
+	require.Nil(t, err)
+
+	newXfer2 := &Transfer{
+		Timestamp:      time.Unix(int64(1654516428), 0),
+		Value:          125000,
+		OriginChain:    vaa.ChainIDEthereum,
+		OriginAddress:  tokenAddr,
+		EmitterChain:   vaa.ChainIDEthereum,
+		EmitterAddress: ethereumTokenBridgeAddr,
+		TargetChain:    vaa.ChainIDBSC,
+		TargetAddress:  bscTokenBridgeAddr,
+		MsgID:          "2/0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16/789101112131418",
 		Hash:           "Hash2",
 	}
 
-	err = db.StoreTransfer(xfer2)
+	err = db.StoreTransfer(newXfer2)
 	require.Nil(t, err)
 
 	now := time.Unix(time.Now().Unix(), 0)
@@ -484,7 +548,7 @@ func TestLoadingOldPendingTransfers(t *testing.T) {
 			Nonce:            123456,
 			Sequence:         789101112131417,
 			EmitterChain:     vaa.ChainIDEthereum,
-			EmitterAddress:   tokenBridgeAddr,
+			EmitterAddress:   ethereumTokenBridgeAddr,
 			Payload:          []byte{4, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 			ConsistencyLevel: 16,
 			// IsReobservation will not be serialized. It should be set to false on reload.
@@ -505,7 +569,7 @@ func TestLoadingOldPendingTransfers(t *testing.T) {
 			Nonce:            123456,
 			Sequence:         789101112131418,
 			EmitterChain:     vaa.ChainIDEthereum,
-			EmitterAddress:   tokenBridgeAddr,
+			EmitterAddress:   ethereumTokenBridgeAddr,
 			Payload:          []byte{4, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 			ConsistencyLevel: 16,
 			IsReobservation:  true,
@@ -519,16 +583,23 @@ func TestLoadingOldPendingTransfers(t *testing.T) {
 	xfers, pendings, err := db.GetChainGovernorDataForTime(logger, now)
 
 	require.Nil(t, err)
-	require.Equal(t, 2, len(xfers))
+	require.Equal(t, 4, len(xfers))
 	require.Equal(t, 2, len(pendings))
+
+	sort.SliceStable(xfers, func(i, j int) bool {
+		return xfers[i].Timestamp.Before(xfers[j].Timestamp)
+	})
+
+	assert.Equal(t, oldXfer1, xfers[0])
+	assert.Equal(t, newXfer1, xfers[1])
+	assert.Equal(t, oldXfer2, xfers[2])
+	assert.Equal(t, newXfer2, xfers[3])
 
 	// Updated old pending events get placed at the end, so we need to sort into timestamp order.
 	sort.SliceStable(pendings, func(i, j int) bool {
 		return pendings[i].Msg.Timestamp.Before(pendings[j].Msg.Timestamp)
 	})
 
-	assert.Equal(t, xfer1, xfers[0])
-	assert.Equal(t, xfer2, xfers[1])
 	assert.Equal(t, pending1.Msg, pendings[0].Msg)
 	assert.Equal(t, pending2.Msg, pendings[1].Msg)
 
@@ -537,24 +608,39 @@ func TestLoadingOldPendingTransfers(t *testing.T) {
 	xfers2, pendings2, err := db.GetChainGovernorDataForTime(logger, now)
 
 	require.Nil(t, err)
-	require.Equal(t, 2, len(xfers2))
+	require.Equal(t, 4, len(xfers2))
 	require.Equal(t, 2, len(pendings2))
 
-	assert.Equal(t, xfer1, xfers2[0])
-	assert.Equal(t, xfer2, xfers2[1])
+	sort.SliceStable(xfers2, func(i, j int) bool {
+		return xfers2[i].Timestamp.Before(xfers2[j].Timestamp)
+	})
+
+	assert.Equal(t, oldXfer1, xfers2[0])
+	assert.Equal(t, newXfer1, xfers2[1])
+	assert.Equal(t, oldXfer2, xfers2[2])
+	assert.Equal(t, newXfer2, xfers2[3])
+
 	assert.Equal(t, pending1.Msg, pendings2[0].Msg)
 	assert.Equal(t, pending2.Msg, pendings2[1].Msg)
 }
 
-func marshalOldTransfer(xfer *Transfer) []byte {
+func marshalOldTransfer(t *Transfer) []byte {
 	buf := new(bytes.Buffer)
-	vaa.MustWrite(buf, binary.BigEndian, uint32(xfer.Timestamp.Unix()))
-	vaa.MustWrite(buf, binary.BigEndian, xfer.Value)
-	vaa.MustWrite(buf, binary.BigEndian, xfer.OriginChain)
-	buf.Write(xfer.OriginAddress[:])
-	vaa.MustWrite(buf, binary.BigEndian, xfer.EmitterChain)
-	buf.Write(xfer.EmitterAddress[:])
-	buf.Write([]byte(xfer.MsgID))
+
+	vaa.MustWrite(buf, binary.BigEndian, uint32(t.Timestamp.Unix()))
+	vaa.MustWrite(buf, binary.BigEndian, t.Value)
+	vaa.MustWrite(buf, binary.BigEndian, t.OriginChain)
+	buf.Write(t.OriginAddress[:])
+	vaa.MustWrite(buf, binary.BigEndian, t.EmitterChain)
+	buf.Write(t.EmitterAddress[:])
+	vaa.MustWrite(buf, binary.BigEndian, uint16(len(t.MsgID)))
+	if len(t.MsgID) > 0 {
+		buf.Write([]byte(t.MsgID))
+	}
+	vaa.MustWrite(buf, binary.BigEndian, uint16(len(t.Hash)))
+	if len(t.Hash) > 0 {
+		buf.Write([]byte(t.Hash))
+	}
 	return buf.Bytes()
 }
 
@@ -574,7 +660,7 @@ func TestDeserializeOfOldTransfer(t *testing.T) {
 	tokenAddr, err := vaa.StringToAddress("0x707f9118e33a9b8998bea41dd0d46f38bb963fc8")
 	require.NoError(t, err)
 
-	tokenBridgeAddr, _ := vaa.StringToAddress("0x0290fb167208af455bb137780163b7b7a9a10c16")
+	ethereumTokenBridgeAddr, _ := vaa.StringToAddress("0x0290fb167208af455bb137780163b7b7a9a10c16")
 	require.NoError(t, err)
 
 	xfer1 := &Transfer{
@@ -583,9 +669,10 @@ func TestDeserializeOfOldTransfer(t *testing.T) {
 		OriginChain:    vaa.ChainIDEthereum,
 		OriginAddress:  tokenAddr,
 		EmitterChain:   vaa.ChainIDEthereum,
-		EmitterAddress: tokenBridgeAddr,
-		MsgID:          "2/0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16/789101112131415",
-		// Do not set the Hash.
+		EmitterAddress: ethereumTokenBridgeAddr,
+		// Don't set TargetChain or TargetAddress.
+		MsgID: "2/0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16/789101112131415",
+		Hash:  "Hash1",
 	}
 
 	bytes := marshalOldTransfer(xfer1)
@@ -595,7 +682,7 @@ func TestDeserializeOfOldTransfer(t *testing.T) {
 
 	assert.Equal(t, xfer1, xfer2)
 
-	expectedTransferKey := "GOV:XFER2:2/0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16/789101112131415"
+	expectedTransferKey := "GOV:XFER3:2/0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16/789101112131415"
 	assert.Equal(t, expectedTransferKey, string(TransferMsgID(xfer2)))
 }
 
@@ -608,7 +695,10 @@ func TestOldTransfersUpdatedWhenReloading(t *testing.T) {
 	defer db.Close()
 	defer os.Remove(dbPath)
 
-	tokenBridgeAddr, err := vaa.StringToAddress("0x0290fb167208af455bb137780163b7b7a9a10c16")
+	ethereumTokenBridgeAddr, err := vaa.StringToAddress("0x0290fb167208af455bb137780163b7b7a9a10c16")
+	require.NoError(t, err)
+
+	bscTokenBridgeAddr, _ := vaa.StringToAddress("0x26b4afb60d6c903165150c6f0aa14f8016be4aec")
 	require.NoError(t, err)
 
 	tokenAddr, err := vaa.StringToAddress("0x707f9118e33a9b8998bea41dd0d46f38bb963fc8")
@@ -621,8 +711,9 @@ func TestOldTransfersUpdatedWhenReloading(t *testing.T) {
 		OriginChain:    vaa.ChainIDEthereum,
 		OriginAddress:  tokenAddr,
 		EmitterChain:   vaa.ChainIDEthereum,
-		EmitterAddress: tokenBridgeAddr,
-		MsgID:          "2/0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16/789101112131415",
+		EmitterAddress: ethereumTokenBridgeAddr,
+		// Don't set TargetChain or TargetAddress.
+		MsgID: "2/0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16/789101112131415",
 		// Do not set the Hash.
 	}
 
@@ -636,7 +727,9 @@ func TestOldTransfersUpdatedWhenReloading(t *testing.T) {
 		OriginChain:    vaa.ChainIDEthereum,
 		OriginAddress:  tokenAddr,
 		EmitterChain:   vaa.ChainIDEthereum,
-		EmitterAddress: tokenBridgeAddr,
+		EmitterAddress: ethereumTokenBridgeAddr,
+		TargetChain:    vaa.ChainIDBSC,
+		TargetAddress:  bscTokenBridgeAddr,
 		MsgID:          "2/0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16/789101112131416",
 		Hash:           "Hash2",
 	}

--- a/node/pkg/governor/governor.go
+++ b/node/pkg/governor/governor.go
@@ -581,37 +581,41 @@ func (gov *ChainGovernor) CheckPendingForTime(now time.Time) ([]*common.MessageP
 						zap.String("msgID", pe.dbData.Msg.MessageIDString()))
 				}
 
-				// If we get here, publish it and remove it from the pending list.
-				msgsToPublish = append(msgsToPublish, &pe.dbData.Msg)
-
-				if countsTowardsTransfers {
-					payload, err := vaa.DecodeTransferPayloadHdr(pe.dbData.Msg.Payload)
-					if err != nil {
-						gov.logger.Error("failed to decode payload for pending VAA", zap.String("msgID", pe.dbData.Msg.MessageIDString()), zap.Error(err))
-						return nil, err
-					}
-
-					xfer := db.Transfer{Timestamp: now,
-						Value:          value,
-						OriginChain:    pe.token.token.chain,
-						OriginAddress:  pe.token.token.addr,
-						EmitterChain:   pe.dbData.Msg.EmitterChain,
-						EmitterAddress: pe.dbData.Msg.EmitterAddress,
-						TargetChain:    payload.TargetChain,
-						TargetAddress:  payload.TargetAddress,
-						MsgID:          pe.dbData.Msg.MessageIDString(),
-						Hash:           pe.hash,
-					}
-
-					if err := gov.db.StoreTransfer(&xfer); err != nil {
-						gov.msgsToPublish = msgsToPublish
-						return nil, err
-					}
-
-					ce.transfers = append(ce.transfers, &xfer)
-					gov.msgsSeen[pe.hash] = transferComplete
+				payload, err := vaa.DecodeTransferPayloadHdr(pe.dbData.Msg.Payload)
+				if err != nil {
+					gov.logger.Error("failed to decode payload for pending VAA, dropping it",
+						zap.String("msgID", pe.dbData.Msg.MessageIDString()),
+						zap.String("hash", pe.hash),
+						zap.Error(err),
+					)
+					delete(gov.msgsSeen, pe.hash) // Rest of the clean up happens below.
 				} else {
-					delete(gov.msgsSeen, pe.hash)
+					// If we get here, publish it and remove it from the pending list.
+					msgsToPublish = append(msgsToPublish, &pe.dbData.Msg)
+
+					if countsTowardsTransfers {
+						xfer := db.Transfer{Timestamp: now,
+							Value:          value,
+							OriginChain:    pe.token.token.chain,
+							OriginAddress:  pe.token.token.addr,
+							EmitterChain:   pe.dbData.Msg.EmitterChain,
+							EmitterAddress: pe.dbData.Msg.EmitterAddress,
+							TargetChain:    payload.TargetChain,
+							TargetAddress:  payload.TargetAddress,
+							MsgID:          pe.dbData.Msg.MessageIDString(),
+							Hash:           pe.hash,
+						}
+
+						if err := gov.db.StoreTransfer(&xfer); err != nil {
+							gov.msgsToPublish = msgsToPublish
+							return nil, err
+						}
+
+						ce.transfers = append(ce.transfers, &xfer)
+						gov.msgsSeen[pe.hash] = transferComplete
+					} else {
+						delete(gov.msgsSeen, pe.hash)
+					}
 				}
 
 				if err := gov.db.DeletePendingMsg(&pe.dbData); err != nil {

--- a/node/pkg/governor/governor.go
+++ b/node/pkg/governor/governor.go
@@ -427,6 +427,8 @@ func (gov *ChainGovernor) ProcessMsgForTime(msg *common.MessagePublication, now 
 		OriginAddress:  token.token.addr,
 		EmitterChain:   msg.EmitterChain,
 		EmitterAddress: msg.EmitterAddress,
+		TargetChain:    payload.TargetChain,
+		TargetAddress:  payload.TargetAddress,
 		MsgID:          msg.MessageIDString(),
 		Hash:           hash,
 	}
@@ -583,12 +585,20 @@ func (gov *ChainGovernor) CheckPendingForTime(now time.Time) ([]*common.MessageP
 				msgsToPublish = append(msgsToPublish, &pe.dbData.Msg)
 
 				if countsTowardsTransfers {
+					payload, err := vaa.DecodeTransferPayloadHdr(pe.dbData.Msg.Payload)
+					if err != nil {
+						gov.logger.Error("failed to decode payload for pending VAA", zap.String("msgID", pe.dbData.Msg.MessageIDString()), zap.Error(err))
+						return nil, err
+					}
+
 					xfer := db.Transfer{Timestamp: now,
 						Value:          value,
 						OriginChain:    pe.token.token.chain,
 						OriginAddress:  pe.token.token.addr,
 						EmitterChain:   pe.dbData.Msg.EmitterChain,
 						EmitterAddress: pe.dbData.Msg.EmitterAddress,
+						TargetChain:    payload.TargetChain,
+						TargetAddress:  payload.TargetAddress,
 						MsgID:          pe.dbData.Msg.MessageIDString(),
 						Hash:           pe.hash,
 					}

--- a/node/pkg/governor/governor_test.go
+++ b/node/pkg/governor/governor_test.go
@@ -20,6 +20,9 @@ import (
 	"github.com/certusone/wormhole/node/pkg/db"
 	"github.com/wormhole-foundation/wormhole/sdk/vaa"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 // This is so we can have consistent config data for unit tests.
@@ -256,11 +259,14 @@ func TestTrimmingAllTransfersShouldReturnZero(t *testing.T) {
 }
 
 func newChainGovernorForTest(ctx context.Context) (*ChainGovernor, error) {
+	return newChainGovernorForTestWithLogger(ctx, zap.NewNop())
+}
+
+func newChainGovernorForTestWithLogger(ctx context.Context, logger *zap.Logger) (*ChainGovernor, error) {
 	if ctx == nil {
 		return nil, fmt.Errorf("ctx is nil")
 	}
 
-	logger := zap.NewNop()
 	var db db.MockGovernorDB
 	gov := NewChainGovernor(logger, &db, common.GoTest)
 
@@ -1807,4 +1813,126 @@ func TestCoinGeckoQueries(t *testing.T) {
 			}
 		})
 	}
+}
+
+// setupLogsCapture is a helper function for making a zap logger/observer combination for testing that certain logs have been made
+func setupLogsCapture(t testing.TB, options ...zap.Option) (*zap.Logger, *observer.ObservedLogs) {
+	t.Helper()
+	observedCore, observedLogs := observer.New(zap.InfoLevel)
+	consoleLogger := zaptest.NewLogger(t, zaptest.Level(zap.InfoLevel))
+	parentLogger := zap.New(zapcore.NewTee(observedCore, consoleLogger.Core()), options...)
+	return parentLogger, observedLogs
+}
+
+func TestPendingTransferWithBadPayloadGetsDroppedNotReleased(t *testing.T) {
+	ctx := context.Background()
+	zapLogger, zapObserver := setupLogsCapture(t)
+	gov, err := newChainGovernorForTestWithLogger(ctx, zapLogger)
+	require.NoError(t, err)
+	require.NotNil(t, gov)
+
+	tokenAddrStr := "0xDDb64fE46a91D46ee29420539FC25FD07c5FEa3E" //nolint:gosec
+	toAddrStr := "0x707f9118e33a9b8998bea41dd0d46f38bb963fc8"
+	tokenBridgeAddrStr := "0x0290fb167208af455bb137780163b7b7a9a10c16" //nolint:gosec
+	tokenBridgeAddr, err := vaa.StringToAddress(tokenBridgeAddrStr)
+	require.NoError(t, err)
+
+	gov.setDayLengthInMinutes(24 * 60)
+
+	err = gov.setChainForTesting(vaa.ChainIDEthereum, tokenBridgeAddrStr, 10000, 100000)
+	require.NoError(t, err)
+	err = gov.setTokenForTesting(vaa.ChainIDEthereum, tokenAddrStr, "WETH", 1774.62)
+	require.NoError(t, err)
+
+	// Create two big transactions.
+	msg1 := common.MessagePublication{
+		TxHash:           hashFromString("0x06f541f5ecfc43407c31587aa6ac3a689e8960f36dc23c332db5510dfc6a4063"),
+		Timestamp:        time.Unix(int64(1654543099), 0),
+		Nonce:            uint32(1),
+		Sequence:         uint64(1),
+		EmitterChain:     vaa.ChainIDEthereum,
+		EmitterAddress:   tokenBridgeAddr,
+		ConsistencyLevel: uint8(32),
+		Payload: buildMockTransferPayloadBytes(1,
+			vaa.ChainIDEthereum,
+			tokenAddrStr,
+			vaa.ChainIDPolygon,
+			toAddrStr,
+			5000,
+		),
+	}
+
+	msg2 := common.MessagePublication{
+		TxHash:           hashFromString("0x06f541f5ecfc43407c31587aa6ac3a689e8960f36dc23c332db5510dfc6a4063"),
+		Timestamp:        time.Unix(int64(1654543099), 0),
+		Nonce:            uint32(2),
+		Sequence:         uint64(2),
+		EmitterChain:     vaa.ChainIDEthereum,
+		EmitterAddress:   tokenBridgeAddr,
+		ConsistencyLevel: uint8(32),
+		Payload: buildMockTransferPayloadBytes(1,
+			vaa.ChainIDEthereum,
+			tokenAddrStr,
+			vaa.ChainIDPolygon,
+			toAddrStr,
+			5000,
+		),
+	}
+
+	// Post the two big transfers and and verify they get enqueued.
+	now, _ := time.Parse("Jan 2, 2006 at 3:04pm (MST)", "Jun 1, 2022 at 12:00pm (CST)")
+	canPost, err := gov.ProcessMsgForTime(&msg1, now)
+	require.NoError(t, err)
+	assert.Equal(t, false, canPost)
+
+	canPost, err = gov.ProcessMsgForTime(&msg2, now)
+	require.NoError(t, err)
+	assert.Equal(t, false, canPost)
+
+	numTrans, _, numPending, _ := gov.getStatsForAllChains()
+	assert.Equal(t, 2, len(gov.msgsSeen))
+	assert.Equal(t, 0, numTrans)
+	assert.Equal(t, 2, numPending)
+
+	// Corrupt the payload of msg2 so that when we try to release it, it will get dropped.
+	gov.mutex.Lock()
+	ce, exists := gov.chains[vaa.ChainIDEthereum]
+	require.True(t, exists)
+	require.Equal(t, 2, len(ce.pending))
+	require.Equal(t, "2/0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16/2", ce.pending[1].dbData.Msg.MessageIDString())
+	ce.pending[1].dbData.Msg.Payload = nil
+	gov.mutex.Unlock()
+
+	// After 24hrs, msg1 should get released but msg2 should get dropped.
+	now, _ = time.Parse("Jan 2, 2006 at 3:04pm (MST)", "Jun 2, 2022 at 12:01pm (CST)")
+	toBePublished, err := gov.CheckPendingForTime(now)
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(toBePublished))
+	checkTargetOnReleasedIsSet(t, toBePublished, vaa.ChainIDPolygon, toAddrStr)
+	assert.Equal(t, "2/0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16/1", toBePublished[0].MessageIDString())
+
+	// Verify that we got the expected error in the logs.
+	loggedEntries := zapObserver.FilterMessage("failed to decode payload for pending VAA, dropping it").All()
+	require.Equal(t, 1, len(loggedEntries))
+
+	foundIt := false
+	for _, f := range loggedEntries[0].Context {
+		if f.Key == "msgID" && f.String == "2/0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16/2" {
+			foundIt = true
+		}
+	}
+	assert.True(t, foundIt)
+
+	// Verify that the message is no longer pending.
+	gov.mutex.Lock()
+	ce, exists = gov.chains[vaa.ChainIDEthereum]
+	require.True(t, exists)
+	assert.Equal(t, 0, len(ce.pending))
+	gov.mutex.Unlock()
+
+	// Neither one should be in the map of messages seen.
+	_, exists = gov.msgsSeen[gov.HashFromMsg(&msg1)]
+	assert.False(t, exists)
+	_, exists = gov.msgsSeen[gov.HashFromMsg(&msg2)]
+	assert.False(t, exists)
 }


### PR DESCRIPTION
This PR adds the target chain and address to the governor transfers stored in the DB. It also handles reloading transfers that do not have those fields and migrating them to the new format.