### PR TITLE
change ioutil to io and os

### DIFF
--- a/near/test/watcher.go
+++ b/near/test/watcher.go
@@ -7,9 +7,11 @@ package main
 import (
 	"bytes"
 	"fmt"
+
 	"github.com/tidwall/gjson"
+
 	//	"encoding/base64"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -27,7 +29,7 @@ func getTxStatus(tx string, src string) ([]byte, error) {
 	}
 
 	defer resp.Body.Close()
-	return ioutil.ReadAll(resp.Body)
+	return io.ReadAll(resp.Body)
 }
 
 func getBlock(block uint64) ([]byte, error) {
@@ -39,7 +41,7 @@ func getBlock(block uint64) ([]byte, error) {
 	}
 
 	defer resp.Body.Close()
-	return ioutil.ReadAll(resp.Body)
+	return io.ReadAll(resp.Body)
 }
 
 func getFinalBlock() ([]byte, error) {
@@ -51,7 +53,7 @@ func getFinalBlock() ([]byte, error) {
 	}
 
 	defer resp.Body.Close()
-	return ioutil.ReadAll(resp.Body)
+	return io.ReadAll(resp.Body)
 }
 
 func getChunk(chunk string) ([]byte, error) {
@@ -64,7 +66,7 @@ func getChunk(chunk string) ([]byte, error) {
 	}
 
 	defer resp.Body.Close()
-	return ioutil.ReadAll(resp.Body)
+	return io.ReadAll(resp.Body)
 }
 
 func inspectBody(block uint64, body gjson.Result) error {
@@ -121,7 +123,7 @@ func inspectBody(block uint64, body gjson.Result) error {
 						if !strings.HasPrefix(event, "EVENT_JSON:") {
 							continue
 						}
-//						event_json := gjson.ParseBytes(event[11:])
+						//event_json := gjson.ParseBytes(event[11:])
 						fmt.Printf("log: %s\n", event[11:])
 					}
 				}

--- a/wormchain/testutil/keeper/wormhole.go
+++ b/wormchain/testutil/keeper/wormhole.go
@@ -1,7 +1,7 @@
 package keeper
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -97,10 +97,7 @@ func WormholeKeeperAndWasmd(t testing.TB) (*keeper.Keeper, wasmkeeper.Keeper, *w
 	appapp.CapabilityKeeper = capabilitykeeper.NewKeeper(appCodec, keys[capabilitytypes.StoreKey], memKeys[capabilitytypes.MemStoreKey])
 	scopedWasmKeeper := appapp.CapabilityKeeper.ScopeToModule(wasm.ModuleName)
 
-	wasmDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		panic(err)
-	}
+	wasmDir := os.TempDir()
 	wasmKeeper := wasm.NewKeeper(
 		appCodec,
 		keys[wasmtypes.StoreKey],

--- a/wormchain/x/wormhole/client/cli/genesis.go
+++ b/wormchain/x/wormhole/client/cli/genesis.go
@@ -6,7 +6,6 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"strings"
@@ -79,11 +78,11 @@ func CmdGenerateTestGuardianKey() *cobra.Command {
 			private_key := [32]byte{}
 			key.D.FillBytes(private_key[:])
 
-			err = ioutil.WriteFile(outPrivatePath, []byte(hex.EncodeToString(private_key[:])), 0644)
+			err = os.WriteFile(outPrivatePath, []byte(hex.EncodeToString(private_key[:])), 0644)
 			if err != nil {
 				return err
 			}
-			ioutil.WriteFile(outPublicPath, []byte(hex.EncodeToString(addr.Bytes())), 0644)
+			os.WriteFile(outPublicPath, []byte(hex.EncodeToString(addr.Bytes())), 0644)
 			if err != nil {
 				return err
 			}
@@ -131,7 +130,7 @@ func CmdDecodeAddress() *cobra.Command {
 
 func ImportKeyFromFile(filePath string) (*ecdsa.PrivateKey, error) {
 	priv := ecdsa.PrivateKey{}
-	bz, err := ioutil.ReadFile(filePath)
+	bz, err := io.ReadFile(filePath)
 	if err != nil {
 		return &priv, err
 	}
@@ -139,7 +138,7 @@ func ImportKeyFromFile(filePath string) (*ecdsa.PrivateKey, error) {
 }
 
 func ImportPublicKeyFromFile(filePath string) ([]byte, error) {
-	hexBz, err := ioutil.ReadFile(filePath)
+	hexBz, err := io.ReadFile(filePath)
 	if err != nil {
 		return []byte{}, err
 	}

--- a/wormchain/x/wormhole/client/cli/genesis.go
+++ b/wormchain/x/wormhole/client/cli/genesis.go
@@ -130,7 +130,7 @@ func CmdDecodeAddress() *cobra.Command {
 
 func ImportKeyFromFile(filePath string) (*ecdsa.PrivateKey, error) {
 	priv := ecdsa.PrivateKey{}
-	bz, err := io.ReadFile(filePath)
+	bz, err := os.ReadFile(filePath)
 	if err != nil {
 		return &priv, err
 	}
@@ -138,7 +138,7 @@ func ImportKeyFromFile(filePath string) (*ecdsa.PrivateKey, error) {
 }
 
 func ImportPublicKeyFromFile(filePath string) ([]byte, error) {
-	hexBz, err := io.ReadFile(filePath)
+	hexBz, err := os.ReadFile(filePath)
 	if err != nil {
 		return []byte{}, err
 	}

--- a/wormchain/x/wormhole/client/cli/tx_wasmd.go
+++ b/wormchain/x/wormhole/client/cli/tx_wasmd.go
@@ -2,7 +2,7 @@ package cli
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 
 	"encoding/hex"
@@ -22,7 +22,7 @@ import (
 var _ = strconv.Itoa(0)
 
 func parseStoreCodeArgs(file string, sender sdk.AccAddress, vaa []byte) (types.MsgStoreCode, error) {
-	wasm, err := ioutil.ReadFile(file)
+	wasm, err := os.ReadFile(file)
 	if err != nil {
 		return types.MsgStoreCode{}, err
 	}


### PR DESCRIPTION
According to https://pkg.go.dev/io/ioutil.
> Deprecated: As of Go 1.16, the same functionality is now provided by package [io](https://pkg.go.dev/io) or package [os](https://pkg.go.dev/os), and those implementations should be preferred in new code. See the specific function documentation for details.

This PR changes those deprecated packages to the new one.