### PR TITLE
clients/js: add chain and rpc support for worm verify-vaa command

### DIFF
--- a/clients/js/README.md
+++ b/clients/js/README.md
@@ -347,13 +347,14 @@ Options:
                             [required] [choices: "mainnet", "testnet", "devnet"]
   -c, --chain             chain name
   [required] [choices: "unset", "solana", "ethereum", "terra", "bsc", "polygon",
-   "avalanche", "oasis", "algorand", "aurora", "fantom", "karura", "acala", "kla
-  ytn", "celo", "near", "moonbeam", "neon", "terra2", "injective", "osmosis", "s
-  ui", "aptos", "arbitrum", "optimism", "gnosis", "pythnet", "xpla", "btc", "bas
-  e", "sei", "rootstock", "scroll", "mantle", "blast", "xlayer", "linea", "berac
-  hain", "seievm", "wormchain", "cosmoshub", "evmos", "kujira", "neutron", "cele
-  stia", "stargaze", "seda", "dymension", "provenance", "sepolia", "arbitrum_sep
-        olia", "base_sepolia", "optimism_sepolia", "holesky", "polygon_sepolia"]
+        "avalanche", "oasis", "algorand", "aurora", "fantom", "karura", "acala",
+            "klaytn", "celo", "near", "moonbeam", "neon", "terra2", "injective",
+         "osmosis", "sui", "aptos", "arbitrum", "optimism", "gnosis", "pythnet",
+         "xpla", "btc", "base", "sei", "rootstock", "scroll", "mantle", "blast",
+    "xlayer", "linea", "berachain", "seievm", "wormchain", "cosmoshub", "evmos",
+               "kujira", "neutron", "celestia", "stargaze", "seda", "dymension",
+                    "provenance", "sepolia", "arbitrum_sepolia", "base_sepolia",
+                               "optimism_sepolia", "holesky", "polygon_sepolia"]
   -a, --contract-address  Contract to verify VAA on (override config)   [string]
       --rpc               RPC endpoint                                  [string]
 ```

--- a/clients/js/README.md
+++ b/clients/js/README.md
@@ -35,7 +35,7 @@ Commands:
   worm recover <digest> <signature>  Recover an address from a signature
   worm submit <vaa>                  Execute a VAA
   worm sui                           Sui utilities
-  worm verify-vaa                    Verifies a VAA by querying the core contract on Ethereum
+  worm verify-vaa                    Verifies a VAA by querying the core contract on the specified EVM chain
 
 Options:
   --help     Show help                                                 [boolean]
@@ -340,10 +340,22 @@ Options:
 
 ```sh
 Options:
-      --help     Show help                                             [boolean]
-      --version  Show version number                                   [boolean]
-  -v, --vaa      vaa in hex format                           [string] [required]
-  -n, --network  Network    [required] [choices: "mainnet", "testnet", "devnet"]
+      --help              Show help                                    [boolean]
+      --version           Show version number                          [boolean]
+  -v, --vaa               vaa in hex format                  [string] [required]
+  -n, --network           Network
+                            [required] [choices: "mainnet", "testnet", "devnet"]
+  -c, --chain             chain name
+  [required] [choices: "unset", "solana", "ethereum", "terra", "bsc", "polygon",
+   "avalanche", "oasis", "algorand", "aurora", "fantom", "karura", "acala", "kla
+  ytn", "celo", "near", "moonbeam", "neon", "terra2", "injective", "osmosis", "s
+  ui", "aptos", "arbitrum", "optimism", "gnosis", "pythnet", "xpla", "btc", "bas
+  e", "sei", "rootstock", "scroll", "mantle", "blast", "xlayer", "linea", "berac
+  hain", "seievm", "wormchain", "cosmoshub", "evmos", "kujira", "neutron", "cele
+  stia", "stargaze", "seda", "dymension", "provenance", "sepolia", "arbitrum_sep
+        olia", "base_sepolia", "optimism_sepolia", "holesky", "polygon_sepolia"]
+  -a, --contract-address  Contract to verify VAA on (override config)   [string]
+      --rpc               RPC endpoint                                  [string]
 ```
 </details>
 

--- a/clients/js/src/cmds/verifyVaa.ts
+++ b/clients/js/src/cmds/verifyVaa.ts
@@ -1,11 +1,12 @@
 // The verify-vaa command invokes the parseAndVerifyVM method on the core contract on the specified EVM chain to verify the specified VAA.
 
 import { Implementation__factory } from "@certusone/wormhole-sdk/lib/esm/ethers-contracts";
-import { 
+import {
   CONTRACTS,
   CHAINS,
+  ChainName,
   assertChain,
-  assertEVMChain
+  assertEVMChain,
 } from "@certusone/wormhole-sdk/lib/esm/utils/consts";
 import { ethers } from "ethers";
 import yargs from "yargs";
@@ -13,7 +14,8 @@ import { NETWORKS, NETWORK_OPTIONS } from "../consts";
 import { assertNetwork } from "../utils";
 
 export const command = "verify-vaa";
-export const desc = "Verifies a VAA by querying the core contract on the specified EVM chain";
+export const desc =
+  "Verifies a VAA by querying the core contract on the specified EVM chain";
 export const builder = (y: typeof yargs) =>
   y
     .option("vaa", {
@@ -39,7 +41,7 @@ export const builder = (y: typeof yargs) =>
       describe: "RPC endpoint",
       type: "string",
       demandOption: false,
-    })
+    });
 export const handler = async (
   argv: Awaited<ReturnType<typeof builder>["argv"]>
 ) => {
@@ -51,7 +53,8 @@ export const handler = async (
   assertNetwork(network);
 
   const rpc = argv.rpc ?? NETWORKS[network][chain].rpc;
-  const contract_address = argv["contract-address"] ?? CONTRACTS[network][chain].core;
+  const contract_address =
+    argv["contract-address"] ?? CONTRACTS[network][chain].core;
   if (!contract_address) {
     throw Error(`Unknown core contract on ${network} for ${chain}`);
   }


### PR DESCRIPTION
## Changes
* Added `--rpc`, `--chain` and `--contract-address` args to `worm verify-vaa` command
* Updated README.md
