### PR TITLE
docs: Modify Governor whitepaper to include information about Flow Cancelling

### DIFF
--- a/cspell-custom-words.txt
+++ b/cspell-custom-words.txt
@@ -155,6 +155,9 @@ readyz
 regen
 reinit
 reobservation
+reobservations
+Reobservation
+Reobservations
 reobserved
 repoint
 rustup

--- a/whitepapers/0007_governor.md
+++ b/whitepapers/0007_governor.md
@@ -45,7 +45,7 @@ If a Guardian decides to enable this feature:
 
 * A list of allow-listed assets for flow canceling is configured in [flow_cancel_tokens.go](https://github.com/wormhole-foundation/wormhole/blob/main/node/pkg/governor/flow_cancel_tokens.go).
 
-* A list of allow-listed chain ID pairs for flow canceling is configured in [flow_cancel_tokens.go](https://github.com/wormhole-foundation/wormhole/blob/main/node/pkg/governor/flow_cancel_corridors.go).
+* A list of allow-listed chain ID pairs, or corridors, for flow canceling is configured in [flow_cancel_tokens.go](https://github.com/wormhole-foundation/wormhole/blob/main/node/pkg/governor/flow_cancel_corridors.go).
 
 The Governor divides token-based transactions into two categories: small transactions and large transactions.
 
@@ -64,7 +64,7 @@ The headroom for a chain is the amount left over after subtracting the current
 sum of small transfers from the chain's daily limit.
 
 Inbound transfers of certain tokens can also decrease this sum, a
-process we refer to as Flow Canceling.
+process referred to as Flow Canceling.
 
 #### Flow Canceling
 
@@ -87,7 +87,7 @@ Since the thresholds are denominated in the base currency, the Governor must kno
 1. **Hardcoded Floor Price**: This price is hard coded into the governor and is based on a fixed point in time (usually during a Wormhole Guardian release) which polls CoinGecko for a known set of known tokens that are governed.
 2. **Dynamic Price:** This price is dynamically polled from CoinGecko at 5-10min intervals.
 
-The token configurations are in [manual_tokens.go](https://github.com/wormhole-foundation/wormhole/blob/main/node/pkg/governor/manual_tokens.go) and [generated_mainnet_tokens.go](https://github.com/wormhole-foundation/wormhole/blob/main/node/pkg/governor/generated_mainnet_tokens.go). [flow_cancel_tokens.go](https://github.com/wormhole-foundation/wormhole/blob/main/node/pkg/governor/flow_cancel_tokens.go) contains the token list of Flow Cancel tokens but does not include price information.
+The token configurations are in [manual_tokens.go](https://github.com/wormhole-foundation/wormhole/blob/main/node/pkg/governor/manual_tokens.go) and [generated_mainnet_tokens.go](https://github.com/wormhole-foundation/wormhole/blob/main/node/pkg/governor/generated_mainnet_tokens.go). [flow_cancel_tokens.go](https://github.com/wormhole-foundation/wormhole/blob/main/node/pkg/governor/flow_cancel_tokens.go) contains the list of Flow Cancel tokens but does not include price information.
 
 If CoinGecko was to provide an erroneously low price for a token, the Governor errs on the side of safety by using the hardcoded floor price instead.
 

--- a/whitepapers/0007_governor.md
+++ b/whitepapers/0007_governor.md
@@ -54,32 +54,13 @@ The Governor divides token-based transactions into two categories: small transac
 
 #### Headroom Calculations
 
-Each chain has a configured limit, denoted in USD, that determines the maximum
-value of transfers that can be emitted within a 24 hour period. This is
-sometimes referred to as the "daily limit", though it uses a 24-hour sliding
-window rather than discrete calendar days. When the sum exceeds the limit,
-any new small transfers that exceed the limit will be queued.
-
-The headroom for a chain is the amount left over after subtracting the current
-sum of small transfers from the chain's daily limit.
-
-Inbound transfers of certain tokens can also decrease this sum, a
-process referred to as Flow Canceling.
+Each chain has a configured limit, denoted in USD, that determines the maximum value of transfers that can be emitted within a 24 hour period. This is sometimes referred to as the "daily limit", though it uses a 24-hour sliding window rather than discrete calendar days. When the sum exceeds the limit, any new small transfers that exceed the limit will be queued. The headroom for a chain is the amount left over after subtracting the current sum of small transfers from the chain's daily limit. Inbound transfers of certain tokens can also decrease this sum, a process referred to as Flow Canceling.
 
 #### Flow Canceling
 
-Guardians can optionally enable "flow canceling". This feature allows incoming
-transfers to reduce the current "daily limit" (sum of the USD value of all
-small transactions within the past 24 hours). This creates additional headroom,
-allowing a greater volume of notional value to leave the chain without being
-delayed.
+Guardians can optionally enable "flow canceling". This feature allows incoming transfers to reduce the current "daily limit" (sum of the USD value of all small transactions within the past 24 hours). This creates additional headroom, allowing a greater volume of notional value to leave the chain without being delayed.
 
-The general idea is to allow certain transfers to offset the consumption of an
-outgoing "budget" that the Governor records. A flow cancel transfer is akin to
-a credit transferred into the Governor which is measured against the total
-debits of the day, 'paying off the debt', and allowing for further consumption.
-
-
+The general idea is to allow certain transfers to offset the consumption of an outgoing "budget" that the Governor records. A flow cancel transfer is akin toa credit transferred into the Governor which is measured against the total debits of the day, 'paying off the debt', and allowing for further consumption.
 
 ### Asset pricing
 
@@ -89,7 +70,7 @@ Since the thresholds are denominated in the base currency, the Governor must kno
 
 The token configurations are in [manual_tokens.go](https://github.com/wormhole-foundation/wormhole/blob/main/node/pkg/governor/manual_tokens.go) and [generated_mainnet_tokens.go](https://github.com/wormhole-foundation/wormhole/blob/main/node/pkg/governor/generated_mainnet_tokens.go). [flow_cancel_tokens.go](https://github.com/wormhole-foundation/wormhole/blob/main/node/pkg/governor/flow_cancel_tokens.go) contains the list of Flow Cancel tokens but does not include price information.
 
-If CoinGecko was to provide an erroneously low price for a token, the Governor errs on the side of safety by using the hardcoded floor price instead.
+If CoinGecko was to provide an erroneously low price for a token, the Governor errs on the side of safety by using the hard-coded floor price instead.
 
 ### Visibility
 Each Guardian publishes its Governor configuration and status on the Wormhole gossip network, which anyone can subscribe to via a guardian spy ([instructions](https://github.com/wormhole-foundation/wormhole/blob/main/docs/operations.md)). Some Guardians also make the Governor status available through a public API, which can be visualized on the [Wormhole Dashboard](https://wormhole-foundation.github.io/wormhole-dashboard/). A more feature-rich [Wormhole Explorer](https://github.com/wormhole-foundation/wormhole-explorer) that will aggregate Governor status across all Guardians is work-in-progress.
@@ -98,7 +79,7 @@ Each Guardian publishes its Governor configuration and status on the Wormhole go
 * The Governor can only reduce the impact of an exploit, but not prevent it.
 * Excessively high transfer activity, even if manufactured and not organic, will cause transactions to be delayed by up to 24h.
 * If CoinGecko reports an unreasonably high price for a token, the 24h threshold will be exhausted sooner.
-* Guardians need to manually respond to erroneous messages within the 24h time window. It is expected that all Guardians operate collateralization monitoring for the protocol, taking into account the Governor queue. All Guardians should have alerting and incident response procedures in case of an undercollateralization.
+* Guardians need to manually respond to erroneous messages within the 24h time window. It is expected that all Guardians operate collateralization monitoring for the protocol, taking into account the Governor queue. All Guardians should have alerting and incident response procedures in case of an under-collateralization.
 * An attacker could utilize liquidity pools and other bridges to launder illicitly minted wrapped assets.
 
 ## Detailed Design
@@ -200,16 +181,9 @@ Right now, adding more governed emitters requires modifying guardian code. In th
 
 ### Flow Canceling could weaken Governor protections during an exploit
 
-Enabling Flow Canceling allows more funds to exit a chain when compared with 
-running the Chain Governor without this feature enabled. In the
-context of an exploit of one of the core contracts or the RPC,
-an attacker may be able to craft a series of flow-canceling
-transfers that subvert the Governor limits.
+Enabling Flow Canceling allows more funds to exit a chain when compared with running the Chain Governor without this feature enabled. In the context of an exploit of one of the core contracts or the RPC, an attacker may be able to craft a series of flow-canceling transfers that subvert the Governor limits.
 
-This motivates the design decision to make flow cancel functionality
-optional. If malicious activity is detected, Guardians can toggle
-the CLI flag and restart the node software in order to quickly
-disable the feature.
+This motivates the design decision to make flow cancel functionality optional. If malicious activity is detected, Guardians can toggle the CLI flag and restart the node software in order to quickly disable the feature.
 
 When evaluating whether to enable flow canceling, consider:
 - Is this corridor experiencing chronic congestion?
@@ -217,7 +191,4 @@ When evaluating whether to enable flow canceling, consider:
 - Is the chain and its watcher considered stable?
 - Does historical transfer data show that a small number of assets represent most of the congestion?
 
-All of the above should be taken into account so that flow canceling is enabled
-for a minimal set of assets and corridors. This should mitigate some the risk
-involved with increasing the volume allowed by the Governor.
-
+All of the above should be taken into account so that flow canceling is enabled for a minimal set of assets and corridors. This should mitigate some the risk involved with increasing the volume allowed by the Governor.

--- a/whitepapers/0007_governor.md
+++ b/whitepapers/0007_governor.md
@@ -50,7 +50,7 @@ Governor divides token-based transactions into two categories: small transaction
 #### Headroom Calculations
 
 The headroom for a given chain is the sum of the notional USD value of all transfers of governed tokens emitted from that chain within a 24 hour sliding window.
-Inbound transfers of certain tokens can also decrease this sum, a process we refer to as Flow Canceling. The tokens are listed in [flow_cancel_tokens.go]. An inbound transfer of these tokens to chain will reduce that chain's outbound limit: effectively the net-flow is zero. This allows for a relaxing of the Governor's rate-limiting as it accounts for the net flow of these assets rather than calculating only the outbound value.
+Inbound transfers of certain tokens can also decrease this sum, a process we refer to as Flow Canceling. The tokens are listed in [flow_cancel_tokens.go](https://github.com/wormhole-foundation/wormhole/blob/main/node/pkg/governor/flow_cancel_tokens.go). An inbound transfer of these tokens to chain will reduce that chain's outbound limit: effectively the net-flow is zero. This allows for a relaxing of the Governor's rate-limiting as it accounts for the net flow of these assets rather than calculating only the outbound value.
 
 ### Asset pricing
 
@@ -58,7 +58,7 @@ Since the thresholds are denominated in the base currency, the Governor must kno
 1. **Hardcoded Floor Price**: This price is hard coded into the governor and is based on a fixed point in time (usually during a Wormhole Guardian release) which polls CoinGecko for a known set of known tokens that are governed.
 2. **Dynamic Price:** This price is dynamically polled from CoinGecko at 5-10min intervals.
 
-The token configurations are in [manual_tokens.go](https://github.com/wormhole-foundation/wormhole/blob/main/node/pkg/governor/manual_tokens.go) and [generated_mainnet_tokens.go](https://github.com/wormhole-foundation/wormhole/blob/main/node/pkg/governor/generated_mainnet_tokens.go). [flow_cancel_tokens.go] contains the token list of Flow Cancel tokens but does not include price information.
+The token configurations are in [manual_tokens.go](https://github.com/wormhole-foundation/wormhole/blob/main/node/pkg/governor/manual_tokens.go) and [generated_mainnet_tokens.go](https://github.com/wormhole-foundation/wormhole/blob/main/node/pkg/governor/generated_mainnet_tokens.go). [flow_cancel_tokens.go](https://github.com/wormhole-foundation/wormhole/blob/main/node/pkg/governor/flow_cancel_tokens.go) contains the token list of Flow Cancel tokens but does not include price information.
 
 If CoinGecko was to provide an erroneously low price for a token, the Governor errs on the side of safety by using the hardcoded floor price instead.
 

--- a/whitepapers/0007_governor.md
+++ b/whitepapers/0007_governor.md
@@ -55,7 +55,7 @@ The Governor divides token-based transactions into two categories: small transac
 #### Headroom Calculations
 
 Each chain has a configured limit, denoted in USD, that determines the maximum
-value of transfers that can be emitted within a 24 hour period. . This is
+value of transfers that can be emitted within a 24 hour period. This is
 sometimes referred to as the "daily limit", though it uses a 24-hour sliding
 window rather than discrete calendar days. When the sum exceeds the limit,
 transfer will be queued.

--- a/whitepapers/0007_governor.md
+++ b/whitepapers/0007_governor.md
@@ -58,7 +58,7 @@ Each chain has a configured limit, denoted in USD, that determines the maximum
 value of transfers that can be emitted within a 24 hour period. This is
 sometimes referred to as the "daily limit", though it uses a 24-hour sliding
 window rather than discrete calendar days. When the sum exceeds the limit,
-any new small transfers the exceed the limit will be queued.
+any new small transfers that exceed the limit will be queued.
 
 The headroom for a chain is the amount left over after subtracting the current
 sum of small transfers from the chain's daily limit.

--- a/whitepapers/0007_governor.md
+++ b/whitepapers/0007_governor.md
@@ -154,6 +154,9 @@ An incoming transfer to a chain can flow cancel if all of the following conditio
 * The asset is allow-listed in the file [flow_cancel_tokens.go](https://github.com/wormhole-foundation/wormhole/blob/main/node/pkg/governor/flow_cancel_tokens.go).
 * The source (emitter) chain and the destination (target) chain are connected by a corridor.
 * The flow cancel feature is enabled by a Guardian on start.
+* The message publication containing the transfer data is not a reobservation.
+  * Reobservations could be very old and not reflect current transfer patterns.
+  * This slightly limits the effectiveness of flow cancel but makes the system much simpler to reason about.
 
 ### Effects
 

--- a/whitepapers/0007_governor.md
+++ b/whitepapers/0007_governor.md
@@ -58,7 +58,7 @@ Each chain has a configured limit, denoted in USD, that determines the maximum
 value of transfers that can be emitted within a 24 hour period. This is
 sometimes referred to as the "daily limit", though it uses a 24-hour sliding
 window rather than discrete calendar days. When the sum exceeds the limit,
-transfer will be queued.
+any new small transfers the exceed the limit will be queued.
 
 The headroom for a chain is the amount left over after subtracting the current
 sum of small transfers from the chain's daily limit.
@@ -105,7 +105,7 @@ Each Guardian publishes its Governor configuration and status on the Wormhole go
 
 The Governor is implemented as an additional package that defines 
 1. a `ChainGovernor` object
-2. `mainnet_tokens.go`, a single map of tokens that
+2. `mainnet_tokens.go`, a single map of tokens that will be monitored
 3. `mainnet_chains.go`, a map of chains governed by the chain governor
 4. `flow_cancel_tokens.go`, a map of tokens that can reduce a chain's calculated aggregate flow.
 5. `flow_cancel_corridors.go`, a list of chain ID pairs which allow flow canceling between those two chains

--- a/whitepapers/0007_governor.md
+++ b/whitepapers/0007_governor.md
@@ -192,3 +192,29 @@ Guardian operators can use the `ChainGovernorDropPendingVAA` admin RPC or `gover
 ## Potential Improvements
 
 Right now, adding more governed emitters requires modifying guardian code. In the future, it would be ideal to be able to dynamically add new contracts for guardian nodes to observe.
+
+## Security Considerations
+
+### Flow Canceling could weaken Governor protections during an exploit
+
+Enabling Flow Canceling allows more funds to exit a chain when compared with 
+running the Chain Governor without this feature enabled. In the
+context of an exploit of one of the core contracts or the RPC,
+an attacker may be able to craft a series of flow-canceling
+transfers that subvert the Governor limits.
+
+This motivates the design decision to make flow cancel functionality
+optional. If malicious activity is detected, Guardians can toggle
+the CLI flag and restart the node software in order to quickly
+disable the feature.
+
+When evaluating whether to enable flow canceling, consider:
+- Is this corridor experiencing chronic congestion?
+- Could the congestion be addressed by modifying the daily limit or big transaction limit?
+- Is the chain and its watcher considered stable?
+- Does historical transfer data show that a small number of assets represent most of the congestion?
+
+All of the above should be taken into account so that flow canceling is enabled
+for a minimal set of assets and corridors. This should mitigate some the risk
+involved with increasing the volume allowed by the Governor.
+

--- a/whitepapers/0007_governor.md
+++ b/whitepapers/0007_governor.md
@@ -47,29 +47,37 @@ If a Guardian decides to enable this feature:
 
 * A list of allow-listed chain ID pairs for flow canceling is configured in [flow_cancel_tokens.go](https://github.com/wormhole-foundation/wormhole/blob/main/node/pkg/governor/flow_cancel_corridors.go).
 
-Governor divides token-based transactions into two categories: small transactions, and large transactions.
+The Governor divides token-based transactions into two categories: small transactions and large transactions.
 
 - **Small Transactions:** Transactions smaller than the single-transaction threshold of the chain where the transfer is originating from are considered small transactions.  During any 24h sliding window, the Guardian will sign token bridge transfers in aggregate value up to the 24h threshold with no finality delay.  When small transactions exceed this limit, they will be delayed until sufficient headroom is present in the 24h sliding window. A transaction either fits or is delayed, they are not artificially split into multiple transactions. If a small transaction has been delayed for more than 24h, it will be released immediately and it will not count towards the 24h threshold.
 - **Large Transactions:** Transactions larger than the single-transaction threshold of the chain where the transfer is originating from are considered large transactions.  All large transactions have an imposed 24h finality delay before Wormhole Guardians sign them. These transactions do not affect the 24h threshold counter.
 
 #### Headroom Calculations
 
-The headroom for a given chain is the sum of the notional USD value of all
-transfers of governed tokens emitted from that chain within a 24 hour sliding
-window. Inbound transfers of certain tokens can also decrease this sum, a
-process we refer to as Flow Canceling. The tokens are listed in
+Each chain has a configured limit, denoted in USD, that determines the maximum
+value of transfers that can be emitted within a 24 hour period. . This is
+sometimes referred to as the "daily limit", though it uses a 24-hour sliding
+window rather than discrete calendar days. When the sum exceeds the limit,
+transfer will be queued.
 
-This is sometimes referred to as the "daily limit", though it uses a sliding window rather than discrete calendar days.
+The headroom for a chain is the amount left over after subtracting the current
+sum of small transfers from the chain's daily limit.
+
+Inbound transfers of certain tokens can also decrease this sum, a
+process we refer to as Flow Canceling.
 
 #### Flow Canceling
 
-Guardians can optionally enable "flow canceling". This feature allows incoming transfers to reduce the current
-"daily limit" (sum of the USD value of all small transactions within the past 24 hours). This creates additional headroom,
-allowing a greater volume of notional value to leave the chain without being delayed.
+Guardians can optionally enable "flow canceling". This feature allows incoming
+transfers to reduce the current "daily limit" (sum of the USD value of all
+small transactions within the past 24 hours). This creates additional headroom,
+allowing a greater volume of notional value to leave the chain without being
+delayed.
 
-The general idea is to allow certain transfers to offset the consumption of an outgoing "budget" that the Governor records.
-A flow cancel transfer is akin to a credit transferred into the Governor which is measured against the total debits
-of the day, 'paying off the debt', and allowing for further consumption.
+The general idea is to allow certain transfers to offset the consumption of an
+outgoing "budget" that the Governor records. A flow cancel transfer is akin to
+a credit transferred into the Governor which is measured against the total
+debits of the day, 'paying off the debt', and allowing for further consumption.
 
 
 
@@ -137,8 +145,8 @@ In this design, there are three mechanisms for enqueued messages to be published
 
 ### Flow Canceling assets and Corridors
 Only certain assets transferred between certain chains can flow cancel. This works using two allow-lists:
-* The Flow Cancel token list
-* The Flow Cancel corridors list. A corridor is a pair of two chains.
+* The Flow Cancel token list.
+* The Flow Cancel corridors list. A corridor is a pair of chain IDs.
 
 ### Criteria for flow canceling
 An incoming transfer to a chain can flow cancel if all of the following conditions are met:


### PR DESCRIPTION
A documentation PR that adds information on Flow Cancel Tokens added in https://github.com/wormhole-foundation/wormhole/pull/3798.

Please let me know if the level of detail is sufficient or if it would be better to move the text to another section.