### PR TITLE
node: Allow tokens to change their symbol in generator script

### DIFF
--- a/node/hack/governor/src/index.ts
+++ b/node/hack/governor/src/index.ts
@@ -215,7 +215,7 @@ axios
               notional +
               "\n";
 
-            newTokenKeys[chain + "-" + wormholeAddr + "-" + data.Symbol] = true;
+            newTokenKeys[chain + "-" + wormholeAddr] = true;
             newTokensCount += 1;
           }
         }
@@ -224,7 +224,9 @@ axios
 
     for (var token of existingTokenKeys) {
       // A token has been removed from the token list 
-      if (!newTokenKeys[token]) {
+      // We cut the symbol off the end of the key as it's possible for a token to change its symbol
+      var tokenParts = token.split("-");
+      if (!newTokenKeys[tokenParts[0] + "-" + tokenParts[1]]) {
         removedTokens.push(token);
       }
     }


### PR DESCRIPTION
When trying to update the governor token list, the script was failing on this check:

```
// Sanity check to make sure the script is doing what we think it is
    if (existingTokenKeys.length + addedTokens.length - removedTokens.length != newTokensCount) {
      console.error(`Num existing tokens (${existingTokenKeys.length}) + Added tokens (${addedTokens.length}) - Removed tokens (${removedTokens.length}) != Num new tokens (${newTokensCount})`);
      process.exit(1);
    }
```

It turned out that a token was being classified as "removed" because its symbol had changed. We should allow tokens to change their symbol (like we do on the new token side) so this PR updates the script to only use the chain + address key for removed token lookups; that's a unique identifier after all.

Even if the token symbol included a "-" character this change is safe since we only concat the first 2 elements of the array, and the symbol is the last element in the key strings.