### PR TITLE
Replace Terra2 RPCs with new endpoint

### DIFF
--- a/clients/js/src/consts/networks.ts
+++ b/clients/js/src/consts/networks.ts
@@ -138,7 +138,7 @@ const MAINNET = {
     chain_id: undefined,
   },
   terra2: {
-    rpc: "https://phoenix-lcd.terra.dev",
+    rpc: "https://lcd-terra.tfl.foundation",
     chain_id: "phoenix-1",
     key: getEnvVar("TERRA_MNEMONIC"),
   },

--- a/cosmwasm/deployment/terra2/tools/store_single.js
+++ b/cosmwasm/deployment/terra2/tools/store_single.js
@@ -30,7 +30,7 @@ const artifact = argv.artifact;
 const host =
   argv.network === "mainnet"
     ? {
-        URL: "https://phoenix-lcd.terra.dev",
+        URL: "https://lcd-terra.tfl.foundation",
         chainID: "phoenix-1",
         name: "mainnet",
       }

--- a/cosmwasm/verify
+++ b/cosmwasm/verify
@@ -81,9 +81,9 @@ case "$network" in
         code_id_url="https://columbus-lcd.terra.dev/terra/wasm/v1beta1/contracts/"
         code_id_jq="jq '.contract_info.code_id' -r "
         ;;
-      terra2) url="https://phoenix-lcd.terra.dev/wasm/code/"
+      terra2) url="https://lcd-terra.tfl.foundation/wasm/code/"
         jq_cmd="jq '.result.data_hash' -r "
-        code_id_url="https://phoenix-lcd.terra.dev/wasm/contract/"
+        code_id_url="https://lcd-terra.tfl.foundation/wasm/contract/"
         code_id_jq="jq '.result.code_id' -r "
         ;;
       xpla) url="https://dimension-lcd.xpla.dev/cosmwasm/wasm/v1/code/"

--- a/sdk/js/src/relayer/consts.ts
+++ b/sdk/js/src/relayer/consts.ts
@@ -194,7 +194,7 @@ export const RPCS_BY_CHAIN: {
     near: "https://rpc.mainnet.near.org",
     xpla: "https://dimension-lcd.xpla.dev",
     sui: "https://fullnode.mainnet.sui.io:443",
-    terra2: "https://phoenix-lcd.terra.dev",
+    terra2: "https://lcd-terra.tfl.foundation",
     terra: "https://columbus-fcd.terra.dev",
     injective: "https://k8s.mainnet.lcd.injective.network",
     solana: "https://api.mainnet-beta.solana.com",


### PR DESCRIPTION
https://phoenix-lcd.terra.dev is being deprecated. The new LCD for Terra2 is https://lcd-terra.tfl.foundation