### PR TITLE
node: Throttle CoinGecko queries

### DIFF
--- a/node/pkg/governor/governor_prices.go
+++ b/node/pkg/governor/governor_prices.go
@@ -135,6 +135,9 @@ func (gov *ChainGovernor) queryCoinGecko(ctx context.Context) error {
 	params := url.Values{}
 	params.Add("bust", strconv.Itoa(int(time.Now().Unix()))+strconv.Itoa(rand.Int())) // #nosec G404
 
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	// Throttle the queries to the CoinGecko API. We query for 200 tokens at a time, so this throttling would
 	// allow us to query up to 18,000 tokens in a 15 minute window (the query interval). Currently there are
 	// between 1000 and 2000 tokens.

--- a/node/pkg/governor/governor_prices.go
+++ b/node/pkg/governor/governor_prices.go
@@ -139,15 +139,16 @@ func (gov *ChainGovernor) queryCoinGecko(ctx context.Context) error {
 	defer cancel()
 
 	// Throttle the queries to the CoinGecko API. We query for 200 tokens at a time, so this throttling would
-	// allow us to query up to 18,000 tokens in a 15 minute window (the query interval). Currently there are
+	// allow us to query up to 12,000 tokens in a 15 minute window (the query interval). Currently there are
 	// between 1000 and 2000 tokens.
-	throttle := make(chan time.Time, 1)
+	throttle := make(chan int, 1)
 	go func() {
-		ticker := time.NewTicker(time.Duration(10) * time.Second)
+		ticker := time.NewTicker(time.Duration(15) * time.Second)
 		defer ticker.Stop()
-		for t := range ticker.C {
+		for {
 			select {
-			case throttle <- t:
+			case <-ticker.C:
+				throttle <- 1
 			case <-ctx.Done():
 				return
 			}


### PR DESCRIPTION
We're consistently hitting the CoinGecko API rate limit now on the free plan which means we're not always updating prices and the query check fails when trying to update the governor token list. Rather than paying for the premium API plans we could instead just throttle our requests, since these price updates are not time critical.

Someone better then me at Go can tell me if this is rubbish!