### PR TITLE
aptos: upgrade to 3.1.0 (toolchain and stdlib)

### DIFF
--- a/aptos/Docker.md
+++ b/aptos/Docker.md
@@ -5,8 +5,8 @@
 
 # tag the image with the appropriate version
 
-docker tag aptos:latest ghcr.io/wormhole-foundation/aptos:2.0.3
+docker tag aptos:latest ghcr.io/wormhole-foundation/aptos:3.1.0
 
 # push to ghcr
 
-docker push ghcr.io/wormhole-foundation/aptos:2.0.3
+docker push ghcr.io/wormhole-foundation/aptos:3.1.0

--- a/aptos/Dockerfile
+++ b/aptos/Dockerfile
@@ -1,6 +1,6 @@
 FROM cli-gen AS cli-export
 FROM const-gen AS const-export
-FROM ghcr.io/wormhole-foundation/aptos:3.1.0@sha256:_ as aptos
+FROM ghcr.io/wormhole-foundation/aptos:3.1.0@sha256:c359f25cd6b2cd9edb2634504756a3b179cd416fd73fda59f66c48168e3b69da as aptos
 
 # Install nodejs
 # todo(aki): move this into base image?

--- a/aptos/Dockerfile
+++ b/aptos/Dockerfile
@@ -1,6 +1,6 @@
 FROM cli-gen AS cli-export
 FROM const-gen AS const-export
-FROM ghcr.io/wormhole-foundation/aptos:2.0.3@sha256:1e79c5a615b10073a780122abfaaf9b90735912df560b4e7b6a056fe45816392 as aptos
+FROM ghcr.io/wormhole-foundation/aptos:3.1.0@sha256:_ as aptos
 
 # Install nodejs
 # todo(aki): move this into base image?

--- a/aptos/Dockerfile.base
+++ b/aptos/Dockerfile.base
@@ -8,7 +8,7 @@ RUN git clone https://github.com/aptos-labs/aptos-core.git
 WORKDIR /tmp/aptos-core
 
 # Build aptos 2.0.3
-RUN git reset --hard eb0144a39ada521d8dee01c9dbd601853d383fb3
+RUN git reset --hard 6f83bc6d02207298b2dee91133d75538789bf582
 RUN cargo build -p aptos --profile cli
 
 FROM rust:1.62@sha256:5777f201f507075309c4d2d1c1e8d8219e654ae1de154c844341050016a64a0c as export-stage

--- a/aptos/Dockerfile.base
+++ b/aptos/Dockerfile.base
@@ -1,6 +1,6 @@
 FROM rust:1.62@sha256:5777f201f507075309c4d2d1c1e8d8219e654ae1de154c844341050016a64a0c as aptos-node
 
-RUN apt-get update && apt-get -y install libclang-dev jq cmake curl npm gcc g++ make lld
+RUN apt-get update && apt-get -y install libclang-dev libudev-dev libdw-dev jq cmake curl npm gcc g++ make lld
 
 WORKDIR /tmp
 

--- a/aptos/coin/Move.toml
+++ b/aptos/coin/Move.toml
@@ -7,7 +7,7 @@ upgrade_policy = "compatible"
 MoveStdlib = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/move-stdlib/", rev = "6f83bc6d02207298b2dee91133d75538789bf582" }
 
 [dev-addresses]
-wrapped_coin = "0x0"
+wrapped_coin = "0xBEEF"
 
 [addresses]
 wrapped_coin = "_"

--- a/aptos/coin/Move.toml
+++ b/aptos/coin/Move.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 upgrade_policy = "compatible"
 
 [dependencies]
-MoveStdlib = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/move-stdlib/", rev = "eb0144a39ada521d8dee01c9dbd601853d383fb3" }
+MoveStdlib = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/move-stdlib/", rev = "6f83bc6d02207298b2dee91133d75538789bf582" }
 
 [dev-addresses]
 wrapped_coin = "0x0"

--- a/aptos/deployer/Move.toml
+++ b/aptos/deployer/Move.toml
@@ -4,7 +4,7 @@ version = '1.0.0'
 
 [dependencies.AptosFramework]
 git = 'https://github.com/aptos-labs/aptos-core.git'
-rev = 'eb0144a39ada521d8dee01c9dbd601853d383fb3'
+rev = '6f83bc6d02207298b2dee91133d75538789bf582'
 subdir = 'aptos-move/framework/aptos-framework'
 
 [dev-addresses]

--- a/aptos/nft_bridge/Move.toml
+++ b/aptos/nft_bridge/Move.toml
@@ -3,10 +3,10 @@ name = "NFTBridge"
 version = "0.0.1"
 
 [dependencies]
-AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework/", rev = "eb0144a39ada521d8dee01c9dbd601853d383fb3" }
-MoveStdlib = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/move-stdlib/", rev = "eb0144a39ada521d8dee01c9dbd601853d383fb3" }
-AptosStdlib = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-stdlib/", rev = "eb0144a39ada521d8dee01c9dbd601853d383fb3" }
-AptosToken = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-token/", rev = "eb0144a39ada521d8dee01c9dbd601853d383fb3" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework/", rev = "6f83bc6d02207298b2dee91133d75538789bf582" }
+MoveStdlib = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/move-stdlib/", rev = "6f83bc6d02207298b2dee91133d75538789bf582" }
+AptosStdlib = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-stdlib/", rev = "6f83bc6d02207298b2dee91133d75538789bf582" }
+AptosToken = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-token/", rev = "6f83bc6d02207298b2dee91133d75538789bf582" }
 Wormhole = { local = "../wormhole/" }
 TokenBridge = { local = "../token_bridge/" }
 Deployer = { local = "../deployer/" }

--- a/aptos/start_node.sh
+++ b/aptos/start_node.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-aptos node run-local-testnet --with-faucet --force-restart
+aptos node run-local-testnet --with-faucet --force-restart --bind-to 0.0.0.0

--- a/aptos/token_bridge/Move.toml
+++ b/aptos/token_bridge/Move.toml
@@ -3,10 +3,10 @@ name = "TokenBridge"
 version = "0.0.1"
 
 [dependencies]
-AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework/", rev = "eb0144a39ada521d8dee01c9dbd601853d383fb3" }
-MoveStdlib = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/move-stdlib/", rev = "eb0144a39ada521d8dee01c9dbd601853d383fb3" }
-AptosStdlib = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-stdlib/", rev = "eb0144a39ada521d8dee01c9dbd601853d383fb3" }
-AptosToken = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-token/", rev = "eb0144a39ada521d8dee01c9dbd601853d383fb3" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework/", rev = "6f83bc6d02207298b2dee91133d75538789bf582" }
+MoveStdlib = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/move-stdlib/", rev = "6f83bc6d02207298b2dee91133d75538789bf582" }
+AptosStdlib = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-stdlib/", rev = "6f83bc6d02207298b2dee91133d75538789bf582" }
+AptosToken = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-token/", rev = "6f83bc6d02207298b2dee91133d75538789bf582" }
 Wormhole = { local = "../wormhole/" }
 Deployer = { local = "../deployer/" }
 

--- a/aptos/wormhole/Move.toml
+++ b/aptos/wormhole/Move.toml
@@ -4,10 +4,10 @@ version = "0.0.1"
 upgrade_policy = "compatible"
 
 [dependencies]
-AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework/", rev = "eb0144a39ada521d8dee01c9dbd601853d383fb3" }
-MoveStdlib = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/move-stdlib/", rev = "eb0144a39ada521d8dee01c9dbd601853d383fb3" }
-AptosStdlib = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-stdlib/", rev = "eb0144a39ada521d8dee01c9dbd601853d383fb3" }
-AptosToken = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-token/", rev = "eb0144a39ada521d8dee01c9dbd601853d383fb3" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework/", rev = "6f83bc6d02207298b2dee91133d75538789bf582" }
+MoveStdlib = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/move-stdlib/", rev = "6f83bc6d02207298b2dee91133d75538789bf582" }
+AptosStdlib = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-stdlib/", rev = "6f83bc6d02207298b2dee91133d75538789bf582" }
+AptosToken = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-token/", rev = "6f83bc6d02207298b2dee91133d75538789bf582" }
 Deployer = { local = "../deployer/" }
 # U256 = { git = "https://github.com/pontem-network/u256", rev = "main"  }
 


### PR DESCRIPTION
This bumps the toolchain and libs for the aptos contracts to 3.1.0 after it was raised that Pyth was behind the current aptos deployment, which will allow us to update our wormhole dependent contracts as well. This PR is modeled on [the last change that previously bumped to 2.0.3](https://github.com/wormhole-foundation/wormhole/commit/4a4873c9a3a1110dfb13a44dec51445dfd5be86d), the latest CLI rev can be found [here](https://github.com/aptos-labs/aptos-core/commit/6f83bc6d02207298b2dee91133d75538789bf582).

The PR is in draft state because `aptos/Dockerfile` requires a docker hash that I am unable to push myself so assuming this PR looks OK, and someone with permission can do that push, I can fix the PR as well and mark ready.