### PR TITLE
Node/P2P: Add default bootstrap peers

### DIFF
--- a/devnet/query-server.yaml
+++ b/devnet/query-server.yaml
@@ -52,6 +52,8 @@ spec:
             - http://eth-devnet:8545
             - --ethContract
             - "0xC89Ce4735882C9F0f0FE26686c53074E09B0D550"
+            - --network
+            - /wormhole/dev
             # Hardcoded devnet bootstrap (generated from deterministic key in guardiand)
             - --bootstrap
             - /dns4/guardian-0.guardian/udp/8996/quic/p2p/12D3KooWL3XJ9EMCyZvmmGXL2LMiVBtrVa2BuESsJiXkSj7333Jw

--- a/devnet/spy.yaml
+++ b/devnet/spy.yaml
@@ -43,6 +43,8 @@ spec:
             - /tmp/node.key
             - --spyRPC
             - "[::]:7072"
+            - --network
+            - /wormhole/dev
             # Hardcoded devnet bootstrap (generated from deterministic key in guardiand)
             - --bootstrap
             - /dns4/guardian-0.guardian/udp/8999/quic/p2p/12D3KooWL3XJ9EMCyZvmmGXL2LMiVBtrVa2BuESsJiXkSj7333Jw

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -53,6 +53,7 @@ If you use the same RPC node for Wormhole v1, you also need the following additi
 `getProgramAccount` queries:
 
 <!-- cspell:disable -->
+
 ```
 [... see above for other required parameters ...]
 
@@ -60,6 +61,7 @@ If you use the same RPC node for Wormhole v1, you also need the following additi
 --account-index-include-key WormT3McKhFJ2RkiGpdw9GKvNCrB2aB54gb2uV9MfQC   # for mainnet
 --account-index-include-key 5gQf5AUhAgWYgUCt9ouShm9H7dzzXUsLdssYwe5krKhg  # for testnet
 ```
+
 <!-- cspell:enable -->
 
 Alternatively, if you want to run a general-purpose RPC node with indexes for all programs instead of only Wormhole,
@@ -72,10 +74,12 @@ leave out the filtering:
 On mainnet, we strongly recommend blacklisting KIN and the token program to speed up catchup:
 
 <!-- cspell:disable -->
+
 ```
 --account-index-exclude-key kinXdEcpDQeHPEuQnqmUgtYykqKGVFq6CeVX5iAHJq6  # Mainnet only
 --account-index-exclude-key TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA  # Mainnet only
 ```
+
 <!-- cspell:enable -->
 
 Note that these indexes require extra disk space and may slow down catchup. The first startup after
@@ -261,27 +265,12 @@ may include support for remote signing.
 
 ## Bootstrap Peers
 
-The following bootstrap peers are available in each environment.
+The list of supported bootstrap peers is defined in `node/pkg/p2p/network_consts.go`. That file also provides golang functions
+for obtaining the network parameters (network ID and bootstrap peers) based on the environment (mainnet or testnet).
 
-### Mainnet
-
-<!-- cspell:disable -->
-```bash
---bootstrap "/dns4/wormhole-v2-mainnet-bootstrap.xlabs.xyz/udp/8999/quic/p2p/12D3KooWNQ9tVrcb64tw6bNs2CaNrUGPM7yRrKvBBheQ5yCyPHKC,/dns4/wormhole.mcf.rocks/udp/8999/quic/p2p/12D3KooWDZVv7BhZ8yFLkarNdaSWaB43D6UbQwExJ8nnGAEmfHcU,/dns4/wormhole-v2-mainnet-bootstrap.staking.fund/udp/8999/quic/p2p/12D3KooWG8obDX9DNi1KUwZNu9xkGwfKqTp2GFwuuHpWZ3nQruS1"
-
---ccqP2pBootstrap "/dns4/wormhole-v2-mainnet-bootstrap.xlabs.xyz/udp/8996/quic/p2p/12D3KooWNQ9tVrcb64tw6bNs2CaNrUGPM7yRrKvBBheQ5yCyPHKC,/dns4/wormhole.mcf.rocks/udp/8996/quic/p2p/12D3KooWDZVv7BhZ8yFLkarNdaSWaB43D6UbQwExJ8nnGAEmfHcU,/dns4/wormhole-v2-mainnet-bootstrap.staking.fund/udp/8996/quic/p2p/12D3KooWG8obDX9DNi1KUwZNu9xkGwfKqTp2GFwuuHpWZ3nQruS1"
-```
-<!-- cspell:enable -->
-
-### Testnet
-
-<!-- cspell:disable -->
-```bash
---bootstrap "/dns4/t-guardian-01.nodes.stable.io/udp/8999/quic/p2p/12D3KooWCW3LGUtkCVkHZmVSZHzL3C4WRKWfqAiJPz1NR7dT9Bxh,/dns4/t-guardian-02.nodes.stable.io/udp/8999/quic/p2p/12D3KooWJXA6goBCiWM8ucjzc4jVUBSqL9Rri6UpjHbkMPErz5zK,/dns4/p2p-guardian-testnet-1.solana.p2p.org/udp/8999/quic/p2p/12D3KooWE4dmZwxhfjCKHLUqSaww96Cf7kmq1ZuKmzPz3MrJgZxp"
-
---ccqP2pBootstrap "/dns4/t-guardian-01.nodes.stable.io/udp/8996/quic/p2p/12D3KooWCW3LGUtkCVkHZmVSZHzL3C4WRKWfqAiJPz1NR7dT9Bxh,/dns4/t-guardian-02.nodes.stable.io/udp/8996/quic/p2p/12D3KooWJXA6goBCiWM8ucjzc4jVUBSqL9Rri6UpjHbkMPErz5zK,/dns4/p2p-guardian-testnet-1.solana.p2p.org/udp/8996/quic/p2p/12D3KooWE4dmZwxhfjCKHLUqSaww96Cf7kmq1ZuKmzPz3MrJgZxp"
-```
-<!-- cspell:enable -->
+The common Wormhole applications (guardiand, spy and query proxy server) use those functions, so it is not necessary to specify
+the actual bootstrap parameters in their configs. Developers of any new applications are strongly urged to do the same, and not
+proliferate lists of bootstrap peers which might change over time.
 
 ## Run the Guardian Spy
 
@@ -290,27 +279,31 @@ The spy connects to the wormhole guardian peer to peer network and listens for n
 Start the spy against the testnet wormhole guardian:
 
 <!-- cspell:disable -->
+
 ```bash
 docker run \
     --platform=linux/amd64 \
     -p 7073:7073 \
     --entrypoint /guardiand \
     ghcr.io/wormhole-foundation/guardiand:latest \
-spy --nodeKey /node.key --spyRPC "[::]:7073" --network /wormhole/testnet/2/1 --bootstrap "/dns4/t-guardian-01.nodes.stable.io/udp/8999/quic/p2p/12D3KooWCW3LGUtkCVkHZmVSZHzL3C4WRKWfqAiJPz1NR7dT9Bxh,/dns4/t-guardian-02.nodes.stable.io/udp/8999/quic/p2p/12D3KooWJXA6goBCiWM8ucjzc4jVUBSqL9Rri6UpjHbkMPErz5zK,/dns4/p2p-guardian-testnet-1.solana.p2p.org/udp/8999/quic/p2p/12D3KooWE4dmZwxhfjCKHLUqSaww96Cf7kmq1ZuKmzPz3MrJgZxp"
+    spy --nodeKey /node.key --spyRPC "[::]:7073" --env testnet
 ```
+
 <!-- cspell:enable -->
 
 To run the spy against mainnet:
 
 <!-- cspell:disable -->
+
 ```bash
 docker run \
     --platform=linux/amd64 \
     -p 7073:7073 \
     --entrypoint /guardiand \
     ghcr.io/wormhole-foundation/guardiand:latest \
-spy --nodeKey /node.key --spyRPC "[::]:7073" --network /wormhole/mainnet/2 --bootstrap /dns4/wormhole-v2-mainnet-bootstrap.xlabs.xyz/udp/8999/quic/p2p/12D3KooWNQ9tVrcb64tw6bNs2CaNrUGPM7yRrKvBBheQ5yCyPHKC,/dns4/wormhole.mcf.rocks/udp/8999/quic/p2p/12D3KooWDZVv7BhZ8yFLkarNdaSWaB43D6UbQwExJ8nnGAEmfHcU,/dns4/wormhole-v2-mainnet-bootstrap.staking.fund/udp/8999/quic/p2p/12D3KooWG8obDX9DNi1KUwZNu9xkGwfKqTp2GFwuuHpWZ3nQruS1
+    spy --nodeKey /node.key --spyRPC "[::]:7073" --env mainnet
 ```
+
 <!-- cspell:enable -->
 
 ## Guardian Configurations
@@ -326,12 +319,14 @@ Configuration files, environment variables and flags are all supported.
 **Example**:
 
 <!-- cspell:disable -->
+
 ```yaml
 ethRPC: "ws://eth-devnet:8545"
 ethContract: "0xC89Ce4735882C9F0f0FE26686c53074E09B0D550"
 solanaRPC: "http://solana-devnet:8899"
 solanaContract: "Bridge1p5gheXUvJ6jGWGeCsgPKgnE3YgdGKRVCMY9o"
 ```
+
 <!-- cspell:enable -->
 
 ### Environment Variables

--- a/node/cmd/ccq/query_server.go
+++ b/node/cmd/ccq/query_server.go
@@ -99,7 +99,7 @@ func runQueryServer(cmd *cobra.Command, args []string) {
 		if *envStr == "" {
 			logger.Fatal("Please specify --env")
 		}
-		logger.Fatal("Invalid value for --env, must be dev, test or prod", zap.String("val", *envStr))
+		logger.Fatal("Invalid value for --env, should be devnet, testnet or mainnet", zap.String("val", *envStr))
 	}
 
 	if *p2pNetworkID == "" {

--- a/node/pkg/p2p/network_consts.go
+++ b/node/pkg/p2p/network_consts.go
@@ -1,0 +1,52 @@
+package p2p
+
+import (
+	"fmt"
+
+	"github.com/certusone/wormhole/node/pkg/common"
+)
+
+// This is the definitive source for the default network parameters. Please reference these (or use the methods below), but avoid copying them!
+const MainnetNetworkId = "/wormhole/mainnet/2"
+const MainnetBootstrapPeers = "/dns4/wormhole-v2-mainnet-bootstrap.xlabs.xyz/udp/8999/quic/p2p/12D3KooWNQ9tVrcb64tw6bNs2CaNrUGPM7yRrKvBBheQ5yCyPHKC,/dns4/wormhole.mcf.rocks/udp/8999/quic/p2p/12D3KooWDZVv7BhZ8yFLkarNdaSWaB43D6UbQwExJ8nnGAEmfHcU,/dns4/wormhole-v2-mainnet-bootstrap.staking.fund/udp/8999/quic/p2p/12D3KooWG8obDX9DNi1KUwZNu9xkGwfKqTp2GFwuuHpWZ3nQruS1"
+const MainnetCcqBootstrapPeers = "/dns4/wormhole-v2-mainnet-bootstrap.xlabs.xyz/udp/8996/quic/p2p/12D3KooWNQ9tVrcb64tw6bNs2CaNrUGPM7yRrKvBBheQ5yCyPHKC,/dns4/wormhole.mcf.rocks/udp/8996/quic/p2p/12D3KooWDZVv7BhZ8yFLkarNdaSWaB43D6UbQwExJ8nnGAEmfHcU,/dns4/wormhole-v2-mainnet-bootstrap.staking.fund/udp/8996/quic/p2p/12D3KooWG8obDX9DNi1KUwZNu9xkGwfKqTp2GFwuuHpWZ3nQruS1"
+
+const TestnetNetworkId = "/wormhole/testnet/2/1"
+const TestnetBootstrapPeers = "/dns4/t-guardian-01.nodes.stable.io/udp/8999/quic/p2p/12D3KooWCW3LGUtkCVkHZmVSZHzL3C4WRKWfqAiJPz1NR7dT9Bxh,/dns4/t-guardian-02.nodes.stable.io/udp/8999/quic/p2p/12D3KooWJXA6goBCiWM8ucjzc4jVUBSqL9Rri6UpjHbkMPErz5zK,/dns4/p2p-guardian-testnet-1.solana.p2p.org/udp/8999/quic/p2p/12D3KooWE4dmZwxhfjCKHLUqSaww96Cf7kmq1ZuKmzPz3MrJgZxp"
+const TestnetCcqBootstrapPeers = "/dns4/t-guardian-01.nodes.stable.io/udp/8996/quic/p2p/12D3KooWCW3LGUtkCVkHZmVSZHzL3C4WRKWfqAiJPz1NR7dT9Bxh,/dns4/t-guardian-02.nodes.stable.io/udp/8996/quic/p2p/12D3KooWJXA6goBCiWM8ucjzc4jVUBSqL9Rri6UpjHbkMPErz5zK,/dns4/p2p-guardian-testnet-1.solana.p2p.org/udp/8996/quic/p2p/12D3KooWE4dmZwxhfjCKHLUqSaww96Cf7kmq1ZuKmzPz3MrJgZxp"
+
+// The Devnet bootstrap peers are derived from the guardian key so we can't include them here.
+const DevnetNetworkId = "/wormhole/dev"
+
+// GetNetworkId returns the default network ID.
+func GetNetworkId(env common.Environment) string {
+	if env == common.MainNet {
+		return MainnetNetworkId
+	}
+	if env == common.TestNet {
+		return TestnetNetworkId
+	}
+	return DevnetNetworkId
+}
+
+// GetBootstrapPeers returns the default p2p bootstrap peers for mainnet and testnet. For any other environment, it returns an error.
+func GetBootstrapPeers(env common.Environment) (string, error) {
+	if env == common.MainNet {
+		return MainnetBootstrapPeers, nil
+	}
+	if env == common.TestNet {
+		return TestnetBootstrapPeers, nil
+	}
+	return "", fmt.Errorf("unsupported environment")
+}
+
+// GetCcqBootstrapPeers returns the default ccq bootstrap peers for mainnet and testnet. For any other environment, it returns an error.
+func GetCcqBootstrapPeers(env common.Environment) (string, error) {
+	if env == common.MainNet {
+		return MainnetCcqBootstrapPeers, nil
+	}
+	if env == common.TestNet {
+		return TestnetCcqBootstrapPeers, nil
+	}
+	return "", fmt.Errorf("unsupported environment")
+}

--- a/node/pkg/p2p/network_consts_test.go
+++ b/node/pkg/p2p/network_consts_test.go
@@ -1,0 +1,82 @@
+package p2p
+
+import (
+	"testing"
+
+	"github.com/certusone/wormhole/node/pkg/common"
+	"go.uber.org/zap"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateMainnetNetworkId(t *testing.T) {
+	networkId := GetNetworkId(common.MainNet)
+	require.Equal(t, MainnetNetworkId, networkId)
+}
+
+func TestValidateTestnetNetworkId(t *testing.T) {
+	networkId := GetNetworkId(common.TestNet)
+	require.Equal(t, TestnetNetworkId, networkId)
+}
+
+func TestValidateDevnetNetworkId(t *testing.T) {
+	networkId := GetNetworkId(common.UnsafeDevNet)
+	require.Equal(t, DevnetNetworkId, networkId)
+}
+
+func TestValidateMainnetBootstrapPeers(t *testing.T) {
+	bootstrapPeers, err := GetBootstrapPeers(common.MainNet)
+	require.NoError(t, err)
+	require.NotEqual(t, "", bootstrapPeers)
+
+	// Make sure we can parse the result.
+	logger := zap.NewNop()
+	bootStrappers, _ := BootstrapAddrs(logger, bootstrapPeers, "somePeerID")
+	assert.Equal(t, 3, len(bootStrappers))
+}
+
+func TestValidateMainnetCcqBootstrapPeers(t *testing.T) {
+	bootstrapPeers, err := GetCcqBootstrapPeers(common.MainNet)
+	require.NoError(t, err)
+	require.NotEqual(t, "", bootstrapPeers)
+
+	// Make sure we can parse the result.
+	logger := zap.NewNop()
+	bootStrappers, _ := BootstrapAddrs(logger, bootstrapPeers, "somePeerID")
+	assert.Equal(t, 3, len(bootStrappers))
+}
+
+func TestValidateTestnetBootstrapPeers(t *testing.T) {
+	bootstrapPeers, err := GetBootstrapPeers(common.TestNet)
+	require.NoError(t, err)
+	require.NotEqual(t, "", bootstrapPeers)
+
+	// Make sure we can parse the result.
+	logger := zap.NewNop()
+	bootStrappers, _ := BootstrapAddrs(logger, bootstrapPeers, "somePeerID")
+	assert.Equal(t, 3, len(bootStrappers))
+}
+
+func TestValidateTestnetCcqBootstrapPeers(t *testing.T) {
+	bootstrapPeers, err := GetCcqBootstrapPeers(common.TestNet)
+	require.NoError(t, err)
+	require.NotEqual(t, "", bootstrapPeers)
+
+	// Make sure we can parse the result.
+	logger := zap.NewNop()
+	bootStrappers, _ := BootstrapAddrs(logger, bootstrapPeers, "somePeerID")
+	assert.Equal(t, 3, len(bootStrappers))
+}
+
+func TestGetBootstrapPeersFailsForUnsupportedEnvironment(t *testing.T) {
+	bootstrapPeers, err := GetBootstrapPeers(common.UnsafeDevNet)
+	require.ErrorContains(t, err, "unsupported environment")
+	require.Equal(t, "", bootstrapPeers)
+}
+
+func TestGetCcqBootstrapPeersFailsForUnsupportedEnvironment(t *testing.T) {
+	bootstrapPeers, err := GetCcqBootstrapPeers(common.UnsafeDevNet)
+	require.ErrorContains(t, err, "unsupported environment")
+	require.Equal(t, "", bootstrapPeers)
+}


### PR DESCRIPTION
This PR hard codes the bootstrap peers and network ID for the guardian, spy and query proxy server, based on the environment (mainnet or testnet). It allows them to be overridden using the existing parameters, but that should be discouraged.

For devnet / tilt, the existing parameters should still be used because the bootstrap peer may not be deterministic.

The following config parameters should be removed for guardiand and the query proxy server:

- --network
- --bootstrap
- --ccqP2pBootstrap

The following config changes should be made for the spy:

- Add --env with a value of `mainnet` or `testnet`.
- Remove --network
- Remove --bootstrap

### Scenarios Tested

- [x] Spy in tilt (devnet)
- [x] Spy with `--env mainnet`
- [x] Spy with `--env testnet`
- [x] Spy with no `--env` but network parameters (allowed)
- [x] Spy with both `--env` and network parameters (not allowed)
- [x] CCQ server in tilt (devnet)
- [x] CCQ server with `--env mainnet`
- [x] CCQ server with `--env testnet`
- [x] Guardian in tilt (devnet)
- [x] Guardian in testnet, no network parameters (allowed)
- [x] Guardian in testnet, with network parameters (allowed)
- [x] Guardian in mainnet, no network parameters (allowed)
- [x] Guardian in mainnet, with network parameters (allowed)
