### PR TITLE
Deploy Gnosis Chiado Testnet

### DIFF
--- a/ethereum/env/.env.gnosis.testnet
+++ b/ethereum/env/.env.gnosis.testnet
@@ -1,9 +1,16 @@
 # Gnosis testnet read only env
 # Rename to .env to use with truffle migrations
 
+RPC_URL=https://rpc.chiadochain.net
+
 # Wormhole Core Migrations
 INIT_SIGNERS=["0x13947Bd48b18E53fdAeEe77F3473391aC727C638"]
 INIT_CHAIN_ID=25
 INIT_GOV_CHAIN_ID=0x1
 INIT_GOV_CONTRACT=0x0000000000000000000000000000000000000000000000000000000000000004
-INIT_EVM_CHAIN_ID=77
+
+# Chiado
+INIT_EVM_CHAIN_ID=10200
+
+# Sokol is deprecated as of 6/2024.
+#INIT_EVM_CHAIN_ID=77

--- a/sdk/js/src/utils/consts.ts
+++ b/sdk/js/src/utils/consts.ts
@@ -563,7 +563,7 @@ const TESTNET = {
     nft_bridge: "0x23908A62110e21C04F3A4e011d24F901F911744A",
   },
   gnosis: {
-    core: "0xE4eacc10990ba3308DdCC72d985f2a27D20c7d03",
+    core: "0xBB73cB66C26740F31d1FabDC6b7A46a038A300dd",
     token_bridge: undefined,
     nft_bridge: undefined,
   },


### PR DESCRIPTION
Re-doing read-only deploy to Gnosis Chiado testnet since Sokol is deprecated.

```
-- Wormhole Core Addresses --------------------------------------------------
| Setup address                | 0x3245D2bC406af46B56c2a2328F7734E7D4C0231e |
| Implementation address       | 0x06Bc50Cf4768929465E07199567B36Da6C74808c |
| Wormhole address             | 0xBB73cB66C26740F31d1FabDC6b7A46a038A300dd |
-----------------------------------------------------------------------------
```

Core:
https://gnosis-chiado.blockscout.com/address/0xBB73cB66C26740F31d1FabDC6b7A46a038A300dd?tab=txs

Implementation:
https://gnosis-chiado.blockscout.com/address/0x06Bc50Cf4768929465E07199567B36Da6C74808c
