### PR TITLE
node: clean up duplicate imports

### DIFF
--- a/node/hack/query/utils/fetchCurrentGuardianSet.go
+++ b/node/hack/query/utils/fetchCurrentGuardianSet.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/certusone/wormhole/node/pkg/common"
-	"github.com/certusone/wormhole/node/pkg/watchers/evm/connectors/ethabi"
 	ethAbi "github.com/certusone/wormhole/node/pkg/watchers/evm/connectors/ethabi"
 	ethBind "github.com/ethereum/go-ethereum/accounts/abi/bind"
 	eth_common "github.com/ethereum/go-ethereum/common"
@@ -51,7 +50,7 @@ func FetchLatestBlockNumberFromUrl(ctx context.Context, rawUrl string) (*big.Int
 	return header.Number, nil
 }
 
-func FetchCurrentGuardianSet(network common.Environment) (uint32, *ethabi.StructsGuardianSet, error) {
+func FetchCurrentGuardianSet(network common.Environment) (uint32, *ethAbi.StructsGuardianSet, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 

--- a/node/pkg/node/node_test.go
+++ b/node/pkg/node/node_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/certusone/wormhole/node/pkg/watchers"
 	"github.com/certusone/wormhole/node/pkg/watchers/mock"
 	eth_crypto "github.com/ethereum/go-ethereum/crypto"
-	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 	libp2p_crypto "github.com/libp2p/go-libp2p/core/crypto"
 	libp2p_peer "github.com/libp2p/go-libp2p/core/peer"
 	"github.com/stretchr/testify/assert"
@@ -123,7 +122,7 @@ func newMockGuardianSet(t testing.TB, testId uint, n int) []*mockGuardian {
 			MockObservationC: make(chan *common.MessagePublication),
 			MockSetC:         make(chan *common.GuardianSet),
 			gk:               gk,
-			guardianAddr:     ethcrypto.PubkeyToAddress(gk.PublicKey),
+			guardianAddr:     eth_crypto.PubkeyToAddress(gk.PublicKey),
 			config:           createGuardianConfig(t, testId, uint(i)),
 		}
 	}
@@ -1015,7 +1014,7 @@ func (c fatalHook) OnWrite(ce *zapcore.CheckedEntry, fields []zapcore.Field) {
 func signingMsgs(n int) [][]byte {
 	msgs := make([][]byte, n)
 	for i := 0; i < len(msgs); i++ {
-		msgs[i] = ethcrypto.Keccak256Hash([]byte{byte(i)}).Bytes()
+		msgs[i] = eth_crypto.Keccak256Hash([]byte{byte(i)}).Bytes()
 	}
 	return msgs
 }
@@ -1039,7 +1038,7 @@ func signMsgsEth(pk *ecdsa.PrivateKey, msgs [][]byte) [][]byte {
 	signatures := make([][]byte, n)
 	// Ed25519.Sign
 	for i := 0; i < n; i++ {
-		sig, err := ethcrypto.Sign(msgs[i], pk)
+		sig, err := eth_crypto.Sign(msgs[i], pk)
 		if err != nil {
 			panic(err)
 		}
@@ -1111,9 +1110,9 @@ func BenchmarkCrypto(b *testing.B) {
 		})
 	})
 
-	b.Run("ethcrypto (secp256k1)", func(b *testing.B) {
+	b.Run("eth_crypto (secp256k1)", func(b *testing.B) {
 
-		gk := devnet.InsecureDeterministicEcdsaKeyByIndex(ethcrypto.S256(), 0)
+		gk := devnet.InsecureDeterministicEcdsaKeyByIndex(eth_crypto.S256(), 0)
 
 		b.Run("sign", func(b *testing.B) {
 			msgs := signingMsgs(b.N)
@@ -1128,7 +1127,7 @@ func BenchmarkCrypto(b *testing.B) {
 
 			// Ed25519.Verify
 			for i := 0; i < b.N; i++ {
-				_, err := ethcrypto.Ecrecover(msgs[i], signatures[i])
+				_, err := eth_crypto.Ecrecover(msgs[i], signatures[i])
 				assert.NoError(b, err)
 			}
 		})

--- a/node/pkg/p2p/p2p_test.go
+++ b/node/pkg/p2p/p2p_test.go
@@ -13,7 +13,6 @@ import (
 	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
-	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 )
 
 func TestSignedHeartbeat(t *testing.T) {
@@ -31,7 +30,7 @@ func TestSignedHeartbeat(t *testing.T) {
 
 	gk, err := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	assert.NoError(t, err)
-	gAddr := ethcrypto.PubkeyToAddress(gk.PublicKey)
+	gAddr := crypto.PubkeyToAddress(gk.PublicKey)
 	fromP2pId, err := peer.Decode("12D3KooWSgMXkhzTbKTeupHYmyG7sFJ5LpVreQcwVnX8RD7LBpy9")
 	assert.NoError(t, err)
 	p2pNodeId, err := fromP2pId.Marshal()
@@ -39,7 +38,7 @@ func TestSignedHeartbeat(t *testing.T) {
 
 	gk2, err := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	assert.NoError(t, err)
-	gAddr2 := ethcrypto.PubkeyToAddress(gk2.PublicKey)
+	gAddr2 := crypto.PubkeyToAddress(gk2.PublicKey)
 	fromP2pId2, err := peer.Decode("12D3KooWDZVv7BhZ8yFLkarNdaSWaB43D6UbQwExJ8nnGAEmfHcU")
 	assert.NoError(t, err)
 	p2pNodeId2, err := fromP2pId2.Marshal()
@@ -96,7 +95,7 @@ func TestSignedHeartbeat(t *testing.T) {
 
 	testFunc := func(t *testing.T, tc testCase) {
 
-		addr := ethcrypto.PubkeyToAddress(gk.PublicKey)
+		addr := crypto.PubkeyToAddress(gk.PublicKey)
 
 		heartbeat := &gossipv1.Heartbeat{
 			NodeName:      "someNode",

--- a/node/pkg/watchers/evm/ccq_backfill.go
+++ b/node/pkg/watchers/evm/ccq_backfill.go
@@ -11,7 +11,6 @@ import (
 	"go.uber.org/zap"
 
 	ethHexUtil "github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/rpc"
 	ethRpc "github.com/ethereum/go-ethereum/rpc"
 )
 
@@ -148,7 +147,7 @@ func (w *Watcher) ccqBackfillInit(ctx context.Context) error {
 
 // ccqBackfillConn is defined to allow for testing of ccqBackFillDetermineMaxBatchSize without mocking a full ethereum connection.
 type ccqBackfillConn interface {
-	RawBatchCallContext(ctx context.Context, b []rpc.BatchElem) error
+	RawBatchCallContext(ctx context.Context, b []ethRpc.BatchElem) error
 }
 
 // ccqBackFillDetermineMaxBatchSize performs a series of batch queries, starting with a size of 1000 and stepping down by halves, and then back up until we circle in on the maximum batch size supported by the RPC.

--- a/node/pkg/watchers/evm/connectors/batch_poller_test.go
+++ b/node/pkg/watchers/evm/connectors/batch_poller_test.go
@@ -17,7 +17,6 @@ import (
 
 	ethereum "github.com/ethereum/go-ethereum"
 	ethCommon "github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
 	ethClient "github.com/ethereum/go-ethereum/ethclient"
 	ethEvent "github.com/ethereum/go-ethereum/event"
@@ -190,7 +189,7 @@ func (m mockSubscription) Err() <-chan error {
 	return m.errC
 }
 
-func (e *mockConnectorForBatchPoller) SubscribeNewHead(ctx context.Context, ch chan<- *types.Header) (ethereum.Subscription, error) {
+func (e *mockConnectorForBatchPoller) SubscribeNewHead(ctx context.Context, ch chan<- *ethTypes.Header) (ethereum.Subscription, error) {
 	e.headSink = ch
 	return mockSubscription{}, nil
 }

--- a/node/pkg/watchers/evm/connectors/celo.go
+++ b/node/pkg/watchers/evm/connectors/celo.go
@@ -15,7 +15,6 @@ import (
 
 	ethereum "github.com/ethereum/go-ethereum"
 	ethCommon "github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
 	ethClient "github.com/ethereum/go-ethereum/ethclient"
 	ethEvent "github.com/ethereum/go-ethereum/event"
@@ -216,7 +215,7 @@ func (c *CeloConnector) Client() *ethClient.Client {
 	panic("unimplemented")
 }
 
-func (c *CeloConnector) SubscribeNewHead(ctx context.Context, ch chan<- *types.Header) (ethereum.Subscription, error) {
+func (c *CeloConnector) SubscribeNewHead(ctx context.Context, ch chan<- *ethTypes.Header) (ethereum.Subscription, error) {
 	panic("unimplemented")
 }
 

--- a/node/pkg/watchers/evm/connectors/ethereum.go
+++ b/node/pkg/watchers/evm/connectors/ethereum.go
@@ -11,7 +11,6 @@ import (
 	ethereum "github.com/ethereum/go-ethereum"
 	ethBind "github.com/ethereum/go-ethereum/accounts/abi/bind"
 	ethCommon "github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
 	ethClient "github.com/ethereum/go-ethereum/ethclient"
 	ethEvent "github.com/ethereum/go-ethereum/event"
@@ -114,6 +113,6 @@ func (e *EthereumBaseConnector) Client() *ethClient.Client {
 	return e.client
 }
 
-func (e *EthereumBaseConnector) SubscribeNewHead(ctx context.Context, ch chan<- *types.Header) (ethereum.Subscription, error) {
+func (e *EthereumBaseConnector) SubscribeNewHead(ctx context.Context, ch chan<- *ethTypes.Header) (ethereum.Subscription, error) {
 	return e.client.SubscribeNewHead(ctx, ch)
 }

--- a/node/pkg/watchers/evm/connectors/finalizer_poller_test.go
+++ b/node/pkg/watchers/evm/connectors/finalizer_poller_test.go
@@ -17,7 +17,6 @@ import (
 
 	ethereum "github.com/ethereum/go-ethereum"
 	ethCommon "github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	ethTypes "github.com/ethereum/go-ethereum/core/types"
 	ethClient "github.com/ethereum/go-ethereum/ethclient"
 	ethEvent "github.com/ethereum/go-ethereum/event"
@@ -140,7 +139,7 @@ func (e *mockConnectorForPoller) Client() *ethClient.Client {
 	return e.client
 }
 
-func (e *mockConnectorForPoller) SubscribeNewHead(ctx context.Context, ch chan<- *types.Header) (ethereum.Subscription, error) {
+func (e *mockConnectorForPoller) SubscribeNewHead(ctx context.Context, ch chan<- *ethTypes.Header) (ethereum.Subscription, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
Some Go packages are imported more than once. Clean up a bit.