### PR TITLE
Node: Adminserver commands should not panic

### DIFF
--- a/node/cmd/guardiand/admintemplate.go
+++ b/node/cmd/guardiand/admintemplate.go
@@ -717,7 +717,7 @@ func runWormchainMigrateContractTemplate(cmd *cobra.Command, args []string) {
 		log.Fatal("--contract-address must be specified.")
 	}
 	if *wormchainMigrateContractInstantiationMsg == "" {
-		log.Fatal("--instantiate-msg must be specified.")
+		log.Fatal("--instantiation-msg must be specified.")
 	}
 
 	m := &nodev1.InjectGovernanceVAARequest{

--- a/node/pkg/adminrpc/adminserver.go
+++ b/node/pkg/adminrpc/adminserver.go
@@ -118,12 +118,16 @@ func adminGuardianSetUpdateToVAA(req *nodev1.GuardianSetUpdate, timestamp time.T
 		addrs[i] = ethAddr
 	}
 
-	v := vaa.CreateGovernanceVAA(timestamp, nonce, sequence, guardianSetIndex,
-		vaa.BodyGuardianSetUpdate{
-			Keys:     addrs,
-			NewIndex: guardianSetIndex + 1,
-		}.Serialize())
+	body, err := vaa.BodyGuardianSetUpdate{
+		Keys:     addrs,
+		NewIndex: guardianSetIndex + 1,
+	}.Serialize()
 
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize governance body: %w", err)
+	}
+
+	v := vaa.CreateGovernanceVAA(timestamp, nonce, sequence, guardianSetIndex, body)
 	return v, nil
 }
 
@@ -146,12 +150,16 @@ func adminContractUpgradeToVAA(req *nodev1.ContractUpgrade, timestamp time.Time,
 	newContractAddress := vaa.Address{}
 	copy(newContractAddress[:], b)
 
-	v := vaa.CreateGovernanceVAA(timestamp, nonce, sequence, guardianSetIndex,
-		vaa.BodyContractUpgrade{
-			ChainID:     vaa.ChainID(req.ChainId),
-			NewContract: newContractAddress,
-		}.Serialize())
+	body, err := vaa.BodyContractUpgrade{
+		ChainID:     vaa.ChainID(req.ChainId),
+		NewContract: newContractAddress,
+	}.Serialize()
 
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize governance body: %w", err)
+	}
+
+	v := vaa.CreateGovernanceVAA(timestamp, nonce, sequence, guardianSetIndex, body)
 	return v, nil
 }
 

--- a/node/pkg/adminrpc/adminserver.go
+++ b/node/pkg/adminrpc/adminserver.go
@@ -174,13 +174,17 @@ func tokenBridgeRegisterChain(req *nodev1.BridgeRegisterChain, timestamp time.Ti
 	emitterAddress := vaa.Address{}
 	copy(emitterAddress[:], b)
 
-	v := vaa.CreateGovernanceVAA(timestamp, nonce, sequence, guardianSetIndex,
-		vaa.BodyTokenBridgeRegisterChain{
-			Module:         req.Module,
-			ChainID:        vaa.ChainID(req.ChainId),
-			EmitterAddress: emitterAddress,
-		}.Serialize())
+	body, err := vaa.BodyTokenBridgeRegisterChain{
+		Module:         req.Module,
+		ChainID:        vaa.ChainID(req.ChainId),
+		EmitterAddress: emitterAddress,
+	}.Serialize()
 
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize governance body: %w", err)
+	}
+
+	v := vaa.CreateGovernanceVAA(timestamp, nonce, sequence, guardianSetIndex, body)
 	return v, nil
 }
 
@@ -203,13 +207,17 @@ func recoverChainId(req *nodev1.RecoverChainId, timestamp time.Time, guardianSet
 		return nil, errors.New("invalid new_chain_id")
 	}
 
-	v := vaa.CreateGovernanceVAA(timestamp, nonce, sequence, guardianSetIndex,
-		vaa.BodyRecoverChainId{
-			Module:     req.Module,
-			EvmChainID: evm_chain_id,
-			NewChainID: vaa.ChainID(req.NewChainId),
-		}.Serialize())
+	body, err := vaa.BodyRecoverChainId{
+		Module:     req.Module,
+		EvmChainID: evm_chain_id,
+		NewChainID: vaa.ChainID(req.NewChainId),
+	}.Serialize()
 
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize governance body: %w", err)
+	}
+
+	v := vaa.CreateGovernanceVAA(timestamp, nonce, sequence, guardianSetIndex, body)
 	return v, nil
 }
 
@@ -254,20 +262,24 @@ func accountantModifyBalance(req *nodev1.AccountantModifyBalance, timestamp time
 	tokenAdress := vaa.Address{}
 	copy(tokenAdress[:], b)
 
-	v := vaa.CreateGovernanceVAA(timestamp, nonce, sequence, guardianSetIndex,
-		vaa.BodyAccountantModifyBalance{
-			Module:        req.Module,
-			TargetChainID: vaa.ChainID(req.TargetChainId),
+	body, err := vaa.BodyAccountantModifyBalance{
+		Module:        req.Module,
+		TargetChainID: vaa.ChainID(req.TargetChainId),
 
-			Sequence:     req.Sequence,
-			ChainId:      vaa.ChainID(req.ChainId),
-			TokenChain:   vaa.ChainID(req.TokenChain),
-			TokenAddress: tokenAdress,
-			Kind:         uint8(req.Kind),
-			Amount:       amount,
-			Reason:       req.Reason,
-		}.Serialize())
+		Sequence:     req.Sequence,
+		ChainId:      vaa.ChainID(req.ChainId),
+		TokenChain:   vaa.ChainID(req.TokenChain),
+		TokenAddress: tokenAdress,
+		Kind:         uint8(req.Kind),
+		Amount:       amount,
+		Reason:       req.Reason,
+	}.Serialize()
 
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize governance body: %w", err)
+	}
+
+	v := vaa.CreateGovernanceVAA(timestamp, nonce, sequence, guardianSetIndex, body)
 	return v, nil
 }
 
@@ -290,13 +302,17 @@ func tokenBridgeUpgradeContract(req *nodev1.BridgeUpgradeContract, timestamp tim
 	newContract := vaa.Address{}
 	copy(newContract[:], b)
 
-	v := vaa.CreateGovernanceVAA(timestamp, nonce, sequence, guardianSetIndex,
-		vaa.BodyTokenBridgeUpgradeContract{
-			Module:        req.Module,
-			TargetChainID: vaa.ChainID(req.TargetChainId),
-			NewContract:   newContract,
-		}.Serialize())
+	body, err := vaa.BodyTokenBridgeUpgradeContract{
+		Module:        req.Module,
+		TargetChainID: vaa.ChainID(req.TargetChainId),
+		NewContract:   newContract,
+	}.Serialize()
 
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize governance body: %w", err)
+	}
+
+	v := vaa.CreateGovernanceVAA(timestamp, nonce, sequence, guardianSetIndex, body)
 	return v, nil
 }
 
@@ -316,11 +332,15 @@ func wormchainStoreCode(req *nodev1.WormchainStoreCode, timestamp time.Time, gua
 	wasmHash := [32]byte{}
 	copy(wasmHash[:], b)
 
-	v := vaa.CreateGovernanceVAA(timestamp, nonce, sequence, guardianSetIndex,
-		vaa.BodyWormchainStoreCode{
-			WasmHash: wasmHash,
-		}.Serialize())
+	body, err := vaa.BodyWormchainStoreCode{
+		WasmHash: wasmHash,
+	}.Serialize()
 
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize governance body: %w", err)
+	}
+
+	v := vaa.CreateGovernanceVAA(timestamp, nonce, sequence, guardianSetIndex, body)
 	return v, nil
 }
 
@@ -329,11 +349,15 @@ func wormchainStoreCode(req *nodev1.WormchainStoreCode, timestamp time.Time, gua
 func wormchainInstantiateContract(req *nodev1.WormchainInstantiateContract, timestamp time.Time, guardianSetIndex uint32, nonce uint32, sequence uint64) (*vaa.VAA, error) { //nolint:unparam // error is always nil but kept to mirror function signature of other functions
 	instantiationParams_hash := vaa.CreateInstatiateCosmwasmContractHash(req.CodeId, req.Label, []byte(req.InstantiationMsg))
 
-	v := vaa.CreateGovernanceVAA(timestamp, nonce, sequence, guardianSetIndex,
-		vaa.BodyWormchainInstantiateContract{
-			InstantiationParamsHash: instantiationParams_hash,
-		}.Serialize())
+	body, err := vaa.BodyWormchainInstantiateContract{
+		InstantiationParamsHash: instantiationParams_hash,
+	}.Serialize()
 
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize governance body: %w", err)
+	}
+
+	v := vaa.CreateGovernanceVAA(timestamp, nonce, sequence, guardianSetIndex, body)
 	return v, nil
 }
 
@@ -341,11 +365,15 @@ func wormchainInstantiateContract(req *nodev1.WormchainInstantiateContract, time
 func wormchainMigrateContract(req *nodev1.WormchainMigrateContract, timestamp time.Time, guardianSetIndex uint32, nonce uint32, sequence uint64) (*vaa.VAA, error) { //nolint:unparam // error is always nil but kept to mirror function signature of other functions
 	instantiationParams_hash := vaa.CreateMigrateCosmwasmContractHash(req.CodeId, req.Contract, []byte(req.InstantiationMsg))
 
-	v := vaa.CreateGovernanceVAA(timestamp, nonce, sequence, guardianSetIndex,
-		vaa.BodyWormchainMigrateContract{
-			MigrationParamsHash: instantiationParams_hash,
-		}.Serialize())
+	body, err := vaa.BodyWormchainMigrateContract{
+		MigrationParamsHash: instantiationParams_hash,
+	}.Serialize()
 
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize governance body: %w", err)
+	}
+
+	v := vaa.CreateGovernanceVAA(timestamp, nonce, sequence, guardianSetIndex, body)
 	return v, nil
 }
 
@@ -373,11 +401,16 @@ func wormchainWasmInstantiateAllowlist(
 	var decodedAddr32 [32]byte
 	copy(decodedAddr32[:], decodedAddr)
 
-	v := vaa.CreateGovernanceVAA(timestamp, nonce, sequence, guardianSetIndex, vaa.BodyWormchainWasmAllowlistInstantiate{
+	body, err := vaa.BodyWormchainWasmAllowlistInstantiate{
 		ContractAddr: decodedAddr32,
 		CodeId:       req.CodeId,
-	}.Serialize(action))
+	}.Serialize(action)
 
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize governance body: %w", err)
+	}
+
+	v := vaa.CreateGovernanceVAA(timestamp, nonce, sequence, guardianSetIndex, body)
 	return v, nil
 }
 
@@ -388,11 +421,17 @@ func gatewayScheduleUpgrade(
 	nonce uint32,
 	sequence uint64,
 ) (*vaa.VAA, error) { //nolint:unparam // error is always nil but kept to mirror function signature of other functions
-	v := vaa.CreateGovernanceVAA(timestamp, nonce, sequence, guardianSetIndex, vaa.BodyGatewayScheduleUpgrade{
+
+	body, err := vaa.BodyGatewayScheduleUpgrade{
 		Name:   req.Name,
 		Height: req.Height,
-	}.Serialize())
+	}.Serialize()
 
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize governance body: %w", err)
+	}
+
+	v := vaa.CreateGovernanceVAA(timestamp, nonce, sequence, guardianSetIndex, body)
 	return v, nil
 }
 
@@ -402,10 +441,14 @@ func gatewayCancelUpgrade(
 	nonce uint32,
 	sequence uint64,
 ) (*vaa.VAA, error) { //nolint:unparam // error is always nil but kept to mirror function signature of other functions
-	v := vaa.CreateGovernanceVAA(timestamp, nonce, sequence, guardianSetIndex,
-		vaa.EmptyPayloadVaa(vaa.GatewayModuleStr, vaa.ActionCancelUpgrade, vaa.ChainIDWormchain),
-	)
 
+	body, err := vaa.EmptyPayloadVaa(vaa.GatewayModuleStr, vaa.ActionCancelUpgrade, vaa.ChainIDWormchain)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize governance body: %w", err)
+	}
+
+	v := vaa.CreateGovernanceVAA(timestamp, nonce, sequence, guardianSetIndex, body)
 	return v, nil
 }
 
@@ -424,10 +467,15 @@ func gatewayIbcComposabilityMwSetContract(
 	var decodedAddr32 [32]byte
 	copy(decodedAddr32[:], decodedAddr)
 
-	v := vaa.CreateGovernanceVAA(timestamp, nonce, sequence, guardianSetIndex, vaa.BodyGatewayIbcComposabilityMwContract{
+	body, err := vaa.BodyGatewayIbcComposabilityMwContract{
 		ContractAddr: decodedAddr32,
-	}.Serialize())
+	}.Serialize()
 
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize governance body: %w", err)
+	}
+
+	v := vaa.CreateGovernanceVAA(timestamp, nonce, sequence, guardianSetIndex, body)
 	return v, nil
 }
 
@@ -440,12 +488,17 @@ func circleIntegrationUpdateWormholeFinality(req *nodev1.CircleIntegrationUpdate
 	if req.Finality > math.MaxUint8 {
 		return nil, fmt.Errorf("invalid finality, must be <= %d", math.MaxUint8)
 	}
-	v := vaa.CreateGovernanceVAA(timestamp, nonce, sequence, guardianSetIndex,
-		vaa.BodyCircleIntegrationUpdateWormholeFinality{
-			TargetChainID: vaa.ChainID(req.TargetChainId),
-			Finality:      uint8(req.Finality),
-		}.Serialize())
 
+	body, err := vaa.BodyCircleIntegrationUpdateWormholeFinality{
+		TargetChainID: vaa.ChainID(req.TargetChainId),
+		Finality:      uint8(req.Finality),
+	}.Serialize()
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize governance body: %w", err)
+	}
+
+	v := vaa.CreateGovernanceVAA(timestamp, nonce, sequence, guardianSetIndex, body)
 	return v, nil
 }
 
@@ -470,14 +523,18 @@ func circleIntegrationRegisterEmitterAndDomain(req *nodev1.CircleIntegrationRegi
 	foreignEmitterAddress := vaa.Address{}
 	copy(foreignEmitterAddress[:], b)
 
-	v := vaa.CreateGovernanceVAA(timestamp, nonce, sequence, guardianSetIndex,
-		vaa.BodyCircleIntegrationRegisterEmitterAndDomain{
-			TargetChainID:         vaa.ChainID(req.TargetChainId),
-			ForeignEmitterChainId: vaa.ChainID(req.ForeignEmitterChainId),
-			ForeignEmitterAddress: foreignEmitterAddress,
-			CircleDomain:          req.CircleDomain,
-		}.Serialize())
+	body, err := vaa.BodyCircleIntegrationRegisterEmitterAndDomain{
+		TargetChainID:         vaa.ChainID(req.TargetChainId),
+		ForeignEmitterChainId: vaa.ChainID(req.ForeignEmitterChainId),
+		ForeignEmitterAddress: foreignEmitterAddress,
+		CircleDomain:          req.CircleDomain,
+	}.Serialize()
 
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize governance body: %w", err)
+	}
+
+	v := vaa.CreateGovernanceVAA(timestamp, nonce, sequence, guardianSetIndex, body)
 	return v, nil
 }
 
@@ -499,12 +556,16 @@ func circleIntegrationUpgradeContractImplementation(req *nodev1.CircleIntegratio
 	newImplementationAddress := vaa.Address{}
 	copy(newImplementationAddress[:], b)
 
-	v := vaa.CreateGovernanceVAA(timestamp, nonce, sequence, guardianSetIndex,
-		vaa.BodyCircleIntegrationUpgradeContractImplementation{
-			TargetChainID:            vaa.ChainID(req.TargetChainId),
-			NewImplementationAddress: newImplementationAddress,
-		}.Serialize())
+	body, err := vaa.BodyCircleIntegrationUpgradeContractImplementation{
+		TargetChainID:            vaa.ChainID(req.TargetChainId),
+		NewImplementationAddress: newImplementationAddress,
+	}.Serialize()
 
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize governance body: %w", err)
+	}
+
+	v := vaa.CreateGovernanceVAA(timestamp, nonce, sequence, guardianSetIndex, body)
 	return v, nil
 }
 
@@ -527,7 +588,10 @@ func ibcUpdateChannelChain(
 	if len(req.ChannelId) > 64 {
 		return nil, fmt.Errorf("invalid channel ID length, must be <= 64")
 	}
-	channelId := vaa.LeftPadIbcChannelId(req.ChannelId)
+	channelId, err := vaa.LeftPadIbcChannelId(req.ChannelId)
+	if err != nil {
+		return nil, fmt.Errorf("failed to left pad channel id: %w", err)
+	}
 
 	var module string
 	if req.Module == nodev1.IbcUpdateChannelChainModule_IBC_UPDATE_CHANNEL_CHAIN_MODULE_RECEIVER {
@@ -538,14 +602,17 @@ func ibcUpdateChannelChain(
 		return nil, fmt.Errorf("unrecognized ibc update channel chain module")
 	}
 
-	// create governance VAA
-	v := vaa.CreateGovernanceVAA(timestamp, nonce, sequence, guardianSetIndex,
-		vaa.BodyIbcUpdateChannelChain{
-			TargetChainId: vaa.ChainID(req.TargetChainId),
-			ChannelId:     channelId,
-			ChainId:       vaa.ChainID(req.ChainId),
-		}.Serialize(module))
+	body, err := vaa.BodyIbcUpdateChannelChain{
+		TargetChainId: vaa.ChainID(req.TargetChainId),
+		ChannelId:     channelId,
+		ChainId:       vaa.ChainID(req.ChainId),
+	}.Serialize(module)
 
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize governance body: %w", err)
+	}
+
+	v := vaa.CreateGovernanceVAA(timestamp, nonce, sequence, guardianSetIndex, body)
 	return v, nil
 }
 
@@ -568,12 +635,16 @@ func wormholeRelayerSetDefaultDeliveryProvider(req *nodev1.WormholeRelayerSetDef
 	NewDefaultDeliveryProviderAddress := vaa.Address{}
 	copy(NewDefaultDeliveryProviderAddress[:], b)
 
-	v := vaa.CreateGovernanceVAA(timestamp, nonce, sequence, guardianSetIndex,
-		vaa.BodyWormholeRelayerSetDefaultDeliveryProvider{
-			ChainID:                           vaa.ChainID(req.ChainId),
-			NewDefaultDeliveryProviderAddress: NewDefaultDeliveryProviderAddress,
-		}.Serialize())
+	body, err := vaa.BodyWormholeRelayerSetDefaultDeliveryProvider{
+		ChainID:                           vaa.ChainID(req.ChainId),
+		NewDefaultDeliveryProviderAddress: NewDefaultDeliveryProviderAddress,
+	}.Serialize()
 
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize governance body: %w", err)
+	}
+
+	v := vaa.CreateGovernanceVAA(timestamp, nonce, sequence, guardianSetIndex, body)
 	return v, nil
 }
 
@@ -598,7 +669,6 @@ func evmCallToVaa(evmCall *nodev1.EvmCall, timestamp time.Time, guardianSetIndex
 	}
 
 	v := vaa.CreateGovernanceVAA(timestamp, nonce, sequence, guardianSetIndex, body)
-
 	return v, nil
 }
 
@@ -619,13 +689,17 @@ func solanaCallToVaa(solanaCall *nodev1.SolanaCall, timestamp time.Time, guardia
 		return nil, fmt.Errorf("failed to decode instruction: %w", err)
 	}
 
-	v := vaa.CreateGovernanceVAA(timestamp, nonce, sequence, guardianSetIndex,
-		vaa.BodyGeneralPurposeGovernanceSolana{
-			ChainID:            vaa.ChainID(solanaCall.ChainId),
-			GovernanceContract: governanceContract,
-			Instruction:        instruction,
-		}.Serialize())
+	body, err := vaa.BodyGeneralPurposeGovernanceSolana{
+		ChainID:            vaa.ChainID(solanaCall.ChainId),
+		GovernanceContract: governanceContract,
+		Instruction:        instruction,
+	}.Serialize()
 
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize governance body: %w", err)
+	}
+
+	v := vaa.CreateGovernanceVAA(timestamp, nonce, sequence, guardianSetIndex, body)
 	return v, nil
 }
 
@@ -677,7 +751,7 @@ func GovMsgToVaa(message *nodev1.GovernanceMessage, currentSetIndex uint32, time
 	case *nodev1.GovernanceMessage_SolanaCall:
 		v, err = solanaCallToVaa(payload.SolanaCall, timestamp, currentSetIndex, message.Nonce, message.Sequence)
 	default:
-		panic(fmt.Sprintf("unsupported VAA type: %T", payload))
+		err = fmt.Errorf("unsupported VAA type: %T", payload)
 	}
 
 	return v, err

--- a/node/pkg/adminrpc/prototext_test.go
+++ b/node/pkg/adminrpc/prototext_test.go
@@ -1,0 +1,1121 @@
+//nolint:unparam
+package adminrpc
+
+type adminCommandTestEntry struct {
+	label     string
+	errText   string // empty string means success
+	prototext string
+}
+
+var adminCommandTest = []adminCommandTestEntry{
+	// build/bin/guardiand template guardian-set-update --num=2 --idx=4
+	{
+		label:   "GuardianSetUpdate success",
+		errText: "",
+		prototext: `
+			current_set_index: 4
+			messages: {
+				sequence: 13675600082943268828
+				nonce: 1875482155
+				guardian_set: {
+					guardians: {
+						pubkey: "0xbeFA429d57cD18b7F8A4d91A2da9AB4AF05d0FBe"
+						name: "Example validator 0"
+					}
+					guardians: {
+						pubkey: "0x88D7D8B32a9105d228100E72dFFe2Fae0705D31c"
+						name: "Example validator 1"
+					}
+				}
+			}`,
+	},
+	{
+		label:   "GuardianSetUpdate no guardian keys",
+		errText: "empty guardian set specified",
+		prototext: `
+			current_set_index: 4
+			messages: {
+				sequence: 13675600082943268828
+				nonce: 1875482155
+				guardian_set: {
+				}
+			}`,
+	},
+	{
+		label:   "GuardianSetUpdate too many guardian keys",
+		errText: "too many guardians",
+		prototext: `
+			current_set_index: 4
+			messages: {
+				sequence: 13675600082943268828
+				nonce: 1875482155
+				guardian_set: {
+					guardians: {
+						pubkey: "0xbeFA429d57cD18b7F8A4d91A2da9AB4AF05d0FBe"
+						name: "Example validator 0"
+					}
+					guardians: {
+						pubkey: "0x88D7D8B32a9105d228100E72dFFe2Fae0705D31c"
+						name: "Example validator 1"
+					}
+					guardians: {
+						pubkey: "0x88D7D8B32a9105d228100E72dFFe2Fae0705D31c"
+						name: "Example validator 1"
+					}
+					guardians: {
+						pubkey: "0x88D7D8B32a9105d228100E72dFFe2Fae0705D31c"
+						name: "Example validator 1"
+					}
+					guardians: {
+						pubkey: "0x88D7D8B32a9105d228100E72dFFe2Fae0705D31c"
+						name: "Example validator 1"
+					}
+					guardians: {
+						pubkey: "0x88D7D8B32a9105d228100E72dFFe2Fae0705D31c"
+						name: "Example validator 1"
+					}
+					guardians: {
+						pubkey: "0x88D7D8B32a9105d228100E72dFFe2Fae0705D31c"
+						name: "Example validator 1"
+					}
+					guardians: {
+						pubkey: "0x88D7D8B32a9105d228100E72dFFe2Fae0705D31c"
+						name: "Example validator 1"
+					}
+					guardians: {
+						pubkey: "0x88D7D8B32a9105d228100E72dFFe2Fae0705D31c"
+						name: "Example validator 1"
+					}
+					guardians: {
+						pubkey: "0x88D7D8B32a9105d228100E72dFFe2Fae0705D31c"
+						name: "Example validator 1"
+					}
+					guardians: {
+						pubkey: "0x88D7D8B32a9105d228100E72dFFe2Fae0705D31c"
+						name: "Example validator 1"
+					}
+					guardians: {
+						pubkey: "0x88D7D8B32a9105d228100E72dFFe2Fae0705D31c"
+						name: "Example validator 1"
+					}
+					guardians: {
+						pubkey: "0x88D7D8B32a9105d228100E72dFFe2Fae0705D31c"
+						name: "Example validator 1"
+					}
+					guardians: {
+						pubkey: "0x88D7D8B32a9105d228100E72dFFe2Fae0705D31c"
+						name: "Example validator 1"
+					}
+					guardians: {
+						pubkey: "0x88D7D8B32a9105d228100E72dFFe2Fae0705D31c"
+						name: "Example validator 1"
+					}
+					guardians: {
+						pubkey: "0x88D7D8B32a9105d228100E72dFFe2Fae0705D31c"
+						name: "Example validator 1"
+					}
+					guardians: {
+						pubkey: "0x88D7D8B32a9105d228100E72dFFe2Fae0705D31c"
+						name: "Example validator 1"
+					}
+					guardians: {
+						pubkey: "0x88D7D8B32a9105d228100E72dFFe2Fae0705D31c"
+						name: "Example validator 1"
+					}
+					guardians: {
+						pubkey: "0x88D7D8B32a9105d228100E72dFFe2Fae0705D31c"
+						name: "Example validator 1"
+					}
+					guardians: {
+						pubkey: "0x88D7D8B32a9105d228100E72dFFe2Fae0705D31c"
+						name: "Example validator 1"
+					}
+				}
+			}`,
+	},
+	{
+		label:   "GuardianSetUpdate invalid guardian key",
+		errText: "invalid pubkey format",
+		prototext: `
+			current_set_index: 4
+			messages: {
+				sequence: 13675600082943268828
+				nonce: 1875482155
+				guardian_set: {
+					guardians: {
+						pubkey: "Hello, World!"
+						name: "Example validator 0"
+					}
+				}
+			}`,
+	},
+	{
+		label:   "GuardianSetUpdate duplicate guardian key",
+		errText: "duplicate pubkey at index 1",
+		prototext: `
+			current_set_index: 4
+			messages: {
+				sequence: 13675600082943268828
+				nonce: 1875482155
+				guardian_set: {
+					guardians: {
+						pubkey: "0xbeFA429d57cD18b7F8A4d91A2da9AB4AF05d0FBe"
+						name: "Example validator 0"
+					}
+					guardians: {
+						pubkey: "0xbeFA429d57cD18b7F8A4d91A2da9AB4AF05d0FBe"
+						name: "Example validator 0"
+					}
+				}
+			}`,
+	},
+
+	// build/bin/guardiand template contract-upgrade --chain-id "ethereum" --new-address 0xC89Ce4735882C9F0f0FE26686c53074E09B0D550
+	{
+		label:   "ContractUpgrade success",
+		errText: "",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 12970493895929703138
+					nonce: 700990237
+					contract_upgrade: {
+						chain_id: 2
+						new_contract: "000000000000000000000000c89ce4735882c9f0f0fe26686c53074e09b0d550"
+					}
+				}`,
+	},
+	{
+		label:   "ContractUpgrade invalid contract address",
+		errText: "invalid new contract address encoding (expected hex)",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 12970493895929703138
+					nonce: 700990237
+					contract_upgrade: {
+						chain_id: 2
+						new_contract: "Hello, World!"
+					}
+				}`,
+	},
+	{
+		label:   "ContractUpgrade contract address wrong length",
+		errText: "invalid new_contract address",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 12970493895929703138
+					nonce: 700990237
+					contract_upgrade: {
+						chain_id: 2
+						new_contract: "c89ce4735882c9f0f0fe26686c53074e09b0d550"
+					}
+				}`,
+	},
+	{
+		label:   "ContractUpgrade chain id too large",
+		errText: "invalid chain_id",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 12970493895929703138
+					nonce: 700990237
+					contract_upgrade: {
+						chain_id: 65536
+						new_contract: "000000000000000000000000c89ce4735882c9f0f0fe26686c53074e09b0d550"
+					}
+				}`,
+	},
+
+	// build/bin/guardiand template token-bridge-register-chain --chain-id ethereum --module TokenBridge --new-address 0x0290FB167208Af455bB137780163b7B7a9a10C16
+	{
+		label:   "BridgeRegisterChain success",
+		errText: "",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 13048739474937843907
+					nonce: 277897432
+					bridge_register_chain: {
+						module: "TokenBridge"
+						chain_id: 2
+						emitter_address: "0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16"
+					}
+				}`,
+	},
+	{
+		label:   "BridgeRegisterChain invalid chain id",
+		errText: "invalid chain_id",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 13048739474937843907
+					nonce: 277897432
+					bridge_register_chain: {
+						module: "TokenBridge"
+						chain_id: 65536
+						emitter_address: "0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16"
+					}
+				}`,
+	},
+	{
+		label:   "BridgeRegisterChain invalid emitter address",
+		errText: "invalid emitter address encoding (expected hex)",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 13048739474937843907
+					nonce: 277897432
+					bridge_register_chain: {
+						module: "TokenBridge"
+						chain_id: 2
+						emitter_address: "Hello, World!"
+					}
+				}`,
+	},
+	{
+		label:   "BridgeRegisterChain invalid emitter address length",
+		errText: "invalid emitter address (expected 32 bytes)",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 13048739474937843907
+					nonce: 277897432
+					bridge_register_chain: {
+						module: "TokenBridge"
+						chain_id: 2
+						emitter_address: "0290fb167208af455bb137780163b7b7a9a10c16"
+					}
+				}`,
+	},
+
+	// build/bin/guardiand template recover-chain-id --module TokenBridge --evm-chain-id 42 --new-chain-id 43
+	{
+		label:   "RecoverChainId success",
+		errText: "",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 4474356899438211298
+					nonce: 4040780926
+					recover_chain_id: {
+						module: "TokenBridge"
+						evm_chain_id: "42"
+						new_chain_id: 43
+					}
+				}`,
+	},
+	{
+		label:   "RecoverChainId invalid evm chain id",
+		errText: "invalid evm_chain_id",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 4474356899438211298
+					nonce: 4040780926
+					recover_chain_id: {
+						module: "TokenBridge"
+						evm_chain_id: "Hello, World!"
+						new_chain_id: 43
+					}
+				}`,
+	},
+	{
+		label:   "RecoverChainId evm chain id too large",
+		errText: "evm_chain_id overflow",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 4474356899438211298
+					nonce: 4040780926
+					recover_chain_id: {
+						module: "TokenBridge"
+						evm_chain_id: "115792089237316195423570985008687907853269984665640564039457584007913129639936"
+						new_chain_id: 43
+					}
+				}`,
+	},
+	{
+		label:   "RecoverChainId invalid new chain id",
+		errText: "invalid new_chain_id",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 4474356899438211298
+					nonce: 4040780926
+					recover_chain_id: {
+						module: "TokenBridge"
+						evm_chain_id: "42"
+						new_chain_id: 65536
+					}
+				}`,
+	},
+
+	// TODO: There is no admin template command for AccountantModifyBalance. Issue #3902.
+	{
+		label:   "AccountantModifyBalance success",
+		errText: "",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 315027427769585223
+					nonce: 2920957782
+					accountant_modify_balance: {
+						module:  "GlobalAccountant"
+						target_chain_id: 3104
+						sequence: 3
+						chain_id: 1
+						token_chain: 2
+						token_address: "000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+						kind: 1
+						amount: "12000000000000"
+						reason: "fix bad value"
+					}
+				}`,
+	},
+	{
+		label:   "AccountantModifyBalance invalid target chain id",
+		errText: "invalid target_chain_id",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 315027427769585223
+					nonce: 2920957782
+					accountant_modify_balance: {
+						module:  "GlobalAccountant"
+						target_chain_id: 65536
+						sequence: 3
+						chain_id: 1
+						token_chain: 2
+						token_address: "000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+						kind: 1
+						amount: "12000000000000"
+						reason: "fix bad value"
+					}
+				}`,
+	},
+	{
+		label:   "AccountantModifyBalance invalid chain id",
+		errText: "invalid chain_id",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 315027427769585223
+					nonce: 2920957782
+					accountant_modify_balance: {
+						module:  "GlobalAccountant"
+						target_chain_id: 3104
+						sequence: 3
+						chain_id: 65536
+						token_chain: 2
+						token_address: "000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+						kind: 1
+						amount: "12000000000000"
+						reason: "fix bad value"
+					}
+				}`,
+	},
+	{
+		label:   "AccountantModifyBalance invalid token chain id",
+		errText: "invalid token_chain",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 315027427769585223
+					nonce: 2920957782
+					accountant_modify_balance: {
+						module:  "GlobalAccountant"
+						target_chain_id: 3104
+						sequence: 3
+						chain_id: 1
+						token_chain: 65536
+						token_address: "000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+						kind: 1
+						amount: "12000000000000"
+						reason: "fix bad value"
+					}
+				}`,
+	},
+	{
+		label:   "AccountantModifyBalance invalid token address",
+		errText: "invalid token address (expected hex)",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 315027427769585223
+					nonce: 2920957782
+					accountant_modify_balance: {
+						module:  "GlobalAccountant"
+						target_chain_id: 3104
+						sequence: 3
+						chain_id: 1
+						token_chain: 2
+						token_address: "Hello, World!"
+						kind: 1
+						amount: "12000000000000"
+						reason: "fix bad value"
+					}
+				}`,
+	},
+	{
+		label:   "AccountantModifyBalance token address wrong length",
+		errText: "invalid new token address (expected 32 bytes)",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 315027427769585223
+					nonce: 2920957782
+					accountant_modify_balance: {
+						module:  "GlobalAccountant"
+						target_chain_id: 3104
+						sequence: 3
+						chain_id: 1
+						token_chain: 2
+						token_address: "0000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+						kind: 1
+						amount: "12000000000000"
+						reason: "fix bad value"
+					}
+				}`,
+	},
+	{
+		label:   "AccountantModifyBalance reason too long",
+		errText: "the reason should not be larger than 32 bytes",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 315027427769585223
+					nonce: 2920957782
+					accountant_modify_balance: {
+						module:  "GlobalAccountant"
+						target_chain_id: 3104
+						sequence: 3
+						chain_id: 1
+						token_chain: 2
+						token_address: "000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+						kind: 1
+						amount: "12000000000000"
+						reason: "reason is too long!!!!!!!!!!!!!!!"
+					}
+				}`,
+	},
+	{
+		label:   "AccountantModifyBalance invalid amount",
+		errText: "invalid amount",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 315027427769585223
+					nonce: 2920957782
+					accountant_modify_balance: {
+						module:  "GlobalAccountant"
+						target_chain_id: 3104
+						sequence: 3
+						chain_id: 1
+						token_chain: 2
+						token_address: "000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+						kind: 1
+						amount: "Hello, World!"
+						reason: "fix bad value"
+					}
+				}`,
+	},
+	{
+		label:   "AccountantModifyBalance amount overflow",
+		errText: "amount overflow",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 315027427769585223
+					nonce: 2920957782
+					accountant_modify_balance: {
+						module:  "GlobalAccountant"
+						target_chain_id: 3104
+						sequence: 3
+						chain_id: 1
+						token_chain: 2
+						token_address: "000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+						kind: 1
+						amount: "115792089237316195423570985008687907853269984665640564039457584007913129639936"
+						reason: "fix bad value"
+					}
+				}`,
+	},
+
+	// build/bin/guardiand template token-bridge-upgrade-contract --chain-id ethereum --module TokenBridge --new-address 0x0290FB167208Af455bB137780163b7B7a9a10C16
+	{
+		label:   "BridgeUpgradeContract success",
+		errText: "",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 2474806415844516465
+					nonce: 1137535017
+					bridge_contract_upgrade: {
+						module: "TokenBridge"
+						target_chain_id: 2
+						new_contract: "0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16"
+					}
+				}`,
+	},
+	{
+		label:   "BridgeUpgradeContract invalid target chain id",
+		errText: "invalid target_chain_id",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 2474806415844516465
+					nonce: 1137535017
+					bridge_contract_upgrade: {
+						module: "TokenBridge"
+						target_chain_id: 65536
+						new_contract: "0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16"
+					}
+				}`,
+	},
+	{
+		label:   "BridgeUpgradeContract invalid new contract address",
+		errText: "invalid new contract address (expected hex)",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 2474806415844516465
+					nonce: 1137535017
+					bridge_contract_upgrade: {
+						module: "TokenBridge"
+						target_chain_id: 2
+						new_contract: "Hello, World!"
+					}
+				}`,
+	},
+	{
+		label:   "BridgeUpgradeContract contract address too long",
+		errText: "invalid new contract address (expected 32 bytes)",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 2474806415844516465
+					nonce: 1137535017
+					bridge_contract_upgrade: {
+						module: "TokenBridge"
+						target_chain_id: 2
+						new_contract: "0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c1600"
+					}
+				}`,
+	},
+
+	// build/bin/guardiand template wormchain-store-code --wasm-hash 0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16
+	{
+		label:   "WormchainStoreCode success",
+		errText: "",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 1985924966232230622
+					nonce: 1162627577
+					wormchain_store_code: {
+						wasm_hash: "0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16"
+					}
+				}`,
+	},
+	{
+		label:   "WormchainStoreCode invalid wasm hash",
+		errText: "invalid cosmwasm bytecode hash (expected hex)",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 1985924966232230622
+					nonce: 1162627577
+					wormchain_store_code: {
+						wasm_hash: "Hello, World!"
+					}
+				}`,
+	},
+	{
+		label:   "WormchainStoreCode invalid wasm hash length",
+		errText: "invalid cosmwasm bytecode hash (expected 32 bytes but received 33 bytes)",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 1985924966232230622
+					nonce: 1162627577
+					wormchain_store_code: {
+						wasm_hash: "0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c1600"
+					}
+				}`,
+	},
+
+	// build/bin/guardiand template wormchain-instantiate-contract --code-id 12345678 --label "Hi, Mom!" --instantiation-msg "Some random junk"
+	{
+		label:   "WormchainInstantiateContract success",
+		errText: "",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 3355941316502237895
+					nonce: 749992725
+					wormchain_instantiate_contract: {
+						code_id: 12345678
+						label: "Hi, Mom!"
+						instantiation_msg: "Some random junk"
+					}
+				}`,
+	},
+
+	// build/bin/guardiand template wormchain-migrate-contract --code-id 12345678 --contract-address wormhole1ghd753shjuwexxywmgs4xz7x2q732vcnkm6h2pyv9s6ah3hylvrqtm7t3h --instantiation-msg "Some junk"
+	{
+		label:   "WormchainMigrateContract success",
+		errText: "",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 13069018493465262425
+					nonce: 222803138
+					wormchain_migrate_contract: {
+						code_id: 12345678
+						contract: "wormhole1ghd753shjuwexxywmgs4xz7x2q732vcnkm6h2pyv9s6ah3hylvrqtm7t3h"
+						instantiation_msg: "Some junk"
+					}
+				}`,
+	},
+
+	// build/bin/guardiand template wormchain-add-wasm-instantiate-allowlist --code-id 12345678 --contract-address wormchain-add-wasm-instantiate-allowlist
+	{
+		label:   "WormchainWasmInstantiateAllowlist success",
+		errText: "",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 14341603504021037676
+					nonce: 1682273406
+					wormchain_wasm_instantiate_allowlist: {
+						code_id: 12345678
+						contract: "wormhole1466nf3zuxpya8q9emxukd7vftaf6h4psr0a07srl5zw74zh84yjq4lyjmh"
+						action: WORMCHAIN_WASM_INSTANTIATE_ALLOWLIST_ACTION_ADD
+					}
+				}`,
+	},
+	{
+		label:   "WormchainWasmInstantiateAllowlist invalid bech32 contract address",
+		errText: "decoding bech32 failed",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 14341603504021037676
+					nonce: 1682273406
+					wormchain_wasm_instantiate_allowlist: {
+						code_id: 12345678
+						contract: "Hi, Mom!"
+						action: WORMCHAIN_WASM_INSTANTIATE_ALLOWLIST_ACTION_ADD
+					}
+				}`,
+	},
+	{
+		label:   "WormchainWasmInstantiateAllowlist unexpected action",
+		errText: "unrecognized wasm instantiate allowlist action",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 14341603504021037676
+					nonce: 1682273406
+					wormchain_wasm_instantiate_allowlist: {
+						code_id: 12345678
+						contract: "wormhole1466nf3zuxpya8q9emxukd7vftaf6h4psr0a07srl5zw74zh84yjq4lyjmh"
+						action: WORMCHAIN_WASM_INSTANTIATE_ALLOWLIST_ACTION_UNSPECIFIED
+					}
+				}`,
+	},
+
+	// build/bin/guardiand template circle-integration-update-wormhole-finality --chain-id ethereum --finality 42
+	{
+		label:   "CircleIntegrationUpdateWormholeFinality success",
+		errText: "",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 6415677735604800159
+					nonce: 1410643993
+					circle_integration_update_wormhole_finality: {
+						finality: 42
+						target_chain_id: 2
+					}
+				}`,
+	},
+
+	// build/bin/guardiand template circle-integration-register-emitter-and-domain --chain-id ethereum --circle-domain 42 --foreign-emitter-chain-id bsc --foreign-emitter-address 0x0290FB167208Af455bB137780163b7B7a9a10C16
+	{
+		label:   "CircleIntegrationRegisterEmitterAndDomain success",
+		errText: "",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 4922548351928530675
+					nonce: 1868545932
+					circle_integration_register_emitter_and_domain: {
+						foreign_emitter_chain_id: 4
+						foreign_emitter_address: "0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16"
+						circle_domain: 42
+						target_chain_id: 2
+					}
+				}`,
+	},
+	{
+		label:   "CircleIntegrationRegisterEmitterAndDomain invalid target chain id",
+		errText: "invalid target chain id",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 4922548351928530675
+					nonce: 1868545932
+					circle_integration_register_emitter_and_domain: {
+						foreign_emitter_chain_id: 4
+						foreign_emitter_address: "0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16"
+						circle_domain: 42
+						target_chain_id: 65536
+					}
+				}`,
+	},
+	{
+		label:   "CircleIntegrationRegisterEmitterAndDomain invalid foreign chain id",
+		errText: "invalid foreign emitter chain id",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 4922548351928530675
+					nonce: 1868545932
+					circle_integration_register_emitter_and_domain: {
+						foreign_emitter_chain_id: 65536
+						foreign_emitter_address: "0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16"
+						circle_domain: 42
+						target_chain_id: 2
+					}
+				}`,
+	},
+	{
+		label:   "CircleIntegrationRegisterEmitterAndDomain invalid foreign emitter address",
+		errText: "invalid foreign emitter address encoding",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 4922548351928530675
+					nonce: 1868545932
+					circle_integration_register_emitter_and_domain: {
+						foreign_emitter_chain_id: 4
+						foreign_emitter_address: "Hello, World!"
+						circle_domain: 42
+						target_chain_id: 2
+					}
+				}`,
+	},
+	{
+		label:   "CircleIntegrationRegisterEmitterAndDomain foreign emitter address too short",
+		errText: "invalid foreign emitter address (expected 32 bytes)",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 4922548351928530675
+					nonce: 1868545932
+					circle_integration_register_emitter_and_domain: {
+						foreign_emitter_chain_id: 4
+						foreign_emitter_address: "00000000000000000000000290fb167208af455bb137780163b7b7a9a10c16"
+						circle_domain: 42
+						target_chain_id: 2
+					}
+				}`,
+	},
+
+	// build/bin/guardiand template circle-integration-upgrade-contract-implementation --chain-id ethereum --new-implementation-address 0x0290FB167208Af455bB137780163b7B7a9a10C16
+	{
+		label:   "CircleIntegrationUpgradeContractImplementation success",
+		errText: "",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 17801246082911495918
+					nonce: 3226303109
+					circle_integration_upgrade_contract_implementation: {
+						new_implementation_address: "0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16"
+						target_chain_id: 2
+					}
+				}`,
+	},
+	{
+		label:   "CircleIntegrationUpgradeContractImplementation invalid target chain id",
+		errText: "invalid target chain id, must be <= 65535",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 17801246082911495918
+					nonce: 3226303109
+					circle_integration_upgrade_contract_implementation: {
+						new_implementation_address: "0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16"
+						target_chain_id: 65536
+					}
+				}`,
+	},
+	{
+		label:   "CircleIntegrationUpgradeContractImplementation invalid implementation address",
+		errText: "invalid new implementation address encoding (expected hex)",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 17801246082911495918
+					nonce: 3226303109
+					circle_integration_upgrade_contract_implementation: {
+						new_implementation_address: "Hello, World!"
+						target_chain_id: 2
+					}
+				}`,
+	},
+	{
+		label:   "CircleIntegrationUpgradeContractImplementation invalid implementation address length",
+		errText: "invalid new implementation address (expected 32 bytes)",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 17801246082911495918
+					nonce: 3226303109
+					circle_integration_upgrade_contract_implementation: {
+						new_implementation_address: "00000000000000000000000290fb167208af455bb137780163b7b7a9a10c16"
+						target_chain_id: 2
+					}
+				}`,
+	},
+
+	// build/bin/guardiand template ibc-receiver-update-channel-chain --target-chain-id 3104 --channel-id "channel-3" --chain-id 20
+	{
+		label:   "IbcUpdateChannelChain success",
+		errText: "",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 17350963017355124444
+					nonce: 45403294
+					ibc_update_channel_chain: {
+						target_chain_id: 3104
+						channel_id: "channel-3"
+						chain_id: 20
+						module: IBC_UPDATE_CHANNEL_CHAIN_MODULE_RECEIVER
+					}
+				}`,
+	},
+	{
+		label:   "IbcUpdateChannelChain invalid target chain id",
+		errText: "invalid target chain id, must be <= 65535",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 17350963017355124444
+					nonce: 45403294
+					ibc_update_channel_chain: {
+						target_chain_id: 65536
+						channel_id: "channel-3"
+						chain_id: 20
+						module: IBC_UPDATE_CHANNEL_CHAIN_MODULE_RECEIVER
+					}
+				}`,
+	},
+	{
+		label:   "IbcUpdateChannelChain invalid chain id",
+		errText: "invalid chain id, must be <= 65535",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 17350963017355124444
+					nonce: 45403294
+					ibc_update_channel_chain: {
+						target_chain_id: 3104
+						channel_id: "channel-3"
+						chain_id: 65536
+						module: IBC_UPDATE_CHANNEL_CHAIN_MODULE_RECEIVER
+					}
+				}`,
+	},
+	{
+		label:   "IbcUpdateChannelChain invalid chain id",
+		errText: "invalid channel ID length, must be <= 64",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 17350963017355124444
+					nonce: 45403294
+					ibc_update_channel_chain: {
+						target_chain_id: 3104
+						channel_id: "channel-that-is-too-long!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+						chain_id: 20
+						module: IBC_UPDATE_CHANNEL_CHAIN_MODULE_RECEIVER
+					}
+				}`,
+	},
+	{
+		label:   "IbcUpdateChannelChain invalid module",
+		errText: "unrecognized ibc update channel chain module",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 17350963017355124444
+					nonce: 45403294
+					ibc_update_channel_chain: {
+						target_chain_id: 3104
+						channel_id: "channel-3"
+						chain_id: 20
+						module: IBC_UPDATE_CHANNEL_CHAIN_MODULE_UNSPECIFIED
+					}
+				}`,
+	},
+
+	// build/bin/guardiand template wormhole-relayer-set-default-delivery-provider --chain-id ethereum --new-address 0x0290fb167208af455bb137780163b7b7a9a10c16
+	{
+		label:   "WormholeRelayerSetDefaultDeliveryProvider success",
+		errText: "",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 13862516333551023628
+					nonce: 2155214233
+					wormhole_relayer_set_default_delivery_provider: {
+						chain_id: 2
+						new_default_delivery_provider_address: "0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16"
+					}
+				}`,
+	},
+	{
+		label:   "WormholeRelayerSetDefaultDeliveryProvider invalid target chain id",
+		errText: "invalid target_chain_id",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 13862516333551023628
+					nonce: 2155214233
+					wormhole_relayer_set_default_delivery_provider: {
+						chain_id: 65536
+						new_default_delivery_provider_address: "0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16"
+					}
+				}`,
+	},
+	{
+		label:   "WormholeRelayerSetDefaultDeliveryProvider invalid new address",
+		errText: "invalid new default delivery provider address (expected hex)",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 13862516333551023628
+					nonce: 2155214233
+					wormhole_relayer_set_default_delivery_provider: {
+						chain_id: 2
+						new_default_delivery_provider_address: "Hello, World!"
+					}
+				}`,
+	},
+	{
+		label:   "WormholeRelayerSetDefaultDeliveryProvider new address wrong length",
+		errText: "invalid new default delivery provider address (expected 32 bytes)",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 13862516333551023628
+					nonce: 2155214233
+					wormhole_relayer_set_default_delivery_provider: {
+						chain_id: 2
+						new_default_delivery_provider_address: "00000000000000000000000290fb167208af455bb137780163b7b7a9a10c16"
+					}
+				}`,
+	},
+
+	// build/bin/guardiand template governance-evm-call --chain-id ethereum --target-address 0x0290fb167208af455bb137780163b7b7a9a10c16 --call-data 00010304 --governance-contract 0x0000000000000000000000000000000000000004
+	{
+		label:   "EvmCall success",
+		errText: "",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 13339105063374311672
+					nonce: 2195389763
+					evm_call: {
+						chain_id: 2
+						governance_contract: "0x0000000000000000000000000000000000000004"
+						target_contract: "0x0290FB167208Af455bB137780163b7B7a9a10C16"
+						abi_encoded_call: "00010304"
+					}
+				}`,
+	},
+	{
+		label:   "EvmCall invalid call data (shouldn't start with 0x)",
+		errText: "failed to decode ABI encoded call",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 13339105063374311672
+					nonce: 2195389763
+					evm_call: {
+						chain_id: 2
+						governance_contract: "0x0000000000000000000000000000000000000004"
+						target_contract: "0x0290FB167208Af455bB137780163b7B7a9a10C16"
+						abi_encoded_call: "0x00010304"
+					}
+				}`,
+	},
+
+	// build/bin/guardiand template governance-solana-call --chain-id solana --call-data 00010304 --governance-contract B6RHG3mfcckmrYN1UhmJzyS1XX3fZKbkeUcpJe9Sy3FE
+	{
+		label:   "SolanaCall success",
+		errText: "",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 315027427769585223
+					nonce: 2920957782
+					solana_call: {
+						chain_id: 1
+						governance_contract: "B6RHG3mfcckmrYN1UhmJzyS1XX3fZKbkeUcpJe9Sy3FE"
+						encoded_instruction: "00010304"
+					}
+				}`,
+	},
+	{
+		label:   "SolanaCall invalid governance contract",
+		errText: "failed to decode base58 governance contract address",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 315027427769585223
+					nonce: 2920957782
+					solana_call: {
+						chain_id: 1
+						governance_contract: "0x0290FB167208Af455bB137780163b7B7a9a10C16"
+						encoded_instruction: "00010304"
+					}
+				}`,
+	},
+	{
+		label:   "SolanaCall invalid governance contract length",
+		errText: "invalid governance contract address length (expected 32 bytes)",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 315027427769585223
+					nonce: 2920957782
+					solana_call: {
+						chain_id: 1
+						governance_contract: "3HdmTyMzgniBchBeicyFxGxWaCLdq72XjUZ8YdxqUef"
+						encoded_instruction: "00010304"
+					}
+				}`,
+	},
+	{
+		label:   "SolanaCall invalid instruction",
+		errText: "failed to decode instruction",
+		prototext: `
+				current_set_index: 4
+				messages: {
+					sequence: 315027427769585223
+					nonce: 2920957782
+					solana_call: {
+						chain_id: 1
+						governance_contract: "B6RHG3mfcckmrYN1UhmJzyS1XX3fZKbkeUcpJe9Sy3FE"
+						encoded_instruction: "Hello, World!"
+					}
+				}`,
+	},
+}

--- a/sdk/vaa/payloads.go
+++ b/sdk/vaa/payloads.go
@@ -249,7 +249,7 @@ type (
 	}
 )
 
-func (b BodyContractUpgrade) Serialize() []byte {
+func (b BodyContractUpgrade) Serialize() ([]byte, error) {
 	buf := new(bytes.Buffer)
 
 	// Module
@@ -261,10 +261,10 @@ func (b BodyContractUpgrade) Serialize() []byte {
 
 	buf.Write(b.NewContract[:])
 
-	return buf.Bytes()
+	return buf.Bytes(), nil
 }
 
-func (b BodyGuardianSetUpdate) Serialize() []byte {
+func (b BodyGuardianSetUpdate) Serialize() ([]byte, error) {
 	buf := new(bytes.Buffer)
 
 	// Module
@@ -280,7 +280,7 @@ func (b BodyGuardianSetUpdate) Serialize() []byte {
 		buf.Write(k[:])
 	}
 
-	return buf.Bytes()
+	return buf.Bytes(), nil
 }
 
 func (r BodyTokenBridgeRegisterChain) Serialize() ([]byte, error) {
@@ -398,9 +398,10 @@ func (r BodyGatewayScheduleUpgrade) Serialize() ([]byte, error) {
 	return serializeBridgeGovernanceVaa(GatewayModuleStr, ActionScheduleUpgrade, ChainIDWormchain, payload.Bytes())
 }
 
-func (r *BodyGatewayScheduleUpgrade) Deserialize(bz []byte) {
+func (r *BodyGatewayScheduleUpgrade) Deserialize(bz []byte) error {
 	r.Name = string(bz[0 : len(bz)-8])
 	r.Height = binary.BigEndian.Uint64(bz[len(bz)-8:])
+	return nil
 }
 
 func (r BodyCircleIntegrationUpdateWormholeFinality) Serialize() ([]byte, error) {

--- a/sdk/vaa/payloads_test.go
+++ b/sdk/vaa/payloads_test.go
@@ -56,7 +56,8 @@ func TestBodyTokenBridgeUpgradeContract(t *testing.T) {
 func TestBodyContractUpgradeSerialize(t *testing.T) {
 	bodyContractUpgrade := BodyContractUpgrade{ChainID: 1, NewContract: addr}
 	expected := "00000000000000000000000000000000000000000000000000000000436f72650100010000000000000000000000000000000000000000000000000000000000000004"
-	serializedBodyContractUpgrade := bodyContractUpgrade.Serialize()
+	serializedBodyContractUpgrade, err := bodyContractUpgrade.Serialize()
+	require.NoError(t, err)
 	assert.Equal(t, expected, hex.EncodeToString(serializedBodyContractUpgrade))
 }
 
@@ -67,7 +68,8 @@ func TestBodyGuardianSetUpdateSerialize(t *testing.T) {
 	}
 	bodyGuardianSetUpdate := BodyGuardianSetUpdate{Keys: keys, NewIndex: uint32(1)}
 	expected := "00000000000000000000000000000000000000000000000000000000436f726502000000000001025aaeb6053f3e94c9b9a09f33669435e7ef1beaed5aaeb6053f3e94c9b9a09f33669435e7ef1beaee"
-	serializedBodyGuardianSetUpdate := bodyGuardianSetUpdate.Serialize()
+	serializedBodyGuardianSetUpdate, err := bodyGuardianSetUpdate.Serialize()
+	require.NoError(t, err)
 	assert.Equal(t, expected, hex.EncodeToString(serializedBodyGuardianSetUpdate))
 }
 

--- a/sdk/vaa/types_test.go
+++ b/sdk/vaa/types_test.go
@@ -91,7 +91,8 @@ func TestBodyRegisterChain_Serialize(t *testing.T) {
 		EmitterAddress: Address{1, 2, 3, 4},
 	}
 
-	data := msg.Serialize()
+	data, err := msg.Serialize()
+	require.NoError(t, err)
 	require.Equal(t, "000000000000000000000000000000000000000000000000000000000000000001000000080102030400000000000000000000000000000000000000000000000000000000", hex.EncodeToString(data))
 }
 

--- a/wormchain/x/wormhole/keeper/msg_server_wasmd_test.go
+++ b/wormchain/x/wormhole/keeper/msg_server_wasmd_test.go
@@ -501,7 +501,9 @@ func TestWasmdAccountantContractModify(t *testing.T) {
 		Reason:        "test modify",
 	}
 	ts := time.Date(2012, 12, 12, 12, 12, 12, 12, time.UTC)
-	modify_vaa := vaa.CreateGovernanceVAA(ts, 1, 1, tb.set.Index, modify_msg.Serialize())
+	modify_buf, err := modify_msg.Serialize()
+	require.NoError(t, err)
+	modify_vaa := vaa.CreateGovernanceVAA(ts, 1, 1, tb.set.Index, modify_buf)
 	*modify_vaa = signVaa(*modify_vaa, tb.privateKeys)
 	vBz, err := modify_vaa.Marshal()
 	require.NoError(t, err)


### PR DESCRIPTION
This PR fixes https://github.com/wormhole-foundation/wormhole/issues/3897. It removes the `panic` calls from the code that handles injected governance commands.

This PR also adds a bunch of tests for the governance commands.

Created issue https://github.com/wormhole-foundation/wormhole/issues/3902 to address adding a missing admin template command.