### PR TITLE
Node/Devnet: Extract first guardian name from bootstrap peers

### DIFF
--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -785,19 +785,17 @@ func runNode(cmd *cobra.Command, args []string) {
 		p2pKey = devnet.DeterministicP2PPrivKeyByIndex(int64(idx))
 
 		if idx != 0 {
+			firstGuardianName, err := devnet.GetFirstGuardianNameFromBootstrapPeers(*p2pBootstrap)
+			if err != nil {
+				logger.Fatal("failed to get first guardian name from bootstrap peers", zap.String("bootstrapPeers", *p2pBootstrap), zap.Error(err))
+			}
 			// try to connect to guardian-0
 			for {
-				// tilt uses this hostname format
-				_, err := net.LookupIP("guardian-0.guardian")
+				_, err := net.LookupIP(firstGuardianName)
 				if err == nil {
 					break
 				}
-				// load tests use this hostname format
-				_, err = net.LookupIP("guardian-0")
-				if err == nil {
-					break
-				}
-				logger.Info("Error resolving guardian-0.guardian. Trying again...")
+				logger.Info(fmt.Sprintf("Error resolving %s. Trying again...", firstGuardianName))
 				time.Sleep(time.Second)
 			}
 			// TODO this is a hack. If this is not the bootstrap Guardian, we wait 10s such that the bootstrap Guardian has enough time to start.

--- a/node/pkg/devnet/hostname.go
+++ b/node/pkg/devnet/hostname.go
@@ -1,6 +1,7 @@
 package devnet
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -26,4 +27,17 @@ func GetDevnetIndex() (int, error) {
 	}
 
 	return i, nil
+}
+
+// GetFirstGuardianNameFromBootstrapPeers extracts the hostname of the first peer from the bootstrap peers string.
+func GetFirstGuardianNameFromBootstrapPeers(bootstrapPeers string) (string, error) {
+	peers := strings.Split(bootstrapPeers, ",")
+	if len(peers) == 0 {
+		return "", errors.New("failed to parse devnet bootstrap peers")
+	}
+	fields := strings.Split(peers[0], "/")
+	if len(fields) < 3 {
+		return "", errors.New("failed to parse devnet first bootstrap peer")
+	}
+	return fields[2], nil
 }

--- a/node/pkg/devnet/hostname_test.go
+++ b/node/pkg/devnet/hostname_test.go
@@ -1,0 +1,69 @@
+package devnet
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetFirstGuardianNameFromBootstrapPeers(t *testing.T) {
+	type test struct {
+		label            string
+		bootstrapPeers   string
+		errText          string // empty string means success
+		expectedHostName string
+	}
+
+	var tests = []test{
+		{
+			label:            "Success with one bootstrap peer",
+			bootstrapPeers:   "/dns4/guardian-0.guardian/udp/8999/quic/p2p/12D3KooWL3XJ9EMCyZvmmGXL2LMiVBtrVa2BuESsJiXkSj7333Jw",
+			errText:          "",
+			expectedHostName: "guardian-0.guardian",
+		},
+		{
+			label:            "Success with two bootstrap peer",
+			bootstrapPeers:   "/dns4/guardian-0.guardian/udp/8999/quic/p2p/12D3KooWL3XJ9EMCyZvmmGXL2LMiVBtrVa2BuESsJiXkSj7333Jw,/dns4/guardian-1.guardian/udp/8999/quic/p2p/12D3KooWL3XJ9EMCyZvmmGXL2LMiVBtrVa2BuESsJiXkSj7333Jx",
+			errText:          "",
+			expectedHostName: "guardian-0.guardian",
+		},
+		{
+			label:            "Success when using IP",
+			bootstrapPeers:   "/dns4/10.121.2.4/udp/8999/quic/p2p/12D3KooWL3XJ9EMCyZvmmGXL2LMiVBtrVa2BuESsJiXkSj7333Jw",
+			errText:          "",
+			expectedHostName: "10.121.2.4",
+		},
+		{
+			label:            "Empty bootstrap peers",
+			bootstrapPeers:   "",
+			errText:          "failed to parse devnet first bootstrap peer",
+			expectedHostName: "",
+		},
+		{
+			label:            "Empty first bootstrap peer",
+			bootstrapPeers:   ",/dns4/guardian-0.guardian/udp/8999/quic/p2p/12D3KooWL3XJ9EMCyZvmmGXL2LMiVBtrVa2BuESsJiXkSj7333Jw",
+			errText:          "failed to parse devnet first bootstrap peer",
+			expectedHostName: "",
+		},
+		{
+			label:            "No slashes",
+			bootstrapPeers:   ":dns4:10.121.2.4:udp:8999:quic:p2p:12D3KooWL3XJ9EMCyZvmmGXL2LMiVBtrVa2BuESsJiXkSj7333Jw",
+			errText:          "failed to parse devnet first bootstrap peer",
+			expectedHostName: "",
+		},
+	}
+
+	for _, tst := range tests {
+		t.Run(tst.label, func(t *testing.T) {
+			hostName, err := GetFirstGuardianNameFromBootstrapPeers(tst.bootstrapPeers)
+			if tst.errText == "" {
+				require.NoError(t, err)
+				assert.Equal(t, tst.expectedHostName, hostName)
+			} else {
+				require.ErrorContains(t, err, tst.errText)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
The guardian in Tilt currently expects the first guardian name as listed in the bootstrap peers to be "guardian-0.guardian" so for the other guardians, waits until this host is visible before finishing initialization. In load testing, we have to use a different format host name. This PR extracts the host name from the first entry in the bootstrap peers. 

Note that PR only effects devnet, not testnet or mainnet.