### PR TITLE
node: Update flow cancel tokens

### DIFF
--- a/node/pkg/governor/flow_cancel_tokens.go
+++ b/node/pkg/governor/flow_cancel_tokens.go
@@ -11,10 +11,10 @@ package governor
 func FlowCancelTokenList() []tokenConfigEntry {
 	return []tokenConfigEntry{
 		// USDC variants
-		{chain: 2, addr: "000000000000000000000000bcca60bb61934080951369a648fb03df4f96263c", symbol: "aUSDC"},
+		{chain: 1, addr: "c6fa7af3bedbad3a3d65f36aabc97431b1bbe4c2d2f6e0e47ca60203452f5d61", symbol: "USDC"},
+		{chain: 2, addr: "000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", symbol: "USDC"},
 
 		// USDT variants
-		{chain: 1, addr: "b7db4e83eb727f1187bd7a50303f5b4e4e943503da8571ad6564a51131504792", symbol: ""},
 		{chain: 1, addr: "ce010e60afedb22717bd63192f54145a3f965a33bb82d2c7029eb2ce1e208264", symbol: "USDT"},
 		{chain: 2, addr: "000000000000000000000000dac17f958d2ee523a2206206994597c13d831ec7", symbol: "USDT"},
 

--- a/node/pkg/governor/governor_test.go
+++ b/node/pkg/governor/governor_test.go
@@ -188,9 +188,9 @@ func TestSumWithFlowCancelling(t *testing.T) {
 
 	// Choose a hard-coded value from the Flow Cancel Token List
 	// NOTE: Replace this Chain:Address pair if the Flow Cancel Token List is modified
-	var originChain vaa.ChainID = 2
+	var originChain vaa.ChainID = 1
 	var originAddress vaa.Address
-	originAddress, err = vaa.StringToAddress("000000000000000000000000bcca60bb61934080951369a648fb03df4f96263c")
+	originAddress, err = vaa.StringToAddress("c6fa7af3bedbad3a3d65f36aabc97431b1bbe4c2d2f6e0e47ca60203452f5d61")
 	require.NoError(t, err)
 
 	// Ensure asset is registered in the governor and can flow cancel
@@ -269,9 +269,9 @@ func TestFlowCancelCannotUnderflow(t *testing.T) {
 
 	// Set-up asset to be used in the test
 	// NOTE: Replace this Chain:Address pair if the Flow Cancel Token List is modified
-	var originChain vaa.ChainID = 2
+	var originChain vaa.ChainID = 1
 	var originAddress vaa.Address
-	originAddress, err = vaa.StringToAddress("000000000000000000000000bcca60bb61934080951369a648fb03df4f96263c")
+	originAddress, err = vaa.StringToAddress("c6fa7af3bedbad3a3d65f36aabc97431b1bbe4c2d2f6e0e47ca60203452f5d61")
 	require.NoError(t, err)
 
 	// Ensure asset is registered in the governor and can flow cancel


### PR DESCRIPTION
- Add canonical Solana and Ethereum stablecoins
- Remove Aave USDC

The original flow cancel PR had a token list that wasn't representative of the actual tokens that we want to flow cancel #3798. This PR modifies that list.

The updated token list now consists of:
- USDC originating on Ethereum and Solana
- USDT originating on Ethereum and Solana
- DAI originating on Ethereum