### PR TITLE
include xlayer in the docs

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -210,6 +210,7 @@ historical limitation.
 * Arbitrum
 * Base
 * Optimism
+* xLayer - Use [xlayer-erigon](https://github.com/okx/xlayer-erigon) instead of [xlayer-node](https://github.com/okx/xlayer-node) for a simpler setup, as it requires a single binary rather than multiple ones or multiple Docker containers.
 
 Newer execution clients such as [reth](https://github.com/paradigmxyz/reth) lack this limitation and are worth
 investigating once they are stable.


### PR DESCRIPTION
Note: This PR Is not ready yet

It's likely the fixes from xLabs will be included in the next release cycle https://github.com/0xPolygonHermez/cdk-erigon/issues/441, which will imply new operators just need to compile from https://github.com/0xPolygonHermez/cdk-erigon and they should be good to go with the defaults