### PR TITLE
script: uses only first digest as identifier for governance prototxt

### DIFF
--- a/scripts/register-chain-governance.sh
+++ b/scripts/register-chain-governance.sh
@@ -165,8 +165,8 @@ digest=$(echo "$verify" | grep "VAA with digest" | cut -d' ' -f6 | sed 's/://g')
 
 # massage the digest into the same format that the inject command prints it
 digest=$(echo "$digest" | awk '{print toupper($0)}' | sed 's/^0X//')
-# we use the first 7 characters of the digest as an identifier for the prototxt file
-gov_id=$(echo "$digest" | cut -c1-7)
+# we use the first 7 characters of the first digest as an identifier for the prototxt file
+gov_id=$(echo "$digest" | head -n 1 | cut -c1-7)
 
 ################################################################################
 # Print vote command and expected digests


### PR DESCRIPTION
This fixes the governance message document template when using multi mode.

When generating more than one governance message you could observe this being generated as the shell command to generate the prototxt:
```
cat << EOF > governance-206690B
259B804.prototxt
current_set_index:  4
[...]
```

Which breaks the format of the governance message.