### PR TITLE
Node/CCQ: Load testing tweaks

### DIFF
--- a/node/pkg/node/node.go
+++ b/node/pkg/node/node.go
@@ -120,8 +120,8 @@ func (g *G) initializeBasic(rootCtxCancel context.CancelFunc) {
 	// Cross Chain Query Handler channels
 	g.chainQueryReqC = make(map[vaa.ChainID]chan *query.PerChainQueryInternal)
 	g.signedQueryReqC = makeChannelPair[*gossipv1.SignedQueryRequest](query.SignedQueryRequestChannelSize)
-	g.queryResponseC = makeChannelPair[*query.PerChainQueryResponseInternal](0)
-	g.queryResponsePublicationC = makeChannelPair[*query.QueryResponsePublication](0)
+	g.queryResponseC = makeChannelPair[*query.PerChainQueryResponseInternal](query.QueryResponseBufferSize)
+	g.queryResponsePublicationC = makeChannelPair[*query.QueryResponsePublication](query.QueryResponsePublicationChannelSize)
 
 	// Guardian set state managed by processor
 	g.gst = common.NewGuardianSetState(nil)

--- a/node/pkg/node/options.go
+++ b/node/pkg/node/options.go
@@ -355,7 +355,7 @@ func GuardianOptionWatchers(watcherConfigs []watchers.WatcherConfig, ibcWatcherC
 			// aggregate per-chain msgC into msgC.
 			// SECURITY defense-in-depth: This way we enforce that a watcher must set the msg.EmitterChain to its chainId, which makes the code easier to audit
 			for _, chainId := range vaa.GetAllNetworkIDs() {
-				chainQueryResponseC[chainId] = make(chan *query.PerChainQueryResponseInternal)
+				chainQueryResponseC[chainId] = make(chan *query.PerChainQueryResponseInternal, query.QueryResponseBufferSize)
 				go func(c <-chan *query.PerChainQueryResponseInternal, chainId vaa.ChainID) {
 					for {
 						select {

--- a/node/pkg/query/query.go
+++ b/node/pkg/query/query.go
@@ -29,10 +29,16 @@ const (
 	AuditInterval = time.Second
 
 	// SignedQueryRequestChannelSize is the buffer size of the incoming query request channel.
-	SignedQueryRequestChannelSize = 50
+	SignedQueryRequestChannelSize = 500
 
 	// QueryRequestBufferSize is the buffer size of the per-network query request channel.
-	QueryRequestBufferSize = 25
+	QueryRequestBufferSize = 250
+
+	// QueryResponseBufferSize is the buffer size of the single query response channel from the watchers.
+	QueryResponseBufferSize = 500
+
+	// QueryResponsePublicationChannelSize is the buffer size of the single query response channel back to the P2P publisher.
+	QueryResponsePublicationChannelSize = 500
 )
 
 func NewQueryHandler(

--- a/node/pkg/watchers/evm/ccq_backfill.go
+++ b/node/pkg/watchers/evm/ccq_backfill.go
@@ -115,7 +115,7 @@ func (w *Watcher) ccqBackfillInit(ctx context.Context) error {
 		}
 
 		if len(newBlocks) == 0 {
-			w.ccqLogger.Error("failed to read any more blocks, giving up on the backfill")
+			w.ccqLogger.Warn("failed to read any more blocks, giving up on the backfill")
 			break
 		}
 


### PR DESCRIPTION
This PR addresses a few small issues seen during query load testing:

- Internal message queues were filling up, causing unnecessary retries.
- The proxy metric to track current level of concurrent queries was not properly updating when a query completed.
- A few watcher logging improvements.