### PR TITLE
CLI: Add NTT Transfer VAA generation command

### DIFF
--- a/clients/js/README.md
+++ b/clients/js/README.md
@@ -143,6 +143,7 @@ Options:
 worm generate [command]
 
 Commands:
+  worm generate ntt-transfer                Generate an NTT transfer VAA
   worm generate registration                Generate registration VAA
   worm generate upgrade                     Generate contract upgrade VAA
   worm generate attestation                 Generate a token attestation VAA

--- a/clients/js/package-lock.json
+++ b/clients/js/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@celo-tools/celo-ethers-wrapper": "^0.1.0",
-        "@certusone/wormhole-sdk": "^0.10.10",
+        "@certusone/wormhole-sdk": "0.10.8",
         "@cosmjs/encoding": "^0.26.2",
         "@improbable-eng/grpc-web-node-http-transport": "^0.15.0",
         "@injectivelabs/networks": "^1.10.7",
@@ -53,7 +53,7 @@
         "@types/node-fetch": "^2.6.3",
         "@types/yargs": "^17.0.24",
         "copy-dir": "^1.3.0",
-        "typescript": "^4.6"
+        "typescript": "^5.3"
       }
     },
     "node_modules/@adraffy/ens-normalize": {
@@ -502,9 +502,9 @@
       }
     },
     "node_modules/@certusone/wormhole-sdk": {
-      "version": "0.10.11",
-      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk/-/wormhole-sdk-0.10.11.tgz",
-      "integrity": "sha512-WG2gmVqc5t5T6WeSkh6aDPMToN0whTJ1WQv9Kke3/bk4ssR6Gn6gv2OXHL0ZzYcUS8hft5EQBTNr1HGNQT2gMQ==",
+      "version": "0.10.8",
+      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk/-/wormhole-sdk-0.10.8.tgz",
+      "integrity": "sha512-W2rA8fMdkVFWvy93+51K+8Kv/bpjuFtxCYCQI4YkWe+g4zLkDXw+yYMVPPqc/chFLFNSutPMqUtXAg7+y8lowg==",
       "dependencies": {
         "@certusone/wormhole-sdk-proto-web": "0.0.7",
         "@certusone/wormhole-sdk-wasm": "^0.0.1",
@@ -3572,19 +3572,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/connect-sdk-evm/node_modules/typescript": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/@wormhole-foundation/connect-sdk-evm/node_modules/ws": {
@@ -7972,15 +7959,15 @@
       "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
     },
     "node_modules/typescript": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
-      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/typical": {
@@ -8736,9 +8723,9 @@
       "requires": {}
     },
     "@certusone/wormhole-sdk": {
-      "version": "0.10.11",
-      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk/-/wormhole-sdk-0.10.11.tgz",
-      "integrity": "sha512-WG2gmVqc5t5T6WeSkh6aDPMToN0whTJ1WQv9Kke3/bk4ssR6Gn6gv2OXHL0ZzYcUS8hft5EQBTNr1HGNQT2gMQ==",
+      "version": "0.10.8",
+      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk/-/wormhole-sdk-0.10.8.tgz",
+      "integrity": "sha512-W2rA8fMdkVFWvy93+51K+8Kv/bpjuFtxCYCQI4YkWe+g4zLkDXw+yYMVPPqc/chFLFNSutPMqUtXAg7+y8lowg==",
       "requires": {
         "@certusone/wormhole-sdk-proto-web": "0.0.7",
         "@certusone/wormhole-sdk-wasm": "^0.0.1",
@@ -11158,12 +11145,6 @@
             "tslib": "2.4.0",
             "ws": "8.5.0"
           }
-        },
-        "typescript": {
-          "version": "5.3.3",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-          "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
-          "peer": true
         },
         "ws": {
           "version": "8.5.0",
@@ -14765,9 +14746,9 @@
       "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
     },
     "typescript": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
-      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw=="
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw=="
     },
     "typical": {
       "version": "4.0.0",

--- a/clients/js/package-lock.json
+++ b/clients/js/package-lock.json
@@ -22,9 +22,9 @@
         "@solana/web3.js": "^1.22.0",
         "@terra-money/terra.js": "^3.1.9",
         "@types/config": "^3.3.0",
-        "@wormhole-foundation/connect-sdk": "^0.4.2-beta.0",
-        "@wormhole-foundation/connect-sdk-evm": "^0.4.2-beta.0",
-        "@wormhole-foundation/connect-sdk-solana": "^0.4.2-beta.0",
+        "@wormhole-foundation/connect-sdk": "^0.4.2-beta.1",
+        "@wormhole-foundation/connect-sdk-evm": "^0.4.2-beta.1",
+        "@wormhole-foundation/connect-sdk-solana": "^0.4.2-beta.1",
         "@xpla/xpla.js": "^0.2.1",
         "algosdk": "^2.4.0",
         "aptos": "^1.3.16",
@@ -3480,12 +3480,12 @@
       "dev": true
     },
     "node_modules/@wormhole-foundation/connect-sdk": {
-      "version": "0.4.2-beta.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk/-/connect-sdk-0.4.2-beta.0.tgz",
-      "integrity": "sha512-XN08s7vEn8fRlOaGqH7qOocpXvAdTzht/zRXsp9ZiOYHSeg+xyYBjqxfx7kavtK0J3eTbqDEmPP6q+ZZJIrE8w==",
+      "version": "0.4.2-beta.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk/-/connect-sdk-0.4.2-beta.1.tgz",
+      "integrity": "sha512-R4oqzksEGRf+4d0iVZ3WuTIyuUs5PGOkhGNQmZUrRz554OCquJbIoixYHHBhy5HF6vzq2p43+9g1I7Gxh/o63g==",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "^0.4.2-beta.0",
-        "@wormhole-foundation/sdk-definitions": "^0.4.2-beta.0",
+        "@wormhole-foundation/sdk-base": "^0.4.2-beta.1",
+        "@wormhole-foundation/sdk-definitions": "^0.4.2-beta.1",
         "axios": "^1.4.0"
       },
       "engines": {
@@ -3493,12 +3493,12 @@
       }
     },
     "node_modules/@wormhole-foundation/connect-sdk-evm": {
-      "version": "0.4.2-beta.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk-evm/-/connect-sdk-evm-0.4.2-beta.0.tgz",
-      "integrity": "sha512-24QltyDq1dGiDZxR9JLexCKmsZtQtLEanoObTmP3LrdbTRstQ0+8LY7Ye0h0S1+6bqqk/3ppVjsEM1ZUPnMBdQ==",
+      "version": "0.4.2-beta.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk-evm/-/connect-sdk-evm-0.4.2-beta.1.tgz",
+      "integrity": "sha512-Fk6WoLssdRo063z+UEsRZhfWKYOVgJTaidqOXCuN29JKTukKHqXFSGF8gUO5xebMWPUnZdOhfPB9Uertqpcm4Q==",
       "dependencies": {
         "@typechain/ethers-v6": "^0.4.0",
-        "@wormhole-foundation/connect-sdk": "^0.4.2-beta.0",
+        "@wormhole-foundation/connect-sdk": "^0.4.2-beta.1",
         "ethers": "^6.5.1",
         "typechain": "^8.2.0"
       },
@@ -3608,16 +3608,16 @@
       }
     },
     "node_modules/@wormhole-foundation/connect-sdk-solana": {
-      "version": "0.4.2-beta.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk-solana/-/connect-sdk-solana-0.4.2-beta.0.tgz",
-      "integrity": "sha512-Q7RpKryvEyVLNpeMmy8H9093AHQlI/B4HWgZ28m9S/PSijKcw0mgJZp3eDcN8UMqYLe0grPVP1Kyv7EVaa0yIg==",
+      "version": "0.4.2-beta.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk-solana/-/connect-sdk-solana-0.4.2-beta.1.tgz",
+      "integrity": "sha512-0i1WtGKGucd8Evxli1Ml9UHps+JWXg4OuzyEC9CjwCROXrd7TcJF6s3KDB7h9xUWBPtp0lC83cB8qW9VPHuMGw==",
       "dependencies": {
         "@coral-xyz/borsh": "0.2.6",
         "@project-serum/anchor": "0.25.0",
         "@project-serum/borsh": "0.2.5",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "1.89.1",
-        "@wormhole-foundation/connect-sdk": "^0.4.2-beta.0",
+        "@wormhole-foundation/connect-sdk": "^0.4.2-beta.1",
         "lodash": "^4.17.21"
       },
       "engines": {
@@ -3648,20 +3648,20 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-base": {
-      "version": "0.4.2-beta.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-0.4.2-beta.0.tgz",
-      "integrity": "sha512-0kg/IRUI15eGcroiOxB36zHB9iqqOSpj9FA0mBj3FKQQb0+wTQUDApPSHUvVe7WL97XLLI3rvyknzeAIy89QGA==",
+      "version": "0.4.2-beta.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-0.4.2-beta.1.tgz",
+      "integrity": "sha512-tm6dmim+1CuCNdArT3O3Ap+H7rwNJN4QiuVe8plhCbjuJQLWIFatlDTKY1UHMOElQjY35Lh1MLpMoYXp4agwXA==",
       "dependencies": {
         "@scure/base": "^1.1.3"
       }
     },
     "node_modules/@wormhole-foundation/sdk-definitions": {
-      "version": "0.4.2-beta.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-0.4.2-beta.0.tgz",
-      "integrity": "sha512-avfZBwo18t8Xwy+iQs4ZwZz1vZed3eblqZVxAFADYHPL/QYLznc86tAUpTStKRRwYKvXhdkEIZ7UmW1e3FefPQ==",
+      "version": "0.4.2-beta.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-0.4.2-beta.1.tgz",
+      "integrity": "sha512-ThoIBRfoEoPTOYqSHDED8wjHfRdaXexryQJ4fyvgTE9uNKs+N85cIkw5lN44u9mKpEj8UIkC/ashvo4ylrutwg==",
       "dependencies": {
         "@noble/hashes": "^1.3.1",
-        "@wormhole-foundation/sdk-base": "^0.4.2-beta.0"
+        "@wormhole-foundation/sdk-base": "^0.4.2-beta.1"
       }
     },
     "node_modules/@wormhole-foundation/sdk-definitions/node_modules/@noble/hashes": {
@@ -11077,12 +11077,12 @@
       "dev": true
     },
     "@wormhole-foundation/connect-sdk": {
-      "version": "0.4.2-beta.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk/-/connect-sdk-0.4.2-beta.0.tgz",
-      "integrity": "sha512-XN08s7vEn8fRlOaGqH7qOocpXvAdTzht/zRXsp9ZiOYHSeg+xyYBjqxfx7kavtK0J3eTbqDEmPP6q+ZZJIrE8w==",
+      "version": "0.4.2-beta.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk/-/connect-sdk-0.4.2-beta.1.tgz",
+      "integrity": "sha512-R4oqzksEGRf+4d0iVZ3WuTIyuUs5PGOkhGNQmZUrRz554OCquJbIoixYHHBhy5HF6vzq2p43+9g1I7Gxh/o63g==",
       "requires": {
-        "@wormhole-foundation/sdk-base": "^0.4.2-beta.0",
-        "@wormhole-foundation/sdk-definitions": "^0.4.2-beta.0",
+        "@wormhole-foundation/sdk-base": "^0.4.2-beta.1",
+        "@wormhole-foundation/sdk-definitions": "^0.4.2-beta.1",
         "axios": "^1.4.0"
       },
       "dependencies": {
@@ -11109,12 +11109,12 @@
       }
     },
     "@wormhole-foundation/connect-sdk-evm": {
-      "version": "0.4.2-beta.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk-evm/-/connect-sdk-evm-0.4.2-beta.0.tgz",
-      "integrity": "sha512-24QltyDq1dGiDZxR9JLexCKmsZtQtLEanoObTmP3LrdbTRstQ0+8LY7Ye0h0S1+6bqqk/3ppVjsEM1ZUPnMBdQ==",
+      "version": "0.4.2-beta.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk-evm/-/connect-sdk-evm-0.4.2-beta.1.tgz",
+      "integrity": "sha512-Fk6WoLssdRo063z+UEsRZhfWKYOVgJTaidqOXCuN29JKTukKHqXFSGF8gUO5xebMWPUnZdOhfPB9Uertqpcm4Q==",
       "requires": {
         "@typechain/ethers-v6": "^0.4.0",
-        "@wormhole-foundation/connect-sdk": "^0.4.2-beta.0",
+        "@wormhole-foundation/connect-sdk": "^0.4.2-beta.1",
         "ethers": "^6.5.1",
         "typechain": "^8.2.0"
       },
@@ -11175,34 +11175,34 @@
       }
     },
     "@wormhole-foundation/connect-sdk-solana": {
-      "version": "0.4.2-beta.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk-solana/-/connect-sdk-solana-0.4.2-beta.0.tgz",
-      "integrity": "sha512-Q7RpKryvEyVLNpeMmy8H9093AHQlI/B4HWgZ28m9S/PSijKcw0mgJZp3eDcN8UMqYLe0grPVP1Kyv7EVaa0yIg==",
+      "version": "0.4.2-beta.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk-solana/-/connect-sdk-solana-0.4.2-beta.1.tgz",
+      "integrity": "sha512-0i1WtGKGucd8Evxli1Ml9UHps+JWXg4OuzyEC9CjwCROXrd7TcJF6s3KDB7h9xUWBPtp0lC83cB8qW9VPHuMGw==",
       "requires": {
         "@coral-xyz/borsh": "0.2.6",
         "@project-serum/anchor": "0.25.0",
         "@project-serum/borsh": "0.2.5",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "1.89.1",
-        "@wormhole-foundation/connect-sdk": "^0.4.2-beta.0",
+        "@wormhole-foundation/connect-sdk": "^0.4.2-beta.1",
         "lodash": "^4.17.21"
       }
     },
     "@wormhole-foundation/sdk-base": {
-      "version": "0.4.2-beta.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-0.4.2-beta.0.tgz",
-      "integrity": "sha512-0kg/IRUI15eGcroiOxB36zHB9iqqOSpj9FA0mBj3FKQQb0+wTQUDApPSHUvVe7WL97XLLI3rvyknzeAIy89QGA==",
+      "version": "0.4.2-beta.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-0.4.2-beta.1.tgz",
+      "integrity": "sha512-tm6dmim+1CuCNdArT3O3Ap+H7rwNJN4QiuVe8plhCbjuJQLWIFatlDTKY1UHMOElQjY35Lh1MLpMoYXp4agwXA==",
       "requires": {
         "@scure/base": "^1.1.3"
       }
     },
     "@wormhole-foundation/sdk-definitions": {
-      "version": "0.4.2-beta.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-0.4.2-beta.0.tgz",
-      "integrity": "sha512-avfZBwo18t8Xwy+iQs4ZwZz1vZed3eblqZVxAFADYHPL/QYLznc86tAUpTStKRRwYKvXhdkEIZ7UmW1e3FefPQ==",
+      "version": "0.4.2-beta.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-0.4.2-beta.1.tgz",
+      "integrity": "sha512-ThoIBRfoEoPTOYqSHDED8wjHfRdaXexryQJ4fyvgTE9uNKs+N85cIkw5lN44u9mKpEj8UIkC/ashvo4ylrutwg==",
       "requires": {
         "@noble/hashes": "^1.3.1",
-        "@wormhole-foundation/sdk-base": "^0.4.2-beta.0"
+        "@wormhole-foundation/sdk-base": "^0.4.2-beta.1"
       },
       "dependencies": {
         "@noble/hashes": {

--- a/clients/js/package-lock.json
+++ b/clients/js/package-lock.json
@@ -22,7 +22,9 @@
         "@solana/web3.js": "^1.22.0",
         "@terra-money/terra.js": "^3.1.9",
         "@types/config": "^3.3.0",
-        "@wormhole-foundation/connect-sdk": "^0.4.1",
+        "@wormhole-foundation/connect-sdk": "^0.4.2-beta.0",
+        "@wormhole-foundation/connect-sdk-evm": "^0.4.2-beta.0",
+        "@wormhole-foundation/connect-sdk-solana": "^0.4.2-beta.0",
         "@xpla/xpla.js": "^0.2.1",
         "algosdk": "^2.4.0",
         "aptos": "^1.3.16",
@@ -53,6 +55,11 @@
         "copy-dir": "^1.3.0",
         "typescript": "^4.6"
       }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
+      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw=="
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.0",
@@ -2617,50 +2624,12 @@
         "@scure/base": "~1.1.0"
       }
     },
-    "node_modules/@mysten/sui.js/node_modules/@types/node": {
-      "version": "12.20.55",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
-      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="
-    },
-    "node_modules/@mysten/sui.js/node_modules/jayson": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/jayson/-/jayson-4.1.0.tgz",
-      "integrity": "sha512-R6JlbyLN53Mjku329XoRT2zJAE6ZgOQ8f91ucYdMCD4nkGCF9kZSrcGXpHIU4jeKj58zUZke2p+cdQchU7Ly7A==",
-      "dependencies": {
-        "@types/connect": "^3.4.33",
-        "@types/node": "^12.12.54",
-        "@types/ws": "^7.4.4",
-        "commander": "^2.20.3",
-        "delay": "^5.0.0",
-        "es6-promisify": "^5.0.0",
-        "eyes": "^0.1.8",
-        "isomorphic-ws": "^4.0.1",
-        "json-stringify-safe": "^5.0.1",
-        "JSONStream": "^1.3.5",
-        "uuid": "^8.3.2",
-        "ws": "^7.4.5"
-      },
-      "bin": {
-        "jayson": "bin/jayson.js"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@mysten/sui.js/node_modules/superstruct": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-1.0.3.tgz",
       "integrity": "sha512-8iTn3oSS8nRGn+C2pgXSKPI3jmpm6FExNazNpjvqS6ZUJQCej3PUXEKM8NjHBOs54ExM+LPW/FBRhymrdcCiSg==",
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@mysten/sui.js/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@noble/curves": {
@@ -2688,17 +2657,6 @@
         }
       ]
     },
-    "node_modules/@noble/ed25519": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.1.tgz",
-      "integrity": "sha512-Rk4SkJFaXZiznFyC/t77Q0NKS4FL7TLJJsVG2V2oiEq3kJVeTdxysEe/yRWSpnWMe808XRDJ+VFh5pt/FN5plw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ]
-    },
     "node_modules/@noble/hashes": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.3.tgz",
@@ -2714,6 +2672,7 @@
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.6.3.tgz",
       "integrity": "sha512-T04e4iTurVy7I8Sw4+c5OSN9/RkPlo1uKxAomtxQNLq8j1uPAqnsqG1bqvY3Jv7c13gyr6dui0zmh/I3+f/JaQ==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -3185,9 +3144,9 @@
       }
     },
     "node_modules/@solana/buffer-layout": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/buffer-layout/-/buffer-layout-4.0.0.tgz",
-      "integrity": "sha512-lR0EMP2HC3+Mxwd4YcnZb0smnaDw7Bl2IQWZiTevRH5ZZBZn6VRWn3/92E3qdU4SSImJkA6IDHawOHAnx/qUvQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@solana/buffer-layout/-/buffer-layout-4.0.1.tgz",
+      "integrity": "sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA==",
       "dependencies": {
         "buffer": "~6.0.3"
       },
@@ -3209,33 +3168,10 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@solana/buffer-layout/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
     "node_modules/@solana/spl-token": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.3.5.tgz",
-      "integrity": "sha512-0bGC6n415lGjKu02gkLOIpP1wzndSP0SHwN9PefJ+wKAhmfU1rl3AV1Pa41uap2kzSCD6F9642ngNO8KXPvh/g==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.3.9.tgz",
+      "integrity": "sha512-1EXHxKICMnab35MvvY/5DBc/K/uQAOJCYnDZXw83McCAYUAfi+rwq6qfd6MmITmSTEhcfBcl/zYxmW/OSN0RmA==",
       "dependencies": {
         "@solana/buffer-layout": "^4.0.0",
         "@solana/buffer-layout-utils": "^0.2.0",
@@ -3248,53 +3184,65 @@
         "@solana/web3.js": "^1.47.4"
       }
     },
-    "node_modules/@solana/spl-token/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
     "node_modules/@solana/web3.js": {
-      "version": "1.66.2",
-      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.66.2.tgz",
-      "integrity": "sha512-RyaHMR2jGmaesnYP045VLeBGfR/gAW3cvZHzMFGg7bkO+WOYOYp1nEllf0/la4U4qsYGKCsO9eEevR5fhHiVHg==",
+      "version": "1.89.1",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.89.1.tgz",
+      "integrity": "sha512-t9TTLtPQxtQB3SAf/5E8xPXfVDsC6WGOsgKY02l2cbe0HLymT7ynE8Hu48Lk5qynHCquj6nhISfEHcjMkYpu/A==",
       "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "@noble/ed25519": "^1.7.0",
-        "@noble/hashes": "^1.1.2",
-        "@noble/secp256k1": "^1.6.3",
-        "@solana/buffer-layout": "^4.0.0",
+        "@babel/runtime": "^7.23.4",
+        "@noble/curves": "^1.2.0",
+        "@noble/hashes": "^1.3.2",
+        "@solana/buffer-layout": "^4.0.1",
+        "agentkeepalive": "^4.5.0",
         "bigint-buffer": "^1.1.5",
-        "bn.js": "^5.0.0",
+        "bn.js": "^5.2.1",
         "borsh": "^0.7.0",
         "bs58": "^4.0.1",
-        "buffer": "6.0.1",
+        "buffer": "6.0.3",
         "fast-stable-stringify": "^1.0.0",
-        "jayson": "^3.4.4",
-        "node-fetch": "2",
-        "rpc-websockets": "^7.5.0",
+        "jayson": "^4.1.0",
+        "node-fetch": "^2.7.0",
+        "rpc-websockets": "^7.5.1",
         "superstruct": "^0.14.2"
+      }
+    },
+    "node_modules/@solana/web3.js/node_modules/@babel/runtime": {
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.9.tgz",
+      "integrity": "sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
       },
       "engines": {
-        "node": ">=12.20.0"
+        "node": ">=6.9.0"
       }
+    },
+    "node_modules/@solana/web3.js/node_modules/@noble/curves": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.3.0.tgz",
+      "integrity": "sha512-t01iSXPuN+Eqzb4eBX0S5oubSqXbK/xXa1Ne18Hj8f9pStxztHCE2gfboSp/dZRLSqfuLpRK2nDXDK+W9puocA==",
+      "dependencies": {
+        "@noble/hashes": "1.3.3"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@solana/web3.js/node_modules/@noble/hashes": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.3.tgz",
+      "integrity": "sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@solana/web3.js/node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/@suchipi/femver": {
       "version": "1.0.0",
@@ -3442,15 +3390,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/express-serve-static-core": {
-      "version": "4.17.24",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/qs": "*",
-        "@types/range-parser": "*"
-      }
-    },
     "node_modules/@types/lodash": {
       "version": "4.14.171",
       "license": "MIT"
@@ -3469,9 +3408,9 @@
       "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
     },
     "node_modules/@types/node": {
-      "version": "18.7.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.6.tgz",
-      "integrity": "sha512-EdxgKRXgYsNITy5mjjXjVE/CS8YENSdhiagGrLqjG0pvA2owgJ6i4l7wy/PFZGC0B1/H20lWKN7ONVDNYDZm7A=="
+      "version": "18.15.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz",
+      "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q=="
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.3",
@@ -3505,13 +3444,10 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/qs": {
-      "version": "6.9.7",
-      "license": "MIT"
-    },
-    "node_modules/@types/range-parser": {
-      "version": "1.2.4",
-      "license": "MIT"
+    "node_modules/@types/prettier": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.3.tgz",
+      "integrity": "sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA=="
     },
     "node_modules/@types/secp256k1": {
       "version": "4.0.3",
@@ -3544,13 +3480,145 @@
       "dev": true
     },
     "node_modules/@wormhole-foundation/connect-sdk": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk/-/connect-sdk-0.4.1.tgz",
-      "integrity": "sha512-qbvAWiZiVrJmuoG/z+oxjlaUZfnfyazenTLEbR8x4IyHSJ+yxWRcGUxOiqMXP9yohEawKsIlWxjB13cVX+0PFA==",
+      "version": "0.4.2-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk/-/connect-sdk-0.4.2-beta.0.tgz",
+      "integrity": "sha512-XN08s7vEn8fRlOaGqH7qOocpXvAdTzht/zRXsp9ZiOYHSeg+xyYBjqxfx7kavtK0J3eTbqDEmPP6q+ZZJIrE8w==",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "^0.4.1",
-        "@wormhole-foundation/sdk-definitions": "^0.4.1",
+        "@wormhole-foundation/sdk-base": "^0.4.2-beta.0",
+        "@wormhole-foundation/sdk-definitions": "^0.4.2-beta.0",
         "axios": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@wormhole-foundation/connect-sdk-evm": {
+      "version": "0.4.2-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk-evm/-/connect-sdk-evm-0.4.2-beta.0.tgz",
+      "integrity": "sha512-24QltyDq1dGiDZxR9JLexCKmsZtQtLEanoObTmP3LrdbTRstQ0+8LY7Ye0h0S1+6bqqk/3ppVjsEM1ZUPnMBdQ==",
+      "dependencies": {
+        "@typechain/ethers-v6": "^0.4.0",
+        "@wormhole-foundation/connect-sdk": "^0.4.2-beta.0",
+        "ethers": "^6.5.1",
+        "typechain": "^8.2.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@wormhole-foundation/connect-sdk-evm/node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@wormhole-foundation/connect-sdk-evm/node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@wormhole-foundation/connect-sdk-evm/node_modules/@typechain/ethers-v6": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@typechain/ethers-v6/-/ethers-v6-0.4.3.tgz",
+      "integrity": "sha512-TrxBsyb4ryhaY9keP6RzhFCviWYApcLCIRMPyWaKp2cZZrfaM3QBoxXTnw/eO4+DAY3l+8O0brNW0WgeQeOiDA==",
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "ts-essentials": "^7.0.1"
+      },
+      "peerDependencies": {
+        "ethers": "6.x",
+        "typechain": "^8.3.1",
+        "typescript": ">=4.7.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/connect-sdk-evm/node_modules/aes-js": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="
+    },
+    "node_modules/@wormhole-foundation/connect-sdk-evm/node_modules/ethers": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.11.1.tgz",
+      "integrity": "sha512-mxTAE6wqJQAbp5QAe/+o+rXOID7Nw91OZXvgpjDa1r4fAbq2Nu314oEZSbjoRLacuCzs7kUC3clEvkCQowffGg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/ethers-io/"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.10.1",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@types/node": "18.15.13",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.4.0",
+        "ws": "8.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/connect-sdk-evm/node_modules/typescript": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/@wormhole-foundation/connect-sdk-evm/node_modules/ws": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@wormhole-foundation/connect-sdk-solana": {
+      "version": "0.4.2-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk-solana/-/connect-sdk-solana-0.4.2-beta.0.tgz",
+      "integrity": "sha512-Q7RpKryvEyVLNpeMmy8H9093AHQlI/B4HWgZ28m9S/PSijKcw0mgJZp3eDcN8UMqYLe0grPVP1Kyv7EVaa0yIg==",
+      "dependencies": {
+        "@coral-xyz/borsh": "0.2.6",
+        "@project-serum/anchor": "0.25.0",
+        "@project-serum/borsh": "0.2.5",
+        "@solana/spl-token": "0.3.9",
+        "@solana/web3.js": "1.89.1",
+        "@wormhole-foundation/connect-sdk": "^0.4.2-beta.0",
+        "lodash": "^4.17.21"
       },
       "engines": {
         "node": ">=16"
@@ -3580,20 +3648,20 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-base": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-0.4.1.tgz",
-      "integrity": "sha512-Ahumd2EIPRFWA8hXu76g37qNcUgjzoKLOCyvnveuUMu53Y1YxgGNC4IOQR723+og1+5VZS2SP4rORCX1FUZNpw==",
+      "version": "0.4.2-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-0.4.2-beta.0.tgz",
+      "integrity": "sha512-0kg/IRUI15eGcroiOxB36zHB9iqqOSpj9FA0mBj3FKQQb0+wTQUDApPSHUvVe7WL97XLLI3rvyknzeAIy89QGA==",
       "dependencies": {
         "@scure/base": "^1.1.3"
       }
     },
     "node_modules/@wormhole-foundation/sdk-definitions": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-0.4.1.tgz",
-      "integrity": "sha512-cQxoOO/mKiFAwGQYQ7MZvuMFDsN98rTq1+0/A/VzfnHTkPpWSU4byGpqDYxv2QuVdfx/Pdo476gg0Syap/AYCQ==",
+      "version": "0.4.2-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-0.4.2-beta.0.tgz",
+      "integrity": "sha512-avfZBwo18t8Xwy+iQs4ZwZz1vZed3eblqZVxAFADYHPL/QYLznc86tAUpTStKRRwYKvXhdkEIZ7UmW1e3FefPQ==",
       "dependencies": {
         "@noble/hashes": "^1.3.1",
-        "@wormhole-foundation/sdk-base": "^0.4.1"
+        "@wormhole-foundation/sdk-base": "^0.4.2-beta.0"
       }
     },
     "node_modules/@wormhole-foundation/sdk-definitions/node_modules/@noble/hashes": {
@@ -3697,6 +3765,17 @@
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
       "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw=="
     },
+    "node_modules/agentkeepalive": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.5.0.tgz",
+      "integrity": "sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -3739,29 +3818,6 @@
       },
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "node_modules/algosdk/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
       }
     },
     "node_modules/algosdk/node_modules/cross-fetch": {
@@ -3829,6 +3885,14 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/array-back": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/asn1": {
@@ -4225,7 +4289,9 @@
       }
     },
     "node_modules/buffer": {
-      "version": "6.0.1",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
       "funding": [
         {
           "type": "github",
@@ -4240,7 +4306,6 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
@@ -4400,6 +4465,50 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/command-line-args": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.1.tgz",
+      "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
+      "dependencies": {
+        "array-back": "^3.1.0",
+        "find-replace": "^3.0.0",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/command-line-usage": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.3.tgz",
+      "integrity": "sha512-sH5ZSPr+7UStsloltmDh7Ce5fb8XPlHyoPzTpyyMuYCtervL65+ubVZ6Q61cFtFl62UyJlc8/JwERRbAFPUqgw==",
+      "dependencies": {
+        "array-back": "^4.0.2",
+        "chalk": "^2.4.2",
+        "table-layout": "^1.0.2",
+        "typical": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/array-back": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
+      "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/typical": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/commander": {
@@ -4588,7 +4697,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -4605,6 +4713,14 @@
       "version": "10.3.1",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
       "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ=="
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "engines": {
+        "node": ">=4.0.0"
+      }
     },
     "node_modules/deferred-leveldown": {
       "version": "1.2.2",
@@ -5561,6 +5677,17 @@
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
+    "node_modules/find-replace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
+      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
+      "dependencies": {
+        "array-back": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/follow-redirects": {
       "version": "1.15.5",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
@@ -5601,6 +5728,19 @@
       },
       "engines": {
         "node": ">= 0.12"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
       }
     },
     "node_modules/fs.realpath": {
@@ -5716,6 +5856,11 @@
       "version": "3.21.2",
       "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.2.tgz",
       "integrity": "sha512-3MSOYFO5U9mPGikIYCzK0SaThypfGgS6bHqrUGXG3DPHCrb+txNqeEcns1W0lkGfk0rCyNXm7xB9rMxnCiZOoA=="
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "node_modules/graphql": {
       "version": "16.6.0",
@@ -5886,6 +6031,14 @@
       "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.2.0.tgz",
       "integrity": "sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng=="
     },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "funding": [
@@ -5999,12 +6152,11 @@
       "dev": true
     },
     "node_modules/jayson": {
-      "version": "3.6.4",
-      "license": "MIT",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/jayson/-/jayson-4.1.0.tgz",
+      "integrity": "sha512-R6JlbyLN53Mjku329XoRT2zJAE6ZgOQ8f91ucYdMCD4nkGCF9kZSrcGXpHIU4jeKj58zUZke2p+cdQchU7Ly7A==",
       "dependencies": {
         "@types/connect": "^3.4.33",
-        "@types/express-serve-static-core": "^4.17.9",
-        "@types/lodash": "^4.14.159",
         "@types/node": "^12.12.54",
         "@types/ws": "^7.4.4",
         "commander": "^2.20.3",
@@ -6014,8 +6166,7 @@
         "isomorphic-ws": "^4.0.1",
         "json-stringify-safe": "^5.0.1",
         "JSONStream": "^1.3.5",
-        "lodash": "^4.17.20",
-        "uuid": "^3.4.0",
+        "uuid": "^8.3.2",
         "ws": "^7.4.5"
       },
       "bin": {
@@ -6026,8 +6177,17 @@
       }
     },
     "node_modules/jayson/node_modules/@types/node": {
-      "version": "12.20.16",
-      "license": "MIT"
+      "version": "12.20.55",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="
+    },
+    "node_modules/jayson/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/js-base64": {
       "version": "3.6.1",
@@ -6152,6 +6312,14 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "node_modules/jsonify": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
@@ -6227,29 +6395,6 @@
         "bn.js": "^5.2.0",
         "buffer": "^6.0.3",
         "keccak": "^3.0.2"
-      }
-    },
-    "node_modules/keccak256/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
       }
     },
     "node_modules/level-codec": {
@@ -6397,6 +6542,11 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "license": "MIT"
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -6637,8 +6787,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/mustache": {
       "version": "4.2.0",
@@ -6918,6 +7067,20 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/printj": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/printj/-/printj-1.1.2.tgz",
@@ -7066,6 +7229,14 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/reduce-flatten": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
+      "integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/regenerator-runtime": {
@@ -7336,29 +7507,6 @@
         "buffer": "6.0.3"
       }
     },
-    "node_modules/sha3/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
     "node_modules/shelljs": {
       "version": "0.8.5",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
@@ -7464,6 +7612,11 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/string-format": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/string-format/-/string-format-2.0.0.tgz",
+      "integrity": "sha512-bbEs3scLeYNXLecRRuk6uJxdXUSj6le/8rNPHChIJTn2V79aXVTR1EH2OH5zLKKoz0V02fOUKZZcw01pLUShZA=="
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -7521,6 +7674,36 @@
       "integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==",
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/table-layout": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-1.0.2.tgz",
+      "integrity": "sha512-qd/R7n5rQTRFi+Zf2sk5XVVd9UQl6ZkduPFC3S7WEGJAmetDTjY3qPN50eSKzwuzEyQKy5TN2TiZdkIjos2L6A==",
+      "dependencies": {
+        "array-back": "^4.0.1",
+        "deep-extend": "~0.6.0",
+        "typical": "^5.2.0",
+        "wordwrapjs": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/table-layout/node_modules/array-back": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
+      "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table-layout/node_modules/typical": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/text-encoding-utf-8": {
@@ -7657,6 +7840,62 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
     },
+    "node_modules/ts-command-line-args": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/ts-command-line-args/-/ts-command-line-args-2.5.1.tgz",
+      "integrity": "sha512-H69ZwTw3rFHb5WYpQya40YAX2/w7Ut75uUECbgBIsLmM+BNuYnxsltfyyLMxy6sEeKxgijLTnQtLd0nKd6+IYw==",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "command-line-args": "^5.1.1",
+        "command-line-usage": "^6.1.0",
+        "string-format": "^2.0.0"
+      },
+      "bin": {
+        "write-markdown": "dist/write-markdown.js"
+      }
+    },
+    "node_modules/ts-command-line-args/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ts-command-line-args/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ts-command-line-args/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ts-essentials": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-7.0.3.tgz",
+      "integrity": "sha512-8+gr5+lqO3G84KdiTSMRLtuyJ+nTBVRKuCrK4lidMPdVeEp0uqC875uE5NMcaA7YYMN7XsNiFQuMvasF8HT/xQ==",
+      "peerDependencies": {
+        "typescript": ">=3.7.0"
+      }
+    },
     "node_modules/ts-invariant": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.10.3.tgz",
@@ -7705,6 +7944,29 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/typechain": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/typechain/-/typechain-8.3.2.tgz",
+      "integrity": "sha512-x/sQYr5w9K7yv3es7jo4KTX05CLxOf7TRWwoHlrjRh8H82G64g+k7VuWPJlgMo6qrjfCulOdfBjiaDtmhFYD/Q==",
+      "dependencies": {
+        "@types/prettier": "^2.1.1",
+        "debug": "^4.3.1",
+        "fs-extra": "^7.0.0",
+        "glob": "7.1.7",
+        "js-sha3": "^0.8.0",
+        "lodash": "^4.17.15",
+        "mkdirp": "^1.0.4",
+        "prettier": "^2.3.1",
+        "ts-command-line-args": "^2.2.0",
+        "ts-essentials": "^7.0.1"
+      },
+      "bin": {
+        "typechain": "dist/cli/cli.js"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.3.0"
+      }
+    },
     "node_modules/typeforce": {
       "version": "1.18.0",
       "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
@@ -7714,7 +7976,6 @@
       "version": "4.6.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
       "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
-      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7723,10 +7984,26 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/typical": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/u3": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/u3/-/u3-0.1.1.tgz",
       "integrity": "sha512-+J5D5ir763y+Am/QY6hXNRlwljIeRMZMGs0cT6qqZVVzzT3X3nFPXVyPOFRMOR4kupB0T8JnCdpWdp6Q/iXn3w=="
+    },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
     },
     "node_modules/untildify": {
       "version": "4.0.0",
@@ -7792,6 +8069,7 @@
     },
     "node_modules/uuid": {
       "version": "3.4.0",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "uuid": "bin/uuid"
@@ -7941,6 +8219,26 @@
       "integrity": "sha1-CNP1IFbGZnkplyb63g1DKudLRwQ=",
       "dependencies": {
         "bs58check": "<3.0.0"
+      }
+    },
+    "node_modules/wordwrapjs": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-4.0.1.tgz",
+      "integrity": "sha512-kKlNACbvHrkpIw6oPeYDSmdCTu2hdMHoyXLTcUKala++lx5Y+wjJ/e474Jqv5abnVmwxw08DiTuHmw69lJGksA==",
+      "dependencies": {
+        "reduce-flatten": "^2.0.0",
+        "typical": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/wordwrapjs/node_modules/typical": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrap-ansi": {
@@ -8111,6 +8409,11 @@
     }
   },
   "dependencies": {
+    "@adraffy/ens-normalize": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
+      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw=="
+    },
     "@ampproject/remapping": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
@@ -9997,39 +10300,10 @@
             "@scure/base": "~1.1.0"
           }
         },
-        "@types/node": {
-          "version": "12.20.55",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
-          "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="
-        },
-        "jayson": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/jayson/-/jayson-4.1.0.tgz",
-          "integrity": "sha512-R6JlbyLN53Mjku329XoRT2zJAE6ZgOQ8f91ucYdMCD4nkGCF9kZSrcGXpHIU4jeKj58zUZke2p+cdQchU7Ly7A==",
-          "requires": {
-            "@types/connect": "^3.4.33",
-            "@types/node": "^12.12.54",
-            "@types/ws": "^7.4.4",
-            "commander": "^2.20.3",
-            "delay": "^5.0.0",
-            "es6-promisify": "^5.0.0",
-            "eyes": "^0.1.8",
-            "isomorphic-ws": "^4.0.1",
-            "json-stringify-safe": "^5.0.1",
-            "JSONStream": "^1.3.5",
-            "uuid": "^8.3.2",
-            "ws": "^7.4.5"
-          }
-        },
         "superstruct": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-1.0.3.tgz",
           "integrity": "sha512-8iTn3oSS8nRGn+C2pgXSKPI3jmpm6FExNazNpjvqS6ZUJQCej3PUXEKM8NjHBOs54ExM+LPW/FBRhymrdcCiSg=="
-        },
-        "uuid": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
         }
       }
     },
@@ -10048,11 +10322,6 @@
         }
       }
     },
-    "@noble/ed25519": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.1.tgz",
-      "integrity": "sha512-Rk4SkJFaXZiznFyC/t77Q0NKS4FL7TLJJsVG2V2oiEq3kJVeTdxysEe/yRWSpnWMe808XRDJ+VFh5pt/FN5plw=="
-    },
     "@noble/hashes": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.3.tgz",
@@ -10061,7 +10330,8 @@
     "@noble/secp256k1": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.6.3.tgz",
-      "integrity": "sha512-T04e4iTurVy7I8Sw4+c5OSN9/RkPlo1uKxAomtxQNLq8j1uPAqnsqG1bqvY3Jv7c13gyr6dui0zmh/I3+f/JaQ=="
+      "integrity": "sha512-T04e4iTurVy7I8Sw4+c5OSN9/RkPlo1uKxAomtxQNLq8j1uPAqnsqG1bqvY3Jv7c13gyr6dui0zmh/I3+f/JaQ==",
+      "dev": true
     },
     "@osmonauts/helpers": {
       "version": "0.6.0",
@@ -10507,22 +10777,11 @@
       }
     },
     "@solana/buffer-layout": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/buffer-layout/-/buffer-layout-4.0.0.tgz",
-      "integrity": "sha512-lR0EMP2HC3+Mxwd4YcnZb0smnaDw7Bl2IQWZiTevRH5ZZBZn6VRWn3/92E3qdU4SSImJkA6IDHawOHAnx/qUvQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@solana/buffer-layout/-/buffer-layout-4.0.1.tgz",
+      "integrity": "sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA==",
       "requires": {
         "buffer": "~6.0.3"
-      },
-      "dependencies": {
-        "buffer": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.2.1"
-          }
-        }
       }
     },
     "@solana/buffer-layout-utils": {
@@ -10537,46 +10796,63 @@
       }
     },
     "@solana/spl-token": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.3.5.tgz",
-      "integrity": "sha512-0bGC6n415lGjKu02gkLOIpP1wzndSP0SHwN9PefJ+wKAhmfU1rl3AV1Pa41uap2kzSCD6F9642ngNO8KXPvh/g==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.3.9.tgz",
+      "integrity": "sha512-1EXHxKICMnab35MvvY/5DBc/K/uQAOJCYnDZXw83McCAYUAfi+rwq6qfd6MmITmSTEhcfBcl/zYxmW/OSN0RmA==",
       "requires": {
         "@solana/buffer-layout": "^4.0.0",
         "@solana/buffer-layout-utils": "^0.2.0",
         "buffer": "^6.0.3"
-      },
-      "dependencies": {
-        "buffer": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.2.1"
-          }
-        }
       }
     },
     "@solana/web3.js": {
-      "version": "1.66.2",
-      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.66.2.tgz",
-      "integrity": "sha512-RyaHMR2jGmaesnYP045VLeBGfR/gAW3cvZHzMFGg7bkO+WOYOYp1nEllf0/la4U4qsYGKCsO9eEevR5fhHiVHg==",
+      "version": "1.89.1",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.89.1.tgz",
+      "integrity": "sha512-t9TTLtPQxtQB3SAf/5E8xPXfVDsC6WGOsgKY02l2cbe0HLymT7ynE8Hu48Lk5qynHCquj6nhISfEHcjMkYpu/A==",
       "requires": {
-        "@babel/runtime": "^7.12.5",
-        "@noble/ed25519": "^1.7.0",
-        "@noble/hashes": "^1.1.2",
-        "@noble/secp256k1": "^1.6.3",
-        "@solana/buffer-layout": "^4.0.0",
+        "@babel/runtime": "^7.23.4",
+        "@noble/curves": "^1.2.0",
+        "@noble/hashes": "^1.3.2",
+        "@solana/buffer-layout": "^4.0.1",
+        "agentkeepalive": "^4.5.0",
         "bigint-buffer": "^1.1.5",
-        "bn.js": "^5.0.0",
+        "bn.js": "^5.2.1",
         "borsh": "^0.7.0",
         "bs58": "^4.0.1",
-        "buffer": "6.0.1",
+        "buffer": "6.0.3",
         "fast-stable-stringify": "^1.0.0",
-        "jayson": "^3.4.4",
-        "node-fetch": "2",
-        "rpc-websockets": "^7.5.0",
+        "jayson": "^4.1.0",
+        "node-fetch": "^2.7.0",
+        "rpc-websockets": "^7.5.1",
         "superstruct": "^0.14.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.23.9",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.9.tgz",
+          "integrity": "sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==",
+          "requires": {
+            "regenerator-runtime": "^0.14.0"
+          }
+        },
+        "@noble/curves": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.3.0.tgz",
+          "integrity": "sha512-t01iSXPuN+Eqzb4eBX0S5oubSqXbK/xXa1Ne18Hj8f9pStxztHCE2gfboSp/dZRLSqfuLpRK2nDXDK+W9puocA==",
+          "requires": {
+            "@noble/hashes": "1.3.3"
+          }
+        },
+        "@noble/hashes": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.3.tgz",
+          "integrity": "sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA=="
+        },
+        "regenerator-runtime": {
+          "version": "0.14.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+          "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
+        }
       }
     },
     "@suchipi/femver": {
@@ -10714,14 +10990,6 @@
         "@types/node": "*"
       }
     },
-    "@types/express-serve-static-core": {
-      "version": "4.17.24",
-      "requires": {
-        "@types/node": "*",
-        "@types/qs": "*",
-        "@types/range-parser": "*"
-      }
-    },
     "@types/lodash": {
       "version": "4.14.171"
     },
@@ -10739,9 +11007,9 @@
       "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
     },
     "@types/node": {
-      "version": "18.7.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.6.tgz",
-      "integrity": "sha512-EdxgKRXgYsNITy5mjjXjVE/CS8YENSdhiagGrLqjG0pvA2owgJ6i4l7wy/PFZGC0B1/H20lWKN7ONVDNYDZm7A=="
+      "version": "18.15.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz",
+      "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q=="
     },
     "@types/node-fetch": {
       "version": "2.6.3",
@@ -10774,11 +11042,10 @@
         "@types/node": "*"
       }
     },
-    "@types/qs": {
-      "version": "6.9.7"
-    },
-    "@types/range-parser": {
-      "version": "1.2.4"
+    "@types/prettier": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.3.tgz",
+      "integrity": "sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA=="
     },
     "@types/secp256k1": {
       "version": "4.0.3",
@@ -10810,12 +11077,12 @@
       "dev": true
     },
     "@wormhole-foundation/connect-sdk": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk/-/connect-sdk-0.4.1.tgz",
-      "integrity": "sha512-qbvAWiZiVrJmuoG/z+oxjlaUZfnfyazenTLEbR8x4IyHSJ+yxWRcGUxOiqMXP9yohEawKsIlWxjB13cVX+0PFA==",
+      "version": "0.4.2-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk/-/connect-sdk-0.4.2-beta.0.tgz",
+      "integrity": "sha512-XN08s7vEn8fRlOaGqH7qOocpXvAdTzht/zRXsp9ZiOYHSeg+xyYBjqxfx7kavtK0J3eTbqDEmPP6q+ZZJIrE8w==",
       "requires": {
-        "@wormhole-foundation/sdk-base": "^0.4.1",
-        "@wormhole-foundation/sdk-definitions": "^0.4.1",
+        "@wormhole-foundation/sdk-base": "^0.4.2-beta.0",
+        "@wormhole-foundation/sdk-definitions": "^0.4.2-beta.0",
         "axios": "^1.4.0"
       },
       "dependencies": {
@@ -10841,21 +11108,101 @@
         }
       }
     },
+    "@wormhole-foundation/connect-sdk-evm": {
+      "version": "0.4.2-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk-evm/-/connect-sdk-evm-0.4.2-beta.0.tgz",
+      "integrity": "sha512-24QltyDq1dGiDZxR9JLexCKmsZtQtLEanoObTmP3LrdbTRstQ0+8LY7Ye0h0S1+6bqqk/3ppVjsEM1ZUPnMBdQ==",
+      "requires": {
+        "@typechain/ethers-v6": "^0.4.0",
+        "@wormhole-foundation/connect-sdk": "^0.4.2-beta.0",
+        "ethers": "^6.5.1",
+        "typechain": "^8.2.0"
+      },
+      "dependencies": {
+        "@noble/curves": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+          "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+          "requires": {
+            "@noble/hashes": "1.3.2"
+          }
+        },
+        "@noble/hashes": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+          "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ=="
+        },
+        "@typechain/ethers-v6": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/@typechain/ethers-v6/-/ethers-v6-0.4.3.tgz",
+          "integrity": "sha512-TrxBsyb4ryhaY9keP6RzhFCviWYApcLCIRMPyWaKp2cZZrfaM3QBoxXTnw/eO4+DAY3l+8O0brNW0WgeQeOiDA==",
+          "requires": {
+            "lodash": "^4.17.15",
+            "ts-essentials": "^7.0.1"
+          }
+        },
+        "aes-js": {
+          "version": "4.0.0-beta.5",
+          "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+          "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="
+        },
+        "ethers": {
+          "version": "6.11.1",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.11.1.tgz",
+          "integrity": "sha512-mxTAE6wqJQAbp5QAe/+o+rXOID7Nw91OZXvgpjDa1r4fAbq2Nu314oEZSbjoRLacuCzs7kUC3clEvkCQowffGg==",
+          "requires": {
+            "@adraffy/ens-normalize": "1.10.1",
+            "@noble/curves": "1.2.0",
+            "@noble/hashes": "1.3.2",
+            "@types/node": "18.15.13",
+            "aes-js": "4.0.0-beta.5",
+            "tslib": "2.4.0",
+            "ws": "8.5.0"
+          }
+        },
+        "typescript": {
+          "version": "5.3.3",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+          "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+          "peer": true
+        },
+        "ws": {
+          "version": "8.5.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+          "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+          "requires": {}
+        }
+      }
+    },
+    "@wormhole-foundation/connect-sdk-solana": {
+      "version": "0.4.2-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk-solana/-/connect-sdk-solana-0.4.2-beta.0.tgz",
+      "integrity": "sha512-Q7RpKryvEyVLNpeMmy8H9093AHQlI/B4HWgZ28m9S/PSijKcw0mgJZp3eDcN8UMqYLe0grPVP1Kyv7EVaa0yIg==",
+      "requires": {
+        "@coral-xyz/borsh": "0.2.6",
+        "@project-serum/anchor": "0.25.0",
+        "@project-serum/borsh": "0.2.5",
+        "@solana/spl-token": "0.3.9",
+        "@solana/web3.js": "1.89.1",
+        "@wormhole-foundation/connect-sdk": "^0.4.2-beta.0",
+        "lodash": "^4.17.21"
+      }
+    },
     "@wormhole-foundation/sdk-base": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-0.4.1.tgz",
-      "integrity": "sha512-Ahumd2EIPRFWA8hXu76g37qNcUgjzoKLOCyvnveuUMu53Y1YxgGNC4IOQR723+og1+5VZS2SP4rORCX1FUZNpw==",
+      "version": "0.4.2-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-0.4.2-beta.0.tgz",
+      "integrity": "sha512-0kg/IRUI15eGcroiOxB36zHB9iqqOSpj9FA0mBj3FKQQb0+wTQUDApPSHUvVe7WL97XLLI3rvyknzeAIy89QGA==",
       "requires": {
         "@scure/base": "^1.1.3"
       }
     },
     "@wormhole-foundation/sdk-definitions": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-0.4.1.tgz",
-      "integrity": "sha512-cQxoOO/mKiFAwGQYQ7MZvuMFDsN98rTq1+0/A/VzfnHTkPpWSU4byGpqDYxv2QuVdfx/Pdo476gg0Syap/AYCQ==",
+      "version": "0.4.2-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-0.4.2-beta.0.tgz",
+      "integrity": "sha512-avfZBwo18t8Xwy+iQs4ZwZz1vZed3eblqZVxAFADYHPL/QYLznc86tAUpTStKRRwYKvXhdkEIZ7UmW1e3FefPQ==",
       "requires": {
         "@noble/hashes": "^1.3.1",
-        "@wormhole-foundation/sdk-base": "^0.4.1"
+        "@wormhole-foundation/sdk-base": "^0.4.2-beta.0"
       },
       "dependencies": {
         "@noble/hashes": {
@@ -10945,6 +11292,14 @@
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
       "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw=="
     },
+    "agentkeepalive": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.5.0.tgz",
+      "integrity": "sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==",
+      "requires": {
+        "humanize-ms": "^1.2.1"
+      }
+    },
     "ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -10979,15 +11334,6 @@
         "vlq": "^2.0.4"
       },
       "dependencies": {
-        "buffer": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.2.1"
-          }
-        },
         "cross-fetch": {
           "version": "3.1.8",
           "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
@@ -11043,6 +11389,11 @@
           }
         }
       }
+    },
+    "array-back": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q=="
     },
     "asn1": {
       "version": "0.2.6",
@@ -11370,7 +11721,9 @@
       "dev": true
     },
     "buffer": {
-      "version": "6.0.1",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
       "requires": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
@@ -11498,6 +11851,40 @@
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "requires": {
         "delayed-stream": "~1.0.0"
+      }
+    },
+    "command-line-args": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.1.tgz",
+      "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
+      "requires": {
+        "array-back": "^3.1.0",
+        "find-replace": "^3.0.0",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^4.0.0"
+      }
+    },
+    "command-line-usage": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.3.tgz",
+      "integrity": "sha512-sH5ZSPr+7UStsloltmDh7Ce5fb8XPlHyoPzTpyyMuYCtervL65+ubVZ6Q61cFtFl62UyJlc8/JwERRbAFPUqgw==",
+      "requires": {
+        "array-back": "^4.0.2",
+        "chalk": "^2.4.2",
+        "table-layout": "^1.0.2",
+        "typical": "^5.2.0"
+      },
+      "dependencies": {
+        "array-back": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
+          "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg=="
+        },
+        "typical": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+          "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
+        }
       }
     },
     "commander": {
@@ -11658,7 +12045,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -11667,6 +12053,11 @@
       "version": "10.3.1",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
       "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ=="
+    },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
     },
     "deferred-leveldown": {
       "version": "1.2.2",
@@ -12538,6 +12929,14 @@
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
+    "find-replace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
+      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
+      "requires": {
+        "array-back": "^3.0.1"
+      }
+    },
     "follow-redirects": {
       "version": "1.15.5",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
@@ -12558,6 +12957,16 @@
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
+      }
+    },
+    "fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
       }
     },
     "fs.realpath": {
@@ -12649,6 +13058,11 @@
       "version": "3.21.2",
       "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.2.tgz",
       "integrity": "sha512-3MSOYFO5U9mPGikIYCzK0SaThypfGgS6bHqrUGXG3DPHCrb+txNqeEcns1W0lkGfk0rCyNXm7xB9rMxnCiZOoA=="
+    },
+    "graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "graphql": {
       "version": "16.6.0",
@@ -12778,6 +13192,14 @@
       "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.2.0.tgz",
       "integrity": "sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng=="
     },
+    "humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "requires": {
+        "ms": "^2.0.0"
+      }
+    },
     "ieee754": {
       "version": "1.2.1"
     },
@@ -12856,11 +13278,11 @@
       "dev": true
     },
     "jayson": {
-      "version": "3.6.4",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/jayson/-/jayson-4.1.0.tgz",
+      "integrity": "sha512-R6JlbyLN53Mjku329XoRT2zJAE6ZgOQ8f91ucYdMCD4nkGCF9kZSrcGXpHIU4jeKj58zUZke2p+cdQchU7Ly7A==",
       "requires": {
         "@types/connect": "^3.4.33",
-        "@types/express-serve-static-core": "^4.17.9",
-        "@types/lodash": "^4.14.159",
         "@types/node": "^12.12.54",
         "@types/ws": "^7.4.4",
         "commander": "^2.20.3",
@@ -12870,13 +13292,19 @@
         "isomorphic-ws": "^4.0.1",
         "json-stringify-safe": "^5.0.1",
         "JSONStream": "^1.3.5",
-        "lodash": "^4.17.20",
-        "uuid": "^3.4.0",
+        "uuid": "^8.3.2",
         "ws": "^7.4.5"
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.20.16"
+          "version": "12.20.55",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+          "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
         }
       }
     },
@@ -12985,6 +13413,14 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
       "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA=="
     },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "jsonify": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
@@ -13036,17 +13472,6 @@
         "bn.js": "^5.2.0",
         "buffer": "^6.0.3",
         "keccak": "^3.0.2"
-      },
-      "dependencies": {
-        "buffer": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.2.1"
-          }
-        }
       }
     },
     "level-codec": {
@@ -13187,6 +13612,11 @@
     },
     "lodash": {
       "version": "4.17.21"
+    },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
     },
     "lodash.debounce": {
       "version": "4.0.8",
@@ -13402,8 +13832,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "mustache": {
       "version": "4.2.0",
@@ -13643,6 +14072,11 @@
       "integrity": "sha512-QCYG84SgGyGzqJ/vlMsxeXd/pgL/I94ixdNFyh1PusWmTCyVfPJjZ1K1jvHtsbfnXQs2TSkEP2fR7QiMZAnKFQ==",
       "dev": true
     },
+    "prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="
+    },
     "printj": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/printj/-/printj-1.1.2.tgz",
@@ -13763,6 +14197,11 @@
       "requires": {
         "resolve": "^1.1.6"
       }
+    },
+    "reduce-flatten": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
+      "integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w=="
     },
     "regenerator-runtime": {
       "version": "0.13.11",
@@ -13959,17 +14398,6 @@
       "integrity": "sha512-S8cNxbyb0UGUM2VhRD4Poe5N58gJnJsLJ5vC7FYWGUmGhcsj4++WaIOBFVDxlG0W3To6xBuiRh+i0Qp2oNCOtg==",
       "requires": {
         "buffer": "6.0.3"
-      },
-      "dependencies": {
-        "buffer": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.2.1"
-          }
-        }
       }
     },
     "shelljs": {
@@ -14053,6 +14481,11 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "string-format": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/string-format/-/string-format-2.0.0.tgz",
+      "integrity": "sha512-bbEs3scLeYNXLecRRuk6uJxdXUSj6le/8rNPHChIJTn2V79aXVTR1EH2OH5zLKKoz0V02fOUKZZcw01pLUShZA=="
+    },
     "string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -14094,6 +14527,29 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
       "integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ=="
+    },
+    "table-layout": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-1.0.2.tgz",
+      "integrity": "sha512-qd/R7n5rQTRFi+Zf2sk5XVVd9UQl6ZkduPFC3S7WEGJAmetDTjY3qPN50eSKzwuzEyQKy5TN2TiZdkIjos2L6A==",
+      "requires": {
+        "array-back": "^4.0.1",
+        "deep-extend": "~0.6.0",
+        "typical": "^5.2.0",
+        "wordwrapjs": "^4.0.0"
+      },
+      "dependencies": {
+        "array-back": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
+          "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg=="
+        },
+        "typical": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+          "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
+        }
+      }
     },
     "text-encoding-utf-8": {
       "version": "1.0.2"
@@ -14212,6 +14668,47 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
     },
+    "ts-command-line-args": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/ts-command-line-args/-/ts-command-line-args-2.5.1.tgz",
+      "integrity": "sha512-H69ZwTw3rFHb5WYpQya40YAX2/w7Ut75uUECbgBIsLmM+BNuYnxsltfyyLMxy6sEeKxgijLTnQtLd0nKd6+IYw==",
+      "requires": {
+        "chalk": "^4.1.0",
+        "command-line-args": "^5.1.1",
+        "command-line-usage": "^6.1.0",
+        "string-format": "^2.0.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "ts-essentials": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-7.0.3.tgz",
+      "integrity": "sha512-8+gr5+lqO3G84KdiTSMRLtuyJ+nTBVRKuCrK4lidMPdVeEp0uqC875uE5NMcaA7YYMN7XsNiFQuMvasF8HT/xQ==",
+      "requires": {}
+    },
     "ts-invariant": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.10.3.tgz",
@@ -14247,6 +14744,23 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
       "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="
     },
+    "typechain": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/typechain/-/typechain-8.3.2.tgz",
+      "integrity": "sha512-x/sQYr5w9K7yv3es7jo4KTX05CLxOf7TRWwoHlrjRh8H82G64g+k7VuWPJlgMo6qrjfCulOdfBjiaDtmhFYD/Q==",
+      "requires": {
+        "@types/prettier": "^2.1.1",
+        "debug": "^4.3.1",
+        "fs-extra": "^7.0.0",
+        "glob": "7.1.7",
+        "js-sha3": "^0.8.0",
+        "lodash": "^4.17.15",
+        "mkdirp": "^1.0.4",
+        "prettier": "^2.3.1",
+        "ts-command-line-args": "^2.2.0",
+        "ts-essentials": "^7.0.1"
+      }
+    },
     "typeforce": {
       "version": "1.18.0",
       "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
@@ -14255,13 +14769,22 @@
     "typescript": {
       "version": "4.6.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
-      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
-      "dev": true
+      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw=="
+    },
+    "typical": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw=="
     },
     "u3": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/u3/-/u3-0.1.1.tgz",
       "integrity": "sha512-+J5D5ir763y+Am/QY6hXNRlwljIeRMZMGs0cT6qqZVVzzT3X3nFPXVyPOFRMOR4kupB0T8JnCdpWdp6Q/iXn3w=="
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "untildify": {
       "version": "4.0.0",
@@ -14305,7 +14828,8 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
-      "version": "3.4.0"
+      "version": "3.4.0",
+      "dev": true
     },
     "verror": {
       "version": "1.10.0",
@@ -14447,6 +14971,22 @@
       "integrity": "sha1-CNP1IFbGZnkplyb63g1DKudLRwQ=",
       "requires": {
         "bs58check": "<3.0.0"
+      }
+    },
+    "wordwrapjs": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-4.0.1.tgz",
+      "integrity": "sha512-kKlNACbvHrkpIw6oPeYDSmdCTu2hdMHoyXLTcUKala++lx5Y+wjJ/e474Jqv5abnVmwxw08DiTuHmw69lJGksA==",
+      "requires": {
+        "reduce-flatten": "^2.0.0",
+        "typical": "^5.2.0"
+      },
+      "dependencies": {
+        "typical": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+          "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
+        }
       }
     },
     "wrap-ansi": {

--- a/clients/js/package-lock.json
+++ b/clients/js/package-lock.json
@@ -22,9 +22,9 @@
         "@solana/web3.js": "^1.22.0",
         "@terra-money/terra.js": "^3.1.9",
         "@types/config": "^3.3.0",
-        "@wormhole-foundation/connect-sdk": "^0.4.4-beta.6",
-        "@wormhole-foundation/connect-sdk-evm": "^0.4.4-beta.6",
-        "@wormhole-foundation/connect-sdk-solana": "^0.4.4-beta.6",
+        "@wormhole-foundation/connect-sdk": "^0.4.6",
+        "@wormhole-foundation/connect-sdk-evm": "^0.4.6",
+        "@wormhole-foundation/connect-sdk-solana": "^0.4.6",
         "@xpla/xpla.js": "^0.2.1",
         "algosdk": "^2.4.0",
         "aptos": "^1.3.16",
@@ -3480,12 +3480,12 @@
       "dev": true
     },
     "node_modules/@wormhole-foundation/connect-sdk": {
-      "version": "0.4.4-beta.6",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk/-/connect-sdk-0.4.4-beta.6.tgz",
-      "integrity": "sha512-XxMqXwIZK7oP01uyQdsmoSiKp81nQ+L40AiEsW+/a7qA0WLVX3GPEZmJ3OiVmN1FP5mLX4laIHuqooB2Pt+LZw==",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk/-/connect-sdk-0.4.6.tgz",
+      "integrity": "sha512-b5WAVfQIw7HLTmbGLl71qFHZhV82CKrYiwVAyXgZ0LwyGvbeNBjcuA05M0+mHQyyMHf/B33Wc4lYbESoTd2tWA==",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "0.4.4-beta.6",
-        "@wormhole-foundation/sdk-definitions": "0.4.4-beta.6",
+        "@wormhole-foundation/sdk-base": "0.4.6",
+        "@wormhole-foundation/sdk-definitions": "0.4.6",
         "axios": "^1.4.0"
       },
       "engines": {
@@ -3493,12 +3493,12 @@
       }
     },
     "node_modules/@wormhole-foundation/connect-sdk-evm": {
-      "version": "0.4.4-beta.6",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk-evm/-/connect-sdk-evm-0.4.4-beta.6.tgz",
-      "integrity": "sha512-IU6B3oYR77oLjxSAM7n+Ez6aqAXwzrtDKwODzLyJUHxrDgTkAuFBXD4J0VKwjfBa00Q6B3Y2IwffT9dEtqQk4w==",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk-evm/-/connect-sdk-evm-0.4.6.tgz",
+      "integrity": "sha512-YTZdvFQpV8+YaOpQmlrgsM+U5LFMMyO5u7VtjuDE9gfEX1DK5+OcW17RPqO8GcupAQK7NT39EuMdT9VBKvrEcA==",
       "dependencies": {
         "@typechain/ethers-v6": "^0.4.0",
-        "@wormhole-foundation/connect-sdk": "0.4.4-beta.6",
+        "@wormhole-foundation/connect-sdk": "0.4.6",
         "ethers": "^6.5.1",
         "typechain": "^8.2.0"
       },
@@ -3595,16 +3595,16 @@
       }
     },
     "node_modules/@wormhole-foundation/connect-sdk-solana": {
-      "version": "0.4.4-beta.6",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk-solana/-/connect-sdk-solana-0.4.4-beta.6.tgz",
-      "integrity": "sha512-OVcYzf9k5cEDJSg1SITv6X2aJTPkdAYKZzxQZQfB9m7At9yxU/3Z9p2SvBUEdF4t92Iq8j14iPPReIXYi1KabQ==",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk-solana/-/connect-sdk-solana-0.4.6.tgz",
+      "integrity": "sha512-x0skE7wy33KhUEnWHtv34MmNDL1BsezPhV70yI8ncm7M1BYrIHTtXfkrhB3+5N3CY2GfCMxAoE260Eb8FKH0zg==",
       "dependencies": {
         "@coral-xyz/borsh": "0.2.6",
         "@project-serum/anchor": "0.25.0",
         "@project-serum/borsh": "0.2.5",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "1.89.1",
-        "@wormhole-foundation/connect-sdk": "0.4.4-beta.6"
+        "@wormhole-foundation/connect-sdk": "0.4.6"
       },
       "engines": {
         "node": ">=16"
@@ -3634,20 +3634,20 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-base": {
-      "version": "0.4.4-beta.6",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-0.4.4-beta.6.tgz",
-      "integrity": "sha512-/5yAG66eVpz062YSo2wODWbfsED0xThiCSZhYrjv02fAYwVOCZZlopnL6ks4oxbWAyK5O+ozsI13SMvcrgRSgg==",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-0.4.6.tgz",
+      "integrity": "sha512-IzSCI6/lb2iiaQQ5gVkO+xybeZL0eD1w5tLs06V1BUGDWj2MKWHCsAug9jkYHBxcxnw4yUZGldzPh9DBhG0vmQ==",
       "dependencies": {
         "@scure/base": "^1.1.3"
       }
     },
     "node_modules/@wormhole-foundation/sdk-definitions": {
-      "version": "0.4.4-beta.6",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-0.4.4-beta.6.tgz",
-      "integrity": "sha512-XpqX7fZFQ7rxjARZfFbpXJD0MZSs1txiDYH/Swit8xhTosyRK8qqFDan2QLdLtW1hlNRJBx5TxumuMWwbTy0uw==",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-0.4.6.tgz",
+      "integrity": "sha512-U3agTi424W0Ip0LMIMpgqymBEGj0QFYEhbJ0QT7ktecVXeF1o6c0NvztmYN9IS0nZ5kCgYdhaq4joIg+axtsyQ==",
       "dependencies": {
         "@noble/hashes": "^1.3.1",
-        "@wormhole-foundation/sdk-base": "0.4.4-beta.6"
+        "@wormhole-foundation/sdk-base": "0.4.6"
       }
     },
     "node_modules/@wormhole-foundation/sdk-definitions/node_modules/@noble/hashes": {
@@ -11063,12 +11063,12 @@
       "dev": true
     },
     "@wormhole-foundation/connect-sdk": {
-      "version": "0.4.4-beta.6",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk/-/connect-sdk-0.4.4-beta.6.tgz",
-      "integrity": "sha512-XxMqXwIZK7oP01uyQdsmoSiKp81nQ+L40AiEsW+/a7qA0WLVX3GPEZmJ3OiVmN1FP5mLX4laIHuqooB2Pt+LZw==",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk/-/connect-sdk-0.4.6.tgz",
+      "integrity": "sha512-b5WAVfQIw7HLTmbGLl71qFHZhV82CKrYiwVAyXgZ0LwyGvbeNBjcuA05M0+mHQyyMHf/B33Wc4lYbESoTd2tWA==",
       "requires": {
-        "@wormhole-foundation/sdk-base": "0.4.4-beta.6",
-        "@wormhole-foundation/sdk-definitions": "0.4.4-beta.6",
+        "@wormhole-foundation/sdk-base": "0.4.6",
+        "@wormhole-foundation/sdk-definitions": "0.4.6",
         "axios": "^1.4.0"
       },
       "dependencies": {
@@ -11095,12 +11095,12 @@
       }
     },
     "@wormhole-foundation/connect-sdk-evm": {
-      "version": "0.4.4-beta.6",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk-evm/-/connect-sdk-evm-0.4.4-beta.6.tgz",
-      "integrity": "sha512-IU6B3oYR77oLjxSAM7n+Ez6aqAXwzrtDKwODzLyJUHxrDgTkAuFBXD4J0VKwjfBa00Q6B3Y2IwffT9dEtqQk4w==",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk-evm/-/connect-sdk-evm-0.4.6.tgz",
+      "integrity": "sha512-YTZdvFQpV8+YaOpQmlrgsM+U5LFMMyO5u7VtjuDE9gfEX1DK5+OcW17RPqO8GcupAQK7NT39EuMdT9VBKvrEcA==",
       "requires": {
         "@typechain/ethers-v6": "^0.4.0",
-        "@wormhole-foundation/connect-sdk": "0.4.4-beta.6",
+        "@wormhole-foundation/connect-sdk": "0.4.6",
         "ethers": "^6.5.1",
         "typechain": "^8.2.0"
       },
@@ -11155,33 +11155,33 @@
       }
     },
     "@wormhole-foundation/connect-sdk-solana": {
-      "version": "0.4.4-beta.6",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk-solana/-/connect-sdk-solana-0.4.4-beta.6.tgz",
-      "integrity": "sha512-OVcYzf9k5cEDJSg1SITv6X2aJTPkdAYKZzxQZQfB9m7At9yxU/3Z9p2SvBUEdF4t92Iq8j14iPPReIXYi1KabQ==",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk-solana/-/connect-sdk-solana-0.4.6.tgz",
+      "integrity": "sha512-x0skE7wy33KhUEnWHtv34MmNDL1BsezPhV70yI8ncm7M1BYrIHTtXfkrhB3+5N3CY2GfCMxAoE260Eb8FKH0zg==",
       "requires": {
         "@coral-xyz/borsh": "0.2.6",
         "@project-serum/anchor": "0.25.0",
         "@project-serum/borsh": "0.2.5",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "1.89.1",
-        "@wormhole-foundation/connect-sdk": "0.4.4-beta.6"
+        "@wormhole-foundation/connect-sdk": "0.4.6"
       }
     },
     "@wormhole-foundation/sdk-base": {
-      "version": "0.4.4-beta.6",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-0.4.4-beta.6.tgz",
-      "integrity": "sha512-/5yAG66eVpz062YSo2wODWbfsED0xThiCSZhYrjv02fAYwVOCZZlopnL6ks4oxbWAyK5O+ozsI13SMvcrgRSgg==",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-0.4.6.tgz",
+      "integrity": "sha512-IzSCI6/lb2iiaQQ5gVkO+xybeZL0eD1w5tLs06V1BUGDWj2MKWHCsAug9jkYHBxcxnw4yUZGldzPh9DBhG0vmQ==",
       "requires": {
         "@scure/base": "^1.1.3"
       }
     },
     "@wormhole-foundation/sdk-definitions": {
-      "version": "0.4.4-beta.6",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-0.4.4-beta.6.tgz",
-      "integrity": "sha512-XpqX7fZFQ7rxjARZfFbpXJD0MZSs1txiDYH/Swit8xhTosyRK8qqFDan2QLdLtW1hlNRJBx5TxumuMWwbTy0uw==",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-0.4.6.tgz",
+      "integrity": "sha512-U3agTi424W0Ip0LMIMpgqymBEGj0QFYEhbJ0QT7ktecVXeF1o6c0NvztmYN9IS0nZ5kCgYdhaq4joIg+axtsyQ==",
       "requires": {
         "@noble/hashes": "^1.3.1",
-        "@wormhole-foundation/sdk-base": "0.4.4-beta.6"
+        "@wormhole-foundation/sdk-base": "0.4.6"
       },
       "dependencies": {
         "@noble/hashes": {

--- a/clients/js/package-lock.json
+++ b/clients/js/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@celo-tools/celo-ethers-wrapper": "^0.1.0",
-        "@certusone/wormhole-sdk": "0.10.8",
+        "@certusone/wormhole-sdk": "^0.10.8",
         "@cosmjs/encoding": "^0.26.2",
         "@improbable-eng/grpc-web-node-http-transport": "^0.15.0",
         "@injectivelabs/networks": "^1.10.7",
@@ -22,9 +22,9 @@
         "@solana/web3.js": "^1.22.0",
         "@terra-money/terra.js": "^3.1.9",
         "@types/config": "^3.3.0",
-        "@wormhole-foundation/connect-sdk": "^0.4.4-beta.4",
-        "@wormhole-foundation/connect-sdk-evm": "^0.4.4-beta.4",
-        "@wormhole-foundation/connect-sdk-solana": "^0.4.4-beta.4",
+        "@wormhole-foundation/connect-sdk": "^0.4.4-beta.6",
+        "@wormhole-foundation/connect-sdk-evm": "^0.4.4-beta.6",
+        "@wormhole-foundation/connect-sdk-solana": "^0.4.4-beta.6",
         "@xpla/xpla.js": "^0.2.1",
         "algosdk": "^2.4.0",
         "aptos": "^1.3.16",
@@ -3480,12 +3480,12 @@
       "dev": true
     },
     "node_modules/@wormhole-foundation/connect-sdk": {
-      "version": "0.4.4-beta.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk/-/connect-sdk-0.4.4-beta.4.tgz",
-      "integrity": "sha512-hBxKAPKFzcfYvsIlupPpAOvQB1kA2IN+gqMoiJcr4Ct9+hqmsZs9/Tpd44qBjPObt9WWiRr2abbgGRx3n5UR2w==",
+      "version": "0.4.4-beta.6",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk/-/connect-sdk-0.4.4-beta.6.tgz",
+      "integrity": "sha512-XxMqXwIZK7oP01uyQdsmoSiKp81nQ+L40AiEsW+/a7qA0WLVX3GPEZmJ3OiVmN1FP5mLX4laIHuqooB2Pt+LZw==",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "0.4.4-beta.4",
-        "@wormhole-foundation/sdk-definitions": "0.4.4-beta.4",
+        "@wormhole-foundation/sdk-base": "0.4.4-beta.6",
+        "@wormhole-foundation/sdk-definitions": "0.4.4-beta.6",
         "axios": "^1.4.0"
       },
       "engines": {
@@ -3493,12 +3493,12 @@
       }
     },
     "node_modules/@wormhole-foundation/connect-sdk-evm": {
-      "version": "0.4.4-beta.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk-evm/-/connect-sdk-evm-0.4.4-beta.4.tgz",
-      "integrity": "sha512-JV5q4/K8NMmnhPW8zzeTZELstxEWwsquzaldCF+IG/r2ibGoCgZ1TLMDzrMy8mz9lzityLgwSgUOndLoZbTGBA==",
+      "version": "0.4.4-beta.6",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk-evm/-/connect-sdk-evm-0.4.4-beta.6.tgz",
+      "integrity": "sha512-IU6B3oYR77oLjxSAM7n+Ez6aqAXwzrtDKwODzLyJUHxrDgTkAuFBXD4J0VKwjfBa00Q6B3Y2IwffT9dEtqQk4w==",
       "dependencies": {
         "@typechain/ethers-v6": "^0.4.0",
-        "@wormhole-foundation/connect-sdk": "0.4.4-beta.4",
+        "@wormhole-foundation/connect-sdk": "0.4.4-beta.6",
         "ethers": "^6.5.1",
         "typechain": "^8.2.0"
       },
@@ -3595,16 +3595,16 @@
       }
     },
     "node_modules/@wormhole-foundation/connect-sdk-solana": {
-      "version": "0.4.4-beta.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk-solana/-/connect-sdk-solana-0.4.4-beta.4.tgz",
-      "integrity": "sha512-wUCFvHFWA/HKjKqYEK0hobNGaEDn6dOGqPHzMnbxKwmc3jk/obBPdn6N94QXpQ9P22th//ySEK0a238FwH0Gjw==",
+      "version": "0.4.4-beta.6",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk-solana/-/connect-sdk-solana-0.4.4-beta.6.tgz",
+      "integrity": "sha512-OVcYzf9k5cEDJSg1SITv6X2aJTPkdAYKZzxQZQfB9m7At9yxU/3Z9p2SvBUEdF4t92Iq8j14iPPReIXYi1KabQ==",
       "dependencies": {
         "@coral-xyz/borsh": "0.2.6",
         "@project-serum/anchor": "0.25.0",
         "@project-serum/borsh": "0.2.5",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "1.89.1",
-        "@wormhole-foundation/connect-sdk": "0.4.4-beta.4"
+        "@wormhole-foundation/connect-sdk": "0.4.4-beta.6"
       },
       "engines": {
         "node": ">=16"
@@ -3634,20 +3634,20 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-base": {
-      "version": "0.4.4-beta.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-0.4.4-beta.4.tgz",
-      "integrity": "sha512-Hsd9gBIEpjTZ2ZaFkGfkbUOMV6hNOQGT0zpnIUWOoR1jrtpSpwVEPxolsULnsC+GF2GIC8fA4aekJsb37n+gFw==",
+      "version": "0.4.4-beta.6",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-0.4.4-beta.6.tgz",
+      "integrity": "sha512-/5yAG66eVpz062YSo2wODWbfsED0xThiCSZhYrjv02fAYwVOCZZlopnL6ks4oxbWAyK5O+ozsI13SMvcrgRSgg==",
       "dependencies": {
         "@scure/base": "^1.1.3"
       }
     },
     "node_modules/@wormhole-foundation/sdk-definitions": {
-      "version": "0.4.4-beta.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-0.4.4-beta.4.tgz",
-      "integrity": "sha512-pHPcHhxISFY56ri1+Fn1S9VJgOq8rBdC97LSw7RPTffBwrAi0vb2FT5JWecf8wUh6KVC5nd6hWugxgbNkmMB+A==",
+      "version": "0.4.4-beta.6",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-0.4.4-beta.6.tgz",
+      "integrity": "sha512-XpqX7fZFQ7rxjARZfFbpXJD0MZSs1txiDYH/Swit8xhTosyRK8qqFDan2QLdLtW1hlNRJBx5TxumuMWwbTy0uw==",
       "dependencies": {
         "@noble/hashes": "^1.3.1",
-        "@wormhole-foundation/sdk-base": "0.4.4-beta.4"
+        "@wormhole-foundation/sdk-base": "0.4.4-beta.6"
       }
     },
     "node_modules/@wormhole-foundation/sdk-definitions/node_modules/@noble/hashes": {
@@ -11063,12 +11063,12 @@
       "dev": true
     },
     "@wormhole-foundation/connect-sdk": {
-      "version": "0.4.4-beta.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk/-/connect-sdk-0.4.4-beta.4.tgz",
-      "integrity": "sha512-hBxKAPKFzcfYvsIlupPpAOvQB1kA2IN+gqMoiJcr4Ct9+hqmsZs9/Tpd44qBjPObt9WWiRr2abbgGRx3n5UR2w==",
+      "version": "0.4.4-beta.6",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk/-/connect-sdk-0.4.4-beta.6.tgz",
+      "integrity": "sha512-XxMqXwIZK7oP01uyQdsmoSiKp81nQ+L40AiEsW+/a7qA0WLVX3GPEZmJ3OiVmN1FP5mLX4laIHuqooB2Pt+LZw==",
       "requires": {
-        "@wormhole-foundation/sdk-base": "0.4.4-beta.4",
-        "@wormhole-foundation/sdk-definitions": "0.4.4-beta.4",
+        "@wormhole-foundation/sdk-base": "0.4.4-beta.6",
+        "@wormhole-foundation/sdk-definitions": "0.4.4-beta.6",
         "axios": "^1.4.0"
       },
       "dependencies": {
@@ -11095,12 +11095,12 @@
       }
     },
     "@wormhole-foundation/connect-sdk-evm": {
-      "version": "0.4.4-beta.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk-evm/-/connect-sdk-evm-0.4.4-beta.4.tgz",
-      "integrity": "sha512-JV5q4/K8NMmnhPW8zzeTZELstxEWwsquzaldCF+IG/r2ibGoCgZ1TLMDzrMy8mz9lzityLgwSgUOndLoZbTGBA==",
+      "version": "0.4.4-beta.6",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk-evm/-/connect-sdk-evm-0.4.4-beta.6.tgz",
+      "integrity": "sha512-IU6B3oYR77oLjxSAM7n+Ez6aqAXwzrtDKwODzLyJUHxrDgTkAuFBXD4J0VKwjfBa00Q6B3Y2IwffT9dEtqQk4w==",
       "requires": {
         "@typechain/ethers-v6": "^0.4.0",
-        "@wormhole-foundation/connect-sdk": "0.4.4-beta.4",
+        "@wormhole-foundation/connect-sdk": "0.4.4-beta.6",
         "ethers": "^6.5.1",
         "typechain": "^8.2.0"
       },
@@ -11155,33 +11155,33 @@
       }
     },
     "@wormhole-foundation/connect-sdk-solana": {
-      "version": "0.4.4-beta.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk-solana/-/connect-sdk-solana-0.4.4-beta.4.tgz",
-      "integrity": "sha512-wUCFvHFWA/HKjKqYEK0hobNGaEDn6dOGqPHzMnbxKwmc3jk/obBPdn6N94QXpQ9P22th//ySEK0a238FwH0Gjw==",
+      "version": "0.4.4-beta.6",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk-solana/-/connect-sdk-solana-0.4.4-beta.6.tgz",
+      "integrity": "sha512-OVcYzf9k5cEDJSg1SITv6X2aJTPkdAYKZzxQZQfB9m7At9yxU/3Z9p2SvBUEdF4t92Iq8j14iPPReIXYi1KabQ==",
       "requires": {
         "@coral-xyz/borsh": "0.2.6",
         "@project-serum/anchor": "0.25.0",
         "@project-serum/borsh": "0.2.5",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "1.89.1",
-        "@wormhole-foundation/connect-sdk": "0.4.4-beta.4"
+        "@wormhole-foundation/connect-sdk": "0.4.4-beta.6"
       }
     },
     "@wormhole-foundation/sdk-base": {
-      "version": "0.4.4-beta.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-0.4.4-beta.4.tgz",
-      "integrity": "sha512-Hsd9gBIEpjTZ2ZaFkGfkbUOMV6hNOQGT0zpnIUWOoR1jrtpSpwVEPxolsULnsC+GF2GIC8fA4aekJsb37n+gFw==",
+      "version": "0.4.4-beta.6",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-0.4.4-beta.6.tgz",
+      "integrity": "sha512-/5yAG66eVpz062YSo2wODWbfsED0xThiCSZhYrjv02fAYwVOCZZlopnL6ks4oxbWAyK5O+ozsI13SMvcrgRSgg==",
       "requires": {
         "@scure/base": "^1.1.3"
       }
     },
     "@wormhole-foundation/sdk-definitions": {
-      "version": "0.4.4-beta.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-0.4.4-beta.4.tgz",
-      "integrity": "sha512-pHPcHhxISFY56ri1+Fn1S9VJgOq8rBdC97LSw7RPTffBwrAi0vb2FT5JWecf8wUh6KVC5nd6hWugxgbNkmMB+A==",
+      "version": "0.4.4-beta.6",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-0.4.4-beta.6.tgz",
+      "integrity": "sha512-XpqX7fZFQ7rxjARZfFbpXJD0MZSs1txiDYH/Swit8xhTosyRK8qqFDan2QLdLtW1hlNRJBx5TxumuMWwbTy0uw==",
       "requires": {
         "@noble/hashes": "^1.3.1",
-        "@wormhole-foundation/sdk-base": "0.4.4-beta.4"
+        "@wormhole-foundation/sdk-base": "0.4.4-beta.6"
       },
       "dependencies": {
         "@noble/hashes": {

--- a/clients/js/package-lock.json
+++ b/clients/js/package-lock.json
@@ -22,9 +22,9 @@
         "@solana/web3.js": "^1.22.0",
         "@terra-money/terra.js": "^3.1.9",
         "@types/config": "^3.3.0",
-        "@wormhole-foundation/connect-sdk": "^0.4.2-beta.1",
-        "@wormhole-foundation/connect-sdk-evm": "^0.4.2-beta.1",
-        "@wormhole-foundation/connect-sdk-solana": "^0.4.2-beta.1",
+        "@wormhole-foundation/connect-sdk": "^0.4.4-beta.4",
+        "@wormhole-foundation/connect-sdk-evm": "^0.4.4-beta.4",
+        "@wormhole-foundation/connect-sdk-solana": "^0.4.4-beta.4",
         "@xpla/xpla.js": "^0.2.1",
         "algosdk": "^2.4.0",
         "aptos": "^1.3.16",
@@ -3480,12 +3480,12 @@
       "dev": true
     },
     "node_modules/@wormhole-foundation/connect-sdk": {
-      "version": "0.4.2-beta.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk/-/connect-sdk-0.4.2-beta.1.tgz",
-      "integrity": "sha512-R4oqzksEGRf+4d0iVZ3WuTIyuUs5PGOkhGNQmZUrRz554OCquJbIoixYHHBhy5HF6vzq2p43+9g1I7Gxh/o63g==",
+      "version": "0.4.4-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk/-/connect-sdk-0.4.4-beta.4.tgz",
+      "integrity": "sha512-hBxKAPKFzcfYvsIlupPpAOvQB1kA2IN+gqMoiJcr4Ct9+hqmsZs9/Tpd44qBjPObt9WWiRr2abbgGRx3n5UR2w==",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "^0.4.2-beta.1",
-        "@wormhole-foundation/sdk-definitions": "^0.4.2-beta.1",
+        "@wormhole-foundation/sdk-base": "0.4.4-beta.4",
+        "@wormhole-foundation/sdk-definitions": "0.4.4-beta.4",
         "axios": "^1.4.0"
       },
       "engines": {
@@ -3493,12 +3493,12 @@
       }
     },
     "node_modules/@wormhole-foundation/connect-sdk-evm": {
-      "version": "0.4.2-beta.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk-evm/-/connect-sdk-evm-0.4.2-beta.1.tgz",
-      "integrity": "sha512-Fk6WoLssdRo063z+UEsRZhfWKYOVgJTaidqOXCuN29JKTukKHqXFSGF8gUO5xebMWPUnZdOhfPB9Uertqpcm4Q==",
+      "version": "0.4.4-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk-evm/-/connect-sdk-evm-0.4.4-beta.4.tgz",
+      "integrity": "sha512-JV5q4/K8NMmnhPW8zzeTZELstxEWwsquzaldCF+IG/r2ibGoCgZ1TLMDzrMy8mz9lzityLgwSgUOndLoZbTGBA==",
       "dependencies": {
         "@typechain/ethers-v6": "^0.4.0",
-        "@wormhole-foundation/connect-sdk": "^0.4.2-beta.1",
+        "@wormhole-foundation/connect-sdk": "0.4.4-beta.4",
         "ethers": "^6.5.1",
         "typechain": "^8.2.0"
       },
@@ -3608,17 +3608,16 @@
       }
     },
     "node_modules/@wormhole-foundation/connect-sdk-solana": {
-      "version": "0.4.2-beta.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk-solana/-/connect-sdk-solana-0.4.2-beta.1.tgz",
-      "integrity": "sha512-0i1WtGKGucd8Evxli1Ml9UHps+JWXg4OuzyEC9CjwCROXrd7TcJF6s3KDB7h9xUWBPtp0lC83cB8qW9VPHuMGw==",
+      "version": "0.4.4-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk-solana/-/connect-sdk-solana-0.4.4-beta.4.tgz",
+      "integrity": "sha512-wUCFvHFWA/HKjKqYEK0hobNGaEDn6dOGqPHzMnbxKwmc3jk/obBPdn6N94QXpQ9P22th//ySEK0a238FwH0Gjw==",
       "dependencies": {
         "@coral-xyz/borsh": "0.2.6",
         "@project-serum/anchor": "0.25.0",
         "@project-serum/borsh": "0.2.5",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "1.89.1",
-        "@wormhole-foundation/connect-sdk": "^0.4.2-beta.1",
-        "lodash": "^4.17.21"
+        "@wormhole-foundation/connect-sdk": "0.4.4-beta.4"
       },
       "engines": {
         "node": ">=16"
@@ -3648,20 +3647,20 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-base": {
-      "version": "0.4.2-beta.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-0.4.2-beta.1.tgz",
-      "integrity": "sha512-tm6dmim+1CuCNdArT3O3Ap+H7rwNJN4QiuVe8plhCbjuJQLWIFatlDTKY1UHMOElQjY35Lh1MLpMoYXp4agwXA==",
+      "version": "0.4.4-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-0.4.4-beta.4.tgz",
+      "integrity": "sha512-Hsd9gBIEpjTZ2ZaFkGfkbUOMV6hNOQGT0zpnIUWOoR1jrtpSpwVEPxolsULnsC+GF2GIC8fA4aekJsb37n+gFw==",
       "dependencies": {
         "@scure/base": "^1.1.3"
       }
     },
     "node_modules/@wormhole-foundation/sdk-definitions": {
-      "version": "0.4.2-beta.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-0.4.2-beta.1.tgz",
-      "integrity": "sha512-ThoIBRfoEoPTOYqSHDED8wjHfRdaXexryQJ4fyvgTE9uNKs+N85cIkw5lN44u9mKpEj8UIkC/ashvo4ylrutwg==",
+      "version": "0.4.4-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-0.4.4-beta.4.tgz",
+      "integrity": "sha512-pHPcHhxISFY56ri1+Fn1S9VJgOq8rBdC97LSw7RPTffBwrAi0vb2FT5JWecf8wUh6KVC5nd6hWugxgbNkmMB+A==",
       "dependencies": {
         "@noble/hashes": "^1.3.1",
-        "@wormhole-foundation/sdk-base": "^0.4.2-beta.1"
+        "@wormhole-foundation/sdk-base": "0.4.4-beta.4"
       }
     },
     "node_modules/@wormhole-foundation/sdk-definitions/node_modules/@noble/hashes": {
@@ -11077,12 +11076,12 @@
       "dev": true
     },
     "@wormhole-foundation/connect-sdk": {
-      "version": "0.4.2-beta.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk/-/connect-sdk-0.4.2-beta.1.tgz",
-      "integrity": "sha512-R4oqzksEGRf+4d0iVZ3WuTIyuUs5PGOkhGNQmZUrRz554OCquJbIoixYHHBhy5HF6vzq2p43+9g1I7Gxh/o63g==",
+      "version": "0.4.4-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk/-/connect-sdk-0.4.4-beta.4.tgz",
+      "integrity": "sha512-hBxKAPKFzcfYvsIlupPpAOvQB1kA2IN+gqMoiJcr4Ct9+hqmsZs9/Tpd44qBjPObt9WWiRr2abbgGRx3n5UR2w==",
       "requires": {
-        "@wormhole-foundation/sdk-base": "^0.4.2-beta.1",
-        "@wormhole-foundation/sdk-definitions": "^0.4.2-beta.1",
+        "@wormhole-foundation/sdk-base": "0.4.4-beta.4",
+        "@wormhole-foundation/sdk-definitions": "0.4.4-beta.4",
         "axios": "^1.4.0"
       },
       "dependencies": {
@@ -11109,12 +11108,12 @@
       }
     },
     "@wormhole-foundation/connect-sdk-evm": {
-      "version": "0.4.2-beta.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk-evm/-/connect-sdk-evm-0.4.2-beta.1.tgz",
-      "integrity": "sha512-Fk6WoLssdRo063z+UEsRZhfWKYOVgJTaidqOXCuN29JKTukKHqXFSGF8gUO5xebMWPUnZdOhfPB9Uertqpcm4Q==",
+      "version": "0.4.4-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk-evm/-/connect-sdk-evm-0.4.4-beta.4.tgz",
+      "integrity": "sha512-JV5q4/K8NMmnhPW8zzeTZELstxEWwsquzaldCF+IG/r2ibGoCgZ1TLMDzrMy8mz9lzityLgwSgUOndLoZbTGBA==",
       "requires": {
         "@typechain/ethers-v6": "^0.4.0",
-        "@wormhole-foundation/connect-sdk": "^0.4.2-beta.1",
+        "@wormhole-foundation/connect-sdk": "0.4.4-beta.4",
         "ethers": "^6.5.1",
         "typechain": "^8.2.0"
       },
@@ -11175,34 +11174,33 @@
       }
     },
     "@wormhole-foundation/connect-sdk-solana": {
-      "version": "0.4.2-beta.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk-solana/-/connect-sdk-solana-0.4.2-beta.1.tgz",
-      "integrity": "sha512-0i1WtGKGucd8Evxli1Ml9UHps+JWXg4OuzyEC9CjwCROXrd7TcJF6s3KDB7h9xUWBPtp0lC83cB8qW9VPHuMGw==",
+      "version": "0.4.4-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk-solana/-/connect-sdk-solana-0.4.4-beta.4.tgz",
+      "integrity": "sha512-wUCFvHFWA/HKjKqYEK0hobNGaEDn6dOGqPHzMnbxKwmc3jk/obBPdn6N94QXpQ9P22th//ySEK0a238FwH0Gjw==",
       "requires": {
         "@coral-xyz/borsh": "0.2.6",
         "@project-serum/anchor": "0.25.0",
         "@project-serum/borsh": "0.2.5",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "1.89.1",
-        "@wormhole-foundation/connect-sdk": "^0.4.2-beta.1",
-        "lodash": "^4.17.21"
+        "@wormhole-foundation/connect-sdk": "0.4.4-beta.4"
       }
     },
     "@wormhole-foundation/sdk-base": {
-      "version": "0.4.2-beta.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-0.4.2-beta.1.tgz",
-      "integrity": "sha512-tm6dmim+1CuCNdArT3O3Ap+H7rwNJN4QiuVe8plhCbjuJQLWIFatlDTKY1UHMOElQjY35Lh1MLpMoYXp4agwXA==",
+      "version": "0.4.4-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-0.4.4-beta.4.tgz",
+      "integrity": "sha512-Hsd9gBIEpjTZ2ZaFkGfkbUOMV6hNOQGT0zpnIUWOoR1jrtpSpwVEPxolsULnsC+GF2GIC8fA4aekJsb37n+gFw==",
       "requires": {
         "@scure/base": "^1.1.3"
       }
     },
     "@wormhole-foundation/sdk-definitions": {
-      "version": "0.4.2-beta.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-0.4.2-beta.1.tgz",
-      "integrity": "sha512-ThoIBRfoEoPTOYqSHDED8wjHfRdaXexryQJ4fyvgTE9uNKs+N85cIkw5lN44u9mKpEj8UIkC/ashvo4ylrutwg==",
+      "version": "0.4.4-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-0.4.4-beta.4.tgz",
+      "integrity": "sha512-pHPcHhxISFY56ri1+Fn1S9VJgOq8rBdC97LSw7RPTffBwrAi0vb2FT5JWecf8wUh6KVC5nd6hWugxgbNkmMB+A==",
       "requires": {
         "@noble/hashes": "^1.3.1",
-        "@wormhole-foundation/sdk-base": "^0.4.2-beta.1"
+        "@wormhole-foundation/sdk-base": "0.4.4-beta.4"
       },
       "dependencies": {
         "@noble/hashes": {

--- a/clients/js/package-lock.json
+++ b/clients/js/package-lock.json
@@ -22,9 +22,7 @@
         "@solana/web3.js": "^1.22.0",
         "@terra-money/terra.js": "^3.1.9",
         "@types/config": "^3.3.0",
-        "@wormhole-foundation/connect-sdk": "^0.4.6",
-        "@wormhole-foundation/connect-sdk-evm": "^0.4.6",
-        "@wormhole-foundation/connect-sdk-solana": "^0.4.6",
+        "@wormhole-foundation/sdk": "^0.5.0-beta.4",
         "@xpla/xpla.js": "^0.2.1",
         "algosdk": "^2.4.0",
         "aptos": "^1.3.16",
@@ -54,6 +52,19 @@
         "@types/yargs": "^17.0.24",
         "copy-dir": "^1.3.0",
         "typescript": "^5.3"
+      }
+    },
+    "node_modules/@0no-co/graphql.web": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.0.4.tgz",
+      "integrity": "sha512-W3ezhHGfO0MS1PtGloaTpg0PbaT8aZSmmaerL7idtU5F7oCI+uu25k+MsMS31BVFlp4aMkHSrNRxiD72IlK8TA==",
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+      },
+      "peerDependenciesMeta": {
+        "graphql": {
+          "optional": true
+        }
       }
     },
     "node_modules/@adraffy/ens-normalize": {
@@ -840,6 +851,16 @@
       "version": "0.29.5",
       "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.29.5.tgz",
       "integrity": "sha512-m7h+RXDUxOzEOGt4P+3OVPX7PuakZT3GBmaM/Y2u+abN3xZkziykD/NvedYFvvCCdQo714XcGl33bwifS9FZPQ=="
+    },
+    "node_modules/@ensdomains/ens-validation": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@ensdomains/ens-validation/-/ens-validation-0.1.0.tgz",
+      "integrity": "sha512-rbDh2K6GfqXvBcJUISaTTYEt3f079WA4ohTE5Lh4/8EaaPAk/9vk3EisMUQV2UVxeFIZQEEyRCIOmRTpqN0W7A=="
+    },
+    "node_modules/@ensdomains/eth-ens-namehash": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@ensdomains/eth-ens-namehash/-/eth-ens-namehash-2.0.15.tgz",
+      "integrity": "sha512-JRDFP6+Hczb1E0/HhIg0PONgBYasfGfDheujmfxaZaAv/NAH4jE6Kf48WbqfRZdxt4IZI3jl3Ri7sZ1nP09lgw=="
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.17.18",
@@ -1880,12 +1901,21 @@
         "@ethersproject/strings": "^5.7.0"
       }
     },
+    "node_modules/@gql.tada/cli-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@gql.tada/cli-utils/-/cli-utils-0.1.0.tgz",
+      "integrity": "sha512-hM1u0eZlCBuMQ26q3D/dzbsdEK98pbhhJLLa3xJWGLHmsRiySijyoKTIMrBhdqV2v5LvQP2dX/6k1rvQt2Mvhg==",
+      "dependencies": {
+        "@urql/introspection": "^1.0.3",
+        "graphql": "^16.8.1"
+      }
+    },
     "node_modules/@graphql-typed-document-node/core": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.1.tgz",
-      "integrity": "sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
       "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@improbable-eng/grpc-web": {
@@ -1946,14 +1976,53 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/@injectivelabs/dmm-proto-ts": {
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/dmm-proto-ts/-/dmm-proto-ts-1.0.19.tgz",
+      "integrity": "sha512-2FCzCziy1RhzmnkAVIU+Asby/GXAVQqKt5/o1s52j0LJXfJMpiCrV6soLfnjTebj61T+1WvJBPFoZCCiVYBpcw==",
+      "dependencies": {
+        "@injectivelabs/grpc-web": "^0.0.1",
+        "google-protobuf": "^3.14.0",
+        "protobufjs": "^7.0.0",
+        "rxjs": "^7.4.0"
+      }
+    },
+    "node_modules/@injectivelabs/dmm-proto-ts/node_modules/long": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+    },
+    "node_modules/@injectivelabs/dmm-proto-ts/node_modules/protobufjs": {
+      "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz",
+      "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/@injectivelabs/exceptions": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/exceptions/-/exceptions-1.11.0.tgz",
-      "integrity": "sha512-jZ0N4cP1KCyErNEiCARaKt70E8KMTNa9R4a5FrCERX4cFKPxdbWpoQ8Lqga2jfHAgiFcChRJ5JmaSYclFtKf9w==",
+      "version": "1.14.6",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/exceptions/-/exceptions-1.14.6.tgz",
+      "integrity": "sha512-A+URJwygeDjFPhulGMNVw70z738NtpIiCr0W8q4Kr4Ggg30i+AaVAjViYLm56pSMXXpomu9CYJ/sY6ijQn48IQ==",
       "hasInstallScript": true,
       "dependencies": {
         "@injectivelabs/grpc-web": "^0.0.1",
-        "@injectivelabs/ts-types": "^1.11.0",
+        "@injectivelabs/ts-types": "^1.14.6",
         "http-status-codes": "^2.2.0",
         "link-module-alias": "^1.2.0",
         "shx": "^0.3.2"
@@ -2297,9 +2366,9 @@
       }
     },
     "node_modules/@injectivelabs/test-utils": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/test-utils/-/test-utils-1.11.0.tgz",
-      "integrity": "sha512-/KIPGeLFsjITs43yQG++SoOtDExZr+Pa3JVYIZEIMFUVG8a7z9Vi5m6a1kbowvozZbLG5KHuuUXF2SdfKSxznQ==",
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/test-utils/-/test-utils-1.14.4.tgz",
+      "integrity": "sha512-M7UoB5CIVVN7BtdmU26GwZsWKp0BQg9qV5a+YvcdhlwlSIkvt3gKVKBMq/vKClCakOu2AjhCVGDMZVnagIBogg==",
       "hasInstallScript": true,
       "dependencies": {
         "axios": "^0.21.1",
@@ -2319,15 +2388,15 @@
       }
     },
     "node_modules/@injectivelabs/token-metadata": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/token-metadata/-/token-metadata-1.11.0.tgz",
-      "integrity": "sha512-RzwJvnjDX8IwXYTvZDCMQcGxkN/0ZfXUEYTVMB0WMU0bRH7cV7WJ6Z9UDOijAehrJHu/fByDz2DuEOcktbwoIw==",
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/token-metadata/-/token-metadata-1.14.7.tgz",
+      "integrity": "sha512-RRRuyirzoThwQ5P8D3STH2YOavGsdnetQy6ZPQ8yA7VUavt00KBB26M92zSLbiUz5VrxhPHDCEEkuJVWx+xtmw==",
       "hasInstallScript": true,
       "dependencies": {
-        "@injectivelabs/exceptions": "^1.11.0",
-        "@injectivelabs/networks": "^1.11.0",
-        "@injectivelabs/ts-types": "^1.11.0",
-        "@injectivelabs/utils": "^1.11.0",
+        "@injectivelabs/exceptions": "^1.14.6",
+        "@injectivelabs/networks": "^1.14.6",
+        "@injectivelabs/ts-types": "^1.14.6",
+        "@injectivelabs/utils": "^1.14.6",
         "@types/lodash.values": "^4.3.6",
         "copyfiles": "^2.4.1",
         "jsonschema": "^1.4.0",
@@ -2338,26 +2407,26 @@
       }
     },
     "node_modules/@injectivelabs/token-metadata/node_modules/@injectivelabs/networks": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/networks/-/networks-1.11.0.tgz",
-      "integrity": "sha512-0dtO/zZ8AzsxGInEWZ7tpOA0Q++M3FhAFxOWzhYC39ZeJlwHhEcYmvmhrGG5gRdus29XfFysRlaz3hyT3XH1Jg==",
+      "version": "1.14.6",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/networks/-/networks-1.14.6.tgz",
+      "integrity": "sha512-O1IkPFJl8ThNL6N+k/9OimrgCYsSWQ8A1FtVMXSQge+0QRZsDKSpRmQRwE601otXXauO31nOUct5AaiWPffXVQ==",
       "hasInstallScript": true,
       "dependencies": {
-        "@injectivelabs/exceptions": "^1.11.0",
-        "@injectivelabs/ts-types": "^1.11.0",
-        "@injectivelabs/utils": "^1.11.0",
+        "@injectivelabs/exceptions": "^1.14.6",
+        "@injectivelabs/ts-types": "^1.14.6",
+        "@injectivelabs/utils": "^1.14.6",
         "link-module-alias": "^1.2.0",
         "shx": "^0.3.2"
       }
     },
     "node_modules/@injectivelabs/token-metadata/node_modules/@injectivelabs/utils": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/utils/-/utils-1.11.0.tgz",
-      "integrity": "sha512-KnUmt4vIvoBz6F3mQomy4GeTkpcHMYwju2AgiqzARrrqgF/2p1ZHfKBpr1ksj/jkl5X+irh3JVfbd/dFjwKi1g==",
+      "version": "1.14.6",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/utils/-/utils-1.14.6.tgz",
+      "integrity": "sha512-5I0h4GiLB5PPTl+g2lpevRP+WScvEbntdkoUQVtAdHewl4kutd5p1Kcnoi1Nvpq+sz5N/e9qtBIRuyxG38akOg==",
       "hasInstallScript": true,
       "dependencies": {
-        "@injectivelabs/exceptions": "^1.11.0",
-        "@injectivelabs/ts-types": "^1.11.0",
+        "@injectivelabs/exceptions": "^1.14.6",
+        "@injectivelabs/ts-types": "^1.14.6",
         "axios": "^0.21.1",
         "bignumber.js": "^9.0.1",
         "http-status-codes": "^2.2.0",
@@ -2376,9 +2445,9 @@
       }
     },
     "node_modules/@injectivelabs/ts-types": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/ts-types/-/ts-types-1.11.0.tgz",
-      "integrity": "sha512-3ZVRW1xMe3RHOxFblRC0LgQcU/rpxgZQZ+sISyRKFGcS/m2ApkdmcPvjMgd5TQe9AXW/6nnvmul3mST8iAaUJg==",
+      "version": "1.14.6",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/ts-types/-/ts-types-1.14.6.tgz",
+      "integrity": "sha512-/Ax5eCSfE9OhcyUc9wZk/LFKTYhIY9RJIaNT/n92rbHjXSfXRLSX+Bvk62vC9Ej+SEBPp77WYngtrePPA1HEgw==",
       "hasInstallScript": true,
       "dependencies": {
         "link-module-alias": "^1.2.0",
@@ -3479,26 +3548,1088 @@
       "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==",
       "dev": true
     },
-    "node_modules/@wormhole-foundation/connect-sdk": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk/-/connect-sdk-0.4.6.tgz",
-      "integrity": "sha512-b5WAVfQIw7HLTmbGLl71qFHZhV82CKrYiwVAyXgZ0LwyGvbeNBjcuA05M0+mHQyyMHf/B33Wc4lYbESoTd2tWA==",
+    "node_modules/@urql/introspection": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@urql/introspection/-/introspection-1.0.3.tgz",
+      "integrity": "sha512-5zgnfUDV10c3qudqYvfZ/rOtWVB2QvqanmoDMttqpt+TCCPkSUZdb2qcLCEB6DL7ph8mQRTZhXI29J57nTnqKg==",
+      "peerDependencies": {
+        "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-0.5.0-beta.4.tgz",
+      "integrity": "sha512-nAFsih7Ob8mvn86cWzxaamRcuMTDOMt877Qiq9RoXy5xHgt7XgLOzWfy29kbIgPtk7TOpRavi3YHhVNOT1kkMg==",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "0.4.6",
-        "@wormhole-foundation/sdk-definitions": "0.4.6",
+        "@wormhole-foundation/sdk-algorand": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-algorand-core": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-algorand-tokenbridge": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-aptos": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-aptos-core": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-aptos-tokenbridge": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-base": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-connect": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-cosmwasm": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-cosmwasm-core": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-cosmwasm-ibc": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-definitions": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-evm": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-evm-cctp": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-evm-core": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-evm-portico": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-solana": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-solana-cctp": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-solana-core": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-solana-tokenbridge": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-sui": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-sui-core": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-sui-tokenbridge": "0.5.0-beta.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-algorand": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-0.5.0-beta.4.tgz",
+      "integrity": "sha512-L+FlTHFktv5YZaBC0exaajpvjbo1O2Xn7MzNZfNwiasQmrhRsLc3To5MjMVrWGUaldKVviMBdgzzKtllHiCbcw==",
+      "dependencies": {
+        "@wormhole-foundation/sdk-connect": "0.5.0-beta.4",
+        "algosdk": "2.7.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-algorand-core": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-0.5.0-beta.4.tgz",
+      "integrity": "sha512-fc/ktKfEw9IxLLGvap9yTMMqHrhgsGHaDX5Xk+wqyYn06VHcZiYnIaKdcNHVguZdqp6fL1pt4yWqipUeZhC3Jg==",
+      "dependencies": {
+        "@wormhole-foundation/sdk-algorand": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-connect": "0.5.0-beta.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-algorand-tokenbridge": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-0.5.0-beta.4.tgz",
+      "integrity": "sha512-pUBkxT0/zXltYnFgHcPPKiO6KfSnDL9KwRGptRKzOgf00YI5fuhm4f/nIUEgMkXrvLi29JsAxmr03e84+zKF8A==",
+      "dependencies": {
+        "@wormhole-foundation/sdk-algorand": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-algorand-core": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-connect": "0.5.0-beta.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-aptos": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-0.5.0-beta.4.tgz",
+      "integrity": "sha512-q8NPKbx/AZArjlGzUq+t5ORzd55DaU+WN3+76ahY11X3wPeFG3Hs3Vy6F07oz+8+wBP1Ks4R3t1qK6zTBGeGHA==",
+      "dependencies": {
+        "@wormhole-foundation/sdk-connect": "0.5.0-beta.4",
+        "aptos": "1.5.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-aptos-core": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-0.5.0-beta.4.tgz",
+      "integrity": "sha512-A5zHVnVF60e/L3PexkT7kgBvYki3Q9nvv8dxEi6vzaqfhQG7JrLbIxrj/zN1g0enxofsrgkARhuAX/beSV/+Wg==",
+      "dependencies": {
+        "@wormhole-foundation/sdk-aptos": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-connect": "0.5.0-beta.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-aptos-tokenbridge": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-0.5.0-beta.4.tgz",
+      "integrity": "sha512-MPJc0RdWUuYjmWdLlcUdJ1YTUUpUg/d3uuOmpuW1CaWsyuvRPsdYpTwy067irjHDFEzWQZai/T82VG1Y832LjQ==",
+      "dependencies": {
+        "@wormhole-foundation/sdk-aptos": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-aptos-core": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-connect": "0.5.0-beta.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-base": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-0.5.0-beta.4.tgz",
+      "integrity": "sha512-uTICIlbh0RkyHgrFdzEdVkc4YPqKtSXo4wxL83TY1XhEpbuq/UTIyr8q4Mp9AOPT5AnNSlY9ZwqUTDu5q+bY2Q==",
+      "dependencies": {
+        "@scure/base": "^1.1.3"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-connect": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-0.5.0-beta.4.tgz",
+      "integrity": "sha512-+FNedvFvEHCdp3Mm3rDPs91q4V7W9yl94Y4baVcbbHFXy5dgUpNgkiHhIrNb2bXAQeIhMpYxJVEEn9XQhFiDsQ==",
+      "dependencies": {
+        "@wormhole-foundation/sdk-base": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-definitions": "0.5.0-beta.4",
         "axios": "^1.4.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
-    "node_modules/@wormhole-foundation/connect-sdk-evm": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk-evm/-/connect-sdk-evm-0.4.6.tgz",
-      "integrity": "sha512-YTZdvFQpV8+YaOpQmlrgsM+U5LFMMyO5u7VtjuDE9gfEX1DK5+OcW17RPqO8GcupAQK7NT39EuMdT9VBKvrEcA==",
+    "node_modules/@wormhole-foundation/sdk-connect/node_modules/axios": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+      "dependencies": {
+        "follow-redirects": "^1.15.4",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-connect/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-0.5.0-beta.4.tgz",
+      "integrity": "sha512-kscEPFI9n01aU7z1I9qKQtJSv6GfD8lFl3I5zRji0wTbhkyQ9tSN/OfBlfRl4TApdlgh4b8pCIEIs6y6fazByA==",
+      "dependencies": {
+        "@cosmjs/cosmwasm-stargate": "^0.32.0",
+        "@cosmjs/crypto": "^0.32.0",
+        "@cosmjs/proto-signing": "^0.32.0",
+        "@cosmjs/stargate": "^0.32.0",
+        "@cosmjs/tendermint-rpc": "^0.32.0",
+        "@injectivelabs/sdk-ts": "^1.14.4",
+        "@wormhole-foundation/sdk-connect": "0.5.0-beta.4",
+        "cosmjs-types": "^0.9.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm-core": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-0.5.0-beta.4.tgz",
+      "integrity": "sha512-Ow7/suQqADJXJz7zibMl9EEKKcaxjT4CeV65pjjjjIOOOIvBjxN6ZwRMkJpi7cRdvbzJU2z4bdl6jPJ1o7hoPw==",
+      "dependencies": {
+        "@cosmjs/cosmwasm-stargate": "^0.32.0",
+        "@cosmjs/stargate": "^0.32.0",
+        "@wormhole-foundation/sdk-connect": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-cosmwasm": "0.5.0-beta.4",
+        "cosmjs-types": "^0.9.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@cosmjs/amino": {
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.32.2.tgz",
+      "integrity": "sha512-lcK5RCVm4OfdAooxKcF2+NwaDVVpghOq6o/A40c2mHXDUzUoRZ33VAHjVJ9Me6vOFxshrw/XEFn1f4KObntjYA==",
+      "dependencies": {
+        "@cosmjs/crypto": "^0.32.2",
+        "@cosmjs/encoding": "^0.32.2",
+        "@cosmjs/math": "^0.32.2",
+        "@cosmjs/utils": "^0.32.2"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@cosmjs/cosmwasm-stargate": {
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/cosmwasm-stargate/-/cosmwasm-stargate-0.32.2.tgz",
+      "integrity": "sha512-OwJHzIx2CoJS6AULxOpNR6m+CI0GXxy8z9svHA1ZawzNM3ZGlL0GvHdhmF0WkpX4E7UdrYlJSLpKcgg5Fo6i7Q==",
+      "dependencies": {
+        "@cosmjs/amino": "^0.32.2",
+        "@cosmjs/crypto": "^0.32.2",
+        "@cosmjs/encoding": "^0.32.2",
+        "@cosmjs/math": "^0.32.2",
+        "@cosmjs/proto-signing": "^0.32.2",
+        "@cosmjs/stargate": "^0.32.2",
+        "@cosmjs/tendermint-rpc": "^0.32.2",
+        "@cosmjs/utils": "^0.32.2",
+        "cosmjs-types": "^0.9.0",
+        "pako": "^2.0.2"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@cosmjs/crypto": {
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.32.2.tgz",
+      "integrity": "sha512-RuxrYKzhrPF9g6NmU7VEq++Hn1vZJjqqJpZ9Tmw9lOYOV8BUsv+j/0BE86kmWi7xVJ7EwxiuxYsKuM8IR18CIA==",
+      "dependencies": {
+        "@cosmjs/encoding": "^0.32.2",
+        "@cosmjs/math": "^0.32.2",
+        "@cosmjs/utils": "^0.32.2",
+        "@noble/hashes": "^1",
+        "bn.js": "^5.2.0",
+        "elliptic": "^6.5.4",
+        "libsodium-wrappers-sumo": "^0.7.11"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@cosmjs/encoding": {
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.32.2.tgz",
+      "integrity": "sha512-WX7m1wLpA9V/zH0zRcz4EmgZdAv1F44g4dbXOgNj1eXZw1PIGR12p58OEkLN51Ha3S4DKRtCv5CkhK1KHEvQtg==",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "bech32": "^1.1.4",
+        "readonly-date": "^1.0.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@cosmjs/json-rpc": {
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.32.2.tgz",
+      "integrity": "sha512-lan2lOgmz4yVE/HR8eCOSiII/1OudIulk8836koyIDCsPEpt6eKBuctnAD168vABGArKccLAo7Mr2gy9nrKrOQ==",
+      "dependencies": {
+        "@cosmjs/stream": "^0.32.2",
+        "xstream": "^11.14.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@cosmjs/math": {
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.32.2.tgz",
+      "integrity": "sha512-b8+ruAAY8aKtVKWSft2IvtCVCUH1LigIlf9ALIiY8n9jtM4kMASiaRbQ/27etnSAInV88IaezKK9rQZrtxTjcw==",
+      "dependencies": {
+        "bn.js": "^5.2.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@cosmjs/proto-signing": {
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.32.2.tgz",
+      "integrity": "sha512-UV4WwkE3W3G3s7wwU9rizNcUEz2g0W8jQZS5J6/3fiN0mRPwtPKQ6EinPN9ASqcAJ7/VQH4/9EPOw7d6XQGnqw==",
+      "dependencies": {
+        "@cosmjs/amino": "^0.32.2",
+        "@cosmjs/crypto": "^0.32.2",
+        "@cosmjs/encoding": "^0.32.2",
+        "@cosmjs/math": "^0.32.2",
+        "@cosmjs/utils": "^0.32.2",
+        "cosmjs-types": "^0.9.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@cosmjs/socket": {
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.32.2.tgz",
+      "integrity": "sha512-Qc8jaw4uSBJm09UwPgkqe3g9TBFx4ZR9HkXpwT6Z9I+6kbLerXPR0Gy3NSJFSUgxIfTpO8O1yqoWAyf0Ay17Mw==",
+      "dependencies": {
+        "@cosmjs/stream": "^0.32.2",
+        "isomorphic-ws": "^4.0.1",
+        "ws": "^7",
+        "xstream": "^11.14.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@cosmjs/stargate": {
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.32.2.tgz",
+      "integrity": "sha512-AsJa29fT7Jd4xt9Ai+HMqhyj7UQu7fyYKdXj/8+/9PD74xe6lZSYhQPcitUmMLJ1ckKPgXSk5Dd2LbsQT0IhZg==",
+      "dependencies": {
+        "@confio/ics23": "^0.6.8",
+        "@cosmjs/amino": "^0.32.2",
+        "@cosmjs/encoding": "^0.32.2",
+        "@cosmjs/math": "^0.32.2",
+        "@cosmjs/proto-signing": "^0.32.2",
+        "@cosmjs/stream": "^0.32.2",
+        "@cosmjs/tendermint-rpc": "^0.32.2",
+        "@cosmjs/utils": "^0.32.2",
+        "cosmjs-types": "^0.9.0",
+        "xstream": "^11.14.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@cosmjs/stream": {
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.32.2.tgz",
+      "integrity": "sha512-gpCufLfHAD8Zp1ZKge7AHbDf4RA0TZp66wZY6JaQR5bSiEF2Drjtp4mwXZPGejtaUMnaAgff3LrUzPJfKYdQwg==",
+      "dependencies": {
+        "xstream": "^11.14.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@cosmjs/tendermint-rpc": {
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.32.2.tgz",
+      "integrity": "sha512-DXyJHDmcAfCix4H/7/dKR0UMdshP01KxJOXHdHxBCbLIpck94BsWD3B2ZTXwfA6sv98so9wOzhp7qGQa5malxg==",
+      "dependencies": {
+        "@cosmjs/crypto": "^0.32.2",
+        "@cosmjs/encoding": "^0.32.2",
+        "@cosmjs/json-rpc": "^0.32.2",
+        "@cosmjs/math": "^0.32.2",
+        "@cosmjs/socket": "^0.32.2",
+        "@cosmjs/stream": "^0.32.2",
+        "@cosmjs/utils": "^0.32.2",
+        "axios": "^1.6.0",
+        "readonly-date": "^1.0.0",
+        "xstream": "^11.14.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@cosmjs/utils": {
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.32.2.tgz",
+      "integrity": "sha512-Gg5t+eR7vPJMAmhkFt6CZrzPd0EKpAslWwk5rFVYZpJsM8JG5KT9XQ99hgNM3Ov6ScNoIWbXkpX27F6A9cXR4Q=="
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/axios": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+      "dependencies": {
+        "follow-redirects": "^1.15.4",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/cosmjs-types": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.9.0.tgz",
+      "integrity": "sha512-MN/yUe6mkJwHnCFfsNPeCfXVhyxHYW6c/xDUzrSbBycYzw++XvWDMJArXp2pLdgD6FQ8DW79vkPjeNKVrXaHeQ=="
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-0.5.0-beta.4.tgz",
+      "integrity": "sha512-Bon7VNhrcksb9ynxIwMcPK5K/j+q2UjBZA6zEDFJNGhVg02GivwFd/6mfHReVEi6AwgudPkzJuK6V5gMuuYC6A==",
+      "dependencies": {
+        "@cosmjs/cosmwasm-stargate": "^0.32.0",
+        "@cosmjs/stargate": "^0.32.0",
+        "@wormhole-foundation/sdk-connect": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-cosmwasm": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-cosmwasm-core": "0.5.0-beta.4",
+        "cosmjs-types": "^0.9.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@cosmjs/amino": {
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.32.2.tgz",
+      "integrity": "sha512-lcK5RCVm4OfdAooxKcF2+NwaDVVpghOq6o/A40c2mHXDUzUoRZ33VAHjVJ9Me6vOFxshrw/XEFn1f4KObntjYA==",
+      "dependencies": {
+        "@cosmjs/crypto": "^0.32.2",
+        "@cosmjs/encoding": "^0.32.2",
+        "@cosmjs/math": "^0.32.2",
+        "@cosmjs/utils": "^0.32.2"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@cosmjs/cosmwasm-stargate": {
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/cosmwasm-stargate/-/cosmwasm-stargate-0.32.2.tgz",
+      "integrity": "sha512-OwJHzIx2CoJS6AULxOpNR6m+CI0GXxy8z9svHA1ZawzNM3ZGlL0GvHdhmF0WkpX4E7UdrYlJSLpKcgg5Fo6i7Q==",
+      "dependencies": {
+        "@cosmjs/amino": "^0.32.2",
+        "@cosmjs/crypto": "^0.32.2",
+        "@cosmjs/encoding": "^0.32.2",
+        "@cosmjs/math": "^0.32.2",
+        "@cosmjs/proto-signing": "^0.32.2",
+        "@cosmjs/stargate": "^0.32.2",
+        "@cosmjs/tendermint-rpc": "^0.32.2",
+        "@cosmjs/utils": "^0.32.2",
+        "cosmjs-types": "^0.9.0",
+        "pako": "^2.0.2"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@cosmjs/crypto": {
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.32.2.tgz",
+      "integrity": "sha512-RuxrYKzhrPF9g6NmU7VEq++Hn1vZJjqqJpZ9Tmw9lOYOV8BUsv+j/0BE86kmWi7xVJ7EwxiuxYsKuM8IR18CIA==",
+      "dependencies": {
+        "@cosmjs/encoding": "^0.32.2",
+        "@cosmjs/math": "^0.32.2",
+        "@cosmjs/utils": "^0.32.2",
+        "@noble/hashes": "^1",
+        "bn.js": "^5.2.0",
+        "elliptic": "^6.5.4",
+        "libsodium-wrappers-sumo": "^0.7.11"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@cosmjs/encoding": {
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.32.2.tgz",
+      "integrity": "sha512-WX7m1wLpA9V/zH0zRcz4EmgZdAv1F44g4dbXOgNj1eXZw1PIGR12p58OEkLN51Ha3S4DKRtCv5CkhK1KHEvQtg==",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "bech32": "^1.1.4",
+        "readonly-date": "^1.0.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@cosmjs/json-rpc": {
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.32.2.tgz",
+      "integrity": "sha512-lan2lOgmz4yVE/HR8eCOSiII/1OudIulk8836koyIDCsPEpt6eKBuctnAD168vABGArKccLAo7Mr2gy9nrKrOQ==",
+      "dependencies": {
+        "@cosmjs/stream": "^0.32.2",
+        "xstream": "^11.14.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@cosmjs/math": {
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.32.2.tgz",
+      "integrity": "sha512-b8+ruAAY8aKtVKWSft2IvtCVCUH1LigIlf9ALIiY8n9jtM4kMASiaRbQ/27etnSAInV88IaezKK9rQZrtxTjcw==",
+      "dependencies": {
+        "bn.js": "^5.2.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@cosmjs/proto-signing": {
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.32.2.tgz",
+      "integrity": "sha512-UV4WwkE3W3G3s7wwU9rizNcUEz2g0W8jQZS5J6/3fiN0mRPwtPKQ6EinPN9ASqcAJ7/VQH4/9EPOw7d6XQGnqw==",
+      "dependencies": {
+        "@cosmjs/amino": "^0.32.2",
+        "@cosmjs/crypto": "^0.32.2",
+        "@cosmjs/encoding": "^0.32.2",
+        "@cosmjs/math": "^0.32.2",
+        "@cosmjs/utils": "^0.32.2",
+        "cosmjs-types": "^0.9.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@cosmjs/socket": {
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.32.2.tgz",
+      "integrity": "sha512-Qc8jaw4uSBJm09UwPgkqe3g9TBFx4ZR9HkXpwT6Z9I+6kbLerXPR0Gy3NSJFSUgxIfTpO8O1yqoWAyf0Ay17Mw==",
+      "dependencies": {
+        "@cosmjs/stream": "^0.32.2",
+        "isomorphic-ws": "^4.0.1",
+        "ws": "^7",
+        "xstream": "^11.14.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@cosmjs/stargate": {
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.32.2.tgz",
+      "integrity": "sha512-AsJa29fT7Jd4xt9Ai+HMqhyj7UQu7fyYKdXj/8+/9PD74xe6lZSYhQPcitUmMLJ1ckKPgXSk5Dd2LbsQT0IhZg==",
+      "dependencies": {
+        "@confio/ics23": "^0.6.8",
+        "@cosmjs/amino": "^0.32.2",
+        "@cosmjs/encoding": "^0.32.2",
+        "@cosmjs/math": "^0.32.2",
+        "@cosmjs/proto-signing": "^0.32.2",
+        "@cosmjs/stream": "^0.32.2",
+        "@cosmjs/tendermint-rpc": "^0.32.2",
+        "@cosmjs/utils": "^0.32.2",
+        "cosmjs-types": "^0.9.0",
+        "xstream": "^11.14.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@cosmjs/stream": {
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.32.2.tgz",
+      "integrity": "sha512-gpCufLfHAD8Zp1ZKge7AHbDf4RA0TZp66wZY6JaQR5bSiEF2Drjtp4mwXZPGejtaUMnaAgff3LrUzPJfKYdQwg==",
+      "dependencies": {
+        "xstream": "^11.14.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@cosmjs/tendermint-rpc": {
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.32.2.tgz",
+      "integrity": "sha512-DXyJHDmcAfCix4H/7/dKR0UMdshP01KxJOXHdHxBCbLIpck94BsWD3B2ZTXwfA6sv98so9wOzhp7qGQa5malxg==",
+      "dependencies": {
+        "@cosmjs/crypto": "^0.32.2",
+        "@cosmjs/encoding": "^0.32.2",
+        "@cosmjs/json-rpc": "^0.32.2",
+        "@cosmjs/math": "^0.32.2",
+        "@cosmjs/socket": "^0.32.2",
+        "@cosmjs/stream": "^0.32.2",
+        "@cosmjs/utils": "^0.32.2",
+        "axios": "^1.6.0",
+        "readonly-date": "^1.0.0",
+        "xstream": "^11.14.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@cosmjs/utils": {
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.32.2.tgz",
+      "integrity": "sha512-Gg5t+eR7vPJMAmhkFt6CZrzPd0EKpAslWwk5rFVYZpJsM8JG5KT9XQ99hgNM3Ov6ScNoIWbXkpX27F6A9cXR4Q=="
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/axios": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+      "dependencies": {
+        "follow-redirects": "^1.15.4",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/cosmjs-types": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.9.0.tgz",
+      "integrity": "sha512-MN/yUe6mkJwHnCFfsNPeCfXVhyxHYW6c/xDUzrSbBycYzw++XvWDMJArXp2pLdgD6FQ8DW79vkPjeNKVrXaHeQ=="
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-0.5.0-beta.4.tgz",
+      "integrity": "sha512-M8qnJnL6IvkBM0hsjWTYcpSJJ03AOfVpDMSx70kf6NRe1FYaqony4qAuFYYC88k7dYm5ec65+MO+ztSnZODwyQ==",
+      "dependencies": {
+        "@cosmjs/cosmwasm-stargate": "^0.32.0",
+        "@cosmjs/stargate": "^0.32.0",
+        "@wormhole-foundation/sdk-connect": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-cosmwasm": "0.5.0-beta.4",
+        "cosmjs-types": "^0.9.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@cosmjs/amino": {
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.32.2.tgz",
+      "integrity": "sha512-lcK5RCVm4OfdAooxKcF2+NwaDVVpghOq6o/A40c2mHXDUzUoRZ33VAHjVJ9Me6vOFxshrw/XEFn1f4KObntjYA==",
+      "dependencies": {
+        "@cosmjs/crypto": "^0.32.2",
+        "@cosmjs/encoding": "^0.32.2",
+        "@cosmjs/math": "^0.32.2",
+        "@cosmjs/utils": "^0.32.2"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@cosmjs/cosmwasm-stargate": {
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/cosmwasm-stargate/-/cosmwasm-stargate-0.32.2.tgz",
+      "integrity": "sha512-OwJHzIx2CoJS6AULxOpNR6m+CI0GXxy8z9svHA1ZawzNM3ZGlL0GvHdhmF0WkpX4E7UdrYlJSLpKcgg5Fo6i7Q==",
+      "dependencies": {
+        "@cosmjs/amino": "^0.32.2",
+        "@cosmjs/crypto": "^0.32.2",
+        "@cosmjs/encoding": "^0.32.2",
+        "@cosmjs/math": "^0.32.2",
+        "@cosmjs/proto-signing": "^0.32.2",
+        "@cosmjs/stargate": "^0.32.2",
+        "@cosmjs/tendermint-rpc": "^0.32.2",
+        "@cosmjs/utils": "^0.32.2",
+        "cosmjs-types": "^0.9.0",
+        "pako": "^2.0.2"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@cosmjs/crypto": {
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.32.2.tgz",
+      "integrity": "sha512-RuxrYKzhrPF9g6NmU7VEq++Hn1vZJjqqJpZ9Tmw9lOYOV8BUsv+j/0BE86kmWi7xVJ7EwxiuxYsKuM8IR18CIA==",
+      "dependencies": {
+        "@cosmjs/encoding": "^0.32.2",
+        "@cosmjs/math": "^0.32.2",
+        "@cosmjs/utils": "^0.32.2",
+        "@noble/hashes": "^1",
+        "bn.js": "^5.2.0",
+        "elliptic": "^6.5.4",
+        "libsodium-wrappers-sumo": "^0.7.11"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@cosmjs/encoding": {
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.32.2.tgz",
+      "integrity": "sha512-WX7m1wLpA9V/zH0zRcz4EmgZdAv1F44g4dbXOgNj1eXZw1PIGR12p58OEkLN51Ha3S4DKRtCv5CkhK1KHEvQtg==",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "bech32": "^1.1.4",
+        "readonly-date": "^1.0.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@cosmjs/json-rpc": {
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.32.2.tgz",
+      "integrity": "sha512-lan2lOgmz4yVE/HR8eCOSiII/1OudIulk8836koyIDCsPEpt6eKBuctnAD168vABGArKccLAo7Mr2gy9nrKrOQ==",
+      "dependencies": {
+        "@cosmjs/stream": "^0.32.2",
+        "xstream": "^11.14.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@cosmjs/math": {
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.32.2.tgz",
+      "integrity": "sha512-b8+ruAAY8aKtVKWSft2IvtCVCUH1LigIlf9ALIiY8n9jtM4kMASiaRbQ/27etnSAInV88IaezKK9rQZrtxTjcw==",
+      "dependencies": {
+        "bn.js": "^5.2.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@cosmjs/proto-signing": {
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.32.2.tgz",
+      "integrity": "sha512-UV4WwkE3W3G3s7wwU9rizNcUEz2g0W8jQZS5J6/3fiN0mRPwtPKQ6EinPN9ASqcAJ7/VQH4/9EPOw7d6XQGnqw==",
+      "dependencies": {
+        "@cosmjs/amino": "^0.32.2",
+        "@cosmjs/crypto": "^0.32.2",
+        "@cosmjs/encoding": "^0.32.2",
+        "@cosmjs/math": "^0.32.2",
+        "@cosmjs/utils": "^0.32.2",
+        "cosmjs-types": "^0.9.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@cosmjs/socket": {
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.32.2.tgz",
+      "integrity": "sha512-Qc8jaw4uSBJm09UwPgkqe3g9TBFx4ZR9HkXpwT6Z9I+6kbLerXPR0Gy3NSJFSUgxIfTpO8O1yqoWAyf0Ay17Mw==",
+      "dependencies": {
+        "@cosmjs/stream": "^0.32.2",
+        "isomorphic-ws": "^4.0.1",
+        "ws": "^7",
+        "xstream": "^11.14.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@cosmjs/stargate": {
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.32.2.tgz",
+      "integrity": "sha512-AsJa29fT7Jd4xt9Ai+HMqhyj7UQu7fyYKdXj/8+/9PD74xe6lZSYhQPcitUmMLJ1ckKPgXSk5Dd2LbsQT0IhZg==",
+      "dependencies": {
+        "@confio/ics23": "^0.6.8",
+        "@cosmjs/amino": "^0.32.2",
+        "@cosmjs/encoding": "^0.32.2",
+        "@cosmjs/math": "^0.32.2",
+        "@cosmjs/proto-signing": "^0.32.2",
+        "@cosmjs/stream": "^0.32.2",
+        "@cosmjs/tendermint-rpc": "^0.32.2",
+        "@cosmjs/utils": "^0.32.2",
+        "cosmjs-types": "^0.9.0",
+        "xstream": "^11.14.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@cosmjs/stream": {
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.32.2.tgz",
+      "integrity": "sha512-gpCufLfHAD8Zp1ZKge7AHbDf4RA0TZp66wZY6JaQR5bSiEF2Drjtp4mwXZPGejtaUMnaAgff3LrUzPJfKYdQwg==",
+      "dependencies": {
+        "xstream": "^11.14.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@cosmjs/tendermint-rpc": {
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.32.2.tgz",
+      "integrity": "sha512-DXyJHDmcAfCix4H/7/dKR0UMdshP01KxJOXHdHxBCbLIpck94BsWD3B2ZTXwfA6sv98so9wOzhp7qGQa5malxg==",
+      "dependencies": {
+        "@cosmjs/crypto": "^0.32.2",
+        "@cosmjs/encoding": "^0.32.2",
+        "@cosmjs/json-rpc": "^0.32.2",
+        "@cosmjs/math": "^0.32.2",
+        "@cosmjs/socket": "^0.32.2",
+        "@cosmjs/stream": "^0.32.2",
+        "@cosmjs/utils": "^0.32.2",
+        "axios": "^1.6.0",
+        "readonly-date": "^1.0.0",
+        "xstream": "^11.14.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@cosmjs/utils": {
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.32.2.tgz",
+      "integrity": "sha512-Gg5t+eR7vPJMAmhkFt6CZrzPd0EKpAslWwk5rFVYZpJsM8JG5KT9XQ99hgNM3Ov6ScNoIWbXkpX27F6A9cXR4Q=="
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/axios": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+      "dependencies": {
+        "follow-redirects": "^1.15.4",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/cosmjs-types": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.9.0.tgz",
+      "integrity": "sha512-MN/yUe6mkJwHnCFfsNPeCfXVhyxHYW6c/xDUzrSbBycYzw++XvWDMJArXp2pLdgD6FQ8DW79vkPjeNKVrXaHeQ=="
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@cosmjs/amino": {
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.32.2.tgz",
+      "integrity": "sha512-lcK5RCVm4OfdAooxKcF2+NwaDVVpghOq6o/A40c2mHXDUzUoRZ33VAHjVJ9Me6vOFxshrw/XEFn1f4KObntjYA==",
+      "dependencies": {
+        "@cosmjs/crypto": "^0.32.2",
+        "@cosmjs/encoding": "^0.32.2",
+        "@cosmjs/math": "^0.32.2",
+        "@cosmjs/utils": "^0.32.2"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@cosmjs/cosmwasm-stargate": {
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/cosmwasm-stargate/-/cosmwasm-stargate-0.32.2.tgz",
+      "integrity": "sha512-OwJHzIx2CoJS6AULxOpNR6m+CI0GXxy8z9svHA1ZawzNM3ZGlL0GvHdhmF0WkpX4E7UdrYlJSLpKcgg5Fo6i7Q==",
+      "dependencies": {
+        "@cosmjs/amino": "^0.32.2",
+        "@cosmjs/crypto": "^0.32.2",
+        "@cosmjs/encoding": "^0.32.2",
+        "@cosmjs/math": "^0.32.2",
+        "@cosmjs/proto-signing": "^0.32.2",
+        "@cosmjs/stargate": "^0.32.2",
+        "@cosmjs/tendermint-rpc": "^0.32.2",
+        "@cosmjs/utils": "^0.32.2",
+        "cosmjs-types": "^0.9.0",
+        "pako": "^2.0.2"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@cosmjs/crypto": {
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.32.2.tgz",
+      "integrity": "sha512-RuxrYKzhrPF9g6NmU7VEq++Hn1vZJjqqJpZ9Tmw9lOYOV8BUsv+j/0BE86kmWi7xVJ7EwxiuxYsKuM8IR18CIA==",
+      "dependencies": {
+        "@cosmjs/encoding": "^0.32.2",
+        "@cosmjs/math": "^0.32.2",
+        "@cosmjs/utils": "^0.32.2",
+        "@noble/hashes": "^1",
+        "bn.js": "^5.2.0",
+        "elliptic": "^6.5.4",
+        "libsodium-wrappers-sumo": "^0.7.11"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@cosmjs/encoding": {
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.32.2.tgz",
+      "integrity": "sha512-WX7m1wLpA9V/zH0zRcz4EmgZdAv1F44g4dbXOgNj1eXZw1PIGR12p58OEkLN51Ha3S4DKRtCv5CkhK1KHEvQtg==",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "bech32": "^1.1.4",
+        "readonly-date": "^1.0.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@cosmjs/json-rpc": {
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.32.2.tgz",
+      "integrity": "sha512-lan2lOgmz4yVE/HR8eCOSiII/1OudIulk8836koyIDCsPEpt6eKBuctnAD168vABGArKccLAo7Mr2gy9nrKrOQ==",
+      "dependencies": {
+        "@cosmjs/stream": "^0.32.2",
+        "xstream": "^11.14.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@cosmjs/math": {
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.32.2.tgz",
+      "integrity": "sha512-b8+ruAAY8aKtVKWSft2IvtCVCUH1LigIlf9ALIiY8n9jtM4kMASiaRbQ/27etnSAInV88IaezKK9rQZrtxTjcw==",
+      "dependencies": {
+        "bn.js": "^5.2.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@cosmjs/proto-signing": {
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.32.2.tgz",
+      "integrity": "sha512-UV4WwkE3W3G3s7wwU9rizNcUEz2g0W8jQZS5J6/3fiN0mRPwtPKQ6EinPN9ASqcAJ7/VQH4/9EPOw7d6XQGnqw==",
+      "dependencies": {
+        "@cosmjs/amino": "^0.32.2",
+        "@cosmjs/crypto": "^0.32.2",
+        "@cosmjs/encoding": "^0.32.2",
+        "@cosmjs/math": "^0.32.2",
+        "@cosmjs/utils": "^0.32.2",
+        "cosmjs-types": "^0.9.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@cosmjs/socket": {
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.32.2.tgz",
+      "integrity": "sha512-Qc8jaw4uSBJm09UwPgkqe3g9TBFx4ZR9HkXpwT6Z9I+6kbLerXPR0Gy3NSJFSUgxIfTpO8O1yqoWAyf0Ay17Mw==",
+      "dependencies": {
+        "@cosmjs/stream": "^0.32.2",
+        "isomorphic-ws": "^4.0.1",
+        "ws": "^7",
+        "xstream": "^11.14.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@cosmjs/stargate": {
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.32.2.tgz",
+      "integrity": "sha512-AsJa29fT7Jd4xt9Ai+HMqhyj7UQu7fyYKdXj/8+/9PD74xe6lZSYhQPcitUmMLJ1ckKPgXSk5Dd2LbsQT0IhZg==",
+      "dependencies": {
+        "@confio/ics23": "^0.6.8",
+        "@cosmjs/amino": "^0.32.2",
+        "@cosmjs/encoding": "^0.32.2",
+        "@cosmjs/math": "^0.32.2",
+        "@cosmjs/proto-signing": "^0.32.2",
+        "@cosmjs/stream": "^0.32.2",
+        "@cosmjs/tendermint-rpc": "^0.32.2",
+        "@cosmjs/utils": "^0.32.2",
+        "cosmjs-types": "^0.9.0",
+        "xstream": "^11.14.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@cosmjs/stream": {
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.32.2.tgz",
+      "integrity": "sha512-gpCufLfHAD8Zp1ZKge7AHbDf4RA0TZp66wZY6JaQR5bSiEF2Drjtp4mwXZPGejtaUMnaAgff3LrUzPJfKYdQwg==",
+      "dependencies": {
+        "xstream": "^11.14.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@cosmjs/tendermint-rpc": {
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.32.2.tgz",
+      "integrity": "sha512-DXyJHDmcAfCix4H/7/dKR0UMdshP01KxJOXHdHxBCbLIpck94BsWD3B2ZTXwfA6sv98so9wOzhp7qGQa5malxg==",
+      "dependencies": {
+        "@cosmjs/crypto": "^0.32.2",
+        "@cosmjs/encoding": "^0.32.2",
+        "@cosmjs/json-rpc": "^0.32.2",
+        "@cosmjs/math": "^0.32.2",
+        "@cosmjs/socket": "^0.32.2",
+        "@cosmjs/stream": "^0.32.2",
+        "@cosmjs/utils": "^0.32.2",
+        "axios": "^1.6.0",
+        "readonly-date": "^1.0.0",
+        "xstream": "^11.14.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@cosmjs/utils": {
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.32.2.tgz",
+      "integrity": "sha512-Gg5t+eR7vPJMAmhkFt6CZrzPd0EKpAslWwk5rFVYZpJsM8JG5KT9XQ99hgNM3Ov6ScNoIWbXkpX27F6A9cXR4Q=="
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@injectivelabs/core-proto-ts": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/core-proto-ts/-/core-proto-ts-0.0.21.tgz",
+      "integrity": "sha512-RBxSkRBCty60R/l55/D1jsSW0Aof5dyGFhCFdN3A010KjMv/SzZGGr+6DZPY/hflyFeaJzDv/VTopCymKNRBvQ==",
+      "dependencies": {
+        "@injectivelabs/grpc-web": "^0.0.1",
+        "google-protobuf": "^3.14.0",
+        "protobufjs": "^7.0.0",
+        "rxjs": "^7.4.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@injectivelabs/indexer-proto-ts": {
+      "version": "1.11.36",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/indexer-proto-ts/-/indexer-proto-ts-1.11.36.tgz",
+      "integrity": "sha512-s7E3Y28JrkylDwRVfF/AvcPy/zPgz52W+XbQ0FOcsqPof78xp8FvnM3ubVZi0Dad39LgDB5eeiMFPmeuLp8Uew==",
+      "dependencies": {
+        "@injectivelabs/grpc-web": "^0.0.1",
+        "google-protobuf": "^3.14.0",
+        "protobufjs": "^7.0.0",
+        "rxjs": "^7.4.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@injectivelabs/mito-proto-ts": {
+      "version": "1.0.62",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/mito-proto-ts/-/mito-proto-ts-1.0.62.tgz",
+      "integrity": "sha512-WtoO80Y597nZiAuE4H+L208I0i3ByWytR+HqABdCaA26uJ7F1LhXw8YXxh3pP9z0LAeW31T+N7bwtOMlVR4riA==",
+      "dependencies": {
+        "@injectivelabs/grpc-web": "^0.0.1",
+        "google-protobuf": "^3.14.0",
+        "protobufjs": "^7.0.0",
+        "rxjs": "^7.4.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@injectivelabs/networks": {
+      "version": "1.14.6",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/networks/-/networks-1.14.6.tgz",
+      "integrity": "sha512-O1IkPFJl8ThNL6N+k/9OimrgCYsSWQ8A1FtVMXSQge+0QRZsDKSpRmQRwE601otXXauO31nOUct5AaiWPffXVQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@injectivelabs/exceptions": "^1.14.6",
+        "@injectivelabs/ts-types": "^1.14.6",
+        "@injectivelabs/utils": "^1.14.6",
+        "link-module-alias": "^1.2.0",
+        "shx": "^0.3.2"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@injectivelabs/sdk-ts": {
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/sdk-ts/-/sdk-ts-1.14.7.tgz",
+      "integrity": "sha512-Qm8y8jKCMyNfYZGZVI+p0SIGJPtP5M9/DPFyPK+JSR2OOU0J4MX2yS/tQB5ViC/3Bt7yQhw/l3Rop93e7pTZEg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@apollo/client": "^3.5.8",
+        "@cosmjs/amino": "^0.32.2",
+        "@cosmjs/proto-signing": "^0.32.2",
+        "@cosmjs/stargate": "^0.32.2",
+        "@ensdomains/ens-validation": "^0.1.0",
+        "@ensdomains/eth-ens-namehash": "^2.0.15",
+        "@ethersproject/bytes": "^5.7.0",
+        "@injectivelabs/core-proto-ts": "^0.0.21",
+        "@injectivelabs/dmm-proto-ts": "1.0.19",
+        "@injectivelabs/exceptions": "^1.14.6",
+        "@injectivelabs/grpc-web": "^0.0.1",
+        "@injectivelabs/grpc-web-node-http-transport": "^0.0.2",
+        "@injectivelabs/grpc-web-react-native-transport": "^0.0.2",
+        "@injectivelabs/indexer-proto-ts": "1.11.36",
+        "@injectivelabs/mito-proto-ts": "1.0.62",
+        "@injectivelabs/networks": "^1.14.6",
+        "@injectivelabs/test-utils": "^1.14.3",
+        "@injectivelabs/token-metadata": "^1.14.7",
+        "@injectivelabs/ts-types": "^1.14.6",
+        "@injectivelabs/utils": "^1.14.6",
+        "@metamask/eth-sig-util": "^4.0.0",
+        "axios": "^0.27.2",
+        "bech32": "^2.0.0",
+        "bip39": "^3.0.4",
+        "cosmjs-types": "^0.9.0",
+        "ethereumjs-util": "^7.1.4",
+        "ethers": "^5.7.2",
+        "google-protobuf": "^3.21.0",
+        "graphql": "^16.3.0",
+        "http-status-codes": "^2.2.0",
+        "js-sha3": "^0.8.0",
+        "jscrypto": "^1.0.3",
+        "keccak256": "^1.0.6",
+        "link-module-alias": "^1.2.0",
+        "secp256k1": "^4.0.3",
+        "shx": "^0.3.2",
+        "snakecase-keys": "^5.4.1"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@injectivelabs/sdk-ts/node_modules/axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@injectivelabs/sdk-ts/node_modules/bech32": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
+      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@injectivelabs/utils": {
+      "version": "1.14.6",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/utils/-/utils-1.14.6.tgz",
+      "integrity": "sha512-5I0h4GiLB5PPTl+g2lpevRP+WScvEbntdkoUQVtAdHewl4kutd5p1Kcnoi1Nvpq+sz5N/e9qtBIRuyxG38akOg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@injectivelabs/exceptions": "^1.14.6",
+        "@injectivelabs/ts-types": "^1.14.6",
+        "axios": "^0.21.1",
+        "bignumber.js": "^9.0.1",
+        "http-status-codes": "^2.2.0",
+        "link-module-alias": "^1.2.0",
+        "shx": "^0.3.2",
+        "snakecase-keys": "^5.1.2",
+        "store2": "^2.12.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@injectivelabs/utils/node_modules/axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "dependencies": {
+        "follow-redirects": "^1.14.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/axios": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+      "dependencies": {
+        "follow-redirects": "^1.15.4",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/cosmjs-types": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.9.0.tgz",
+      "integrity": "sha512-MN/yUe6mkJwHnCFfsNPeCfXVhyxHYW6c/xDUzrSbBycYzw++XvWDMJArXp2pLdgD6FQ8DW79vkPjeNKVrXaHeQ=="
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/long": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+    },
+    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/protobufjs": {
+      "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz",
+      "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-definitions": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-0.5.0-beta.4.tgz",
+      "integrity": "sha512-9mLhF+aR96YGE/QjVnnc9vrdosijsetOpCqynvab4F8yAvMCYb4QWtaaLs0ul3Q1PgaQQGo23qah8IMpnF3BWA==",
+      "dependencies": {
+        "@noble/hashes": "^1.3.1",
+        "@wormhole-foundation/sdk-base": "0.5.0-beta.4"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-definitions/node_modules/@noble/hashes": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.3.tgz",
+      "integrity": "sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-evm": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-0.5.0-beta.4.tgz",
+      "integrity": "sha512-5xrJYxaeDs84b/ivx1w7u03kirGqpJF5iPznpa+gMDaccaGQ7LjxEOOBp1Wc8Nq+4Ei02Vo0jxpSQtb803FPEw==",
       "dependencies": {
         "@typechain/ethers-v6": "^0.4.0",
-        "@wormhole-foundation/connect-sdk": "0.4.6",
+        "@wormhole-foundation/sdk-connect": "0.5.0-beta.4",
         "ethers": "^6.5.1",
         "typechain": "^8.2.0"
       },
@@ -3506,7 +4637,22 @@
         "node": ">=16"
       }
     },
-    "node_modules/@wormhole-foundation/connect-sdk-evm/node_modules/@noble/curves": {
+    "node_modules/@wormhole-foundation/sdk-evm-cctp": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-0.5.0-beta.4.tgz",
+      "integrity": "sha512-rmo1VkN/g5SO2bpNrp08JwnftpVqCfscz3Dsb/2EOsvC0S9aScQLAfsQnWyQZjocqi/GPSQFc35rfEAnTAEGSg==",
+      "dependencies": {
+        "@typechain/ethers-v6": "^0.4.0",
+        "@wormhole-foundation/sdk-connect": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-evm": "0.5.0-beta.4",
+        "ethers": "^6.5.1",
+        "typechain": "^8.2.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-evm-cctp/node_modules/@noble/curves": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
       "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
@@ -3517,7 +4663,7 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@wormhole-foundation/connect-sdk-evm/node_modules/@noble/hashes": {
+    "node_modules/@wormhole-foundation/sdk-evm-cctp/node_modules/@noble/hashes": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
       "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
@@ -3528,7 +4674,7 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@wormhole-foundation/connect-sdk-evm/node_modules/@typechain/ethers-v6": {
+    "node_modules/@wormhole-foundation/sdk-evm-cctp/node_modules/@typechain/ethers-v6": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@typechain/ethers-v6/-/ethers-v6-0.4.3.tgz",
       "integrity": "sha512-TrxBsyb4ryhaY9keP6RzhFCviWYApcLCIRMPyWaKp2cZZrfaM3QBoxXTnw/eO4+DAY3l+8O0brNW0WgeQeOiDA==",
@@ -3542,12 +4688,12 @@
         "typescript": ">=4.7.0"
       }
     },
-    "node_modules/@wormhole-foundation/connect-sdk-evm/node_modules/aes-js": {
+    "node_modules/@wormhole-foundation/sdk-evm-cctp/node_modules/aes-js": {
       "version": "4.0.0-beta.5",
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
       "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="
     },
-    "node_modules/@wormhole-foundation/connect-sdk-evm/node_modules/ethers": {
+    "node_modules/@wormhole-foundation/sdk-evm-cctp/node_modules/ethers": {
       "version": "6.11.1",
       "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.11.1.tgz",
       "integrity": "sha512-mxTAE6wqJQAbp5QAe/+o+rXOID7Nw91OZXvgpjDa1r4fAbq2Nu314oEZSbjoRLacuCzs7kUC3clEvkCQowffGg==",
@@ -3574,7 +4720,7 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@wormhole-foundation/connect-sdk-evm/node_modules/ws": {
+    "node_modules/@wormhole-foundation/sdk-evm-cctp/node_modules/ws": {
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
       "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
@@ -3594,63 +4740,554 @@
         }
       }
     },
-    "node_modules/@wormhole-foundation/connect-sdk-solana": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk-solana/-/connect-sdk-solana-0.4.6.tgz",
-      "integrity": "sha512-x0skE7wy33KhUEnWHtv34MmNDL1BsezPhV70yI8ncm7M1BYrIHTtXfkrhB3+5N3CY2GfCMxAoE260Eb8FKH0zg==",
+    "node_modules/@wormhole-foundation/sdk-evm-core": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-0.5.0-beta.4.tgz",
+      "integrity": "sha512-dlkgXfqnumFT2VqECzH/QY8JW9x3bDqH9iUf1M/hy90JsRxVc0H4CK7O+wY8q65NRT07LyjV/eQ+9X3Ze6Uz9A==",
+      "dependencies": {
+        "@typechain/ethers-v6": "^0.4.0",
+        "@wormhole-foundation/sdk-connect": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-evm": "0.5.0-beta.4",
+        "ethers": "^6.5.1",
+        "typechain": "^8.2.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-evm-core/node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-evm-core/node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-evm-core/node_modules/@typechain/ethers-v6": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@typechain/ethers-v6/-/ethers-v6-0.4.3.tgz",
+      "integrity": "sha512-TrxBsyb4ryhaY9keP6RzhFCviWYApcLCIRMPyWaKp2cZZrfaM3QBoxXTnw/eO4+DAY3l+8O0brNW0WgeQeOiDA==",
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "ts-essentials": "^7.0.1"
+      },
+      "peerDependencies": {
+        "ethers": "6.x",
+        "typechain": "^8.3.1",
+        "typescript": ">=4.7.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-evm-core/node_modules/aes-js": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="
+    },
+    "node_modules/@wormhole-foundation/sdk-evm-core/node_modules/ethers": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.11.1.tgz",
+      "integrity": "sha512-mxTAE6wqJQAbp5QAe/+o+rXOID7Nw91OZXvgpjDa1r4fAbq2Nu314oEZSbjoRLacuCzs7kUC3clEvkCQowffGg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/ethers-io/"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.10.1",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@types/node": "18.15.13",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.4.0",
+        "ws": "8.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-evm-core/node_modules/ws": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-evm-portico": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-0.5.0-beta.4.tgz",
+      "integrity": "sha512-cCW5mtFfR2sMPNDAXrSiv6YMFVWDRJlSREQyZW3YueO+ngaHHc5gaNE4iSrpjBzkU5j46zZ+F6tbieqamqJPQQ==",
+      "dependencies": {
+        "@typechain/ethers-v6": "^0.4.0",
+        "@wormhole-foundation/sdk-connect": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-evm": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-evm-core": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "0.5.0-beta.4",
+        "ethers": "^6.5.1",
+        "typechain": "^8.2.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-evm-portico/node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-evm-portico/node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-evm-portico/node_modules/@typechain/ethers-v6": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@typechain/ethers-v6/-/ethers-v6-0.4.3.tgz",
+      "integrity": "sha512-TrxBsyb4ryhaY9keP6RzhFCviWYApcLCIRMPyWaKp2cZZrfaM3QBoxXTnw/eO4+DAY3l+8O0brNW0WgeQeOiDA==",
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "ts-essentials": "^7.0.1"
+      },
+      "peerDependencies": {
+        "ethers": "6.x",
+        "typechain": "^8.3.1",
+        "typescript": ">=4.7.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-evm-portico/node_modules/aes-js": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="
+    },
+    "node_modules/@wormhole-foundation/sdk-evm-portico/node_modules/ethers": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.11.1.tgz",
+      "integrity": "sha512-mxTAE6wqJQAbp5QAe/+o+rXOID7Nw91OZXvgpjDa1r4fAbq2Nu314oEZSbjoRLacuCzs7kUC3clEvkCQowffGg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/ethers-io/"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.10.1",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@types/node": "18.15.13",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.4.0",
+        "ws": "8.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-evm-portico/node_modules/ws": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-evm-tokenbridge": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-0.5.0-beta.4.tgz",
+      "integrity": "sha512-8Uwc/oecyMK7halZaOlK8cHuLN/E3zZumbyd170rdr5/qNCI7Bd68qfyFKD1qFoKTIixGo61+lsFXdrRFt+vuA==",
+      "dependencies": {
+        "@typechain/ethers-v6": "^0.4.0",
+        "@wormhole-foundation/sdk-connect": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-evm": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-evm-core": "0.5.0-beta.4",
+        "ethers": "^6.5.1",
+        "typechain": "^8.2.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-evm-tokenbridge/node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-evm-tokenbridge/node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-evm-tokenbridge/node_modules/@typechain/ethers-v6": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@typechain/ethers-v6/-/ethers-v6-0.4.3.tgz",
+      "integrity": "sha512-TrxBsyb4ryhaY9keP6RzhFCviWYApcLCIRMPyWaKp2cZZrfaM3QBoxXTnw/eO4+DAY3l+8O0brNW0WgeQeOiDA==",
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "ts-essentials": "^7.0.1"
+      },
+      "peerDependencies": {
+        "ethers": "6.x",
+        "typechain": "^8.3.1",
+        "typescript": ">=4.7.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-evm-tokenbridge/node_modules/aes-js": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="
+    },
+    "node_modules/@wormhole-foundation/sdk-evm-tokenbridge/node_modules/ethers": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.11.1.tgz",
+      "integrity": "sha512-mxTAE6wqJQAbp5QAe/+o+rXOID7Nw91OZXvgpjDa1r4fAbq2Nu314oEZSbjoRLacuCzs7kUC3clEvkCQowffGg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/ethers-io/"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.10.1",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@types/node": "18.15.13",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.4.0",
+        "ws": "8.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-evm-tokenbridge/node_modules/ws": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-evm/node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-evm/node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-evm/node_modules/@typechain/ethers-v6": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@typechain/ethers-v6/-/ethers-v6-0.4.3.tgz",
+      "integrity": "sha512-TrxBsyb4ryhaY9keP6RzhFCviWYApcLCIRMPyWaKp2cZZrfaM3QBoxXTnw/eO4+DAY3l+8O0brNW0WgeQeOiDA==",
+      "dependencies": {
+        "lodash": "^4.17.15",
+        "ts-essentials": "^7.0.1"
+      },
+      "peerDependencies": {
+        "ethers": "6.x",
+        "typechain": "^8.3.1",
+        "typescript": ">=4.7.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-evm/node_modules/aes-js": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="
+    },
+    "node_modules/@wormhole-foundation/sdk-evm/node_modules/ethers": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.11.1.tgz",
+      "integrity": "sha512-mxTAE6wqJQAbp5QAe/+o+rXOID7Nw91OZXvgpjDa1r4fAbq2Nu314oEZSbjoRLacuCzs7kUC3clEvkCQowffGg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/ethers-io/"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.10.1",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@types/node": "18.15.13",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.4.0",
+        "ws": "8.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-evm/node_modules/ws": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-solana": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-0.5.0-beta.4.tgz",
+      "integrity": "sha512-QzVlsM3NTOYUgfuuRNeAsbh1xRaGFUQwImCtNAp2MEexbzep17ZZMNlymzNeUzTBX09Od2XE5YHO+NEHFjNKoQ==",
       "dependencies": {
         "@coral-xyz/borsh": "0.2.6",
         "@project-serum/anchor": "0.25.0",
         "@project-serum/borsh": "0.2.5",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "1.89.1",
-        "@wormhole-foundation/connect-sdk": "0.4.6"
+        "@wormhole-foundation/sdk-connect": "0.5.0-beta.4"
       },
       "engines": {
         "node": ">=16"
       }
     },
-    "node_modules/@wormhole-foundation/connect-sdk/node_modules/axios": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
-      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+    "node_modules/@wormhole-foundation/sdk-solana-cctp": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-0.5.0-beta.4.tgz",
+      "integrity": "sha512-4nb2iqHZhMfUiT0Xqjm//U6SGC9lowMKBpzXWQPH4p31I393f+ZuU5mS3R11xMg7K31Wz14lj3wuoGcR6SLV7w==",
       "dependencies": {
-        "follow-redirects": "^1.15.4",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/connect-sdk/node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
+        "@coral-xyz/borsh": "0.2.6",
+        "@project-serum/anchor": "0.25.0",
+        "@project-serum/borsh": "0.2.5",
+        "@solana/spl-token": "0.3.9",
+        "@solana/web3.js": "1.89.1",
+        "@wormhole-foundation/sdk-connect": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-solana": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-solana-core": "0.5.0-beta.4"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">=16"
       }
     },
-    "node_modules/@wormhole-foundation/sdk-base": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-0.4.6.tgz",
-      "integrity": "sha512-IzSCI6/lb2iiaQQ5gVkO+xybeZL0eD1w5tLs06V1BUGDWj2MKWHCsAug9jkYHBxcxnw4yUZGldzPh9DBhG0vmQ==",
+    "node_modules/@wormhole-foundation/sdk-solana-core": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-0.5.0-beta.4.tgz",
+      "integrity": "sha512-SYoc3zC62B/ySsXMg3SXaXa+rXyL3KMGCqsoL/G2EpgVk+I25xUnm+MoQjoX/t+VS9MQHLSXFT5ret1iapF/lA==",
       "dependencies": {
-        "@scure/base": "^1.1.3"
+        "@coral-xyz/borsh": "0.2.6",
+        "@project-serum/anchor": "0.25.0",
+        "@project-serum/borsh": "0.2.5",
+        "@solana/spl-token": "0.3.9",
+        "@solana/web3.js": "1.89.1",
+        "@wormhole-foundation/sdk-connect": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-solana": "0.5.0-beta.4"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
-    "node_modules/@wormhole-foundation/sdk-definitions": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-0.4.6.tgz",
-      "integrity": "sha512-U3agTi424W0Ip0LMIMpgqymBEGj0QFYEhbJ0QT7ktecVXeF1o6c0NvztmYN9IS0nZ5kCgYdhaq4joIg+axtsyQ==",
+    "node_modules/@wormhole-foundation/sdk-solana-tokenbridge": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-0.5.0-beta.4.tgz",
+      "integrity": "sha512-BRbcYLMLZZyFaYcKOZhpCWFKWEbo2tw0BnRG++DHmLZraRozPXzzvTtnwwlgbRUogTdk6CxknBkBfX0oE4pDiw==",
       "dependencies": {
+        "@coral-xyz/borsh": "0.2.6",
+        "@project-serum/anchor": "0.25.0",
+        "@project-serum/borsh": "0.2.5",
+        "@solana/spl-token": "0.3.9",
+        "@solana/web3.js": "1.89.1",
+        "@wormhole-foundation/sdk-connect": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-solana": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-solana-core": "0.5.0-beta.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-sui": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-0.5.0-beta.4.tgz",
+      "integrity": "sha512-Q1zCQzDDj4zlfN/qZ3+k8nr1i9MCm2QmnpbNzTyea/aWW05rrgbDzTTYX/7Ft8qIAA8Sd1AjEqpJZy6zJQ/8Fg==",
+      "dependencies": {
+        "@mysten/sui.js": "^0.50.1",
+        "@wormhole-foundation/sdk-connect": "0.5.0-beta.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-sui-core": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-0.5.0-beta.4.tgz",
+      "integrity": "sha512-aevK9ry2XpYJuW/lOSJ7TwKbtMA+UeYVs/Pme+MU8bZZmnKozFX+YetqQsScLCM0bpqAfULj1L9f729E5GOBJw==",
+      "dependencies": {
+        "@wormhole-foundation/sdk-connect": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-sui": "0.5.0-beta.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-sui-tokenbridge": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-0.5.0-beta.4.tgz",
+      "integrity": "sha512-PpbcV7k+iez5zFuGPLaOZnaUTGepTexO0kAvP3fXCEqqKCsdeW9DD/6jEFWeQ/y9OPOAUYsv6ZWMuLpFNnN4NA==",
+      "dependencies": {
+        "@wormhole-foundation/sdk-connect": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-sui": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-sui-core": "0.5.0-beta.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-sui/node_modules/@mysten/bcs": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@mysten/bcs/-/bcs-0.11.1.tgz",
+      "integrity": "sha512-xP85isNSYUCHd3O/g+TmZYmg4wK6cU8q/n/MebkIGP4CYVJZz2wU/G24xIZ3wI+0iTop4dfgA5kYrg/DQKCUzA==",
+      "dependencies": {
+        "bs58": "^5.0.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-sui/node_modules/@mysten/sui.js": {
+      "version": "0.50.1",
+      "resolved": "https://registry.npmjs.org/@mysten/sui.js/-/sui.js-0.50.1.tgz",
+      "integrity": "sha512-AY0wb4n6PMTRsDGygzrrTHUK/m5KwKZ4aQcN9cayiwsq2iIhfjGo7uuqMA7Y5UiqvLCoF+z7Ig14Q5qejQ/S/w==",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.2.0",
+        "@mysten/bcs": "0.11.1",
+        "@noble/curves": "^1.1.0",
         "@noble/hashes": "^1.3.1",
-        "@wormhole-foundation/sdk-base": "0.4.6"
+        "@scure/bip32": "^1.3.1",
+        "@scure/bip39": "^1.2.1",
+        "@suchipi/femver": "^1.0.0",
+        "bech32": "^2.0.0",
+        "gql.tada": "^1.2.0",
+        "graphql": "^16.8.1",
+        "superstruct": "^1.0.3",
+        "tweetnacl": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
-    "node_modules/@wormhole-foundation/sdk-definitions/node_modules/@noble/hashes": {
+    "node_modules/@wormhole-foundation/sdk-sui/node_modules/@noble/curves": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.3.0.tgz",
+      "integrity": "sha512-t01iSXPuN+Eqzb4eBX0S5oubSqXbK/xXa1Ne18Hj8f9pStxztHCE2gfboSp/dZRLSqfuLpRK2nDXDK+W9puocA==",
+      "dependencies": {
+        "@noble/hashes": "1.3.3"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-sui/node_modules/@noble/hashes": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.3.tgz",
       "integrity": "sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==",
@@ -3659,6 +5296,57 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-sui/node_modules/@scure/bip32": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.3.3.tgz",
+      "integrity": "sha512-LJaN3HwRbfQK0X1xFSi0Q9amqOgzQnnDngIt+ZlsBC3Bm7/nE7K0kwshZHyaru79yIVRv/e1mQAjZyuZG6jOFQ==",
+      "dependencies": {
+        "@noble/curves": "~1.3.0",
+        "@noble/hashes": "~1.3.2",
+        "@scure/base": "~1.1.4"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-sui/node_modules/@scure/bip39": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.2.2.tgz",
+      "integrity": "sha512-HYf9TUXG80beW+hGAt3TRM8wU6pQoYur9iNypTROm42dorCGmLnFe3eWjz3gOq6G62H2WRh0FCzAR1PI+29zIA==",
+      "dependencies": {
+        "@noble/hashes": "~1.3.2",
+        "@scure/base": "~1.1.4"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-sui/node_modules/base-x": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
+      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
+    },
+    "node_modules/@wormhole-foundation/sdk-sui/node_modules/bech32": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
+      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
+    },
+    "node_modules/@wormhole-foundation/sdk-sui/node_modules/bs58": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
+      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
+      "dependencies": {
+        "base-x": "^4.0.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-sui/node_modules/superstruct": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-1.0.3.tgz",
+      "integrity": "sha512-8iTn3oSS8nRGn+C2pgXSKPI3jmpm6FExNazNpjvqS6ZUJQCej3PUXEKM8NjHBOs54ExM+LPW/FBRhymrdcCiSg==",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@wry/context": {
@@ -3787,13 +5475,12 @@
       }
     },
     "node_modules/algosdk": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/algosdk/-/algosdk-2.4.0.tgz",
-      "integrity": "sha512-sENe6IyUqvhQprfS/7gJAkPC5sX2LI5uc+gXaKNgzKp72UEyXYSoN3h4MZkOlCrOcTSWTJW7605tYgg8nFkflw==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/algosdk/-/algosdk-2.7.0.tgz",
+      "integrity": "sha512-sBE9lpV7bup3rZ+q2j3JQaFAE9JwZvjWKX00vPlG8e9txctXbgLL56jZhSWZndqhDI9oI+0P4NldkuQIWdrUyg==",
       "dependencies": {
         "algo-msgpack-with-bigint": "^2.1.1",
         "buffer": "^6.0.3",
-        "cross-fetch": "^3.1.5",
         "hi-base32": "^0.5.1",
         "js-sha256": "^0.9.0",
         "js-sha3": "^0.8.0",
@@ -3803,15 +5490,7 @@
         "vlq": "^2.0.4"
       },
       "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/algosdk/node_modules/cross-fetch": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
-      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
-      "dependencies": {
-        "node-fetch": "^2.6.12"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/ansi-regex": {
@@ -5843,15 +7522,28 @@
       "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.2.tgz",
       "integrity": "sha512-3MSOYFO5U9mPGikIYCzK0SaThypfGgS6bHqrUGXG3DPHCrb+txNqeEcns1W0lkGfk0rCyNXm7xB9rMxnCiZOoA=="
     },
+    "node_modules/gql.tada": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/gql.tada/-/gql.tada-1.3.1.tgz",
+      "integrity": "sha512-9+L2v5bi/QOFJmDnqsvr1bRryuso1ZqdfKiZT+5V8LB92iUICC+05TwmF2iUiQFdjp1IWgUOYjhrhjUFMIJILw==",
+      "dependencies": {
+        "@0no-co/graphql.web": "^1.0.4",
+        "@gql.tada/cli-utils": "0.1.0"
+      },
+      "bin": {
+        "gql-tada": "bin/cli.js",
+        "gql.tada": "bin/cli.js"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "node_modules/graphql": {
-      "version": "16.6.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
-      "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
+      "version": "16.8.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.1.tgz",
+      "integrity": "sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -6503,12 +8195,25 @@
       "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.7.10.tgz",
       "integrity": "sha512-eY+z7hDrDKxkAK+QKZVNv92A5KYkxfvIshtBJkmg5TSiCnYqZP3i9OO9whE79Pwgm4jGaoHgkM4ao/b9Cyu4zQ=="
     },
+    "node_modules/libsodium-sumo": {
+      "version": "0.7.13",
+      "resolved": "https://registry.npmjs.org/libsodium-sumo/-/libsodium-sumo-0.7.13.tgz",
+      "integrity": "sha512-zTGdLu4b9zSNLfovImpBCbdAA4xkpkZbMnSQjP8HShyOutnGjRHmSOKlsylh1okao6QhLiz7nG98EGn+04cZjQ=="
+    },
     "node_modules/libsodium-wrappers": {
       "version": "0.7.10",
       "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.10.tgz",
       "integrity": "sha512-pO3F1Q9NPLB/MWIhehim42b/Fwb30JNScCNh8TcQ/kIc+qGLQch8ag8wb0keK3EP5kbGakk1H8Wwo7v+36rNQg==",
       "dependencies": {
         "libsodium": "^0.7.0"
+      }
+    },
+    "node_modules/libsodium-wrappers-sumo": {
+      "version": "0.7.13",
+      "resolved": "https://registry.npmjs.org/libsodium-wrappers-sumo/-/libsodium-wrappers-sumo-0.7.13.tgz",
+      "integrity": "sha512-lz4YdplzDRh6AhnLGF2Dj2IUj94xRN6Bh8T0HLNwzYGwPehQJX6c7iYVrFUPZ3QqxE0bqC+K0IIqqZJYWumwSQ==",
+      "dependencies": {
+        "libsodium-sumo": "^0.7.13"
       }
     },
     "node_modules/link-module-alias": {
@@ -8395,6 +10100,12 @@
     }
   },
   "dependencies": {
+    "@0no-co/graphql.web": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.0.4.tgz",
+      "integrity": "sha512-W3ezhHGfO0MS1PtGloaTpg0PbaT8aZSmmaerL7idtU5F7oCI+uu25k+MsMS31BVFlp4aMkHSrNRxiD72IlK8TA==",
+      "requires": {}
+    },
     "@adraffy/ens-normalize": {
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
@@ -9063,6 +10774,16 @@
       "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.29.5.tgz",
       "integrity": "sha512-m7h+RXDUxOzEOGt4P+3OVPX7PuakZT3GBmaM/Y2u+abN3xZkziykD/NvedYFvvCCdQo714XcGl33bwifS9FZPQ=="
     },
+    "@ensdomains/ens-validation": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@ensdomains/ens-validation/-/ens-validation-0.1.0.tgz",
+      "integrity": "sha512-rbDh2K6GfqXvBcJUISaTTYEt3f079WA4ohTE5Lh4/8EaaPAk/9vk3EisMUQV2UVxeFIZQEEyRCIOmRTpqN0W7A=="
+    },
+    "@ensdomains/eth-ens-namehash": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@ensdomains/eth-ens-namehash/-/eth-ens-namehash-2.0.15.tgz",
+      "integrity": "sha512-JRDFP6+Hczb1E0/HhIg0PONgBYasfGfDheujmfxaZaAv/NAH4jE6Kf48WbqfRZdxt4IZI3jl3Ri7sZ1nP09lgw=="
+    },
     "@esbuild/android-arm": {
       "version": "0.17.18",
       "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.18.tgz",
@@ -9592,10 +11313,19 @@
         "@ethersproject/strings": "^5.7.0"
       }
     },
+    "@gql.tada/cli-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@gql.tada/cli-utils/-/cli-utils-0.1.0.tgz",
+      "integrity": "sha512-hM1u0eZlCBuMQ26q3D/dzbsdEK98pbhhJLLa3xJWGLHmsRiySijyoKTIMrBhdqV2v5LvQP2dX/6k1rvQt2Mvhg==",
+      "requires": {
+        "@urql/introspection": "^1.0.3",
+        "graphql": "^16.8.1"
+      }
+    },
     "@graphql-typed-document-node/core": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.1.tgz",
-      "integrity": "sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
       "requires": {}
     },
     "@improbable-eng/grpc-web": {
@@ -9649,13 +11379,50 @@
         }
       }
     },
-    "@injectivelabs/exceptions": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/exceptions/-/exceptions-1.11.0.tgz",
-      "integrity": "sha512-jZ0N4cP1KCyErNEiCARaKt70E8KMTNa9R4a5FrCERX4cFKPxdbWpoQ8Lqga2jfHAgiFcChRJ5JmaSYclFtKf9w==",
+    "@injectivelabs/dmm-proto-ts": {
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/dmm-proto-ts/-/dmm-proto-ts-1.0.19.tgz",
+      "integrity": "sha512-2FCzCziy1RhzmnkAVIU+Asby/GXAVQqKt5/o1s52j0LJXfJMpiCrV6soLfnjTebj61T+1WvJBPFoZCCiVYBpcw==",
       "requires": {
         "@injectivelabs/grpc-web": "^0.0.1",
-        "@injectivelabs/ts-types": "^1.11.0",
+        "google-protobuf": "^3.14.0",
+        "protobufjs": "^7.0.0",
+        "rxjs": "^7.4.0"
+      },
+      "dependencies": {
+        "long": {
+          "version": "5.2.3",
+          "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+          "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+        },
+        "protobufjs": {
+          "version": "7.2.6",
+          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz",
+          "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
+          "requires": {
+            "@protobufjs/aspromise": "^1.1.2",
+            "@protobufjs/base64": "^1.1.2",
+            "@protobufjs/codegen": "^2.0.4",
+            "@protobufjs/eventemitter": "^1.1.0",
+            "@protobufjs/fetch": "^1.1.0",
+            "@protobufjs/float": "^1.0.2",
+            "@protobufjs/inquire": "^1.1.0",
+            "@protobufjs/path": "^1.1.2",
+            "@protobufjs/pool": "^1.1.0",
+            "@protobufjs/utf8": "^1.1.0",
+            "@types/node": ">=13.7.0",
+            "long": "^5.0.0"
+          }
+        }
+      }
+    },
+    "@injectivelabs/exceptions": {
+      "version": "1.14.6",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/exceptions/-/exceptions-1.14.6.tgz",
+      "integrity": "sha512-A+URJwygeDjFPhulGMNVw70z738NtpIiCr0W8q4Kr4Ggg30i+AaVAjViYLm56pSMXXpomu9CYJ/sY6ijQn48IQ==",
+      "requires": {
+        "@injectivelabs/grpc-web": "^0.0.1",
+        "@injectivelabs/ts-types": "^1.14.6",
         "http-status-codes": "^2.2.0",
         "link-module-alias": "^1.2.0",
         "shx": "^0.3.2"
@@ -9989,9 +11756,9 @@
       }
     },
     "@injectivelabs/test-utils": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/test-utils/-/test-utils-1.11.0.tgz",
-      "integrity": "sha512-/KIPGeLFsjITs43yQG++SoOtDExZr+Pa3JVYIZEIMFUVG8a7z9Vi5m6a1kbowvozZbLG5KHuuUXF2SdfKSxznQ==",
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/test-utils/-/test-utils-1.14.4.tgz",
+      "integrity": "sha512-M7UoB5CIVVN7BtdmU26GwZsWKp0BQg9qV5a+YvcdhlwlSIkvt3gKVKBMq/vKClCakOu2AjhCVGDMZVnagIBogg==",
       "requires": {
         "axios": "^0.21.1",
         "bignumber.js": "^9.0.1",
@@ -10012,14 +11779,14 @@
       }
     },
     "@injectivelabs/token-metadata": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/token-metadata/-/token-metadata-1.11.0.tgz",
-      "integrity": "sha512-RzwJvnjDX8IwXYTvZDCMQcGxkN/0ZfXUEYTVMB0WMU0bRH7cV7WJ6Z9UDOijAehrJHu/fByDz2DuEOcktbwoIw==",
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/token-metadata/-/token-metadata-1.14.7.tgz",
+      "integrity": "sha512-RRRuyirzoThwQ5P8D3STH2YOavGsdnetQy6ZPQ8yA7VUavt00KBB26M92zSLbiUz5VrxhPHDCEEkuJVWx+xtmw==",
       "requires": {
-        "@injectivelabs/exceptions": "^1.11.0",
-        "@injectivelabs/networks": "^1.11.0",
-        "@injectivelabs/ts-types": "^1.11.0",
-        "@injectivelabs/utils": "^1.11.0",
+        "@injectivelabs/exceptions": "^1.14.6",
+        "@injectivelabs/networks": "^1.14.6",
+        "@injectivelabs/ts-types": "^1.14.6",
+        "@injectivelabs/utils": "^1.14.6",
         "@types/lodash.values": "^4.3.6",
         "copyfiles": "^2.4.1",
         "jsonschema": "^1.4.0",
@@ -10030,24 +11797,24 @@
       },
       "dependencies": {
         "@injectivelabs/networks": {
-          "version": "1.11.0",
-          "resolved": "https://registry.npmjs.org/@injectivelabs/networks/-/networks-1.11.0.tgz",
-          "integrity": "sha512-0dtO/zZ8AzsxGInEWZ7tpOA0Q++M3FhAFxOWzhYC39ZeJlwHhEcYmvmhrGG5gRdus29XfFysRlaz3hyT3XH1Jg==",
+          "version": "1.14.6",
+          "resolved": "https://registry.npmjs.org/@injectivelabs/networks/-/networks-1.14.6.tgz",
+          "integrity": "sha512-O1IkPFJl8ThNL6N+k/9OimrgCYsSWQ8A1FtVMXSQge+0QRZsDKSpRmQRwE601otXXauO31nOUct5AaiWPffXVQ==",
           "requires": {
-            "@injectivelabs/exceptions": "^1.11.0",
-            "@injectivelabs/ts-types": "^1.11.0",
-            "@injectivelabs/utils": "^1.11.0",
+            "@injectivelabs/exceptions": "^1.14.6",
+            "@injectivelabs/ts-types": "^1.14.6",
+            "@injectivelabs/utils": "^1.14.6",
             "link-module-alias": "^1.2.0",
             "shx": "^0.3.2"
           }
         },
         "@injectivelabs/utils": {
-          "version": "1.11.0",
-          "resolved": "https://registry.npmjs.org/@injectivelabs/utils/-/utils-1.11.0.tgz",
-          "integrity": "sha512-KnUmt4vIvoBz6F3mQomy4GeTkpcHMYwju2AgiqzARrrqgF/2p1ZHfKBpr1ksj/jkl5X+irh3JVfbd/dFjwKi1g==",
+          "version": "1.14.6",
+          "resolved": "https://registry.npmjs.org/@injectivelabs/utils/-/utils-1.14.6.tgz",
+          "integrity": "sha512-5I0h4GiLB5PPTl+g2lpevRP+WScvEbntdkoUQVtAdHewl4kutd5p1Kcnoi1Nvpq+sz5N/e9qtBIRuyxG38akOg==",
           "requires": {
-            "@injectivelabs/exceptions": "^1.11.0",
-            "@injectivelabs/ts-types": "^1.11.0",
+            "@injectivelabs/exceptions": "^1.14.6",
+            "@injectivelabs/ts-types": "^1.14.6",
             "axios": "^0.21.1",
             "bignumber.js": "^9.0.1",
             "http-status-codes": "^2.2.0",
@@ -10068,9 +11835,9 @@
       }
     },
     "@injectivelabs/ts-types": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/ts-types/-/ts-types-1.11.0.tgz",
-      "integrity": "sha512-3ZVRW1xMe3RHOxFblRC0LgQcU/rpxgZQZ+sISyRKFGcS/m2ApkdmcPvjMgd5TQe9AXW/6nnvmul3mST8iAaUJg==",
+      "version": "1.14.6",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/ts-types/-/ts-types-1.14.6.tgz",
+      "integrity": "sha512-/Ax5eCSfE9OhcyUc9wZk/LFKTYhIY9RJIaNT/n92rbHjXSfXRLSX+Bvk62vC9Ej+SEBPp77WYngtrePPA1HEgw==",
       "requires": {
         "link-module-alias": "^1.2.0",
         "shx": "^0.3.2"
@@ -11062,13 +12829,115 @@
       "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==",
       "dev": true
     },
-    "@wormhole-foundation/connect-sdk": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk/-/connect-sdk-0.4.6.tgz",
-      "integrity": "sha512-b5WAVfQIw7HLTmbGLl71qFHZhV82CKrYiwVAyXgZ0LwyGvbeNBjcuA05M0+mHQyyMHf/B33Wc4lYbESoTd2tWA==",
+    "@urql/introspection": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@urql/introspection/-/introspection-1.0.3.tgz",
+      "integrity": "sha512-5zgnfUDV10c3qudqYvfZ/rOtWVB2QvqanmoDMttqpt+TCCPkSUZdb2qcLCEB6DL7ph8mQRTZhXI29J57nTnqKg==",
+      "requires": {}
+    },
+    "@wormhole-foundation/sdk": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-0.5.0-beta.4.tgz",
+      "integrity": "sha512-nAFsih7Ob8mvn86cWzxaamRcuMTDOMt877Qiq9RoXy5xHgt7XgLOzWfy29kbIgPtk7TOpRavi3YHhVNOT1kkMg==",
       "requires": {
-        "@wormhole-foundation/sdk-base": "0.4.6",
-        "@wormhole-foundation/sdk-definitions": "0.4.6",
+        "@wormhole-foundation/sdk-algorand": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-algorand-core": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-algorand-tokenbridge": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-aptos": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-aptos-core": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-aptos-tokenbridge": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-base": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-connect": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-cosmwasm": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-cosmwasm-core": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-cosmwasm-ibc": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-definitions": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-evm": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-evm-cctp": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-evm-core": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-evm-portico": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-solana": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-solana-cctp": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-solana-core": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-solana-tokenbridge": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-sui": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-sui-core": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-sui-tokenbridge": "0.5.0-beta.4"
+      }
+    },
+    "@wormhole-foundation/sdk-algorand": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-0.5.0-beta.4.tgz",
+      "integrity": "sha512-L+FlTHFktv5YZaBC0exaajpvjbo1O2Xn7MzNZfNwiasQmrhRsLc3To5MjMVrWGUaldKVviMBdgzzKtllHiCbcw==",
+      "requires": {
+        "@wormhole-foundation/sdk-connect": "0.5.0-beta.4",
+        "algosdk": "2.7.0"
+      }
+    },
+    "@wormhole-foundation/sdk-algorand-core": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-0.5.0-beta.4.tgz",
+      "integrity": "sha512-fc/ktKfEw9IxLLGvap9yTMMqHrhgsGHaDX5Xk+wqyYn06VHcZiYnIaKdcNHVguZdqp6fL1pt4yWqipUeZhC3Jg==",
+      "requires": {
+        "@wormhole-foundation/sdk-algorand": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-connect": "0.5.0-beta.4"
+      }
+    },
+    "@wormhole-foundation/sdk-algorand-tokenbridge": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-0.5.0-beta.4.tgz",
+      "integrity": "sha512-pUBkxT0/zXltYnFgHcPPKiO6KfSnDL9KwRGptRKzOgf00YI5fuhm4f/nIUEgMkXrvLi29JsAxmr03e84+zKF8A==",
+      "requires": {
+        "@wormhole-foundation/sdk-algorand": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-algorand-core": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-connect": "0.5.0-beta.4"
+      }
+    },
+    "@wormhole-foundation/sdk-aptos": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-0.5.0-beta.4.tgz",
+      "integrity": "sha512-q8NPKbx/AZArjlGzUq+t5ORzd55DaU+WN3+76ahY11X3wPeFG3Hs3Vy6F07oz+8+wBP1Ks4R3t1qK6zTBGeGHA==",
+      "requires": {
+        "@wormhole-foundation/sdk-connect": "0.5.0-beta.4",
+        "aptos": "1.5.0"
+      }
+    },
+    "@wormhole-foundation/sdk-aptos-core": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-0.5.0-beta.4.tgz",
+      "integrity": "sha512-A5zHVnVF60e/L3PexkT7kgBvYki3Q9nvv8dxEi6vzaqfhQG7JrLbIxrj/zN1g0enxofsrgkARhuAX/beSV/+Wg==",
+      "requires": {
+        "@wormhole-foundation/sdk-aptos": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-connect": "0.5.0-beta.4"
+      }
+    },
+    "@wormhole-foundation/sdk-aptos-tokenbridge": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-0.5.0-beta.4.tgz",
+      "integrity": "sha512-MPJc0RdWUuYjmWdLlcUdJ1YTUUpUg/d3uuOmpuW1CaWsyuvRPsdYpTwy067irjHDFEzWQZai/T82VG1Y832LjQ==",
+      "requires": {
+        "@wormhole-foundation/sdk-aptos": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-aptos-core": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-connect": "0.5.0-beta.4"
+      }
+    },
+    "@wormhole-foundation/sdk-base": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-0.5.0-beta.4.tgz",
+      "integrity": "sha512-uTICIlbh0RkyHgrFdzEdVkc4YPqKtSXo4wxL83TY1XhEpbuq/UTIyr8q4Mp9AOPT5AnNSlY9ZwqUTDu5q+bY2Q==",
+      "requires": {
+        "@scure/base": "^1.1.3"
+      }
+    },
+    "@wormhole-foundation/sdk-connect": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-0.5.0-beta.4.tgz",
+      "integrity": "sha512-+FNedvFvEHCdp3Mm3rDPs91q4V7W9yl94Y4baVcbbHFXy5dgUpNgkiHhIrNb2bXAQeIhMpYxJVEEn9XQhFiDsQ==",
+      "requires": {
+        "@wormhole-foundation/sdk-base": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-definitions": "0.5.0-beta.4",
         "axios": "^1.4.0"
       },
       "dependencies": {
@@ -11094,13 +12963,904 @@
         }
       }
     },
-    "@wormhole-foundation/connect-sdk-evm": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk-evm/-/connect-sdk-evm-0.4.6.tgz",
-      "integrity": "sha512-YTZdvFQpV8+YaOpQmlrgsM+U5LFMMyO5u7VtjuDE9gfEX1DK5+OcW17RPqO8GcupAQK7NT39EuMdT9VBKvrEcA==",
+    "@wormhole-foundation/sdk-cosmwasm": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-0.5.0-beta.4.tgz",
+      "integrity": "sha512-kscEPFI9n01aU7z1I9qKQtJSv6GfD8lFl3I5zRji0wTbhkyQ9tSN/OfBlfRl4TApdlgh4b8pCIEIs6y6fazByA==",
+      "requires": {
+        "@cosmjs/cosmwasm-stargate": "^0.32.0",
+        "@cosmjs/crypto": "^0.32.0",
+        "@cosmjs/proto-signing": "^0.32.0",
+        "@cosmjs/stargate": "^0.32.0",
+        "@cosmjs/tendermint-rpc": "^0.32.0",
+        "@injectivelabs/sdk-ts": "^1.14.4",
+        "@wormhole-foundation/sdk-connect": "0.5.0-beta.4",
+        "cosmjs-types": "^0.9.0"
+      },
+      "dependencies": {
+        "@cosmjs/amino": {
+          "version": "0.32.2",
+          "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.32.2.tgz",
+          "integrity": "sha512-lcK5RCVm4OfdAooxKcF2+NwaDVVpghOq6o/A40c2mHXDUzUoRZ33VAHjVJ9Me6vOFxshrw/XEFn1f4KObntjYA==",
+          "requires": {
+            "@cosmjs/crypto": "^0.32.2",
+            "@cosmjs/encoding": "^0.32.2",
+            "@cosmjs/math": "^0.32.2",
+            "@cosmjs/utils": "^0.32.2"
+          }
+        },
+        "@cosmjs/cosmwasm-stargate": {
+          "version": "0.32.2",
+          "resolved": "https://registry.npmjs.org/@cosmjs/cosmwasm-stargate/-/cosmwasm-stargate-0.32.2.tgz",
+          "integrity": "sha512-OwJHzIx2CoJS6AULxOpNR6m+CI0GXxy8z9svHA1ZawzNM3ZGlL0GvHdhmF0WkpX4E7UdrYlJSLpKcgg5Fo6i7Q==",
+          "requires": {
+            "@cosmjs/amino": "^0.32.2",
+            "@cosmjs/crypto": "^0.32.2",
+            "@cosmjs/encoding": "^0.32.2",
+            "@cosmjs/math": "^0.32.2",
+            "@cosmjs/proto-signing": "^0.32.2",
+            "@cosmjs/stargate": "^0.32.2",
+            "@cosmjs/tendermint-rpc": "^0.32.2",
+            "@cosmjs/utils": "^0.32.2",
+            "cosmjs-types": "^0.9.0",
+            "pako": "^2.0.2"
+          }
+        },
+        "@cosmjs/crypto": {
+          "version": "0.32.2",
+          "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.32.2.tgz",
+          "integrity": "sha512-RuxrYKzhrPF9g6NmU7VEq++Hn1vZJjqqJpZ9Tmw9lOYOV8BUsv+j/0BE86kmWi7xVJ7EwxiuxYsKuM8IR18CIA==",
+          "requires": {
+            "@cosmjs/encoding": "^0.32.2",
+            "@cosmjs/math": "^0.32.2",
+            "@cosmjs/utils": "^0.32.2",
+            "@noble/hashes": "^1",
+            "bn.js": "^5.2.0",
+            "elliptic": "^6.5.4",
+            "libsodium-wrappers-sumo": "^0.7.11"
+          }
+        },
+        "@cosmjs/encoding": {
+          "version": "0.32.2",
+          "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.32.2.tgz",
+          "integrity": "sha512-WX7m1wLpA9V/zH0zRcz4EmgZdAv1F44g4dbXOgNj1eXZw1PIGR12p58OEkLN51Ha3S4DKRtCv5CkhK1KHEvQtg==",
+          "requires": {
+            "base64-js": "^1.3.0",
+            "bech32": "^1.1.4",
+            "readonly-date": "^1.0.0"
+          }
+        },
+        "@cosmjs/json-rpc": {
+          "version": "0.32.2",
+          "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.32.2.tgz",
+          "integrity": "sha512-lan2lOgmz4yVE/HR8eCOSiII/1OudIulk8836koyIDCsPEpt6eKBuctnAD168vABGArKccLAo7Mr2gy9nrKrOQ==",
+          "requires": {
+            "@cosmjs/stream": "^0.32.2",
+            "xstream": "^11.14.0"
+          }
+        },
+        "@cosmjs/math": {
+          "version": "0.32.2",
+          "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.32.2.tgz",
+          "integrity": "sha512-b8+ruAAY8aKtVKWSft2IvtCVCUH1LigIlf9ALIiY8n9jtM4kMASiaRbQ/27etnSAInV88IaezKK9rQZrtxTjcw==",
+          "requires": {
+            "bn.js": "^5.2.0"
+          }
+        },
+        "@cosmjs/proto-signing": {
+          "version": "0.32.2",
+          "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.32.2.tgz",
+          "integrity": "sha512-UV4WwkE3W3G3s7wwU9rizNcUEz2g0W8jQZS5J6/3fiN0mRPwtPKQ6EinPN9ASqcAJ7/VQH4/9EPOw7d6XQGnqw==",
+          "requires": {
+            "@cosmjs/amino": "^0.32.2",
+            "@cosmjs/crypto": "^0.32.2",
+            "@cosmjs/encoding": "^0.32.2",
+            "@cosmjs/math": "^0.32.2",
+            "@cosmjs/utils": "^0.32.2",
+            "cosmjs-types": "^0.9.0"
+          }
+        },
+        "@cosmjs/socket": {
+          "version": "0.32.2",
+          "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.32.2.tgz",
+          "integrity": "sha512-Qc8jaw4uSBJm09UwPgkqe3g9TBFx4ZR9HkXpwT6Z9I+6kbLerXPR0Gy3NSJFSUgxIfTpO8O1yqoWAyf0Ay17Mw==",
+          "requires": {
+            "@cosmjs/stream": "^0.32.2",
+            "isomorphic-ws": "^4.0.1",
+            "ws": "^7",
+            "xstream": "^11.14.0"
+          }
+        },
+        "@cosmjs/stargate": {
+          "version": "0.32.2",
+          "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.32.2.tgz",
+          "integrity": "sha512-AsJa29fT7Jd4xt9Ai+HMqhyj7UQu7fyYKdXj/8+/9PD74xe6lZSYhQPcitUmMLJ1ckKPgXSk5Dd2LbsQT0IhZg==",
+          "requires": {
+            "@confio/ics23": "^0.6.8",
+            "@cosmjs/amino": "^0.32.2",
+            "@cosmjs/encoding": "^0.32.2",
+            "@cosmjs/math": "^0.32.2",
+            "@cosmjs/proto-signing": "^0.32.2",
+            "@cosmjs/stream": "^0.32.2",
+            "@cosmjs/tendermint-rpc": "^0.32.2",
+            "@cosmjs/utils": "^0.32.2",
+            "cosmjs-types": "^0.9.0",
+            "xstream": "^11.14.0"
+          }
+        },
+        "@cosmjs/stream": {
+          "version": "0.32.2",
+          "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.32.2.tgz",
+          "integrity": "sha512-gpCufLfHAD8Zp1ZKge7AHbDf4RA0TZp66wZY6JaQR5bSiEF2Drjtp4mwXZPGejtaUMnaAgff3LrUzPJfKYdQwg==",
+          "requires": {
+            "xstream": "^11.14.0"
+          }
+        },
+        "@cosmjs/tendermint-rpc": {
+          "version": "0.32.2",
+          "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.32.2.tgz",
+          "integrity": "sha512-DXyJHDmcAfCix4H/7/dKR0UMdshP01KxJOXHdHxBCbLIpck94BsWD3B2ZTXwfA6sv98so9wOzhp7qGQa5malxg==",
+          "requires": {
+            "@cosmjs/crypto": "^0.32.2",
+            "@cosmjs/encoding": "^0.32.2",
+            "@cosmjs/json-rpc": "^0.32.2",
+            "@cosmjs/math": "^0.32.2",
+            "@cosmjs/socket": "^0.32.2",
+            "@cosmjs/stream": "^0.32.2",
+            "@cosmjs/utils": "^0.32.2",
+            "axios": "^1.6.0",
+            "readonly-date": "^1.0.0",
+            "xstream": "^11.14.0"
+          }
+        },
+        "@cosmjs/utils": {
+          "version": "0.32.2",
+          "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.32.2.tgz",
+          "integrity": "sha512-Gg5t+eR7vPJMAmhkFt6CZrzPd0EKpAslWwk5rFVYZpJsM8JG5KT9XQ99hgNM3Ov6ScNoIWbXkpX27F6A9cXR4Q=="
+        },
+        "@injectivelabs/core-proto-ts": {
+          "version": "0.0.21",
+          "resolved": "https://registry.npmjs.org/@injectivelabs/core-proto-ts/-/core-proto-ts-0.0.21.tgz",
+          "integrity": "sha512-RBxSkRBCty60R/l55/D1jsSW0Aof5dyGFhCFdN3A010KjMv/SzZGGr+6DZPY/hflyFeaJzDv/VTopCymKNRBvQ==",
+          "requires": {
+            "@injectivelabs/grpc-web": "^0.0.1",
+            "google-protobuf": "^3.14.0",
+            "protobufjs": "^7.0.0",
+            "rxjs": "^7.4.0"
+          }
+        },
+        "@injectivelabs/indexer-proto-ts": {
+          "version": "1.11.36",
+          "resolved": "https://registry.npmjs.org/@injectivelabs/indexer-proto-ts/-/indexer-proto-ts-1.11.36.tgz",
+          "integrity": "sha512-s7E3Y28JrkylDwRVfF/AvcPy/zPgz52W+XbQ0FOcsqPof78xp8FvnM3ubVZi0Dad39LgDB5eeiMFPmeuLp8Uew==",
+          "requires": {
+            "@injectivelabs/grpc-web": "^0.0.1",
+            "google-protobuf": "^3.14.0",
+            "protobufjs": "^7.0.0",
+            "rxjs": "^7.4.0"
+          }
+        },
+        "@injectivelabs/mito-proto-ts": {
+          "version": "1.0.62",
+          "resolved": "https://registry.npmjs.org/@injectivelabs/mito-proto-ts/-/mito-proto-ts-1.0.62.tgz",
+          "integrity": "sha512-WtoO80Y597nZiAuE4H+L208I0i3ByWytR+HqABdCaA26uJ7F1LhXw8YXxh3pP9z0LAeW31T+N7bwtOMlVR4riA==",
+          "requires": {
+            "@injectivelabs/grpc-web": "^0.0.1",
+            "google-protobuf": "^3.14.0",
+            "protobufjs": "^7.0.0",
+            "rxjs": "^7.4.0"
+          }
+        },
+        "@injectivelabs/networks": {
+          "version": "1.14.6",
+          "resolved": "https://registry.npmjs.org/@injectivelabs/networks/-/networks-1.14.6.tgz",
+          "integrity": "sha512-O1IkPFJl8ThNL6N+k/9OimrgCYsSWQ8A1FtVMXSQge+0QRZsDKSpRmQRwE601otXXauO31nOUct5AaiWPffXVQ==",
+          "requires": {
+            "@injectivelabs/exceptions": "^1.14.6",
+            "@injectivelabs/ts-types": "^1.14.6",
+            "@injectivelabs/utils": "^1.14.6",
+            "link-module-alias": "^1.2.0",
+            "shx": "^0.3.2"
+          }
+        },
+        "@injectivelabs/sdk-ts": {
+          "version": "1.14.7",
+          "resolved": "https://registry.npmjs.org/@injectivelabs/sdk-ts/-/sdk-ts-1.14.7.tgz",
+          "integrity": "sha512-Qm8y8jKCMyNfYZGZVI+p0SIGJPtP5M9/DPFyPK+JSR2OOU0J4MX2yS/tQB5ViC/3Bt7yQhw/l3Rop93e7pTZEg==",
+          "requires": {
+            "@apollo/client": "^3.5.8",
+            "@cosmjs/amino": "^0.32.2",
+            "@cosmjs/proto-signing": "^0.32.2",
+            "@cosmjs/stargate": "^0.32.2",
+            "@ensdomains/ens-validation": "^0.1.0",
+            "@ensdomains/eth-ens-namehash": "^2.0.15",
+            "@ethersproject/bytes": "^5.7.0",
+            "@injectivelabs/core-proto-ts": "^0.0.21",
+            "@injectivelabs/dmm-proto-ts": "1.0.19",
+            "@injectivelabs/exceptions": "^1.14.6",
+            "@injectivelabs/grpc-web": "^0.0.1",
+            "@injectivelabs/grpc-web-node-http-transport": "^0.0.2",
+            "@injectivelabs/grpc-web-react-native-transport": "^0.0.2",
+            "@injectivelabs/indexer-proto-ts": "1.11.36",
+            "@injectivelabs/mito-proto-ts": "1.0.62",
+            "@injectivelabs/networks": "^1.14.6",
+            "@injectivelabs/test-utils": "^1.14.3",
+            "@injectivelabs/token-metadata": "^1.14.7",
+            "@injectivelabs/ts-types": "^1.14.6",
+            "@injectivelabs/utils": "^1.14.6",
+            "@metamask/eth-sig-util": "^4.0.0",
+            "axios": "^0.27.2",
+            "bech32": "^2.0.0",
+            "bip39": "^3.0.4",
+            "cosmjs-types": "^0.9.0",
+            "ethereumjs-util": "^7.1.4",
+            "ethers": "^5.7.2",
+            "google-protobuf": "^3.21.0",
+            "graphql": "^16.3.0",
+            "http-status-codes": "^2.2.0",
+            "js-sha3": "^0.8.0",
+            "jscrypto": "^1.0.3",
+            "keccak256": "^1.0.6",
+            "link-module-alias": "^1.2.0",
+            "secp256k1": "^4.0.3",
+            "shx": "^0.3.2",
+            "snakecase-keys": "^5.4.1"
+          },
+          "dependencies": {
+            "axios": {
+              "version": "0.27.2",
+              "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+              "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+              "requires": {
+                "follow-redirects": "^1.14.9",
+                "form-data": "^4.0.0"
+              }
+            },
+            "bech32": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
+              "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
+            }
+          }
+        },
+        "@injectivelabs/utils": {
+          "version": "1.14.6",
+          "resolved": "https://registry.npmjs.org/@injectivelabs/utils/-/utils-1.14.6.tgz",
+          "integrity": "sha512-5I0h4GiLB5PPTl+g2lpevRP+WScvEbntdkoUQVtAdHewl4kutd5p1Kcnoi1Nvpq+sz5N/e9qtBIRuyxG38akOg==",
+          "requires": {
+            "@injectivelabs/exceptions": "^1.14.6",
+            "@injectivelabs/ts-types": "^1.14.6",
+            "axios": "^0.21.1",
+            "bignumber.js": "^9.0.1",
+            "http-status-codes": "^2.2.0",
+            "link-module-alias": "^1.2.0",
+            "shx": "^0.3.2",
+            "snakecase-keys": "^5.1.2",
+            "store2": "^2.12.0"
+          },
+          "dependencies": {
+            "axios": {
+              "version": "0.21.4",
+              "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+              "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+              "requires": {
+                "follow-redirects": "^1.14.0"
+              }
+            }
+          }
+        },
+        "axios": {
+          "version": "1.6.7",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+          "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+          "requires": {
+            "follow-redirects": "^1.15.4",
+            "form-data": "^4.0.0",
+            "proxy-from-env": "^1.1.0"
+          }
+        },
+        "cosmjs-types": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.9.0.tgz",
+          "integrity": "sha512-MN/yUe6mkJwHnCFfsNPeCfXVhyxHYW6c/xDUzrSbBycYzw++XvWDMJArXp2pLdgD6FQ8DW79vkPjeNKVrXaHeQ=="
+        },
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "long": {
+          "version": "5.2.3",
+          "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+          "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+        },
+        "protobufjs": {
+          "version": "7.2.6",
+          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz",
+          "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
+          "requires": {
+            "@protobufjs/aspromise": "^1.1.2",
+            "@protobufjs/base64": "^1.1.2",
+            "@protobufjs/codegen": "^2.0.4",
+            "@protobufjs/eventemitter": "^1.1.0",
+            "@protobufjs/fetch": "^1.1.0",
+            "@protobufjs/float": "^1.0.2",
+            "@protobufjs/inquire": "^1.1.0",
+            "@protobufjs/path": "^1.1.2",
+            "@protobufjs/pool": "^1.1.0",
+            "@protobufjs/utf8": "^1.1.0",
+            "@types/node": ">=13.7.0",
+            "long": "^5.0.0"
+          }
+        }
+      }
+    },
+    "@wormhole-foundation/sdk-cosmwasm-core": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-0.5.0-beta.4.tgz",
+      "integrity": "sha512-Ow7/suQqADJXJz7zibMl9EEKKcaxjT4CeV65pjjjjIOOOIvBjxN6ZwRMkJpi7cRdvbzJU2z4bdl6jPJ1o7hoPw==",
+      "requires": {
+        "@cosmjs/cosmwasm-stargate": "^0.32.0",
+        "@cosmjs/stargate": "^0.32.0",
+        "@wormhole-foundation/sdk-connect": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-cosmwasm": "0.5.0-beta.4",
+        "cosmjs-types": "^0.9.0"
+      },
+      "dependencies": {
+        "@cosmjs/amino": {
+          "version": "0.32.2",
+          "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.32.2.tgz",
+          "integrity": "sha512-lcK5RCVm4OfdAooxKcF2+NwaDVVpghOq6o/A40c2mHXDUzUoRZ33VAHjVJ9Me6vOFxshrw/XEFn1f4KObntjYA==",
+          "requires": {
+            "@cosmjs/crypto": "^0.32.2",
+            "@cosmjs/encoding": "^0.32.2",
+            "@cosmjs/math": "^0.32.2",
+            "@cosmjs/utils": "^0.32.2"
+          }
+        },
+        "@cosmjs/cosmwasm-stargate": {
+          "version": "0.32.2",
+          "resolved": "https://registry.npmjs.org/@cosmjs/cosmwasm-stargate/-/cosmwasm-stargate-0.32.2.tgz",
+          "integrity": "sha512-OwJHzIx2CoJS6AULxOpNR6m+CI0GXxy8z9svHA1ZawzNM3ZGlL0GvHdhmF0WkpX4E7UdrYlJSLpKcgg5Fo6i7Q==",
+          "requires": {
+            "@cosmjs/amino": "^0.32.2",
+            "@cosmjs/crypto": "^0.32.2",
+            "@cosmjs/encoding": "^0.32.2",
+            "@cosmjs/math": "^0.32.2",
+            "@cosmjs/proto-signing": "^0.32.2",
+            "@cosmjs/stargate": "^0.32.2",
+            "@cosmjs/tendermint-rpc": "^0.32.2",
+            "@cosmjs/utils": "^0.32.2",
+            "cosmjs-types": "^0.9.0",
+            "pako": "^2.0.2"
+          }
+        },
+        "@cosmjs/crypto": {
+          "version": "0.32.2",
+          "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.32.2.tgz",
+          "integrity": "sha512-RuxrYKzhrPF9g6NmU7VEq++Hn1vZJjqqJpZ9Tmw9lOYOV8BUsv+j/0BE86kmWi7xVJ7EwxiuxYsKuM8IR18CIA==",
+          "requires": {
+            "@cosmjs/encoding": "^0.32.2",
+            "@cosmjs/math": "^0.32.2",
+            "@cosmjs/utils": "^0.32.2",
+            "@noble/hashes": "^1",
+            "bn.js": "^5.2.0",
+            "elliptic": "^6.5.4",
+            "libsodium-wrappers-sumo": "^0.7.11"
+          }
+        },
+        "@cosmjs/encoding": {
+          "version": "0.32.2",
+          "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.32.2.tgz",
+          "integrity": "sha512-WX7m1wLpA9V/zH0zRcz4EmgZdAv1F44g4dbXOgNj1eXZw1PIGR12p58OEkLN51Ha3S4DKRtCv5CkhK1KHEvQtg==",
+          "requires": {
+            "base64-js": "^1.3.0",
+            "bech32": "^1.1.4",
+            "readonly-date": "^1.0.0"
+          }
+        },
+        "@cosmjs/json-rpc": {
+          "version": "0.32.2",
+          "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.32.2.tgz",
+          "integrity": "sha512-lan2lOgmz4yVE/HR8eCOSiII/1OudIulk8836koyIDCsPEpt6eKBuctnAD168vABGArKccLAo7Mr2gy9nrKrOQ==",
+          "requires": {
+            "@cosmjs/stream": "^0.32.2",
+            "xstream": "^11.14.0"
+          }
+        },
+        "@cosmjs/math": {
+          "version": "0.32.2",
+          "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.32.2.tgz",
+          "integrity": "sha512-b8+ruAAY8aKtVKWSft2IvtCVCUH1LigIlf9ALIiY8n9jtM4kMASiaRbQ/27etnSAInV88IaezKK9rQZrtxTjcw==",
+          "requires": {
+            "bn.js": "^5.2.0"
+          }
+        },
+        "@cosmjs/proto-signing": {
+          "version": "0.32.2",
+          "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.32.2.tgz",
+          "integrity": "sha512-UV4WwkE3W3G3s7wwU9rizNcUEz2g0W8jQZS5J6/3fiN0mRPwtPKQ6EinPN9ASqcAJ7/VQH4/9EPOw7d6XQGnqw==",
+          "requires": {
+            "@cosmjs/amino": "^0.32.2",
+            "@cosmjs/crypto": "^0.32.2",
+            "@cosmjs/encoding": "^0.32.2",
+            "@cosmjs/math": "^0.32.2",
+            "@cosmjs/utils": "^0.32.2",
+            "cosmjs-types": "^0.9.0"
+          }
+        },
+        "@cosmjs/socket": {
+          "version": "0.32.2",
+          "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.32.2.tgz",
+          "integrity": "sha512-Qc8jaw4uSBJm09UwPgkqe3g9TBFx4ZR9HkXpwT6Z9I+6kbLerXPR0Gy3NSJFSUgxIfTpO8O1yqoWAyf0Ay17Mw==",
+          "requires": {
+            "@cosmjs/stream": "^0.32.2",
+            "isomorphic-ws": "^4.0.1",
+            "ws": "^7",
+            "xstream": "^11.14.0"
+          }
+        },
+        "@cosmjs/stargate": {
+          "version": "0.32.2",
+          "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.32.2.tgz",
+          "integrity": "sha512-AsJa29fT7Jd4xt9Ai+HMqhyj7UQu7fyYKdXj/8+/9PD74xe6lZSYhQPcitUmMLJ1ckKPgXSk5Dd2LbsQT0IhZg==",
+          "requires": {
+            "@confio/ics23": "^0.6.8",
+            "@cosmjs/amino": "^0.32.2",
+            "@cosmjs/encoding": "^0.32.2",
+            "@cosmjs/math": "^0.32.2",
+            "@cosmjs/proto-signing": "^0.32.2",
+            "@cosmjs/stream": "^0.32.2",
+            "@cosmjs/tendermint-rpc": "^0.32.2",
+            "@cosmjs/utils": "^0.32.2",
+            "cosmjs-types": "^0.9.0",
+            "xstream": "^11.14.0"
+          }
+        },
+        "@cosmjs/stream": {
+          "version": "0.32.2",
+          "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.32.2.tgz",
+          "integrity": "sha512-gpCufLfHAD8Zp1ZKge7AHbDf4RA0TZp66wZY6JaQR5bSiEF2Drjtp4mwXZPGejtaUMnaAgff3LrUzPJfKYdQwg==",
+          "requires": {
+            "xstream": "^11.14.0"
+          }
+        },
+        "@cosmjs/tendermint-rpc": {
+          "version": "0.32.2",
+          "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.32.2.tgz",
+          "integrity": "sha512-DXyJHDmcAfCix4H/7/dKR0UMdshP01KxJOXHdHxBCbLIpck94BsWD3B2ZTXwfA6sv98so9wOzhp7qGQa5malxg==",
+          "requires": {
+            "@cosmjs/crypto": "^0.32.2",
+            "@cosmjs/encoding": "^0.32.2",
+            "@cosmjs/json-rpc": "^0.32.2",
+            "@cosmjs/math": "^0.32.2",
+            "@cosmjs/socket": "^0.32.2",
+            "@cosmjs/stream": "^0.32.2",
+            "@cosmjs/utils": "^0.32.2",
+            "axios": "^1.6.0",
+            "readonly-date": "^1.0.0",
+            "xstream": "^11.14.0"
+          }
+        },
+        "@cosmjs/utils": {
+          "version": "0.32.2",
+          "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.32.2.tgz",
+          "integrity": "sha512-Gg5t+eR7vPJMAmhkFt6CZrzPd0EKpAslWwk5rFVYZpJsM8JG5KT9XQ99hgNM3Ov6ScNoIWbXkpX27F6A9cXR4Q=="
+        },
+        "axios": {
+          "version": "1.6.7",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+          "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+          "requires": {
+            "follow-redirects": "^1.15.4",
+            "form-data": "^4.0.0",
+            "proxy-from-env": "^1.1.0"
+          }
+        },
+        "cosmjs-types": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.9.0.tgz",
+          "integrity": "sha512-MN/yUe6mkJwHnCFfsNPeCfXVhyxHYW6c/xDUzrSbBycYzw++XvWDMJArXp2pLdgD6FQ8DW79vkPjeNKVrXaHeQ=="
+        },
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
+    "@wormhole-foundation/sdk-cosmwasm-ibc": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-0.5.0-beta.4.tgz",
+      "integrity": "sha512-Bon7VNhrcksb9ynxIwMcPK5K/j+q2UjBZA6zEDFJNGhVg02GivwFd/6mfHReVEi6AwgudPkzJuK6V5gMuuYC6A==",
+      "requires": {
+        "@cosmjs/cosmwasm-stargate": "^0.32.0",
+        "@cosmjs/stargate": "^0.32.0",
+        "@wormhole-foundation/sdk-connect": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-cosmwasm": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-cosmwasm-core": "0.5.0-beta.4",
+        "cosmjs-types": "^0.9.0"
+      },
+      "dependencies": {
+        "@cosmjs/amino": {
+          "version": "0.32.2",
+          "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.32.2.tgz",
+          "integrity": "sha512-lcK5RCVm4OfdAooxKcF2+NwaDVVpghOq6o/A40c2mHXDUzUoRZ33VAHjVJ9Me6vOFxshrw/XEFn1f4KObntjYA==",
+          "requires": {
+            "@cosmjs/crypto": "^0.32.2",
+            "@cosmjs/encoding": "^0.32.2",
+            "@cosmjs/math": "^0.32.2",
+            "@cosmjs/utils": "^0.32.2"
+          }
+        },
+        "@cosmjs/cosmwasm-stargate": {
+          "version": "0.32.2",
+          "resolved": "https://registry.npmjs.org/@cosmjs/cosmwasm-stargate/-/cosmwasm-stargate-0.32.2.tgz",
+          "integrity": "sha512-OwJHzIx2CoJS6AULxOpNR6m+CI0GXxy8z9svHA1ZawzNM3ZGlL0GvHdhmF0WkpX4E7UdrYlJSLpKcgg5Fo6i7Q==",
+          "requires": {
+            "@cosmjs/amino": "^0.32.2",
+            "@cosmjs/crypto": "^0.32.2",
+            "@cosmjs/encoding": "^0.32.2",
+            "@cosmjs/math": "^0.32.2",
+            "@cosmjs/proto-signing": "^0.32.2",
+            "@cosmjs/stargate": "^0.32.2",
+            "@cosmjs/tendermint-rpc": "^0.32.2",
+            "@cosmjs/utils": "^0.32.2",
+            "cosmjs-types": "^0.9.0",
+            "pako": "^2.0.2"
+          }
+        },
+        "@cosmjs/crypto": {
+          "version": "0.32.2",
+          "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.32.2.tgz",
+          "integrity": "sha512-RuxrYKzhrPF9g6NmU7VEq++Hn1vZJjqqJpZ9Tmw9lOYOV8BUsv+j/0BE86kmWi7xVJ7EwxiuxYsKuM8IR18CIA==",
+          "requires": {
+            "@cosmjs/encoding": "^0.32.2",
+            "@cosmjs/math": "^0.32.2",
+            "@cosmjs/utils": "^0.32.2",
+            "@noble/hashes": "^1",
+            "bn.js": "^5.2.0",
+            "elliptic": "^6.5.4",
+            "libsodium-wrappers-sumo": "^0.7.11"
+          }
+        },
+        "@cosmjs/encoding": {
+          "version": "0.32.2",
+          "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.32.2.tgz",
+          "integrity": "sha512-WX7m1wLpA9V/zH0zRcz4EmgZdAv1F44g4dbXOgNj1eXZw1PIGR12p58OEkLN51Ha3S4DKRtCv5CkhK1KHEvQtg==",
+          "requires": {
+            "base64-js": "^1.3.0",
+            "bech32": "^1.1.4",
+            "readonly-date": "^1.0.0"
+          }
+        },
+        "@cosmjs/json-rpc": {
+          "version": "0.32.2",
+          "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.32.2.tgz",
+          "integrity": "sha512-lan2lOgmz4yVE/HR8eCOSiII/1OudIulk8836koyIDCsPEpt6eKBuctnAD168vABGArKccLAo7Mr2gy9nrKrOQ==",
+          "requires": {
+            "@cosmjs/stream": "^0.32.2",
+            "xstream": "^11.14.0"
+          }
+        },
+        "@cosmjs/math": {
+          "version": "0.32.2",
+          "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.32.2.tgz",
+          "integrity": "sha512-b8+ruAAY8aKtVKWSft2IvtCVCUH1LigIlf9ALIiY8n9jtM4kMASiaRbQ/27etnSAInV88IaezKK9rQZrtxTjcw==",
+          "requires": {
+            "bn.js": "^5.2.0"
+          }
+        },
+        "@cosmjs/proto-signing": {
+          "version": "0.32.2",
+          "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.32.2.tgz",
+          "integrity": "sha512-UV4WwkE3W3G3s7wwU9rizNcUEz2g0W8jQZS5J6/3fiN0mRPwtPKQ6EinPN9ASqcAJ7/VQH4/9EPOw7d6XQGnqw==",
+          "requires": {
+            "@cosmjs/amino": "^0.32.2",
+            "@cosmjs/crypto": "^0.32.2",
+            "@cosmjs/encoding": "^0.32.2",
+            "@cosmjs/math": "^0.32.2",
+            "@cosmjs/utils": "^0.32.2",
+            "cosmjs-types": "^0.9.0"
+          }
+        },
+        "@cosmjs/socket": {
+          "version": "0.32.2",
+          "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.32.2.tgz",
+          "integrity": "sha512-Qc8jaw4uSBJm09UwPgkqe3g9TBFx4ZR9HkXpwT6Z9I+6kbLerXPR0Gy3NSJFSUgxIfTpO8O1yqoWAyf0Ay17Mw==",
+          "requires": {
+            "@cosmjs/stream": "^0.32.2",
+            "isomorphic-ws": "^4.0.1",
+            "ws": "^7",
+            "xstream": "^11.14.0"
+          }
+        },
+        "@cosmjs/stargate": {
+          "version": "0.32.2",
+          "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.32.2.tgz",
+          "integrity": "sha512-AsJa29fT7Jd4xt9Ai+HMqhyj7UQu7fyYKdXj/8+/9PD74xe6lZSYhQPcitUmMLJ1ckKPgXSk5Dd2LbsQT0IhZg==",
+          "requires": {
+            "@confio/ics23": "^0.6.8",
+            "@cosmjs/amino": "^0.32.2",
+            "@cosmjs/encoding": "^0.32.2",
+            "@cosmjs/math": "^0.32.2",
+            "@cosmjs/proto-signing": "^0.32.2",
+            "@cosmjs/stream": "^0.32.2",
+            "@cosmjs/tendermint-rpc": "^0.32.2",
+            "@cosmjs/utils": "^0.32.2",
+            "cosmjs-types": "^0.9.0",
+            "xstream": "^11.14.0"
+          }
+        },
+        "@cosmjs/stream": {
+          "version": "0.32.2",
+          "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.32.2.tgz",
+          "integrity": "sha512-gpCufLfHAD8Zp1ZKge7AHbDf4RA0TZp66wZY6JaQR5bSiEF2Drjtp4mwXZPGejtaUMnaAgff3LrUzPJfKYdQwg==",
+          "requires": {
+            "xstream": "^11.14.0"
+          }
+        },
+        "@cosmjs/tendermint-rpc": {
+          "version": "0.32.2",
+          "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.32.2.tgz",
+          "integrity": "sha512-DXyJHDmcAfCix4H/7/dKR0UMdshP01KxJOXHdHxBCbLIpck94BsWD3B2ZTXwfA6sv98so9wOzhp7qGQa5malxg==",
+          "requires": {
+            "@cosmjs/crypto": "^0.32.2",
+            "@cosmjs/encoding": "^0.32.2",
+            "@cosmjs/json-rpc": "^0.32.2",
+            "@cosmjs/math": "^0.32.2",
+            "@cosmjs/socket": "^0.32.2",
+            "@cosmjs/stream": "^0.32.2",
+            "@cosmjs/utils": "^0.32.2",
+            "axios": "^1.6.0",
+            "readonly-date": "^1.0.0",
+            "xstream": "^11.14.0"
+          }
+        },
+        "@cosmjs/utils": {
+          "version": "0.32.2",
+          "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.32.2.tgz",
+          "integrity": "sha512-Gg5t+eR7vPJMAmhkFt6CZrzPd0EKpAslWwk5rFVYZpJsM8JG5KT9XQ99hgNM3Ov6ScNoIWbXkpX27F6A9cXR4Q=="
+        },
+        "axios": {
+          "version": "1.6.7",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+          "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+          "requires": {
+            "follow-redirects": "^1.15.4",
+            "form-data": "^4.0.0",
+            "proxy-from-env": "^1.1.0"
+          }
+        },
+        "cosmjs-types": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.9.0.tgz",
+          "integrity": "sha512-MN/yUe6mkJwHnCFfsNPeCfXVhyxHYW6c/xDUzrSbBycYzw++XvWDMJArXp2pLdgD6FQ8DW79vkPjeNKVrXaHeQ=="
+        },
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
+    "@wormhole-foundation/sdk-cosmwasm-tokenbridge": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-0.5.0-beta.4.tgz",
+      "integrity": "sha512-M8qnJnL6IvkBM0hsjWTYcpSJJ03AOfVpDMSx70kf6NRe1FYaqony4qAuFYYC88k7dYm5ec65+MO+ztSnZODwyQ==",
+      "requires": {
+        "@cosmjs/cosmwasm-stargate": "^0.32.0",
+        "@cosmjs/stargate": "^0.32.0",
+        "@wormhole-foundation/sdk-connect": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-cosmwasm": "0.5.0-beta.4",
+        "cosmjs-types": "^0.9.0"
+      },
+      "dependencies": {
+        "@cosmjs/amino": {
+          "version": "0.32.2",
+          "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.32.2.tgz",
+          "integrity": "sha512-lcK5RCVm4OfdAooxKcF2+NwaDVVpghOq6o/A40c2mHXDUzUoRZ33VAHjVJ9Me6vOFxshrw/XEFn1f4KObntjYA==",
+          "requires": {
+            "@cosmjs/crypto": "^0.32.2",
+            "@cosmjs/encoding": "^0.32.2",
+            "@cosmjs/math": "^0.32.2",
+            "@cosmjs/utils": "^0.32.2"
+          }
+        },
+        "@cosmjs/cosmwasm-stargate": {
+          "version": "0.32.2",
+          "resolved": "https://registry.npmjs.org/@cosmjs/cosmwasm-stargate/-/cosmwasm-stargate-0.32.2.tgz",
+          "integrity": "sha512-OwJHzIx2CoJS6AULxOpNR6m+CI0GXxy8z9svHA1ZawzNM3ZGlL0GvHdhmF0WkpX4E7UdrYlJSLpKcgg5Fo6i7Q==",
+          "requires": {
+            "@cosmjs/amino": "^0.32.2",
+            "@cosmjs/crypto": "^0.32.2",
+            "@cosmjs/encoding": "^0.32.2",
+            "@cosmjs/math": "^0.32.2",
+            "@cosmjs/proto-signing": "^0.32.2",
+            "@cosmjs/stargate": "^0.32.2",
+            "@cosmjs/tendermint-rpc": "^0.32.2",
+            "@cosmjs/utils": "^0.32.2",
+            "cosmjs-types": "^0.9.0",
+            "pako": "^2.0.2"
+          }
+        },
+        "@cosmjs/crypto": {
+          "version": "0.32.2",
+          "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.32.2.tgz",
+          "integrity": "sha512-RuxrYKzhrPF9g6NmU7VEq++Hn1vZJjqqJpZ9Tmw9lOYOV8BUsv+j/0BE86kmWi7xVJ7EwxiuxYsKuM8IR18CIA==",
+          "requires": {
+            "@cosmjs/encoding": "^0.32.2",
+            "@cosmjs/math": "^0.32.2",
+            "@cosmjs/utils": "^0.32.2",
+            "@noble/hashes": "^1",
+            "bn.js": "^5.2.0",
+            "elliptic": "^6.5.4",
+            "libsodium-wrappers-sumo": "^0.7.11"
+          }
+        },
+        "@cosmjs/encoding": {
+          "version": "0.32.2",
+          "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.32.2.tgz",
+          "integrity": "sha512-WX7m1wLpA9V/zH0zRcz4EmgZdAv1F44g4dbXOgNj1eXZw1PIGR12p58OEkLN51Ha3S4DKRtCv5CkhK1KHEvQtg==",
+          "requires": {
+            "base64-js": "^1.3.0",
+            "bech32": "^1.1.4",
+            "readonly-date": "^1.0.0"
+          }
+        },
+        "@cosmjs/json-rpc": {
+          "version": "0.32.2",
+          "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.32.2.tgz",
+          "integrity": "sha512-lan2lOgmz4yVE/HR8eCOSiII/1OudIulk8836koyIDCsPEpt6eKBuctnAD168vABGArKccLAo7Mr2gy9nrKrOQ==",
+          "requires": {
+            "@cosmjs/stream": "^0.32.2",
+            "xstream": "^11.14.0"
+          }
+        },
+        "@cosmjs/math": {
+          "version": "0.32.2",
+          "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.32.2.tgz",
+          "integrity": "sha512-b8+ruAAY8aKtVKWSft2IvtCVCUH1LigIlf9ALIiY8n9jtM4kMASiaRbQ/27etnSAInV88IaezKK9rQZrtxTjcw==",
+          "requires": {
+            "bn.js": "^5.2.0"
+          }
+        },
+        "@cosmjs/proto-signing": {
+          "version": "0.32.2",
+          "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.32.2.tgz",
+          "integrity": "sha512-UV4WwkE3W3G3s7wwU9rizNcUEz2g0W8jQZS5J6/3fiN0mRPwtPKQ6EinPN9ASqcAJ7/VQH4/9EPOw7d6XQGnqw==",
+          "requires": {
+            "@cosmjs/amino": "^0.32.2",
+            "@cosmjs/crypto": "^0.32.2",
+            "@cosmjs/encoding": "^0.32.2",
+            "@cosmjs/math": "^0.32.2",
+            "@cosmjs/utils": "^0.32.2",
+            "cosmjs-types": "^0.9.0"
+          }
+        },
+        "@cosmjs/socket": {
+          "version": "0.32.2",
+          "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.32.2.tgz",
+          "integrity": "sha512-Qc8jaw4uSBJm09UwPgkqe3g9TBFx4ZR9HkXpwT6Z9I+6kbLerXPR0Gy3NSJFSUgxIfTpO8O1yqoWAyf0Ay17Mw==",
+          "requires": {
+            "@cosmjs/stream": "^0.32.2",
+            "isomorphic-ws": "^4.0.1",
+            "ws": "^7",
+            "xstream": "^11.14.0"
+          }
+        },
+        "@cosmjs/stargate": {
+          "version": "0.32.2",
+          "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.32.2.tgz",
+          "integrity": "sha512-AsJa29fT7Jd4xt9Ai+HMqhyj7UQu7fyYKdXj/8+/9PD74xe6lZSYhQPcitUmMLJ1ckKPgXSk5Dd2LbsQT0IhZg==",
+          "requires": {
+            "@confio/ics23": "^0.6.8",
+            "@cosmjs/amino": "^0.32.2",
+            "@cosmjs/encoding": "^0.32.2",
+            "@cosmjs/math": "^0.32.2",
+            "@cosmjs/proto-signing": "^0.32.2",
+            "@cosmjs/stream": "^0.32.2",
+            "@cosmjs/tendermint-rpc": "^0.32.2",
+            "@cosmjs/utils": "^0.32.2",
+            "cosmjs-types": "^0.9.0",
+            "xstream": "^11.14.0"
+          }
+        },
+        "@cosmjs/stream": {
+          "version": "0.32.2",
+          "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.32.2.tgz",
+          "integrity": "sha512-gpCufLfHAD8Zp1ZKge7AHbDf4RA0TZp66wZY6JaQR5bSiEF2Drjtp4mwXZPGejtaUMnaAgff3LrUzPJfKYdQwg==",
+          "requires": {
+            "xstream": "^11.14.0"
+          }
+        },
+        "@cosmjs/tendermint-rpc": {
+          "version": "0.32.2",
+          "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.32.2.tgz",
+          "integrity": "sha512-DXyJHDmcAfCix4H/7/dKR0UMdshP01KxJOXHdHxBCbLIpck94BsWD3B2ZTXwfA6sv98so9wOzhp7qGQa5malxg==",
+          "requires": {
+            "@cosmjs/crypto": "^0.32.2",
+            "@cosmjs/encoding": "^0.32.2",
+            "@cosmjs/json-rpc": "^0.32.2",
+            "@cosmjs/math": "^0.32.2",
+            "@cosmjs/socket": "^0.32.2",
+            "@cosmjs/stream": "^0.32.2",
+            "@cosmjs/utils": "^0.32.2",
+            "axios": "^1.6.0",
+            "readonly-date": "^1.0.0",
+            "xstream": "^11.14.0"
+          }
+        },
+        "@cosmjs/utils": {
+          "version": "0.32.2",
+          "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.32.2.tgz",
+          "integrity": "sha512-Gg5t+eR7vPJMAmhkFt6CZrzPd0EKpAslWwk5rFVYZpJsM8JG5KT9XQ99hgNM3Ov6ScNoIWbXkpX27F6A9cXR4Q=="
+        },
+        "axios": {
+          "version": "1.6.7",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+          "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+          "requires": {
+            "follow-redirects": "^1.15.4",
+            "form-data": "^4.0.0",
+            "proxy-from-env": "^1.1.0"
+          }
+        },
+        "cosmjs-types": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.9.0.tgz",
+          "integrity": "sha512-MN/yUe6mkJwHnCFfsNPeCfXVhyxHYW6c/xDUzrSbBycYzw++XvWDMJArXp2pLdgD6FQ8DW79vkPjeNKVrXaHeQ=="
+        },
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
+    "@wormhole-foundation/sdk-definitions": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-0.5.0-beta.4.tgz",
+      "integrity": "sha512-9mLhF+aR96YGE/QjVnnc9vrdosijsetOpCqynvab4F8yAvMCYb4QWtaaLs0ul3Q1PgaQQGo23qah8IMpnF3BWA==",
+      "requires": {
+        "@noble/hashes": "^1.3.1",
+        "@wormhole-foundation/sdk-base": "0.5.0-beta.4"
+      },
+      "dependencies": {
+        "@noble/hashes": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.3.tgz",
+          "integrity": "sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA=="
+        }
+      }
+    },
+    "@wormhole-foundation/sdk-evm": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-0.5.0-beta.4.tgz",
+      "integrity": "sha512-5xrJYxaeDs84b/ivx1w7u03kirGqpJF5iPznpa+gMDaccaGQ7LjxEOOBp1Wc8Nq+4Ei02Vo0jxpSQtb803FPEw==",
       "requires": {
         "@typechain/ethers-v6": "^0.4.0",
-        "@wormhole-foundation/connect-sdk": "0.4.6",
+        "@wormhole-foundation/sdk-connect": "0.5.0-beta.4",
         "ethers": "^6.5.1",
         "typechain": "^8.2.0"
       },
@@ -11154,41 +13914,420 @@
         }
       }
     },
-    "@wormhole-foundation/connect-sdk-solana": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk-solana/-/connect-sdk-solana-0.4.6.tgz",
-      "integrity": "sha512-x0skE7wy33KhUEnWHtv34MmNDL1BsezPhV70yI8ncm7M1BYrIHTtXfkrhB3+5N3CY2GfCMxAoE260Eb8FKH0zg==",
+    "@wormhole-foundation/sdk-evm-cctp": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-0.5.0-beta.4.tgz",
+      "integrity": "sha512-rmo1VkN/g5SO2bpNrp08JwnftpVqCfscz3Dsb/2EOsvC0S9aScQLAfsQnWyQZjocqi/GPSQFc35rfEAnTAEGSg==",
+      "requires": {
+        "@typechain/ethers-v6": "^0.4.0",
+        "@wormhole-foundation/sdk-connect": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-evm": "0.5.0-beta.4",
+        "ethers": "^6.5.1",
+        "typechain": "^8.2.0"
+      },
+      "dependencies": {
+        "@noble/curves": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+          "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+          "requires": {
+            "@noble/hashes": "1.3.2"
+          }
+        },
+        "@noble/hashes": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+          "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ=="
+        },
+        "@typechain/ethers-v6": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/@typechain/ethers-v6/-/ethers-v6-0.4.3.tgz",
+          "integrity": "sha512-TrxBsyb4ryhaY9keP6RzhFCviWYApcLCIRMPyWaKp2cZZrfaM3QBoxXTnw/eO4+DAY3l+8O0brNW0WgeQeOiDA==",
+          "requires": {
+            "lodash": "^4.17.15",
+            "ts-essentials": "^7.0.1"
+          }
+        },
+        "aes-js": {
+          "version": "4.0.0-beta.5",
+          "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+          "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="
+        },
+        "ethers": {
+          "version": "6.11.1",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.11.1.tgz",
+          "integrity": "sha512-mxTAE6wqJQAbp5QAe/+o+rXOID7Nw91OZXvgpjDa1r4fAbq2Nu314oEZSbjoRLacuCzs7kUC3clEvkCQowffGg==",
+          "requires": {
+            "@adraffy/ens-normalize": "1.10.1",
+            "@noble/curves": "1.2.0",
+            "@noble/hashes": "1.3.2",
+            "@types/node": "18.15.13",
+            "aes-js": "4.0.0-beta.5",
+            "tslib": "2.4.0",
+            "ws": "8.5.0"
+          }
+        },
+        "ws": {
+          "version": "8.5.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+          "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+          "requires": {}
+        }
+      }
+    },
+    "@wormhole-foundation/sdk-evm-core": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-0.5.0-beta.4.tgz",
+      "integrity": "sha512-dlkgXfqnumFT2VqECzH/QY8JW9x3bDqH9iUf1M/hy90JsRxVc0H4CK7O+wY8q65NRT07LyjV/eQ+9X3Ze6Uz9A==",
+      "requires": {
+        "@typechain/ethers-v6": "^0.4.0",
+        "@wormhole-foundation/sdk-connect": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-evm": "0.5.0-beta.4",
+        "ethers": "^6.5.1",
+        "typechain": "^8.2.0"
+      },
+      "dependencies": {
+        "@noble/curves": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+          "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+          "requires": {
+            "@noble/hashes": "1.3.2"
+          }
+        },
+        "@noble/hashes": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+          "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ=="
+        },
+        "@typechain/ethers-v6": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/@typechain/ethers-v6/-/ethers-v6-0.4.3.tgz",
+          "integrity": "sha512-TrxBsyb4ryhaY9keP6RzhFCviWYApcLCIRMPyWaKp2cZZrfaM3QBoxXTnw/eO4+DAY3l+8O0brNW0WgeQeOiDA==",
+          "requires": {
+            "lodash": "^4.17.15",
+            "ts-essentials": "^7.0.1"
+          }
+        },
+        "aes-js": {
+          "version": "4.0.0-beta.5",
+          "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+          "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="
+        },
+        "ethers": {
+          "version": "6.11.1",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.11.1.tgz",
+          "integrity": "sha512-mxTAE6wqJQAbp5QAe/+o+rXOID7Nw91OZXvgpjDa1r4fAbq2Nu314oEZSbjoRLacuCzs7kUC3clEvkCQowffGg==",
+          "requires": {
+            "@adraffy/ens-normalize": "1.10.1",
+            "@noble/curves": "1.2.0",
+            "@noble/hashes": "1.3.2",
+            "@types/node": "18.15.13",
+            "aes-js": "4.0.0-beta.5",
+            "tslib": "2.4.0",
+            "ws": "8.5.0"
+          }
+        },
+        "ws": {
+          "version": "8.5.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+          "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+          "requires": {}
+        }
+      }
+    },
+    "@wormhole-foundation/sdk-evm-portico": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-0.5.0-beta.4.tgz",
+      "integrity": "sha512-cCW5mtFfR2sMPNDAXrSiv6YMFVWDRJlSREQyZW3YueO+ngaHHc5gaNE4iSrpjBzkU5j46zZ+F6tbieqamqJPQQ==",
+      "requires": {
+        "@typechain/ethers-v6": "^0.4.0",
+        "@wormhole-foundation/sdk-connect": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-evm": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-evm-core": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "0.5.0-beta.4",
+        "ethers": "^6.5.1",
+        "typechain": "^8.2.0"
+      },
+      "dependencies": {
+        "@noble/curves": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+          "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+          "requires": {
+            "@noble/hashes": "1.3.2"
+          }
+        },
+        "@noble/hashes": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+          "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ=="
+        },
+        "@typechain/ethers-v6": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/@typechain/ethers-v6/-/ethers-v6-0.4.3.tgz",
+          "integrity": "sha512-TrxBsyb4ryhaY9keP6RzhFCviWYApcLCIRMPyWaKp2cZZrfaM3QBoxXTnw/eO4+DAY3l+8O0brNW0WgeQeOiDA==",
+          "requires": {
+            "lodash": "^4.17.15",
+            "ts-essentials": "^7.0.1"
+          }
+        },
+        "aes-js": {
+          "version": "4.0.0-beta.5",
+          "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+          "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="
+        },
+        "ethers": {
+          "version": "6.11.1",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.11.1.tgz",
+          "integrity": "sha512-mxTAE6wqJQAbp5QAe/+o+rXOID7Nw91OZXvgpjDa1r4fAbq2Nu314oEZSbjoRLacuCzs7kUC3clEvkCQowffGg==",
+          "requires": {
+            "@adraffy/ens-normalize": "1.10.1",
+            "@noble/curves": "1.2.0",
+            "@noble/hashes": "1.3.2",
+            "@types/node": "18.15.13",
+            "aes-js": "4.0.0-beta.5",
+            "tslib": "2.4.0",
+            "ws": "8.5.0"
+          }
+        },
+        "ws": {
+          "version": "8.5.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+          "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+          "requires": {}
+        }
+      }
+    },
+    "@wormhole-foundation/sdk-evm-tokenbridge": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-0.5.0-beta.4.tgz",
+      "integrity": "sha512-8Uwc/oecyMK7halZaOlK8cHuLN/E3zZumbyd170rdr5/qNCI7Bd68qfyFKD1qFoKTIixGo61+lsFXdrRFt+vuA==",
+      "requires": {
+        "@typechain/ethers-v6": "^0.4.0",
+        "@wormhole-foundation/sdk-connect": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-evm": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-evm-core": "0.5.0-beta.4",
+        "ethers": "^6.5.1",
+        "typechain": "^8.2.0"
+      },
+      "dependencies": {
+        "@noble/curves": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+          "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+          "requires": {
+            "@noble/hashes": "1.3.2"
+          }
+        },
+        "@noble/hashes": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+          "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ=="
+        },
+        "@typechain/ethers-v6": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/@typechain/ethers-v6/-/ethers-v6-0.4.3.tgz",
+          "integrity": "sha512-TrxBsyb4ryhaY9keP6RzhFCviWYApcLCIRMPyWaKp2cZZrfaM3QBoxXTnw/eO4+DAY3l+8O0brNW0WgeQeOiDA==",
+          "requires": {
+            "lodash": "^4.17.15",
+            "ts-essentials": "^7.0.1"
+          }
+        },
+        "aes-js": {
+          "version": "4.0.0-beta.5",
+          "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+          "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="
+        },
+        "ethers": {
+          "version": "6.11.1",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.11.1.tgz",
+          "integrity": "sha512-mxTAE6wqJQAbp5QAe/+o+rXOID7Nw91OZXvgpjDa1r4fAbq2Nu314oEZSbjoRLacuCzs7kUC3clEvkCQowffGg==",
+          "requires": {
+            "@adraffy/ens-normalize": "1.10.1",
+            "@noble/curves": "1.2.0",
+            "@noble/hashes": "1.3.2",
+            "@types/node": "18.15.13",
+            "aes-js": "4.0.0-beta.5",
+            "tslib": "2.4.0",
+            "ws": "8.5.0"
+          }
+        },
+        "ws": {
+          "version": "8.5.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+          "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+          "requires": {}
+        }
+      }
+    },
+    "@wormhole-foundation/sdk-solana": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-0.5.0-beta.4.tgz",
+      "integrity": "sha512-QzVlsM3NTOYUgfuuRNeAsbh1xRaGFUQwImCtNAp2MEexbzep17ZZMNlymzNeUzTBX09Od2XE5YHO+NEHFjNKoQ==",
       "requires": {
         "@coral-xyz/borsh": "0.2.6",
         "@project-serum/anchor": "0.25.0",
         "@project-serum/borsh": "0.2.5",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "1.89.1",
-        "@wormhole-foundation/connect-sdk": "0.4.6"
+        "@wormhole-foundation/sdk-connect": "0.5.0-beta.4"
       }
     },
-    "@wormhole-foundation/sdk-base": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-0.4.6.tgz",
-      "integrity": "sha512-IzSCI6/lb2iiaQQ5gVkO+xybeZL0eD1w5tLs06V1BUGDWj2MKWHCsAug9jkYHBxcxnw4yUZGldzPh9DBhG0vmQ==",
+    "@wormhole-foundation/sdk-solana-cctp": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-0.5.0-beta.4.tgz",
+      "integrity": "sha512-4nb2iqHZhMfUiT0Xqjm//U6SGC9lowMKBpzXWQPH4p31I393f+ZuU5mS3R11xMg7K31Wz14lj3wuoGcR6SLV7w==",
       "requires": {
-        "@scure/base": "^1.1.3"
+        "@coral-xyz/borsh": "0.2.6",
+        "@project-serum/anchor": "0.25.0",
+        "@project-serum/borsh": "0.2.5",
+        "@solana/spl-token": "0.3.9",
+        "@solana/web3.js": "1.89.1",
+        "@wormhole-foundation/sdk-connect": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-solana": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-solana-core": "0.5.0-beta.4"
       }
     },
-    "@wormhole-foundation/sdk-definitions": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-0.4.6.tgz",
-      "integrity": "sha512-U3agTi424W0Ip0LMIMpgqymBEGj0QFYEhbJ0QT7ktecVXeF1o6c0NvztmYN9IS0nZ5kCgYdhaq4joIg+axtsyQ==",
+    "@wormhole-foundation/sdk-solana-core": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-0.5.0-beta.4.tgz",
+      "integrity": "sha512-SYoc3zC62B/ySsXMg3SXaXa+rXyL3KMGCqsoL/G2EpgVk+I25xUnm+MoQjoX/t+VS9MQHLSXFT5ret1iapF/lA==",
       "requires": {
-        "@noble/hashes": "^1.3.1",
-        "@wormhole-foundation/sdk-base": "0.4.6"
+        "@coral-xyz/borsh": "0.2.6",
+        "@project-serum/anchor": "0.25.0",
+        "@project-serum/borsh": "0.2.5",
+        "@solana/spl-token": "0.3.9",
+        "@solana/web3.js": "1.89.1",
+        "@wormhole-foundation/sdk-connect": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-solana": "0.5.0-beta.4"
+      }
+    },
+    "@wormhole-foundation/sdk-solana-tokenbridge": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-0.5.0-beta.4.tgz",
+      "integrity": "sha512-BRbcYLMLZZyFaYcKOZhpCWFKWEbo2tw0BnRG++DHmLZraRozPXzzvTtnwwlgbRUogTdk6CxknBkBfX0oE4pDiw==",
+      "requires": {
+        "@coral-xyz/borsh": "0.2.6",
+        "@project-serum/anchor": "0.25.0",
+        "@project-serum/borsh": "0.2.5",
+        "@solana/spl-token": "0.3.9",
+        "@solana/web3.js": "1.89.1",
+        "@wormhole-foundation/sdk-connect": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-solana": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-solana-core": "0.5.0-beta.4"
+      }
+    },
+    "@wormhole-foundation/sdk-sui": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-0.5.0-beta.4.tgz",
+      "integrity": "sha512-Q1zCQzDDj4zlfN/qZ3+k8nr1i9MCm2QmnpbNzTyea/aWW05rrgbDzTTYX/7Ft8qIAA8Sd1AjEqpJZy6zJQ/8Fg==",
+      "requires": {
+        "@mysten/sui.js": "^0.50.1",
+        "@wormhole-foundation/sdk-connect": "0.5.0-beta.4"
       },
       "dependencies": {
+        "@mysten/bcs": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/@mysten/bcs/-/bcs-0.11.1.tgz",
+          "integrity": "sha512-xP85isNSYUCHd3O/g+TmZYmg4wK6cU8q/n/MebkIGP4CYVJZz2wU/G24xIZ3wI+0iTop4dfgA5kYrg/DQKCUzA==",
+          "requires": {
+            "bs58": "^5.0.0"
+          }
+        },
+        "@mysten/sui.js": {
+          "version": "0.50.1",
+          "resolved": "https://registry.npmjs.org/@mysten/sui.js/-/sui.js-0.50.1.tgz",
+          "integrity": "sha512-AY0wb4n6PMTRsDGygzrrTHUK/m5KwKZ4aQcN9cayiwsq2iIhfjGo7uuqMA7Y5UiqvLCoF+z7Ig14Q5qejQ/S/w==",
+          "requires": {
+            "@graphql-typed-document-node/core": "^3.2.0",
+            "@mysten/bcs": "0.11.1",
+            "@noble/curves": "^1.1.0",
+            "@noble/hashes": "^1.3.1",
+            "@scure/bip32": "^1.3.1",
+            "@scure/bip39": "^1.2.1",
+            "@suchipi/femver": "^1.0.0",
+            "bech32": "^2.0.0",
+            "gql.tada": "^1.2.0",
+            "graphql": "^16.8.1",
+            "superstruct": "^1.0.3",
+            "tweetnacl": "^1.0.3"
+          }
+        },
+        "@noble/curves": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.3.0.tgz",
+          "integrity": "sha512-t01iSXPuN+Eqzb4eBX0S5oubSqXbK/xXa1Ne18Hj8f9pStxztHCE2gfboSp/dZRLSqfuLpRK2nDXDK+W9puocA==",
+          "requires": {
+            "@noble/hashes": "1.3.3"
+          }
+        },
         "@noble/hashes": {
           "version": "1.3.3",
           "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.3.tgz",
           "integrity": "sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA=="
+        },
+        "@scure/bip32": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.3.3.tgz",
+          "integrity": "sha512-LJaN3HwRbfQK0X1xFSi0Q9amqOgzQnnDngIt+ZlsBC3Bm7/nE7K0kwshZHyaru79yIVRv/e1mQAjZyuZG6jOFQ==",
+          "requires": {
+            "@noble/curves": "~1.3.0",
+            "@noble/hashes": "~1.3.2",
+            "@scure/base": "~1.1.4"
+          }
+        },
+        "@scure/bip39": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.2.2.tgz",
+          "integrity": "sha512-HYf9TUXG80beW+hGAt3TRM8wU6pQoYur9iNypTROm42dorCGmLnFe3eWjz3gOq6G62H2WRh0FCzAR1PI+29zIA==",
+          "requires": {
+            "@noble/hashes": "~1.3.2",
+            "@scure/base": "~1.1.4"
+          }
+        },
+        "base-x": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
+          "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
+        },
+        "bech32": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
+          "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
+        },
+        "bs58": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
+          "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
+          "requires": {
+            "base-x": "^4.0.0"
+          }
+        },
+        "superstruct": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-1.0.3.tgz",
+          "integrity": "sha512-8iTn3oSS8nRGn+C2pgXSKPI3jmpm6FExNazNpjvqS6ZUJQCej3PUXEKM8NjHBOs54ExM+LPW/FBRhymrdcCiSg=="
         }
+      }
+    },
+    "@wormhole-foundation/sdk-sui-core": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-0.5.0-beta.4.tgz",
+      "integrity": "sha512-aevK9ry2XpYJuW/lOSJ7TwKbtMA+UeYVs/Pme+MU8bZZmnKozFX+YetqQsScLCM0bpqAfULj1L9f729E5GOBJw==",
+      "requires": {
+        "@wormhole-foundation/sdk-connect": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-sui": "0.5.0-beta.4"
+      }
+    },
+    "@wormhole-foundation/sdk-sui-tokenbridge": {
+      "version": "0.5.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-0.5.0-beta.4.tgz",
+      "integrity": "sha512-PpbcV7k+iez5zFuGPLaOZnaUTGepTexO0kAvP3fXCEqqKCsdeW9DD/6jEFWeQ/y9OPOAUYsv6ZWMuLpFNnN4NA==",
+      "requires": {
+        "@wormhole-foundation/sdk-connect": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-sui": "0.5.0-beta.4",
+        "@wormhole-foundation/sdk-sui-core": "0.5.0-beta.4"
       }
     },
     "@wry/context": {
@@ -11297,13 +14436,12 @@
       "integrity": "sha512-F1tGh056XczEaEAqu7s+hlZUDWwOBT70Eq0lfMpBP2YguSQVyxRbprLq5rELXKQOyOaixTWYhMeMQMzP0U5FoQ=="
     },
     "algosdk": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/algosdk/-/algosdk-2.4.0.tgz",
-      "integrity": "sha512-sENe6IyUqvhQprfS/7gJAkPC5sX2LI5uc+gXaKNgzKp72UEyXYSoN3h4MZkOlCrOcTSWTJW7605tYgg8nFkflw==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/algosdk/-/algosdk-2.7.0.tgz",
+      "integrity": "sha512-sBE9lpV7bup3rZ+q2j3JQaFAE9JwZvjWKX00vPlG8e9txctXbgLL56jZhSWZndqhDI9oI+0P4NldkuQIWdrUyg==",
       "requires": {
         "algo-msgpack-with-bigint": "^2.1.1",
         "buffer": "^6.0.3",
-        "cross-fetch": "^3.1.5",
         "hi-base32": "^0.5.1",
         "js-sha256": "^0.9.0",
         "js-sha3": "^0.8.0",
@@ -11311,16 +14449,6 @@
         "json-bigint": "^1.0.0",
         "tweetnacl": "^1.0.3",
         "vlq": "^2.0.4"
-      },
-      "dependencies": {
-        "cross-fetch": {
-          "version": "3.1.8",
-          "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
-          "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
-          "requires": {
-            "node-fetch": "^2.6.12"
-          }
-        }
       }
     },
     "ansi-regex": {
@@ -13038,15 +16166,24 @@
       "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.2.tgz",
       "integrity": "sha512-3MSOYFO5U9mPGikIYCzK0SaThypfGgS6bHqrUGXG3DPHCrb+txNqeEcns1W0lkGfk0rCyNXm7xB9rMxnCiZOoA=="
     },
+    "gql.tada": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/gql.tada/-/gql.tada-1.3.1.tgz",
+      "integrity": "sha512-9+L2v5bi/QOFJmDnqsvr1bRryuso1ZqdfKiZT+5V8LB92iUICC+05TwmF2iUiQFdjp1IWgUOYjhrhjUFMIJILw==",
+      "requires": {
+        "@0no-co/graphql.web": "^1.0.4",
+        "@gql.tada/cli-utils": "0.1.0"
+      }
+    },
     "graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "graphql": {
-      "version": "16.6.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
-      "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw=="
+      "version": "16.8.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.1.tgz",
+      "integrity": "sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw=="
     },
     "graphql-tag": {
       "version": "2.12.6",
@@ -13573,12 +16710,25 @@
       "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.7.10.tgz",
       "integrity": "sha512-eY+z7hDrDKxkAK+QKZVNv92A5KYkxfvIshtBJkmg5TSiCnYqZP3i9OO9whE79Pwgm4jGaoHgkM4ao/b9Cyu4zQ=="
     },
+    "libsodium-sumo": {
+      "version": "0.7.13",
+      "resolved": "https://registry.npmjs.org/libsodium-sumo/-/libsodium-sumo-0.7.13.tgz",
+      "integrity": "sha512-zTGdLu4b9zSNLfovImpBCbdAA4xkpkZbMnSQjP8HShyOutnGjRHmSOKlsylh1okao6QhLiz7nG98EGn+04cZjQ=="
+    },
     "libsodium-wrappers": {
       "version": "0.7.10",
       "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.10.tgz",
       "integrity": "sha512-pO3F1Q9NPLB/MWIhehim42b/Fwb30JNScCNh8TcQ/kIc+qGLQch8ag8wb0keK3EP5kbGakk1H8Wwo7v+36rNQg==",
       "requires": {
         "libsodium": "^0.7.0"
+      }
+    },
+    "libsodium-wrappers-sumo": {
+      "version": "0.7.13",
+      "resolved": "https://registry.npmjs.org/libsodium-wrappers-sumo/-/libsodium-wrappers-sumo-0.7.13.tgz",
+      "integrity": "sha512-lz4YdplzDRh6AhnLGF2Dj2IUj94xRN6Bh8T0HLNwzYGwPehQJX6c7iYVrFUPZ3QqxE0bqC+K0IIqqZJYWumwSQ==",
+      "requires": {
+        "libsodium-sumo": "^0.7.13"
       }
     },
     "link-module-alias": {

--- a/clients/js/package-lock.json
+++ b/clients/js/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@celo-tools/celo-ethers-wrapper": "^0.1.0",
-        "@certusone/wormhole-sdk": "^0.10.8",
+        "@certusone/wormhole-sdk": "^0.10.10",
         "@cosmjs/encoding": "^0.26.2",
         "@improbable-eng/grpc-web-node-http-transport": "^0.15.0",
         "@injectivelabs/networks": "^1.10.7",
@@ -22,6 +22,7 @@
         "@solana/web3.js": "^1.22.0",
         "@terra-money/terra.js": "^3.1.9",
         "@types/config": "^3.3.0",
+        "@wormhole-foundation/connect-sdk": "^0.4.1",
         "@xpla/xpla.js": "^0.2.1",
         "algosdk": "^2.4.0",
         "aptos": "^1.3.16",
@@ -494,9 +495,9 @@
       }
     },
     "node_modules/@certusone/wormhole-sdk": {
-      "version": "0.10.8",
-      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk/-/wormhole-sdk-0.10.8.tgz",
-      "integrity": "sha512-W2rA8fMdkVFWvy93+51K+8Kv/bpjuFtxCYCQI4YkWe+g4zLkDXw+yYMVPPqc/chFLFNSutPMqUtXAg7+y8lowg==",
+      "version": "0.10.11",
+      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk/-/wormhole-sdk-0.10.11.tgz",
+      "integrity": "sha512-WG2gmVqc5t5T6WeSkh6aDPMToN0whTJ1WQv9Kke3/bk4ssR6Gn6gv2OXHL0ZzYcUS8hft5EQBTNr1HGNQT2gMQ==",
       "dependencies": {
         "@certusone/wormhole-sdk-proto-web": "0.0.7",
         "@certusone/wormhole-sdk-wasm": "^0.0.1",
@@ -3077,15 +3078,12 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@scure/base": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.1.tgz",
-      "integrity": "sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ]
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.5.tgz",
+      "integrity": "sha512-Brj9FiG2W1MRQSTB212YVPRrcbjkv48FoZi/u4l/zds/ieRrqsh7aUf6CLwkAq61oKXr/ZlTzlY66gLIj3TFTQ==",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@scure/bip32": {
       "version": "1.1.0",
@@ -3544,6 +3542,70 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.1.tgz",
       "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==",
       "dev": true
+    },
+    "node_modules/@wormhole-foundation/connect-sdk": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk/-/connect-sdk-0.4.1.tgz",
+      "integrity": "sha512-qbvAWiZiVrJmuoG/z+oxjlaUZfnfyazenTLEbR8x4IyHSJ+yxWRcGUxOiqMXP9yohEawKsIlWxjB13cVX+0PFA==",
+      "dependencies": {
+        "@wormhole-foundation/sdk-base": "^0.4.1",
+        "@wormhole-foundation/sdk-definitions": "^0.4.1",
+        "axios": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@wormhole-foundation/connect-sdk/node_modules/axios": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+      "dependencies": {
+        "follow-redirects": "^1.15.4",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/@wormhole-foundation/connect-sdk/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-base": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-0.4.1.tgz",
+      "integrity": "sha512-Ahumd2EIPRFWA8hXu76g37qNcUgjzoKLOCyvnveuUMu53Y1YxgGNC4IOQR723+og1+5VZS2SP4rORCX1FUZNpw==",
+      "dependencies": {
+        "@scure/base": "^1.1.3"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-definitions": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-0.4.1.tgz",
+      "integrity": "sha512-cQxoOO/mKiFAwGQYQ7MZvuMFDsN98rTq1+0/A/VzfnHTkPpWSU4byGpqDYxv2QuVdfx/Pdo476gg0Syap/AYCQ==",
+      "dependencies": {
+        "@noble/hashes": "^1.3.1",
+        "@wormhole-foundation/sdk-base": "^0.4.1"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-definitions/node_modules/@noble/hashes": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.3.tgz",
+      "integrity": "sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@wry/context": {
       "version": "0.7.0",
@@ -5500,9 +5562,9 @@
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
       "funding": [
         {
           "type": "individual",
@@ -6928,6 +6990,11 @@
         "pbjs": "bin/pbjs",
         "pbts": "bin/pbts"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/prr": {
       "version": "1.0.1",
@@ -8367,9 +8434,9 @@
       "requires": {}
     },
     "@certusone/wormhole-sdk": {
-      "version": "0.10.8",
-      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk/-/wormhole-sdk-0.10.8.tgz",
-      "integrity": "sha512-W2rA8fMdkVFWvy93+51K+8Kv/bpjuFtxCYCQI4YkWe+g4zLkDXw+yYMVPPqc/chFLFNSutPMqUtXAg7+y8lowg==",
+      "version": "0.10.11",
+      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk/-/wormhole-sdk-0.10.11.tgz",
+      "integrity": "sha512-WG2gmVqc5t5T6WeSkh6aDPMToN0whTJ1WQv9Kke3/bk4ssR6Gn6gv2OXHL0ZzYcUS8hft5EQBTNr1HGNQT2gMQ==",
       "requires": {
         "@certusone/wormhole-sdk-proto-web": "0.0.7",
         "@certusone/wormhole-sdk-wasm": "^0.0.1",
@@ -10347,9 +10414,9 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "@scure/base": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.1.tgz",
-      "integrity": "sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA=="
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.5.tgz",
+      "integrity": "sha512-Brj9FiG2W1MRQSTB212YVPRrcbjkv48FoZi/u4l/zds/ieRrqsh7aUf6CLwkAq61oKXr/ZlTzlY66gLIj3TFTQ=="
     },
     "@scure/bip32": {
       "version": "1.1.0",
@@ -10741,6 +10808,62 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.1.tgz",
       "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==",
       "dev": true
+    },
+    "@wormhole-foundation/connect-sdk": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/connect-sdk/-/connect-sdk-0.4.1.tgz",
+      "integrity": "sha512-qbvAWiZiVrJmuoG/z+oxjlaUZfnfyazenTLEbR8x4IyHSJ+yxWRcGUxOiqMXP9yohEawKsIlWxjB13cVX+0PFA==",
+      "requires": {
+        "@wormhole-foundation/sdk-base": "^0.4.1",
+        "@wormhole-foundation/sdk-definitions": "^0.4.1",
+        "axios": "^1.4.0"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "1.6.7",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+          "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+          "requires": {
+            "follow-redirects": "^1.15.4",
+            "form-data": "^4.0.0",
+            "proxy-from-env": "^1.1.0"
+          }
+        },
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
+    "@wormhole-foundation/sdk-base": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-0.4.1.tgz",
+      "integrity": "sha512-Ahumd2EIPRFWA8hXu76g37qNcUgjzoKLOCyvnveuUMu53Y1YxgGNC4IOQR723+og1+5VZS2SP4rORCX1FUZNpw==",
+      "requires": {
+        "@scure/base": "^1.1.3"
+      }
+    },
+    "@wormhole-foundation/sdk-definitions": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-0.4.1.tgz",
+      "integrity": "sha512-cQxoOO/mKiFAwGQYQ7MZvuMFDsN98rTq1+0/A/VzfnHTkPpWSU4byGpqDYxv2QuVdfx/Pdo476gg0Syap/AYCQ==",
+      "requires": {
+        "@noble/hashes": "^1.3.1",
+        "@wormhole-foundation/sdk-base": "^0.4.1"
+      },
+      "dependencies": {
+        "@noble/hashes": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.3.tgz",
+          "integrity": "sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA=="
+        }
+      }
     },
     "@wry/context": {
       "version": "0.7.0",
@@ -12416,9 +12539,9 @@
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw=="
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -13575,6 +13698,11 @@
         "@types/node": ">=13.7.0",
         "long": "^4.0.0"
       }
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "prr": {
       "version": "1.0.1",

--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -29,9 +29,9 @@
     "cli"
   ],
   "dependencies": {
-    "@wormhole-foundation/connect-sdk": "^0.4.2-beta.0",
-    "@wormhole-foundation/connect-sdk-evm": "^0.4.2-beta.0",
-    "@wormhole-foundation/connect-sdk-solana": "^0.4.2-beta.0",
+    "@wormhole-foundation/connect-sdk": "^0.4.2-beta.1",
+    "@wormhole-foundation/connect-sdk-evm": "^0.4.2-beta.1",
+    "@wormhole-foundation/connect-sdk-solana": "^0.4.2-beta.1",
     "@celo-tools/celo-ethers-wrapper": "^0.1.0",
     "@certusone/wormhole-sdk": "^0.10.10",
     "@cosmjs/encoding": "^0.26.2",

--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -29,9 +29,7 @@
     "cli"
   ],
   "dependencies": {
-    "@wormhole-foundation/connect-sdk": "^0.4.6",
-    "@wormhole-foundation/connect-sdk-evm": "^0.4.6",
-    "@wormhole-foundation/connect-sdk-solana": "^0.4.6",
+    "@wormhole-foundation/sdk": "^0.5.0-beta.4",
     "@celo-tools/celo-ethers-wrapper": "^0.1.0",
     "@certusone/wormhole-sdk": "^0.10.8",
     "@cosmjs/encoding": "^0.26.2",

--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -29,7 +29,9 @@
     "cli"
   ],
   "dependencies": {
-    "@wormhole-foundation/connect-sdk": "^0.4.1",
+    "@wormhole-foundation/connect-sdk": "^0.4.2-beta.0",
+    "@wormhole-foundation/connect-sdk-evm": "^0.4.2-beta.0",
+    "@wormhole-foundation/connect-sdk-solana": "^0.4.2-beta.0",
     "@celo-tools/celo-ethers-wrapper": "^0.1.0",
     "@certusone/wormhole-sdk": "^0.10.10",
     "@cosmjs/encoding": "^0.26.2",

--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "start": "npm run build && node ./build/main.js",
     "build": "esbuild src/main.ts --bundle --outfile=build/main.js --minify --platform=node --target=node16",
-    "check": "tsc --noEmit",
+    "check": "tsc --p tsconfig.json --noEmit",
     "docs": "npx tsx src/doc.ts",
     "prepublishOnly": "npm run check",
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -33,7 +33,7 @@
     "@wormhole-foundation/connect-sdk-evm": "^0.4.4-beta.4",
     "@wormhole-foundation/connect-sdk-solana": "^0.4.4-beta.4",
     "@celo-tools/celo-ethers-wrapper": "^0.1.0",
-    "@certusone/wormhole-sdk": "^0.10.10",
+    "@certusone/wormhole-sdk": "^0.10.8",
     "@cosmjs/encoding": "^0.26.2",
     "@improbable-eng/grpc-web-node-http-transport": "^0.15.0",
     "@injectivelabs/networks": "^1.10.7",
@@ -70,6 +70,6 @@
     "@types/node-fetch": "^2.6.3",
     "@types/yargs": "^17.0.24",
     "copy-dir": "^1.3.0",
-    "typescript": "^4.6"
+    "typescript": "^5.3"
   }
 }

--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -29,9 +29,9 @@
     "cli"
   ],
   "dependencies": {
-    "@wormhole-foundation/connect-sdk": "^0.4.2-beta.1",
-    "@wormhole-foundation/connect-sdk-evm": "^0.4.2-beta.1",
-    "@wormhole-foundation/connect-sdk-solana": "^0.4.2-beta.1",
+    "@wormhole-foundation/connect-sdk": "^0.4.4-beta.4",
+    "@wormhole-foundation/connect-sdk-evm": "^0.4.4-beta.4",
+    "@wormhole-foundation/connect-sdk-solana": "^0.4.4-beta.4",
     "@celo-tools/celo-ethers-wrapper": "^0.1.0",
     "@certusone/wormhole-sdk": "^0.10.10",
     "@cosmjs/encoding": "^0.26.2",

--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -29,8 +29,9 @@
     "cli"
   ],
   "dependencies": {
+    "@wormhole-foundation/connect-sdk": "^0.4.1",
     "@celo-tools/celo-ethers-wrapper": "^0.1.0",
-    "@certusone/wormhole-sdk": "^0.10.8",
+    "@certusone/wormhole-sdk": "^0.10.10",
     "@cosmjs/encoding": "^0.26.2",
     "@improbable-eng/grpc-web-node-http-transport": "^0.15.0",
     "@injectivelabs/networks": "^1.10.7",

--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -29,9 +29,9 @@
     "cli"
   ],
   "dependencies": {
-    "@wormhole-foundation/connect-sdk": "^0.4.4-beta.6",
-    "@wormhole-foundation/connect-sdk-evm": "^0.4.4-beta.6",
-    "@wormhole-foundation/connect-sdk-solana": "^0.4.4-beta.6",
+    "@wormhole-foundation/connect-sdk": "^0.4.6",
+    "@wormhole-foundation/connect-sdk-evm": "^0.4.6",
+    "@wormhole-foundation/connect-sdk-solana": "^0.4.6",
     "@celo-tools/celo-ethers-wrapper": "^0.1.0",
     "@certusone/wormhole-sdk": "^0.10.8",
     "@cosmjs/encoding": "^0.26.2",

--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -29,9 +29,9 @@
     "cli"
   ],
   "dependencies": {
-    "@wormhole-foundation/connect-sdk": "^0.4.4-beta.4",
-    "@wormhole-foundation/connect-sdk-evm": "^0.4.4-beta.4",
-    "@wormhole-foundation/connect-sdk-solana": "^0.4.4-beta.4",
+    "@wormhole-foundation/connect-sdk": "^0.4.4-beta.6",
+    "@wormhole-foundation/connect-sdk-evm": "^0.4.4-beta.6",
+    "@wormhole-foundation/connect-sdk-solana": "^0.4.4-beta.6",
     "@celo-tools/celo-ethers-wrapper": "^0.1.0",
     "@certusone/wormhole-sdk": "^0.10.8",
     "@cosmjs/encoding": "^0.26.2",

--- a/clients/js/src/cmds/editVaa.ts
+++ b/clients/js/src/cmds/editVaa.ts
@@ -24,7 +24,15 @@ import { ethers } from "ethers";
 import yargs from "yargs";
 import { NETWORK_OPTIONS, NETWORKS } from "../consts";
 import { assertNetwork, Network } from "../utils";
-import { parse, Payload, serialiseVAA, sign, Signature, VAA } from "../vaa";
+import {
+  parse,
+  Payload,
+  serialiseVAA,
+  sign,
+  Signature,
+  VAA,
+  vaaDigest,
+} from "../vaa";
 
 export const command = "edit-vaa";
 export const desc = "Edits or generates a VAA";
@@ -193,7 +201,7 @@ export const handler = async (
     );
   } else if (argv["guardian-secret"]) {
     vaa.guardianSetIndex = 0;
-    vaa.signatures = sign([argv["guardian-secret"]], vaa as VAA<Payload>);
+    vaa.signatures = sign([argv["guardian-secret"]], vaaDigest(vaa));
   }
 
   if (argv["emitter-chain-id"]) {

--- a/clients/js/src/cmds/generate.ts
+++ b/clients/js/src/cmds/generate.ts
@@ -17,12 +17,9 @@ import {
   isNative,
   serializeLayout,
   toUniversal,
-  Wormhole,
-} from "@wormhole-foundation/connect-sdk";
-import {
   NativeTokenTransfer,
   nativeTokenTransferLayout,
-} from "@wormhole-foundation/sdk-definitions/dist/cjs/payloads/ntt";
+} from "@wormhole-foundation/connect-sdk";
 import base58 from "bs58";
 import { sha3_256 } from "js-sha3";
 import yargs from "yargs";

--- a/clients/js/src/cmds/generate.ts
+++ b/clients/js/src/cmds/generate.ts
@@ -1,4 +1,3 @@
-import { tryNativeToHexString } from "@certusone/wormhole-sdk/lib/esm/utils/array";
 import {
   assertChain,
   ChainName,
@@ -7,6 +6,12 @@ import {
   isEVMChain,
   toChainId,
 } from "@certusone/wormhole-sdk/lib/esm/utils/consts";
+import {
+  Chain,
+  Wormhole,
+  chains,
+  serialize,
+} from "@wormhole-foundation/connect-sdk";
 import { fromBech32, toHex } from "@cosmjs/encoding";
 import base58 from "bs58";
 import { sha3_256 } from "js-sha3";
@@ -59,6 +64,60 @@ export const builder = function (y: typeof yargs) {
         describe: "Guardians' secret keys (CSV)",
         type: "string",
       })
+      // NTT Transfer VAA
+      .command(
+        "transfer",
+        "Generate an NTT transfer VAA",
+        (yargs) =>
+          yargs
+            .option("source-chain", {
+              alias: "sc",
+              describe: "Chain to send from",
+              choices: Object.keys(chains) as Chain[],
+              demandOption: true,
+            } as const)
+            .option("token-address", {
+              alias: "t",
+              describe: "token to transfer",
+              type: "string",
+              demandOption: true,
+            })
+            .option("amount", {
+              alias: "a",
+              describe: "Amount of token to send",
+              type: "number",
+              demandOption: true,
+            } as const)
+            .option("receiver", {
+              alias: "r",
+              describe: "Address of receiver on destination chain",
+              type: "string",
+              demandOption: true,
+            } as const)
+            .option("destination-chain", {
+              alias: "dc",
+              describe: "Chain to send to",
+              choices: Object.keys(chains) as Chain[],
+              demandOption: true,
+            } as const)
+            .option("payload", {
+              alias: "p",
+              describe: "Payload to pass along with the transfer",
+              type: "string",
+            } as const),
+        (argv) => {
+          const payload = {
+            type: "NTT:TokenTransfer",
+            chain: argv["source-chain"],
+            emitter: Wormhole.parseAddress(
+              argv["chain"] as Chain,
+              argv["contract-address"] as string
+            ),
+          };
+          // ...
+          console.log(payload);
+        }
+      )
       // Registration
       .command(
         "registration",
@@ -144,6 +203,7 @@ export const builder = function (y: typeof yargs) {
           console.log(serialiseVAA(vaa));
         }
       )
+      // Attest token
       .command(
         "attestation",
         "Generate a token attestation VAA",
@@ -255,6 +315,7 @@ export const builder = function (y: typeof yargs) {
           console.log(serialiseVAA(vaa));
         }
       )
+      // SetDefaultDeliveryProvider
       .command(
         "set-default-delivery-provider",
         "Sets the default delivery provider for the Wormhole Relayer contract",

--- a/clients/js/src/cmds/generate.ts
+++ b/clients/js/src/cmds/generate.ts
@@ -144,8 +144,9 @@ export const builder = function (y: typeof yargs) {
                   recipientAddress: receiver,
                   recipientChain: dstChain,
                 },
-                sequence: BigInt(0),
                 sender: sender,
+                // TODO: CLI arg?
+                id: new Uint8Array(32),
               },
             },
             guardianSet: 0,

--- a/clients/js/src/cmds/generate.ts
+++ b/clients/js/src/cmds/generate.ts
@@ -1,5 +1,7 @@
-import "@wormhole-foundation/connect-sdk-evm";
-import "@wormhole-foundation/connect-sdk-solana";
+import "@wormhole-foundation/sdk/evm";
+import "@wormhole-foundation/sdk/solana";
+import * as sdk from "@wormhole-foundation/sdk";
+
 import {
   assertChain,
   ChainName,
@@ -9,7 +11,6 @@ import {
   toChainId,
 } from "@certusone/wormhole-sdk/lib/esm/utils/consts";
 import { fromBech32, toHex } from "@cosmjs/encoding";
-import * as sdk from "@wormhole-foundation/connect-sdk";
 import base58 from "bs58";
 import { sha3_256 } from "js-sha3";
 import yargs from "yargs";
@@ -18,7 +19,6 @@ import { evm_address } from "../utils";
 import {
   ContractUpgrade,
   impossible,
-  Other,
   Payload,
   PortalRegisterChain,
   RecoverChainId,

--- a/clients/js/src/vaa.ts
+++ b/clients/js/src/vaa.ts
@@ -183,7 +183,7 @@ const vaaParser = new Parser()
     assert: (str) => str === "",
   });
 
-export function serialiseVAA(vaa: VAA<Payload>) {
+export function serialiseVAA(vaa: VAA<Payload | Other>) {
   const body = [
     encode("uint8", vaa.version),
     encode("uint32", vaa.guardianSetIndex),
@@ -302,8 +302,7 @@ function vaaBody(vaa: VAA<Payload | Other>) {
   return body.join("");
 }
 
-export function sign(signers: string[], vaa: VAA<Payload>): Signature[] {
-  const hash = vaaDigest(vaa);
+export function sign(signers: string[], hash: string): Signature[] {
   const ec = new elliptic.ec("secp256k1");
 
   return signers.map((signer, i) => {

--- a/clients/js/src/vaa.ts
+++ b/clients/js/src/vaa.ts
@@ -183,7 +183,7 @@ const vaaParser = new Parser()
     assert: (str) => str === "",
   });
 
-export function serialiseVAA(vaa: VAA<Payload | Other>) {
+export function serialiseVAA(vaa: VAA<Payload>) {
   const body = [
     encode("uint8", vaa.version),
     encode("uint32", vaa.guardianSetIndex),

--- a/clients/js/tsconfig.json
+++ b/clients/js/tsconfig.json
@@ -6,6 +6,7 @@
     "outDir": "./build",
     "moduleResolution": "node",
     "esModuleInterop": true,
+    "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true
   },


### PR DESCRIPTION
For some made up fields, running this command will generate a serialized VAA with signatures

```sh 
$ worm generate ntt-transfer \
-g "CiDPsSMDoZzeWAu03XcWObDSa8aDU2RVcajP9RarLuEToBAB" \
-t EdGevanA2MZsDpxDXK6b36FH7RCcTuDZZRcc6MEyE9hy -a 1000 \
--sc Solana -e EdGevanA2MZsDpxDXK6b36FH7RCcTuDZZRcc6MEyE9hy \
--dc Ethereum -r 0x455cDec52B63BEcb987900A04B10eBAd95B1ad13
```

produces:
```
01000000000100372949329b6311deb446073a80a5b0f5e768c862d042d5318dafd39b3fadfafa7ba006c2724d1aebe01b6522a942f0347968b94e5e8b9f29367c11cd8f9ef4680100000001000000010001ca7289fecf033c9129a6878872fe530dc9a21420235765baa353a89821869d900000000000a7274400994e54541200000000000003e8ca7289fecf033c9129a6878872fe530dc9a21420235765baa353a89821869d90000000000000000000000000455cdec52b63becb987900a04b10ebad95b1ad130002
```

