### PR TITLE
Node: Minor tweaks and spy improvement

### DIFF
--- a/node/pkg/common/channel_utils.go
+++ b/node/pkg/common/channel_utils.go
@@ -1,0 +1,20 @@
+package common
+
+import (
+	"context"
+)
+
+// ReadFromChannelWithTimeout reads events from the channel until a timeout occurs or the max maxCount is reached.
+func ReadFromChannelWithTimeout[T any](ctx context.Context, ch <-chan T, maxCount int) ([]T, error) {
+	out := make([]T, 0, maxCount)
+	for len(out) < maxCount {
+		select {
+		case <-ctx.Done():
+			return out, ctx.Err()
+		case msg := <-ch:
+			out = append(out, msg)
+		}
+	}
+
+	return out, nil
+}

--- a/node/pkg/common/channel_utils_test.go
+++ b/node/pkg/common/channel_utils_test.go
@@ -1,0 +1,80 @@
+package common
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const myDelay = time.Millisecond * 100
+const myMaxSize = 2
+const myQueueSize = myMaxSize * 10
+
+func TestReadFromChannelWithTimeout_NoData(t *testing.T) {
+	ctx := context.Background()
+	myChan := make(chan int, myQueueSize)
+
+	// No data should timeout.
+	timeout, cancel := context.WithTimeout(ctx, myDelay)
+	defer cancel()
+	observations, err := ReadFromChannelWithTimeout[int](timeout, myChan, myMaxSize)
+	assert.Equal(t, err, context.DeadlineExceeded)
+	assert.Equal(t, 0, len(observations))
+}
+
+func TestReadFromChannelWithTimeout_SomeData(t *testing.T) {
+	ctx := context.Background()
+	myChan := make(chan int, myQueueSize)
+	myChan <- 1
+
+	// Some data but not enough to fill a message should timeout and return the data.
+	timeout, cancel := context.WithTimeout(ctx, myDelay)
+	defer cancel()
+	observations, err := ReadFromChannelWithTimeout[int](timeout, myChan, myMaxSize)
+	assert.Equal(t, err, context.DeadlineExceeded)
+	require.Equal(t, 1, len(observations))
+	assert.Equal(t, 1, observations[0])
+}
+
+func TestReadFromChannelWithTimeout_JustEnoughData(t *testing.T) {
+	ctx := context.Background()
+	myChan := make(chan int, myQueueSize)
+	myChan <- 1
+	myChan <- 2
+
+	// Just enough data should return the data and no error.
+	timeout, cancel := context.WithTimeout(ctx, myDelay)
+	defer cancel()
+	observations, err := ReadFromChannelWithTimeout[int](timeout, myChan, myMaxSize)
+	assert.NoError(t, err)
+	require.Equal(t, 2, len(observations))
+	assert.Equal(t, 1, observations[0])
+	assert.Equal(t, 2, observations[1])
+}
+
+func TestReadFromChannelWithTimeout_TooMuchData(t *testing.T) {
+	ctx := context.Background()
+	myChan := make(chan int, myQueueSize)
+	myChan <- 1
+	myChan <- 2
+	myChan <- 3
+
+	// If there is more data than will fit, it should immediately return a full message, then timeout and return the remainder.
+	timeout, cancel := context.WithTimeout(ctx, myDelay)
+	defer cancel()
+	observations, err := ReadFromChannelWithTimeout[int](timeout, myChan, myMaxSize)
+	assert.NoError(t, err)
+	require.Equal(t, 2, len(observations))
+	assert.Equal(t, 1, observations[0])
+	assert.Equal(t, 2, observations[1])
+
+	timeout2, cancel2 := context.WithTimeout(ctx, myDelay)
+	defer cancel2()
+	observations, err = ReadFromChannelWithTimeout[int](timeout2, myChan, myMaxSize)
+	assert.Equal(t, err, context.DeadlineExceeded)
+	require.Equal(t, 1, len(observations))
+	assert.Equal(t, 3, observations[0])
+}

--- a/node/pkg/common/guardianset.go
+++ b/node/pkg/common/guardianset.go
@@ -54,13 +54,18 @@ type GuardianSet struct {
 	// On-chain set index
 	Index uint32
 
-	// Quorum value for this set of keys
-	Quorum int
+	// quorum value for this set of keys
+	quorum int
 
 	// A map from address to index. Testing showed that, on average, a map is almost three times faster than a sequential search of the key slice.
 	// Testing also showed that the map was twice as fast as using a sorted slice and `slices.BinarySearchFunc`. That being said, on a 4GHz CPU,
 	// the sequential search takes an average of 800 nanos and the map look up takes about 260 nanos. Is this worth doing?
 	keyMap map[common.Address]int
+}
+
+// Quorum returns the current quorum value.
+func (gs *GuardianSet) Quorum() int {
+	return gs.quorum
 }
 
 func NewGuardianSet(keys []common.Address, index uint32) *GuardianSet {
@@ -71,7 +76,7 @@ func NewGuardianSet(keys []common.Address, index uint32) *GuardianSet {
 	return &GuardianSet{
 		Keys:   keys,
 		Index:  index,
-		Quorum: vaa.CalculateQuorum(len(keys)),
+		quorum: vaa.CalculateQuorum(len(keys)),
 		keyMap: keyMap,
 	}
 }

--- a/node/pkg/common/guardianset_test.go
+++ b/node/pkg/common/guardianset_test.go
@@ -34,7 +34,7 @@ func TestNewGuardianSet(t *testing.T) {
 	gs := NewGuardianSet(keys, 1)
 	assert.True(t, reflect.DeepEqual(keys, gs.Keys))
 	assert.Equal(t, uint32(1), gs.Index)
-	assert.Equal(t, vaa.CalculateQuorum(len(keys)), gs.Quorum)
+	assert.Equal(t, vaa.CalculateQuorum(len(keys)), gs.Quorum())
 }
 
 func TestKeyIndex(t *testing.T) {

--- a/node/pkg/processor/broadcast.go
+++ b/node/pkg/processor/broadcast.go
@@ -8,7 +8,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	ethcommon "github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto"
 	"google.golang.org/protobuf/proto"
 
 	node_common "github.com/certusone/wormhole/node/pkg/common"
@@ -43,7 +42,7 @@ func (p *Processor) broadcastSignature(
 ) {
 	digest := o.SigningDigest()
 	obsv := gossipv1.SignedObservation{
-		Addr:      crypto.PubkeyToAddress(p.gk.PublicKey).Bytes(),
+		Addr:      p.ourAddr.Bytes(),
 		Hash:      digest.Bytes(),
 		Signature: signature,
 		TxHash:    txhash,

--- a/node/pkg/processor/cleanup.go
+++ b/node/pkg/processor/cleanup.go
@@ -115,7 +115,7 @@ func (p *Processor) handleCleanup(ctx context.Context) {
 			}
 
 			hasSigs := len(s.signatures)
-			quorum := hasSigs >= gs.Quorum
+			quorum := hasSigs >= gs.Quorum()
 
 			var chain vaa.ChainID
 			if s.ourObservation != nil {
@@ -128,7 +128,7 @@ func (p *Processor) handleCleanup(ctx context.Context) {
 					zap.String("digest", hash),
 					zap.Duration("delta", delta),
 					zap.Int("have_sigs", hasSigs),
-					zap.Int("required_sigs", gs.Quorum),
+					zap.Int("required_sigs", gs.Quorum()),
 					zap.Bool("quorum", quorum),
 					zap.Stringer("emitter_chain", chain),
 				)
@@ -245,8 +245,8 @@ func (p *Processor) handleCleanup(ctx context.Context) {
 						zap.String("digest", hash),
 						zap.Duration("delta", delta),
 						zap.Int("have_sigs", hasSigs),
-						zap.Int("required_sigs", p.gs.Quorum),
-						zap.Bool("quorum", hasSigs >= p.gs.Quorum),
+						zap.Int("required_sigs", p.gs.Quorum()),
+						zap.Bool("quorum", hasSigs >= p.gs.Quorum()),
 					)
 				}
 				delete(p.state.signatures, hash)

--- a/node/pkg/processor/observation.go
+++ b/node/pkg/processor/observation.go
@@ -228,7 +228,7 @@ func (p *Processor) handleObservation(ctx context.Context, obs *node_common.MsgW
 		// Hence, if len(s.signatures) < quorum, then there is definitely no quorum and we can return early to save additional computation,
 		// but if len(s.signatures) >= quorum, there is not necessarily quorum for the active guardian set.
 		// We will later check for quorum again after assembling the VAA for a particular guardian set.
-		if len(s.signatures) < gs.Quorum {
+		if len(s.signatures) < gs.Quorum() {
 			// no quorum yet, we're done here
 			if p.logger.Level().Enabled(zapcore.DebugLevel) {
 				p.logger.Debug("quorum not yet met",
@@ -250,13 +250,13 @@ func (p *Processor) handleObservation(ctx context.Context, obs *node_common.MsgW
 				zap.Any("set", gs.KeysAsHexStrings()),
 				zap.Uint32("index", gs.Index),
 				zap.Bools("aggregation", agg),
-				zap.Int("required_sigs", gs.Quorum),
+				zap.Int("required_sigs", gs.Quorum()),
 				zap.Int("have_sigs", len(sigsVaaFormat)),
-				zap.Bool("quorum", len(sigsVaaFormat) >= gs.Quorum),
+				zap.Bool("quorum", len(sigsVaaFormat) >= gs.Quorum()),
 			)
 		}
 
-		if len(sigsVaaFormat) >= gs.Quorum {
+		if len(sigsVaaFormat) >= gs.Quorum() {
 			// we have reached quorum *with the active guardian set*
 			s.ourObservation.HandleQuorum(sigsVaaFormat, hash, p)
 		} else {

--- a/node/pkg/processor/processor.go
+++ b/node/pkg/processor/processor.go
@@ -223,7 +223,7 @@ func (p *Processor) Run(ctx context.Context) error {
 			p.logger.Info("guardian set updated",
 				zap.Strings("set", p.gs.KeysAsHexStrings()),
 				zap.Uint32("index", p.gs.Index),
-				zap.Int("quorum", p.gs.Quorum),
+				zap.Int("quorum", p.gs.Quorum()),
 			)
 			p.gst.Set(p.gs)
 		case k := <-p.msgC:


### PR DESCRIPTION
This PR adds several minor tweaks that I came across while investigating the batching of observations:

- Make it so the spy does not have to subscribe for observations, just to drop them.
- Don't format the guardian address each time we publish an observation.
- Move a template function from the accountant package to common so it can be shared.
- Make the `Quorum` in the `GuardianSet` private and add a getter (as suggested by @SEJeff on #3967).