### PR TITLE
Node/CCQ: Add gossipAdvertiseAddress option to proxy server

### DIFF
--- a/docs/query_proxy.md
+++ b/docs/query_proxy.md
@@ -58,6 +58,11 @@ wormhole $build/bin/guardiand query-server \
 - The `telemetryLokiURL`, `telemetryNodeName` and `promRemoteURL` are used for telemetry purposes and
   the values will be provided by Wormhole Foundation personnel if appropriate.
 
+Optional Parameters
+
+- The `gossipAdvertiseAddress` argument allows you to specify an external IP to advertize on P2P (use if behind a NAT or running in k8s).
+- The `monitorPeers` flag will cause the proxy server to periodically check its connectivity to the P2P bootstrap peers, and attempt to reconnect if necessary.
+
 #### Creating the Signing Key File
 
 Do the following to create the signing key file. Note that the `block-type` must exactly match what is specified below,

--- a/node/cmd/ccq/p2p.go
+++ b/node/cmd/ccq/p2p.go
@@ -38,10 +38,24 @@ type P2PSub struct {
 	host       host.Host
 }
 
-func runP2P(ctx context.Context, priv crypto.PrivKey, port uint, networkID, bootstrapPeers, ethRpcUrl, ethCoreAddr string, pendingResponses *PendingResponses, logger *zap.Logger, monitorPeers bool, loggingMap *LoggingMap) (*P2PSub, error) {
+func runP2P(
+	ctx context.Context,
+	priv crypto.PrivKey,
+	port uint,
+	networkID string,
+	bootstrapPeers string,
+	ethRpcUrl string,
+	ethCoreAddr string,
+	pendingResponses *PendingResponses,
+	logger *zap.Logger,
+	monitorPeers bool,
+	loggingMap *LoggingMap,
+	gossipAdvertiseAddress string,
+) (*P2PSub, error) {
 	// p2p setup
 	components := p2p.DefaultComponents()
 	components.Port = port
+	components.GossipAdvertiseAddress = gossipAdvertiseAddress
 
 	h, err := p2p.NewHost(logger, ctx, networkID, bootstrapPeers, components, priv)
 	if err != nil {

--- a/node/cmd/ccq/query_server.go
+++ b/node/cmd/ccq/query_server.go
@@ -28,24 +28,25 @@ import (
 const CCQ_SERVER_SIGNING_KEY = "CCQ SERVER SIGNING KEY"
 
 var (
-	envStr            *string
-	p2pNetworkID      *string
-	p2pPort           *uint
-	p2pBootstrap      *string
-	listenAddr        *string
-	nodeKeyPath       *string
-	signerKeyPath     *string
-	permFile          *string
-	ethRPC            *string
-	ethContract       *string
-	logLevel          *string
-	telemetryLokiURL  *string
-	telemetryNodeName *string
-	statusAddr        *string
-	promRemoteURL     *string
-	shutdownDelay1    *uint
-	shutdownDelay2    *uint
-	monitorPeers      *bool
+	envStr                 *string
+	p2pNetworkID           *string
+	p2pPort                *uint
+	p2pBootstrap           *string
+	listenAddr             *string
+	nodeKeyPath            *string
+	signerKeyPath          *string
+	permFile               *string
+	ethRPC                 *string
+	ethContract            *string
+	logLevel               *string
+	telemetryLokiURL       *string
+	telemetryNodeName      *string
+	statusAddr             *string
+	promRemoteURL          *string
+	shutdownDelay1         *uint
+	shutdownDelay2         *uint
+	monitorPeers           *bool
+	gossipAdvertiseAddress *string
 )
 
 const DEV_NETWORK_ID = "/wormhole/dev"
@@ -67,6 +68,7 @@ func init() {
 	statusAddr = QueryServerCmd.Flags().String("statusAddr", "[::]:6060", "Listen address for status server (disabled if blank)")
 	promRemoteURL = QueryServerCmd.Flags().String("promRemoteURL", "", "Prometheus remote write URL (Grafana)")
 	monitorPeers = QueryServerCmd.Flags().Bool("monitorPeers", false, "Should monitor bootstrap peers and attempt to reconnect")
+	gossipAdvertiseAddress = QueryServerCmd.Flags().String("gossipAdvertiseAddress", "", "External IP to advertize on P2P (use if behind a NAT or running in k8s)")
 
 	// The default health check monitoring is every five seconds, with a five second timeout, and you have to miss two, for 20 seconds total.
 	shutdownDelay1 = QueryServerCmd.Flags().Uint("shutdownDelay1", 25, "Seconds to delay after disabling health check on shutdown")
@@ -189,7 +191,7 @@ func runQueryServer(cmd *cobra.Command, args []string) {
 
 	// Run p2p
 	pendingResponses := NewPendingResponses(logger)
-	p2p, err := runP2P(ctx, priv, *p2pPort, networkID, *p2pBootstrap, *ethRPC, *ethContract, pendingResponses, logger, *monitorPeers, loggingMap)
+	p2p, err := runP2P(ctx, priv, *p2pPort, networkID, *p2pBootstrap, *ethRPC, *ethContract, pendingResponses, logger, *monitorPeers, loggingMap, *gossipAdvertiseAddress)
 	if err != nil {
 		logger.Fatal("Failed to start p2p", zap.Error(err))
 	}


### PR DESCRIPTION
This PR adds support for the `--gossipAdvertiseAddress` option to the CCQ proxy server, like already exists for the guardian.