### PR TITLE
Node/CCQ: Track concurrent queries

### DIFF
--- a/node/cmd/ccq/metrics.go
+++ b/node/cmd/ccq/metrics.go
@@ -1,8 +1,11 @@
 package ccq
 
 import (
+	"fmt"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	dto "github.com/prometheus/client_model/go"
 )
 
 var (
@@ -108,4 +111,19 @@ var (
 			Name: "ccq_server_total_number_of_successful_reconnects",
 			Help: "Total number of successful reconnects to bootstrap peers",
 		})
+
+	maxConcurrentQueriesByChain = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "ccq_server_max_concurrent_queries_by_chain",
+			Help: "Gauge showing the maximum concurrent query requests by chain",
+		}, []string{"chain_name"})
 )
+
+// getGaugeValue returns the current value of a metric.
+func getGaugeValue(gauge prometheus.Gauge) (float64, error) {
+	metric := &dto.Metric{}
+	if err := gauge.Write(metric); err != nil {
+		return 0, fmt.Errorf("failed to read metric value: %w", err)
+	}
+	return metric.GetGauge().GetValue(), nil
+}

--- a/node/cmd/ccq/metrics.go
+++ b/node/cmd/ccq/metrics.go
@@ -112,6 +112,12 @@ var (
 			Help: "Total number of successful reconnects to bootstrap peers",
 		})
 
+	currentNumConcurrentQueriesByChain = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "ccq_server_current_num_concurrent_queries_by_chain",
+			Help: "Gauge showing the current number of concurrent query requests by chain",
+		}, []string{"chain_name"})
+
 	maxConcurrentQueriesByChain = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "ccq_server_max_concurrent_queries_by_chain",

--- a/node/cmd/ccq/pending_request.go
+++ b/node/cmd/ccq/pending_request.go
@@ -92,6 +92,7 @@ func (p *PendingResponses) updateMetricsAlreadyLocked() {
 	}
 
 	for chainId, count := range counts {
+		currentNumConcurrentQueriesByChain.WithLabelValues(chainId.String()).Set(count)
 		currVal, err := getGaugeValue(maxConcurrentQueriesByChain.WithLabelValues(chainId.String()))
 		if err != nil {
 			p.logger.Error("failed to read current value of max concurrent queries metric", zap.String("chainId", chainId.String()), zap.Error(err))

--- a/node/cmd/ccq/query_server.go
+++ b/node/cmd/ccq/query_server.go
@@ -171,7 +171,7 @@ func runQueryServer(cmd *cobra.Command, args []string) {
 	defer cancel()
 
 	// Run p2p
-	pendingResponses := NewPendingResponses()
+	pendingResponses := NewPendingResponses(logger)
 	p2p, err := runP2P(ctx, priv, *p2pPort, networkID, *p2pBootstrap, *ethRPC, *ethContract, pendingResponses, logger, *monitorPeers, loggingMap)
 	if err != nil {
 		logger.Fatal("Failed to start p2p", zap.Error(err))


### PR DESCRIPTION
This PR adds a metric to the proxy server to track the maximum number of concurrent requests by chain. This will be useful for scaling the amount of parallelism in the guardian watchers.