### PR TITLE
Node: Processor performance improvements

### DIFF
--- a/node/pkg/db/db.go
+++ b/node/pkg/db/db.go
@@ -149,12 +149,11 @@ func (d *Database) StoreSignedVAABatch(vaaBatch []*vaa.VAA) error {
 		if err != nil {
 			return err
 		}
-
-		storedVaaTotal.Inc()
 	}
 
 	// Wait for the batch to finish.
 	err := batchTx.Flush()
+	storedVaaTotal.Add(float64(len(vaaBatch)))
 	return err
 }
 

--- a/node/pkg/db/db.go
+++ b/node/pkg/db/db.go
@@ -128,6 +128,36 @@ func (d *Database) StoreSignedVAA(v *vaa.VAA) error {
 	return nil
 }
 
+// StoreSignedVAABatch writes multiple VAAs to the database using the BadgerDB batch API.
+// Note that the API takes care of splitting up the slice into the maximum allowed count
+// and size so we don't need to worry about that.
+func (d *Database) StoreSignedVAABatch(vaaBatch []*vaa.VAA) error {
+	batchTx := d.db.NewWriteBatch()
+	defer batchTx.Cancel()
+
+	for _, v := range vaaBatch {
+		if len(v.Signatures) == 0 {
+			panic("StoreSignedVAABatch called for unsigned VAA")
+		}
+
+		b, err := v.Marshal()
+		if err != nil {
+			panic("StoreSignedVAABatch failed to marshall VAA")
+		}
+
+		err = batchTx.Set(VaaIDFromVAA(v).Bytes(), b)
+		if err != nil {
+			return err
+		}
+
+		storedVaaTotal.Inc()
+	}
+
+	// Wait for the batch to finish.
+	err := batchTx.Flush()
+	return err
+}
+
 func (d *Database) HasVAA(id VAAID) (bool, error) {
 	err := d.db.View(func(txn *badger.Txn) error {
 		_, err := txn.Get(id.Bytes())

--- a/node/pkg/db/db.go
+++ b/node/pkg/db/db.go
@@ -142,7 +142,7 @@ func (d *Database) StoreSignedVAABatch(vaaBatch []*vaa.VAA) error {
 
 		b, err := v.Marshal()
 		if err != nil {
-			panic("StoreSignedVAABatch failed to marshall VAA")
+			panic("StoreSignedVAABatch failed to marshal VAA")
 		}
 
 		err = batchTx.Set(VaaIDFromVAA(v).Bytes(), b)

--- a/node/pkg/processor/cleanup.go
+++ b/node/pkg/processor/cleanup.go
@@ -290,9 +290,9 @@ func (p *Processor) signedVaaAlreadyInDB(hash string, s *state) (bool, error) {
 					)
 				}
 				return false, nil
-			} else {
-				return false, fmt.Errorf(`failed to look up message id "%s" in db: %w`, s.ourObservation.MessageID(), err)
 			}
+
+			return false, fmt.Errorf(`failed to look up message id "%s" in db: %w`, s.ourObservation.MessageID(), err)
 		}
 
 		v, err = vaa.Unmarshal(vb)

--- a/node/pkg/processor/observation.go
+++ b/node/pkg/processor/observation.go
@@ -337,11 +337,5 @@ func (p *Processor) handleInboundSignedVAAWithQuorum(ctx context.Context, m *gos
 		)
 	}
 
-	if err := p.storeSignedVAA(v); err != nil {
-		p.logger.Error("failed to store signed VAA",
-			zap.String("message_id", v.MessageID()),
-			zap.Error(err),
-		)
-		return
-	}
+	p.storeSignedVAA(v)
 }

--- a/node/pkg/processor/observation.go
+++ b/node/pkg/processor/observation.go
@@ -337,5 +337,5 @@ func (p *Processor) handleInboundSignedVAAWithQuorum(ctx context.Context, m *gos
 		)
 	}
 
-	p.storeSignedVAA(v, "")
+	p.storeSignedVAA(v)
 }

--- a/node/pkg/processor/observation.go
+++ b/node/pkg/processor/observation.go
@@ -2,7 +2,6 @@
 package processor
 
 import (
-	"context"
 	"encoding/hex"
 	"fmt"
 	"time"
@@ -70,12 +69,13 @@ func signaturesToVaaFormat(signatures map[common.Address][]byte, gsKeys []common
 
 // handleObservation processes a remote VAA observation, verifies it, checks whether the VAA has met quorum,
 // and assembles and submits a valid VAA if possible.
-func (p *Processor) handleObservation(ctx context.Context, obs *node_common.MsgWithTimeStamp[gossipv1.SignedObservation]) {
+func (p *Processor) handleObservation(obs *node_common.MsgWithTimeStamp[gossipv1.SignedObservation]) {
 	// SECURITY: at this point, observations received from the p2p network are fully untrusted (all fields!)
 	//
 	// Note that observations are never tied to the (verified) p2p identity key - the p2p network
 	// identity is completely decoupled from the guardian identity, p2p is just transport.
 
+	start := time.Now()
 	observationsReceivedTotal.Inc()
 
 	m := obs.Msg
@@ -83,6 +83,7 @@ func (p *Processor) handleObservation(ctx context.Context, obs *node_common.MsgW
 	s := p.state.signatures[hash]
 	if s != nil && s.submitted {
 		// already submitted; ignoring additional signatures for it.
+		timeToHandleObservation.Observe(float64(time.Since(start).Microseconds()))
 		return
 	}
 
@@ -208,7 +209,16 @@ func (p *Processor) handleObservation(ctx context.Context, obs *node_common.MsgW
 	}
 
 	s.signatures[their_addr] = m.Signature
+	p.handleObservationAlreadyVerified(m, s, gs, hash)
+	timeToHandleObservation.Observe(float64(time.Since(start).Microseconds()))
+	observationTotalDelay.Observe(float64(time.Since(obs.Timestamp).Microseconds()))
+}
 
+// handleObservationAlreadyVerified handles an observation after it's validity has been confirmed. It is called both for local and external observations.
+func (p *Processor) handleObservationAlreadyVerified(m *gossipv1.SignedObservation, s *state, gs *node_common.GuardianSet, hash string) {
+	if s.submitted {
+		return
+	}
 	if s.ourObservation != nil {
 		// We have made this observation on chain!
 
@@ -246,8 +256,9 @@ func (p *Processor) handleObservation(ctx context.Context, obs *node_common.MsgW
 
 		if len(sigsVaaFormat) >= gs.Quorum() {
 			// we have reached quorum *with the active guardian set*
+			start := time.Now()
 			s.ourObservation.HandleQuorum(sigsVaaFormat, hash, p)
-			s.submitted = true
+			timeToHandleQuorum.Observe(float64(time.Since(start).Microseconds()))
 		} else {
 			if p.logger.Level().Enabled(zapcore.DebugLevel) {
 				p.logger.Debug("quorum not met, doing nothing",
@@ -264,11 +275,9 @@ func (p *Processor) handleObservation(ctx context.Context, obs *node_common.MsgW
 			)
 		}
 	}
-
-	observationTotalDelay.Observe(float64(time.Since(obs.Timestamp).Microseconds()))
 }
 
-func (p *Processor) handleInboundSignedVAAWithQuorum(ctx context.Context, m *gossipv1.SignedVAAWithQuorum) {
+func (p *Processor) handleInboundSignedVAAWithQuorum(m *gossipv1.SignedVAAWithQuorum) {
 	v, err := vaa.Unmarshal(m.Vaa)
 	if err != nil {
 		p.logger.Warn("received invalid VAA in SignedVAAWithQuorum message",

--- a/node/pkg/processor/observation.go
+++ b/node/pkg/processor/observation.go
@@ -209,14 +209,7 @@ func (p *Processor) handleObservation(ctx context.Context, obs *node_common.MsgW
 
 	s.signatures[their_addr] = m.Signature
 
-	if s.submitted {
-		if p.logger.Level().Enabled(zapcore.DebugLevel) {
-			p.logger.Debug("already submitted, doing nothing",
-				zap.String("messageId", m.MessageId),
-				zap.String("digest", hash),
-			)
-		}
-	} else if s.ourObservation != nil {
+	if s.ourObservation != nil {
 		// We have made this observation on chain!
 
 		// Check if we have more signatures than required for quorum.

--- a/node/pkg/processor/observation.go
+++ b/node/pkg/processor/observation.go
@@ -254,6 +254,7 @@ func (p *Processor) handleObservation(ctx context.Context, obs *node_common.MsgW
 		if len(sigsVaaFormat) >= gs.Quorum() {
 			// we have reached quorum *with the active guardian set*
 			s.ourObservation.HandleQuorum(sigsVaaFormat, hash, p)
+			s.submitted = true
 		} else {
 			if p.logger.Level().Enabled(zapcore.DebugLevel) {
 				p.logger.Debug("quorum not met, doing nothing",

--- a/node/pkg/processor/observation.go
+++ b/node/pkg/processor/observation.go
@@ -337,5 +337,5 @@ func (p *Processor) handleInboundSignedVAAWithQuorum(ctx context.Context, m *gos
 		)
 	}
 
-	p.storeSignedVAA(v)
+	p.storeSignedVAA(v, "")
 }

--- a/node/pkg/processor/observation_test.go
+++ b/node/pkg/processor/observation_test.go
@@ -1,7 +1,6 @@
 package processor
 
 import (
-	"context"
 	"crypto/ecdsa"
 	"crypto/rand"
 	"testing"
@@ -45,12 +44,11 @@ func TestHandleInboundSignedVAAWithQuorum_NilGuardianSet(t *testing.T) {
 	observedZapCore, observedLogs := observer.New(zap.InfoLevel)
 	observedLogger := zap.New(observedZapCore)
 
-	ctx := context.Background()
 	signedVAAWithQuorum := &gossipv1.SignedVAAWithQuorum{Vaa: marshalVAA}
 	processor := Processor{}
 	processor.logger = observedLogger
 
-	processor.handleInboundSignedVAAWithQuorum(ctx, signedVAAWithQuorum)
+	processor.handleInboundSignedVAAWithQuorum(signedVAAWithQuorum)
 
 	// Check to see if we got an error, which we should have,
 	// because a `gs` is not defined on processor
@@ -108,13 +106,12 @@ func TestHandleInboundSignedVAAWithQuorum(t *testing.T) {
 			observedZapCore, observedLogs := observer.New(zap.InfoLevel)
 			observedLogger := zap.New(observedZapCore)
 
-			ctx := context.Background()
 			signedVAAWithQuorum := &gossipv1.SignedVAAWithQuorum{Vaa: marshalVAA}
 			processor := Processor{}
 			processor.gs = &guardianSet
 			processor.logger = observedLogger
 
-			processor.handleInboundSignedVAAWithQuorum(ctx, signedVAAWithQuorum)
+			processor.handleInboundSignedVAAWithQuorum(signedVAAWithQuorum)
 
 			// Check to see if we got an error, which we should have
 			assert.Equal(t, 1, observedLogs.Len())

--- a/node/pkg/processor/processor.go
+++ b/node/pkg/processor/processor.go
@@ -141,7 +141,14 @@ type Processor struct {
 	pythnetVaas    map[string]PythNetVaaEntry
 	gatewayRelayer *gwrelayer.GatewayRelayer
 	updateVAALock  sync.Mutex
-	updatedVAAs    map[string]*vaa.VAA
+	updatedVAAs    map[string]*updateVaaEntry
+}
+
+// updateVaaEntry is used to queue up a VAA to be written to the database.
+type updateVaaEntry struct {
+	v         *vaa.VAA
+	hashToLog string
+	dirty     bool
 }
 
 var (
@@ -196,7 +203,7 @@ func NewProcessor(
 		acctReadC:      acctReadC,
 		pythnetVaas:    make(map[string]PythNetVaaEntry),
 		gatewayRelayer: gatewayRelayer,
-		updatedVAAs:    make(map[string]*vaa.VAA),
+		updatedVAAs:    make(map[string]*updateVaaEntry),
 	}
 }
 
@@ -301,7 +308,7 @@ func (p *Processor) Run(ctx context.Context) error {
 	}
 }
 
-func (p *Processor) storeSignedVAA(v *vaa.VAA) {
+func (p *Processor) storeSignedVAA(v *vaa.VAA, hash string) {
 	if v.EmitterChain == vaa.ChainIDPythNet {
 		key := fmt.Sprintf("%v/%v", v.EmitterAddress, v.Sequence)
 		p.pythnetVaas[key] = PythNetVaaEntry{v: v, updateTime: time.Now()}
@@ -309,7 +316,7 @@ func (p *Processor) storeSignedVAA(v *vaa.VAA) {
 	}
 	key := fmt.Sprintf("%d/%v/%v", v.EmitterChain, v.EmitterAddress, v.Sequence)
 	p.updateVAALock.Lock()
-	p.updatedVAAs[key] = v
+	p.updatedVAAs[key] = &updateVaaEntry{v: v, hashToLog: hash, dirty: true}
 	p.updateVAALock.Unlock()
 }
 
@@ -345,16 +352,23 @@ func (p *Processor) haveSignedVAA(id db.VAAID) bool {
 	return ok
 }
 
+// getVaaFromUpdateMap gets the VAA from the local map. If it's not there, it returns nil.
 func (p *Processor) getVaaFromUpdateMap(key string) *vaa.VAA {
 	p.updateVAALock.Lock()
-	v, exists := p.updatedVAAs[key]
+	entry, exists := p.updatedVAAs[key]
 	p.updateVAALock.Unlock()
 	if !exists {
 		return nil
 	}
-	return v
+	return entry.v
 }
 
+// vaaWriter is the routine that writes VAAs to the database once per minute. It creates a local copy of the map
+// being used by the processor to reduce lock contention. It uses a dirty flag to handle the case where the VAA
+// gets updated again while we are in the process of writing it to the database.
+//
+// This routine also handles writing the "signed VAA with quorum" info log, since doing that inline can take more
+// than a millisecond.
 func (p *Processor) vaaWriter(ctx context.Context) error {
 	ticker := time.NewTicker(time.Second)
 	for {
@@ -362,16 +376,40 @@ func (p *Processor) vaaWriter(ctx context.Context) error {
 		case <-ctx.Done():
 			return nil
 		case <-ticker.C:
+			var updatedVAAs map[string]*updateVaaEntry
 			p.updateVAALock.Lock()
-			updatedVAAs := p.updatedVAAs
-			p.updatedVAAs = make(map[string]*vaa.VAA)
+			if len(p.updatedVAAs) != 0 {
+				// There's something to write. Create a local copy of the map so we can release the lock.
+				updatedVAAs = make(map[string]*updateVaaEntry)
+				for key, entry := range p.updatedVAAs {
+					updatedVAAs[key] = entry
+					entry.dirty = false
+				}
+			}
 			p.updateVAALock.Unlock()
-			if len(updatedVAAs) != 0 {
-				for _, v := range updatedVAAs {
-					if err := p.db.StoreSignedVAA(v); err != nil {
+			if updatedVAAs != nil {
+				// If there's anything to write, do that.
+				for _, entry := range updatedVAAs {
+					if err := p.db.StoreSignedVAA(entry.v); err != nil {
 						p.logger.Error("failed to write VAA to database", zap.Error(err))
 					}
+					if entry.hashToLog != "" {
+						p.logger.Info("signed VAA with quorum",
+							zap.String("message_id", entry.v.MessageID()),
+							zap.String("digest", entry.hashToLog),
+						)
+					}
 				}
+
+				// Go through the map and delete anything we have written that hasn't been updated again.
+				// If something has been updated again, it will get written next interval.
+				p.updateVAALock.Lock()
+				for key, entry := range p.updatedVAAs {
+					if !entry.dirty {
+						delete(p.updatedVAAs, key)
+					}
+				}
+				p.updateVAALock.Unlock()
 			}
 		}
 	}

--- a/node/pkg/processor/processor.go
+++ b/node/pkg/processor/processor.go
@@ -164,6 +164,20 @@ var (
 			Help:    "Latency histogram for total time to process signed observations",
 			Buckets: []float64{10.0, 20.0, 50.0, 100.0, 1000.0, 5000.0, 10_000.0, 100_000.0, 1_000_000.0, 10_000_000.0, 100_000_000.0, 1_000_000_000.0},
 		})
+
+	timeToHandleObservation = promauto.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "wormhole_time_to_handle_observation_us",
+			Help:    "Latency histogram for total time to handle observation on an observation",
+			Buckets: []float64{10.0, 20.0, 50.0, 100.0, 1000.0, 5000.0, 10_000.0, 100_000.0, 1_000_000.0, 10_000_000.0, 100_000_000.0, 1_000_000_000.0},
+		})
+
+	timeToHandleQuorum = promauto.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "wormhole_time_to_handle_quorum_us",
+			Help:    "Latency histogram for total time to handle quorum on an observation",
+			Buckets: []float64{10.0, 20.0, 50.0, 100.0, 1000.0, 5000.0, 10_000.0, 100_000.0, 1_000_000.0, 10_000_000.0, 100_000_000.0, 1_000_000_000.0},
+		})
 )
 
 func NewProcessor(
@@ -268,9 +282,9 @@ func (p *Processor) Run(ctx context.Context) error {
 			p.handleMessage(k)
 		case m := <-p.obsvC:
 			observationChanDelay.Observe(float64(time.Since(m.Timestamp).Microseconds()))
-			p.handleObservation(ctx, m)
+			p.handleObservation(m)
 		case m := <-p.signedInC:
-			p.handleInboundSignedVAAWithQuorum(ctx, m)
+			p.handleInboundSignedVAAWithQuorum(m)
 		case <-cleanup.C:
 			p.handleCleanup(ctx)
 		case <-govTimer.C:

--- a/node/pkg/processor/vaa.go
+++ b/node/pkg/processor/vaa.go
@@ -2,7 +2,6 @@ package processor
 
 import (
 	"github.com/wormhole-foundation/wormhole/sdk/vaa"
-	"go.uber.org/zap"
 )
 
 type VAA struct {
@@ -26,13 +25,7 @@ func (v *VAA) HandleQuorum(sigs []*vaa.Signature, hash string, p *Processor) {
 		ConsistencyLevel: v.ConsistencyLevel,
 	}
 
-	// Store signed VAA in database.
-	p.logger.Info("signed VAA with quorum",
-		zap.String("message_id", signed.MessageID()),
-		zap.String("digest", hash),
-	)
-
-	p.storeSignedVAA(signed)
+	p.storeSignedVAA(signed, hash)
 	p.broadcastSignedVAA(signed)
 	p.state.signatures[hash].submitted = true
 }

--- a/node/pkg/processor/vaa.go
+++ b/node/pkg/processor/vaa.go
@@ -25,8 +25,7 @@ func (v *VAA) HandleQuorum(sigs []*vaa.Signature, hash string, p *Processor) {
 		ConsistencyLevel: v.ConsistencyLevel,
 	}
 
-	p.storeSignedVAA(signed, hash)
-	p.broadcastSignedVAA(signed)
+	p.postSignedVAA(signed, hash)
 	p.state.signatures[hash].submitted = true
 }
 

--- a/node/pkg/processor/vaa.go
+++ b/node/pkg/processor/vaa.go
@@ -11,6 +11,7 @@ type VAA struct {
 	Reobservation bool
 }
 
+// HandleQuorum is called when a VAA reaches quorum. It publishes the VAA to the gossip network and stores it in the database.
 func (v *VAA) HandleQuorum(sigs []*vaa.Signature, hash string, p *Processor) {
 	// Deep copy the observation and add signatures
 	signed := &vaa.VAA{
@@ -26,12 +27,12 @@ func (v *VAA) HandleQuorum(sigs []*vaa.Signature, hash string, p *Processor) {
 		ConsistencyLevel: v.ConsistencyLevel,
 	}
 
-	// Store signed VAA in database.
 	p.logger.Info("signed VAA with quorum",
 		zap.String("message_id", signed.MessageID()),
 		zap.String("digest", hash),
 	)
 
+	// Broadcast the VAA and store it in the database.
 	p.broadcastSignedVAA(signed)
 	p.storeSignedVAA(signed)
 }

--- a/node/pkg/processor/vaa.go
+++ b/node/pkg/processor/vaa.go
@@ -26,7 +26,6 @@ func (v *VAA) HandleQuorum(sigs []*vaa.Signature, hash string, p *Processor) {
 	}
 
 	p.postSignedVAA(signed, hash)
-	p.state.signatures[hash].submitted = true
 }
 
 func (v *VAA) IsReliable() bool {

--- a/node/pkg/processor/vaa.go
+++ b/node/pkg/processor/vaa.go
@@ -32,14 +32,7 @@ func (v *VAA) HandleQuorum(sigs []*vaa.Signature, hash string, p *Processor) {
 		zap.String("digest", hash),
 	)
 
-	if err := p.storeSignedVAA(signed); err != nil {
-		p.logger.Error("failed to store signed VAA",
-			zap.String("message_id", signed.MessageID()),
-			zap.String("digest", hash),
-			zap.Error(err),
-		)
-	}
-
+	p.storeSignedVAA(signed)
 	p.broadcastSignedVAA(signed)
 	p.state.signatures[hash].submitted = true
 }

--- a/node/pkg/processor/vaa.go
+++ b/node/pkg/processor/vaa.go
@@ -2,6 +2,7 @@ package processor
 
 import (
 	"github.com/wormhole-foundation/wormhole/sdk/vaa"
+	"go.uber.org/zap"
 )
 
 type VAA struct {
@@ -25,7 +26,14 @@ func (v *VAA) HandleQuorum(sigs []*vaa.Signature, hash string, p *Processor) {
 		ConsistencyLevel: v.ConsistencyLevel,
 	}
 
-	p.postSignedVAA(signed, hash)
+	// Store signed VAA in database.
+	p.logger.Info("signed VAA with quorum",
+		zap.String("message_id", signed.MessageID()),
+		zap.String("digest", hash),
+	)
+
+	p.broadcastSignedVAA(signed)
+	p.storeSignedVAA(signed)
 }
 
 func (v *VAA) IsReliable() bool {


### PR DESCRIPTION
This PR contains a number of small performance improvements to the processor.

- Writes to the badger DB on a separate go routine. 
- Adds the ability to write multiple VAAs using the BadgerDB batch API.
- Speeds up processing of local observations.
- Adds some measurements to monitor the time to handle observations and quorum.
- Removes some unnecessary map look ups.
- Removes unnecessary debugging code.
