### PR TITLE
sdk,cosmwasm: fix new clippy 1.78.0 lints

### DIFF
--- a/cosmwasm/contracts/ibc-translator/src/reply.rs
+++ b/cosmwasm/contracts/ibc-translator/src/reply.rs
@@ -136,7 +136,7 @@ pub fn convert_cw20_to_bank_and_send(
 
         let mut symbol = token_info.symbol;
         if symbol.is_empty() {
-            symbol = tf_scaled_denom.clone();
+            symbol.clone_from(&tf_scaled_denom);
         }
         let tf_description =
             token_info.name.clone() + ", " + symbol.as_str() + ", " + tokenfactory_denom.as_str();

--- a/cosmwasm/contracts/ibc-translator/tests/test_setup/mod.rs
+++ b/cosmwasm/contracts/ibc-translator/tests/test_setup/mod.rs
@@ -238,17 +238,17 @@ impl<C: DeserializeOwned> MockQuerier<C> {
         self.ibc = IbcQuerier::new(port_id, channels);
     }
 
-    pub fn update_wasm<WH: 'static>(&mut self, handler: WH)
+    pub fn update_wasm<WH>(&mut self, handler: WH)
     where
-        WH: Fn(&WasmQuery) -> QuerierResult,
+        WH: 'static + Fn(&WasmQuery) -> QuerierResult,
     {
         self.wasm.update_handler(handler)
     }
 
     #[allow(dead_code)]
-    pub fn with_custom_handler<CH: 'static>(mut self, handler: CH) -> Self
+    pub fn with_custom_handler<CH>(mut self, handler: CH) -> Self
     where
-        CH: Fn(&C) -> MockQuerierCustomHandlerResult,
+        CH: 'static + Fn(&C) -> MockQuerierCustomHandlerResult,
     {
         self.custom_handler = Box::from(handler);
         self
@@ -311,9 +311,9 @@ impl WasmQuerier {
         Self { handler }
     }
 
-    fn update_handler<WH: 'static>(&mut self, handler: WH)
+    fn update_handler<WH>(&mut self, handler: WH)
     where
-        WH: Fn(&WasmQuery) -> QuerierResult,
+        WH: 'static + Fn(&WasmQuery) -> QuerierResult,
     {
         self.handler = Box::from(handler)
     }

--- a/cosmwasm/packages/cw_transcode/src/ser.rs
+++ b/cosmwasm/packages/cw_transcode/src/ser.rs
@@ -20,6 +20,12 @@ impl Serializer {
     }
 }
 
+impl Default for Serializer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<'a> serde::Serializer for &'a mut Serializer {
     type Ok = ();
     type Error = Error;
@@ -117,9 +123,9 @@ impl<'a> serde::Serializer for &'a mut Serializer {
     }
 
     #[inline]
-    fn serialize_some<T: ?Sized>(self, value: &T) -> Result<Self::Ok, Self::Error>
+    fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         value.serialize(self)
     }
@@ -153,19 +159,15 @@ impl<'a> serde::Serializer for &'a mut Serializer {
     }
 
     #[inline]
-    fn serialize_newtype_struct<T: ?Sized>(
-        self,
-        _: &'static str,
-        _: &T,
-    ) -> Result<Self::Ok, Self::Error>
+    fn serialize_newtype_struct<T>(self, _: &'static str, _: &T) -> Result<Self::Ok, Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         Err(Error::NotAStruct)
     }
 
     #[inline]
-    fn serialize_newtype_variant<T: ?Sized>(
+    fn serialize_newtype_variant<T>(
         self,
         _: &'static str,
         _variant_index: u32,
@@ -173,7 +175,7 @@ impl<'a> serde::Serializer for &'a mut Serializer {
         _: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         Err(Error::NotAStruct)
     }
@@ -246,9 +248,9 @@ impl<'a> serde::Serializer for &'a mut Serializer {
     }
 
     #[inline]
-    fn collect_str<T: ?Sized>(self, _: &T) -> Result<Self::Ok, Self::Error>
+    fn collect_str<T>(self, _: &T) -> Result<Self::Ok, Self::Error>
     where
-        T: Display,
+        T: ?Sized + Display,
     {
         Err(Error::NotAStruct)
     }
@@ -265,9 +267,9 @@ pub struct Transcoder<'a> {
 }
 
 impl<'a> Transcoder<'a> {
-    fn serialize_field<T: ?Sized>(&mut self, k: &'static str, v: &T) -> Result<(), Error>
+    fn serialize_field<T>(&mut self, k: &'static str, v: &T) -> Result<(), Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         let key = k.into();
         let value = serde_json_wasm::to_string(v)?;
@@ -288,13 +290,9 @@ impl<'a> SerializeStruct for Transcoder<'a> {
     type Error = Error;
 
     #[inline]
-    fn serialize_field<T: ?Sized>(
-        &mut self,
-        k: &'static str,
-        v: &T,
-    ) -> Result<Self::Ok, Self::Error>
+    fn serialize_field<T>(&mut self, k: &'static str, v: &T) -> Result<Self::Ok, Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         self.serialize_field(k, v)
     }
@@ -310,13 +308,9 @@ impl<'a> SerializeStructVariant for Transcoder<'a> {
     type Error = Error;
 
     #[inline]
-    fn serialize_field<T: ?Sized>(
-        &mut self,
-        k: &'static str,
-        v: &T,
-    ) -> Result<Self::Ok, Self::Error>
+    fn serialize_field<T>(&mut self, k: &'static str, v: &T) -> Result<Self::Ok, Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         self.serialize_field(k, v)
     }

--- a/sdk/rust/serde_wormhole/src/ser.rs
+++ b/sdk/rust/serde_wormhole/src/ser.rs
@@ -122,9 +122,9 @@ impl<'a, W: Write> ser::Serializer for &'a mut Serializer<W> {
     }
 
     #[inline]
-    fn serialize_some<T: ?Sized>(self, value: &T) -> Result<Self::Ok, Self::Error>
+    fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         value.serialize(self)
     }
@@ -152,13 +152,13 @@ impl<'a, W: Write> ser::Serializer for &'a mut Serializer<W> {
         self.writer.write_all(&[v]).map_err(Error::from)
     }
 
-    fn serialize_newtype_struct<T: ?Sized>(
+    fn serialize_newtype_struct<T>(
         self,
         name: &'static str,
         value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         if name == crate::raw::TOKEN {
             value.serialize(RawMessageSerializer(&mut self.writer))
@@ -167,7 +167,7 @@ impl<'a, W: Write> ser::Serializer for &'a mut Serializer<W> {
         }
     }
 
-    fn serialize_newtype_variant<T: ?Sized>(
+    fn serialize_newtype_variant<T>(
         self,
         name: &'static str,
         _variant_index: u32,
@@ -175,7 +175,7 @@ impl<'a, W: Write> ser::Serializer for &'a mut Serializer<W> {
         value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         let v: u8 = variant
             .parse()
@@ -257,9 +257,9 @@ impl<'a, W: Write> ser::Serializer for &'a mut Serializer<W> {
     }
 
     #[inline]
-    fn collect_str<T: ?Sized>(self, value: &T) -> Result<Self::Ok, Self::Error>
+    fn collect_str<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
     where
-        T: Display,
+        T: ?Sized + Display,
     {
         self.serialize_str(&value.to_string())
     }
@@ -275,9 +275,9 @@ impl<'a, W: Write> ser::SerializeSeq for &'a mut Serializer<W> {
     type Error = Error;
 
     #[inline]
-    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         value.serialize(&mut **self)
     }
@@ -293,9 +293,9 @@ impl<'a, W: Write> ser::SerializeTuple for &'a mut Serializer<W> {
     type Error = Error;
 
     #[inline]
-    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         value.serialize(&mut **self)
     }
@@ -311,9 +311,9 @@ impl<'a, W: Write> ser::SerializeTupleStruct for &'a mut Serializer<W> {
     type Error = Error;
 
     #[inline]
-    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    fn serialize_field<T>(&mut self, value: &T) -> Result<(), Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         value.serialize(&mut **self)
     }
@@ -329,9 +329,9 @@ impl<'a, W: Write> ser::SerializeTupleVariant for &'a mut Serializer<W> {
     type Error = Error;
 
     #[inline]
-    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    fn serialize_field<T>(&mut self, value: &T) -> Result<(), Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         value.serialize(&mut **self)
     }
@@ -347,13 +347,9 @@ impl<'a, W: Write> ser::SerializeStruct for &'a mut Serializer<W> {
     type Error = Error;
 
     #[inline]
-    fn serialize_field<T: ?Sized>(
-        &mut self,
-        _key: &'static str,
-        value: &T,
-    ) -> Result<(), Self::Error>
+    fn serialize_field<T>(&mut self, _key: &'static str, value: &T) -> Result<(), Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         value.serialize(&mut **self)
     }
@@ -369,13 +365,9 @@ impl<'a, W: Write> ser::SerializeStructVariant for &'a mut Serializer<W> {
     type Error = Error;
 
     #[inline]
-    fn serialize_field<T: ?Sized>(
-        &mut self,
-        _key: &'static str,
-        value: &T,
-    ) -> Result<(), Self::Error>
+    fn serialize_field<T>(&mut self, _key: &'static str, value: &T) -> Result<(), Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         value.serialize(&mut **self)
     }
@@ -391,29 +383,25 @@ impl<'a, W: Write> ser::SerializeMap for &'a mut Serializer<W> {
     type Error = Error;
 
     #[inline]
-    fn serialize_key<T: ?Sized>(&mut self, key: &T) -> Result<(), Self::Error>
+    fn serialize_key<T>(&mut self, key: &T) -> Result<(), Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         key.serialize(&mut **self)
     }
 
     #[inline]
-    fn serialize_value<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
+    fn serialize_value<T>(&mut self, value: &T) -> Result<(), Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         value.serialize(&mut **self)
     }
 
-    fn serialize_entry<K: ?Sized, V: ?Sized>(
-        &mut self,
-        key: &K,
-        value: &V,
-    ) -> Result<(), Self::Error>
+    fn serialize_entry<K, V>(&mut self, key: &K, value: &V) -> Result<(), Self::Error>
     where
-        K: Serialize,
-        V: Serialize,
+        K: ?Sized + Serialize,
+        V: ?Sized + Serialize,
     {
         self.serialize_key(key)?;
         self.serialize_value(value)
@@ -508,9 +496,9 @@ impl<W: Write> ser::Serializer for RawMessageSerializer<W> {
         Err(ser::Error::custom("expected RawMessage"))
     }
 
-    fn serialize_some<T: ?Sized>(self, _value: &T) -> Result<Self::Ok, Self::Error>
+    fn serialize_some<T>(self, _value: &T) -> Result<Self::Ok, Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         Err(ser::Error::custom("expected RawMessage"))
     }
@@ -532,18 +520,18 @@ impl<W: Write> ser::Serializer for RawMessageSerializer<W> {
         Err(ser::Error::custom("expected RawMessage"))
     }
 
-    fn serialize_newtype_struct<T: ?Sized>(
+    fn serialize_newtype_struct<T>(
         self,
         _name: &'static str,
         _value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         Err(ser::Error::custom("expected RawMessage"))
     }
 
-    fn serialize_newtype_variant<T: ?Sized>(
+    fn serialize_newtype_variant<T>(
         self,
         _name: &'static str,
         _variant_index: u32,
@@ -551,7 +539,7 @@ impl<W: Write> ser::Serializer for RawMessageSerializer<W> {
         _value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         Err(ser::Error::custom("expected RawMessage"))
     }


### PR DESCRIPTION
The 1.78 version of the rust toolchain has been released on the stable channel: https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-178

It introduces a number of new clippy lints. The relevant ones:

- https://rust-lang.github.io/rust-clippy/master/index.html#/assigning_clones
- https://rust-lang.github.io/rust-clippy/master/index.html#/multiple_bound_locations
- https://rust-lang.github.io/rust-clippy/master/index.html#/new_without_default

This commit fixes these lints.