### PR TITLE
node: add governor support for Mantle

### DIFF
--- a/node/pkg/governor/manual_tokens.go
+++ b/node/pkg/governor/manual_tokens.go
@@ -54,12 +54,12 @@ func manualTokenList() []tokenConfigEntry {
 		{chain: 37, addr: "000000000000000000000000ea034fb02eb1808c2cc3adbc15f447b93cbe08e1", symbol: "WBTC", coinGeckoId: "polygon-hermez-bridged-wbtc-x-layer", decimals: 8, price: 57029},
 		{chain: 37, addr: "000000000000000000000000c5015b9d9161dca7e18e32f6f25c4ad850731fd4", symbol: "DAI", coinGeckoId: "polygon-hermez-bridged-dai-x-layer", decimals: 18, price: 1.0006},
 		// MANTLE (tokens over $50,000 24h volume)
-		{chain: 35, addr: "0000000000000000000000003c3a81e81dc49a522a592e7622a7e711c06bf354", symbol: "MNT", coinGeckoId: "mantle", decimals: 18, price: 1.01},
+		{chain: 35, addr: "000000000000000000000000deaddeaddeaddeaddeaddeaddeaddeaddead0000", symbol: "MNT", coinGeckoId: "mantle", decimals: 18, price: 1.01},
 		{chain: 35, addr: "00000000000000000000000078c1b0c915c4faa5fffa6cabf0219da63d7f4cb8", symbol: "WMNT", coinGeckoId: "wrapped-mantle", decimals: 18, price: 1.01},
 		{chain: 35, addr: "00000000000000000000000009bc4e0d864854c6afb6eb9a9cdf58ac190d0df9", symbol: "USDC", coinGeckoId: "mantle-bridged-usdc-mantle", decimals: 6, price: 1},
 		{chain: 35, addr: "000000000000000000000000201EBa5CC46D216Ce6DC03F6a759e8E766e956aE", symbol: "USDT", coinGeckoId: "mantle-bridged-usdt-mantle", decimals: 6, price: 0.9973},
-		{chain: 35, addr: "000000000000000000000000d5f7838f5c461feff7fe49ea5ebaf7728bb0adfa", symbol: "METH", coinGeckoId: "mantle-staked-ether", decimals: 18, price: 3934.06},
+		{chain: 35, addr: "000000000000000000000000cDA86A272531e8640cD7F1a92c01839911B90bb0", symbol: "METH", coinGeckoId: "mantle-staked-ether", decimals: 18, price: 3934.06},
 		{chain: 35, addr: "000000000000000000000000deaddeaddeaddeaddeaddeaddeaddeaddead1111", symbol: "WETH", coinGeckoId: "wrapped-ether-mantle-bridge", decimals: 18, price: 3825.65},
-		{chain: 35, addr: "0000000000000000000000006e84a6216ea6dacc71ee8e6b0a5b7322eebc0fdd", symbol: "JOE", coinGeckoId: "joe", decimals: 18, price: 0.4911},
+		{chain: 35, addr: "000000000000000000000000371c7ec6d8039ff7933a2aa28eb827ffe1f52f07", symbol: "JOE", coinGeckoId: "joe", decimals: 18, price: 0.4911},
 	}
 }

--- a/node/pkg/governor/manual_tokens.go
+++ b/node/pkg/governor/manual_tokens.go
@@ -56,7 +56,6 @@ func manualTokenList() []tokenConfigEntry {
 		// MANTLE (tokens over $50,000 24h volume)
 		{chain: 35, addr: "0000000000000000000000003c3a81e81dc49a522a592e7622a7e711c06bf354", symbol: "MNT", coinGeckoId: "mantle", decimals: 18, price: 1.01},
 		{chain: 35, addr: "00000000000000000000000078c1b0c915c4faa5fffa6cabf0219da63d7f4cb8", symbol: "WMNT", coinGeckoId: "wrapped-mantle", decimals: 18, price: 1.01},
-		{chain: 35, addr: "000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", symbol: "USDC", coinGeckoId: "usd-coin", decimals: 6, price: 0.9998},
 		{chain: 35, addr: "00000000000000000000000009bc4e0d864854c6afb6eb9a9cdf58ac190d0df9", symbol: "USDC", coinGeckoId: "mantle-bridged-usdc-mantle", decimals: 6, price: 1},
 		{chain: 35, addr: "000000000000000000000000201EBa5CC46D216Ce6DC03F6a759e8E766e956aE", symbol: "USDT", coinGeckoId: "mantle-bridged-usdt-mantle", decimals: 6, price: 0.9973},
 		{chain: 35, addr: "000000000000000000000000d5f7838f5c461feff7fe49ea5ebaf7728bb0adfa", symbol: "METH", coinGeckoId: "mantle-staked-ether", decimals: 18, price: 3934.06},

--- a/node/pkg/governor/manual_tokens.go
+++ b/node/pkg/governor/manual_tokens.go
@@ -53,5 +53,8 @@ func manualTokenList() []tokenConfigEntry {
 		{chain: 37, addr: "00000000000000000000000074b7f16337b8972027f6196a17a631ac6de26d22", symbol: "USDC", coinGeckoId: "polygon-hermez-bridged-usdc-x-layer", decimals: 6, price: 0.9949},
 		{chain: 37, addr: "000000000000000000000000ea034fb02eb1808c2cc3adbc15f447b93cbe08e1", symbol: "WBTC", coinGeckoId: "polygon-hermez-bridged-wbtc-x-layer", decimals: 8, price: 57029},
 		{chain: 37, addr: "000000000000000000000000c5015b9d9161dca7e18e32f6f25c4ad850731fd4", symbol: "DAI", coinGeckoId: "polygon-hermez-bridged-dai-x-layer", decimals: 18, price: 1.0006},
+		// MANTLE (tokens over $50,000 24h volume)
+		{chain: 35, addr: "0000000000000000000000003c3a81e81dc49a522a592e7622a7e711c06bf354", symbol: "MNT", coinGeckoId: "mantle", decimals: 18, price: 1.02},
+		{chain: 35, addr: "000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", symbol: "USDC", coinGeckoId: "usd-coin", decimals: 6, price: 0.9998},
 	}
 }

--- a/node/pkg/governor/manual_tokens.go
+++ b/node/pkg/governor/manual_tokens.go
@@ -54,7 +54,13 @@ func manualTokenList() []tokenConfigEntry {
 		{chain: 37, addr: "000000000000000000000000ea034fb02eb1808c2cc3adbc15f447b93cbe08e1", symbol: "WBTC", coinGeckoId: "polygon-hermez-bridged-wbtc-x-layer", decimals: 8, price: 57029},
 		{chain: 37, addr: "000000000000000000000000c5015b9d9161dca7e18e32f6f25c4ad850731fd4", symbol: "DAI", coinGeckoId: "polygon-hermez-bridged-dai-x-layer", decimals: 18, price: 1.0006},
 		// MANTLE (tokens over $50,000 24h volume)
-		{chain: 35, addr: "0000000000000000000000003c3a81e81dc49a522a592e7622a7e711c06bf354", symbol: "MNT", coinGeckoId: "mantle", decimals: 18, price: 1.02},
+		{chain: 35, addr: "0000000000000000000000003c3a81e81dc49a522a592e7622a7e711c06bf354", symbol: "MNT", coinGeckoId: "mantle", decimals: 18, price: 1.01},
+		{chain: 35, addr: "00000000000000000000000078c1b0c915c4faa5fffa6cabf0219da63d7f4cb8", symbol: "WMNT", coinGeckoId: "wrapped-mantle", decimals: 18, price: 1.01},
 		{chain: 35, addr: "000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", symbol: "USDC", coinGeckoId: "usd-coin", decimals: 6, price: 0.9998},
+		{chain: 35, addr: "00000000000000000000000009bc4e0d864854c6afb6eb9a9cdf58ac190d0df9", symbol: "USDC", coinGeckoId: "mantle-bridged-usdc-mantle", decimals: 6, price: 1},
+		{chain: 35, addr: "000000000000000000000000201EBa5CC46D216Ce6DC03F6a759e8E766e956aE", symbol: "USDT", coinGeckoId: "mantle-bridged-usdt-mantle", decimals: 6, price: 0.9973},
+		{chain: 35, addr: "000000000000000000000000d5f7838f5c461feff7fe49ea5ebaf7728bb0adfa", symbol: "METH", coinGeckoId: "mantle-staked-ether", decimals: 18, price: 3934.06},
+		{chain: 35, addr: "000000000000000000000000deaddeaddeaddeaddeaddeaddeaddeaddead1111", symbol: "WETH", coinGeckoId: "wrapped-ether-mantle-bridge", decimals: 18, price: 3825.65},
+		{chain: 35, addr: "0000000000000000000000006e84a6216ea6dacc71ee8e6b0a5b7322eebc0fdd", symbol: "JOE", coinGeckoId: "joe", decimals: 18, price: 0.4911},
 	}
 }


### PR DESCRIPTION
* Add Mantle to the `mainnet_chains.go` file using the default, minimum limits
* Add manual tokens. Data sourced from: https://www.coingecko.com/en/categories/mantle-ecosystem. I wasn't able to find other token information from e.g. https://explorer.mantle.xyz/ but if anyone knows of another reputable data source that shows other tokens we should add, let me know.

Previous related PRs:
* https://github.com/wormhole-foundation/wormhole/pull/3908
* https://github.com/wormhole-foundation/wormhole/pull/3926

Opening in draft until I can run `check_query.go`. Currently I'm rate-limited