### PR TITLE
Node: Logging cleanup

### DIFF
--- a/node/pkg/p2p/p2p.go
+++ b/node/pkg/p2p/p2p.go
@@ -590,16 +590,19 @@ func Run(
 			}
 
 			if envelope.GetFrom() == h.ID() {
-				logger.Debug("received message from ourselves, ignoring",
-					zap.Any("payload", msg.Message))
+				if logger.Level().Enabled(zapcore.DebugLevel) {
+					logger.Debug("received message from ourselves, ignoring", zap.Any("payload", msg.Message))
+				}
 				p2pMessagesReceived.WithLabelValues("loopback").Inc()
 				continue
 			}
 
-			logger.Debug("received message",
-				zap.Any("payload", msg.Message),
-				zap.Binary("raw", envelope.Data),
-				zap.String("from", envelope.GetFrom().String()))
+			if logger.Level().Enabled(zapcore.DebugLevel) {
+				logger.Debug("received message",
+					zap.Any("payload", msg.Message),
+					zap.Binary("raw", envelope.Data),
+					zap.String("from", envelope.GetFrom().String()))
+			}
 
 			switch m := msg.Message.(type) {
 			case *gossipv1.GossipMessage_SignedHeartbeat:
@@ -659,9 +662,9 @@ func Run(
 								}
 							}
 						} else {
-							logger.Debug("p2p_node_id_not_in_heartbeat",
-								zap.Error(err),
-								zap.Any("payload", heartbeat.NodeName))
+							if logger.Level().Enabled(zapcore.DebugLevel) {
+								logger.Debug("p2p_node_id_not_in_heartbeat", zap.Error(err), zap.Any("payload", heartbeat.NodeName))
+							}
 						}
 					}()
 				}
@@ -693,24 +696,26 @@ func Run(
 				s := m.SignedObservationRequest
 				gs := gst.Get()
 				if gs == nil {
-					logger.Debug("dropping SignedObservationRequest - no guardian set",
-						zap.Any("value", s),
-						zap.String("from", envelope.GetFrom().String()))
+					if logger.Level().Enabled(zapcore.DebugLevel) {
+						logger.Debug("dropping SignedObservationRequest - no guardian set", zap.Any("value", s), zap.String("from", envelope.GetFrom().String()))
+					}
 					break
 				}
 				r, err := processSignedObservationRequest(s, gs)
 				if err != nil {
 					p2pMessagesReceived.WithLabelValues("invalid_signed_observation_request").Inc()
-					logger.Debug("invalid signed observation request received",
-						zap.Error(err),
-						zap.Any("payload", msg.Message),
-						zap.Any("value", s),
-						zap.Binary("raw", envelope.Data),
-						zap.String("from", envelope.GetFrom().String()))
+					if logger.Level().Enabled(zapcore.DebugLevel) {
+						logger.Debug("invalid signed observation request received",
+							zap.Error(err),
+							zap.Any("payload", msg.Message),
+							zap.Any("value", s),
+							zap.Binary("raw", envelope.Data),
+							zap.String("from", envelope.GetFrom().String()))
+					}
 				} else {
-					logger.Debug("valid signed observation request received",
-						zap.Any("value", r),
-						zap.String("from", envelope.GetFrom().String()))
+					if logger.Level().Enabled(zapcore.DebugLevel) {
+						logger.Debug("valid signed observation request received", zap.Any("value", r), zap.String("from", envelope.GetFrom().String()))
+					}
 
 					select {
 					case obsvReqC <- r:

--- a/node/pkg/processor/cleanup.go
+++ b/node/pkg/processor/cleanup.go
@@ -125,7 +125,7 @@ func (p *Processor) handleCleanup(ctx context.Context) {
 
 			if p.logger.Level().Enabled(zapcore.DebugLevel) {
 				p.logger.Debug("observation considered settled",
-					zap.String("message_id", s.MessageID()),
+					zap.String("message_id", s.LoggingID()),
 					zap.String("digest", hash),
 					zap.Duration("delta", delta),
 					zap.Int("have_sigs", hasSigs),
@@ -149,7 +149,7 @@ func (p *Processor) handleCleanup(ctx context.Context) {
 			// and then expired after a while (as noted in observation.go, this can be abused by a byzantine guardian).
 			if p.logger.Level().Enabled(zapcore.DebugLevel) {
 				p.logger.Debug("expiring submitted observation",
-					zap.String("message_id", s.MessageID()),
+					zap.String("message_id", s.LoggingID()),
 					zap.String("digest", hash),
 					zap.Duration("delta", delta),
 				)
@@ -159,7 +159,7 @@ func (p *Processor) handleCleanup(ctx context.Context) {
 		case !s.submitted && ((s.ourMsg != nil && delta > retryLimitOurs) || (s.ourMsg == nil && delta > retryLimitNotOurs)):
 			// Clearly, this horse is dead and continued beatings won't bring it closer to quorum.
 			p.logger.Info("expiring unsubmitted observation after exhausting retries",
-				zap.String("message_id", s.MessageID()),
+				zap.String("message_id", s.LoggingID()),
 				zap.String("digest", hash),
 				zap.Duration("delta", delta),
 				zap.Bool("weObserved", s.ourMsg != nil),
@@ -177,7 +177,7 @@ func (p *Processor) handleCleanup(ctx context.Context) {
 				// Unreliable observations cannot be resubmitted and can be considered failed after 5 minutes
 				if !s.ourObservation.IsReliable() {
 					p.logger.Info("expiring unsubmitted unreliable observation",
-						zap.String("message_id", s.MessageID()),
+						zap.String("message_id", s.LoggingID()),
 						zap.String("digest", hash),
 						zap.Duration("delta", delta),
 					)
@@ -190,7 +190,7 @@ func (p *Processor) handleCleanup(ctx context.Context) {
 				if s.ourObservation.IsReobservation() {
 					if p.logger.Level().Enabled(zapcore.DebugLevel) {
 						p.logger.Debug("not submitting reobservation request for reobservation",
-							zap.String("message_id", s.MessageID()),
+							zap.String("message_id", s.LoggingID()),
 							zap.String("digest", hash),
 							zap.Duration("delta", delta),
 						)
@@ -202,7 +202,7 @@ func (p *Processor) handleCleanup(ctx context.Context) {
 				alreadyInDB, err := p.signedVaaAlreadyInDB(hash, s)
 				if err != nil {
 					p.logger.Error("failed to check if observation is already in DB, requesting reobservation",
-						zap.String("message_id", s.MessageID()),
+						zap.String("message_id", s.LoggingID()),
 						zap.String("hash", hash),
 						zap.Error(err))
 				}
@@ -210,13 +210,13 @@ func (p *Processor) handleCleanup(ctx context.Context) {
 				if alreadyInDB {
 					if p.logger.Level().Enabled(zapcore.DebugLevel) {
 						p.logger.Debug("observation already in DB, not requesting reobservation",
-							zap.String("message_id", s.MessageID()),
+							zap.String("message_id", s.LoggingID()),
 							zap.String("digest", hash),
 						)
 					}
 				} else {
 					p.logger.Info("resubmitting observation",
-						zap.String("message_id", s.MessageID()),
+						zap.String("message_id", s.LoggingID()),
 						zap.String("digest", hash),
 						zap.Duration("delta", delta),
 						zap.String("firstObserved", s.firstObserved.String()),
@@ -226,7 +226,7 @@ func (p *Processor) handleCleanup(ctx context.Context) {
 						TxHash:  s.txHash,
 					}
 					if err := common.PostObservationRequest(p.obsvReqSendC, req); err != nil {
-						p.logger.Warn("failed to broadcast re-observation request", zap.String("message_id", s.MessageID()), zap.Error(err))
+						p.logger.Warn("failed to broadcast re-observation request", zap.String("message_id", s.LoggingID()), zap.Error(err))
 					}
 					p.gossipSendC <- s.ourMsg
 					s.retryCtr++
@@ -242,7 +242,7 @@ func (p *Processor) handleCleanup(ctx context.Context) {
 
 				if p.logger.Level().Enabled(zapcore.DebugLevel) {
 					p.logger.Debug("expiring unsubmitted nil observation",
-						zap.String("message_id", s.MessageID()),
+						zap.String("message_id", s.LoggingID()),
 						zap.String("digest", hash),
 						zap.Duration("delta", delta),
 						zap.Int("have_sigs", hasSigs),

--- a/node/pkg/processor/processor.go
+++ b/node/pkg/processor/processor.go
@@ -3,6 +3,7 @@ package processor
 import (
 	"context"
 	"crypto/ecdsa"
+	"encoding/hex"
 	"fmt"
 	"time"
 
@@ -81,6 +82,14 @@ type (
 		signatures observationMap
 	}
 )
+
+func (s *state) MessageID() string {
+	if s.ourObservation != nil {
+		return s.ourObservation.MessageID()
+	}
+
+	return hex.EncodeToString(s.txHash)
+}
 
 type PythNetVaaEntry struct {
 	v          *vaa.VAA

--- a/node/pkg/processor/processor.go
+++ b/node/pkg/processor/processor.go
@@ -83,7 +83,9 @@ type (
 	}
 )
 
-func (s *state) MessageID() string {
+// LoggingID can be used to identify a state object in a log message. Note that it should not
+// be used to uniquely identify an observation. It is only meant for logging purposes.
+func (s *state) LoggingID() string {
 	if s.ourObservation != nil {
 		return s.ourObservation.MessageID()
 	}

--- a/node/pkg/processor/vaa.go
+++ b/node/pkg/processor/vaa.go
@@ -28,11 +28,16 @@ func (v *VAA) HandleQuorum(sigs []*vaa.Signature, hash string, p *Processor) {
 
 	// Store signed VAA in database.
 	p.logger.Info("signed VAA with quorum",
+		zap.String("message_id", signed.MessageID()),
 		zap.String("digest", hash),
-		zap.String("message_id", signed.MessageID()))
+	)
 
 	if err := p.storeSignedVAA(signed); err != nil {
-		p.logger.Error("failed to store signed VAA", zap.Error(err))
+		p.logger.Error("failed to store signed VAA",
+			zap.String("message_id", signed.MessageID()),
+			zap.String("digest", hash),
+			zap.Error(err),
+		)
 	}
 
 	p.broadcastSignedVAA(signed)


### PR DESCRIPTION
This PR does two things.

First, it adds the standard VAA / Message ID (emitterChain/emitterAddress/seqNo) to messages in the processor to make it easier to follow a message from end-to-end in the logs.

Second, it adds a log level check around a lot of the debug messages so that we don't waste time formatting complex log messages that get dropped anyway.