### PR TITLE
Node/add xlayer tokens to manual token list

### DIFF
--- a/node/pkg/governor/manual_tokens.go
+++ b/node/pkg/governor/manual_tokens.go
@@ -53,7 +53,5 @@ func manualTokenList() []tokenConfigEntry {
 		{chain: 37, addr: "00000000000000000000000074b7f16337b8972027f6196a17a631ac6de26d22", symbol: "USDC", coinGeckoId: "polygon-hermez-bridged-usdc-x-layer", decimals: 6, price: 0.9949},
 		{chain: 37, addr: "000000000000000000000000ea034fb02eb1808c2cc3adbc15f447b93cbe08e1", symbol: "WBTC", coinGeckoId: "polygon-hermez-bridged-wbtc-x-layer", decimals: 8, price: 57029},
 		{chain: 37, addr: "000000000000000000000000c5015b9d9161dca7e18e32f6f25c4ad850731fd4", symbol: "DAI", coinGeckoId: "polygon-hermez-bridged-dai-x-layer", decimals: 18, price: 1.0006},
-		{chain: 37, addr: "00000000000000000000000073644a48a4f540fa49a8b4d41dba2ded5df3912b", symbol: "MUKI", coinGeckoId: "", decimals: 18, price: 0.00002787}, // no coingecko entry. https://www.okx.com/explorer/xlayer/address/0x73644a48a4f540fa49a8b4d41dba2ded5df3912b
-		{chain: 37, addr: "00000000000000000000000054455532324468f5d60ebd6469f2bbd3dc47a7f8", symbol: "ABS", coinGeckoId: "", decimals: 18, price: 0.009466},    // no coingecko entry. https://www.okx.com/explorer/xlayer/address/0x54455532324468f5d60ebd6469f2bbd3dc47a7f8
 	}
 }

--- a/node/pkg/governor/manual_tokens.go
+++ b/node/pkg/governor/manual_tokens.go
@@ -46,5 +46,10 @@ func manualTokenList() []tokenConfigEntry {
 		{chain: 34, addr: "000000000000000000000000f610a9dfb7c89644979b4a0f27063e9e7d7cda32", symbol: "WSTETH", coinGeckoId: "bridged-wrapped-lido-staked-ether-scroll", decimals: 18, price: 3659.28},
 		{chain: 34, addr: "000000000000000000000000cA77eB3fEFe3725Dc33bccB54eDEFc3D9f764f97", symbol: "DAI", coinGeckoId: "dai", decimals: 18, price: 1.00},
 		{chain: 34, addr: "00000000000000000000000053878B874283351D26d206FA512aEcE1Bef6C0dD", symbol: "RETH", coinGeckoId: "rocket-pool-eth", decimals: 18, price: 3475.55},
+		// X LAYER (top 4 tokens as of Wed  1 May 2024: https://www.okx.com/explorer/xlayer/token-list)
+		{chain: 36, addr: "0000000000000000000000001e4a5963abfd975d8c9021ce480b42188849d41d", symbol: "USDT", coinGeckoId: "", decimals: 6, price: 0.9992},
+		{chain: 36, addr: "00000000000000000000000074b7f16337b8972027f6196a17a631ac6de26d22", symbol: "USDC", coinGeckoId: "", decimals: 6, price: 1.0003},
+		{chain: 36, addr: "000000000000000000000000ea034fb02eb1808c2cc3adbc15f447b93cbe08e1", symbol: "WBTC", coinGeckoId: "", decimals: 8, price: 57029},
+		{chain: 36, addr: "000000000000000000000000c5015b9d9161dca7e18e32f6f25c4ad850731fd4", symbol: "DAI", coinGeckoId: "", decimals: 18, price: 1.0006},
 	}
 }

--- a/node/pkg/governor/manual_tokens.go
+++ b/node/pkg/governor/manual_tokens.go
@@ -46,10 +46,14 @@ func manualTokenList() []tokenConfigEntry {
 		{chain: 34, addr: "000000000000000000000000f610a9dfb7c89644979b4a0f27063e9e7d7cda32", symbol: "WSTETH", coinGeckoId: "bridged-wrapped-lido-staked-ether-scroll", decimals: 18, price: 3659.28},
 		{chain: 34, addr: "000000000000000000000000cA77eB3fEFe3725Dc33bccB54eDEFc3D9f764f97", symbol: "DAI", coinGeckoId: "dai", decimals: 18, price: 1.00},
 		{chain: 34, addr: "00000000000000000000000053878B874283351D26d206FA512aEcE1Bef6C0dD", symbol: "RETH", coinGeckoId: "rocket-pool-eth", decimals: 18, price: 3475.55},
-		// X LAYER (top 4 tokens as of Wed  1 May 2024: https://www.okx.com/explorer/xlayer/token-list)
-		{chain: 36, addr: "0000000000000000000000001e4a5963abfd975d8c9021ce480b42188849d41d", symbol: "USDT", coinGeckoId: "", decimals: 6, price: 0.9992},
-		{chain: 36, addr: "00000000000000000000000074b7f16337b8972027f6196a17a631ac6de26d22", symbol: "USDC", coinGeckoId: "", decimals: 6, price: 1.0003},
-		{chain: 36, addr: "000000000000000000000000ea034fb02eb1808c2cc3adbc15f447b93cbe08e1", symbol: "WBTC", coinGeckoId: "", decimals: 8, price: 57029},
-		{chain: 36, addr: "000000000000000000000000c5015b9d9161dca7e18e32f6f25c4ad850731fd4", symbol: "DAI", coinGeckoId: "", decimals: 18, price: 1.0006},
+		// X LAYER (tokens over $50,000 24h volume)
+		{chain: 37, addr: "0000000000000000000000001e4a5963abfd975d8c9021ce480b42188849d41d", symbol: "USDT", coinGeckoId: "polygon-hermez-bridged-usdt-x-layer", decimals: 6, price: 0.9969},
+		{chain: 37, addr: "000000000000000000000000e538905cf8410324e03a5a23c1c177a474d59b2b", symbol: "WOKB", coinGeckoId: "wrapped-okb", decimals: 18, price: 48.76},
+		{chain: 37, addr: "0000000000000000000000005a77f1443d16ee5761d310e38b62f77f726bc71c", symbol: "WETH", coinGeckoId: "weth", decimals: 18, price: 2994.60},
+		{chain: 37, addr: "00000000000000000000000074b7f16337b8972027f6196a17a631ac6de26d22", symbol: "USDC", coinGeckoId: "polygon-hermez-bridged-usdc-x-layer", decimals: 6, price: 0.9949},
+		{chain: 37, addr: "000000000000000000000000ea034fb02eb1808c2cc3adbc15f447b93cbe08e1", symbol: "WBTC", coinGeckoId: "polygon-hermez-bridged-wbtc-x-layer", decimals: 8, price: 57029},
+		{chain: 37, addr: "000000000000000000000000c5015b9d9161dca7e18e32f6f25c4ad850731fd4", symbol: "DAI", coinGeckoId: "polygon-hermez-bridged-dai-x-layer", decimals: 18, price: 1.0006},
+		{chain: 37, addr: "00000000000000000000000073644a48a4f540fa49a8b4d41dba2ded5df3912b", symbol: "MUKI", coinGeckoId: "", decimals: 18, price: 0.00002787}, // no coingecko entry. https://www.okx.com/explorer/xlayer/address/0x73644a48a4f540fa49a8b4d41dba2ded5df3912b
+		{chain: 37, addr: "00000000000000000000000054455532324468f5d60ebd6469f2bbd3dc47a7f8", symbol: "ABS", coinGeckoId: "", decimals: 18, price: 0.009466},    // no coingecko entry. https://www.okx.com/explorer/xlayer/address/0x54455532324468f5d60ebd6469f2bbd3dc47a7f8
 	}
 }


### PR DESCRIPTION
Adds tokens with >50k daily volume for X Layer. Not all of the chain IDs have a coin gecko ID yet so these have been left blank.

To test, I ran `go run check_query.go` (from `node/hack/governor/`) which completed with no issues.