### PR TITLE
node: Fix bug in flow cancel mechanism where the wrong values were being used for tokenEntry

### DIFF
--- a/node/pkg/governor/governor.go
+++ b/node/pkg/governor/governor.go
@@ -571,7 +571,8 @@ func (gov *ChainGovernor) ProcessMsgForTime(msg *common.MessagePublication, now 
 	emitterChainEntry.transfers = append(emitterChainEntry.transfers, transfer)
 
 	// Add inverse transfer to destination chain entry if this asset can cancel flows.
-	key := tokenKey{chain: msg.EmitterChain, addr: msg.EmitterAddress}
+	key := tokenKey{chain: token.token.chain, addr: token.token.addr}
+
 	tokenEntry := gov.tokens[key]
 	if tokenEntry != nil {
 		// Mandatory check to ensure that the token should be able to reduce the Governor limit.

--- a/node/pkg/governor/governor.go
+++ b/node/pkg/governor/governor.go
@@ -390,6 +390,10 @@ func (gov *ChainGovernor) ProcessMsg(msg *common.MessagePublication) bool {
 }
 
 // ProcessMsgForTime handles an incoming message (transfer) and registers it in the chain entries for the Governor.
+// Returns true if:
+// - the message is not governed
+// - the transfer is complete and has already been observed
+// - the transfer does not trigger any error conditions (happy path)
 // Validation:
 // - ensure MessagePublication is not nil
 // - check that the MessagePublication is governed

--- a/node/pkg/governor/governor_test.go
+++ b/node/pkg/governor/governor_test.go
@@ -824,13 +824,14 @@ func TestFlowCancelProcessMsgForTimeFullCancel(t *testing.T) {
 	recipientEthereum := "0x707f9118e33a9b8998bea41dd0d46f38bb963fc8" //nolint:gosec
 
 	// Data for Sui
-	tokenBridgeAddrStrSui := "0xc57508ee0d4595e5a8728974a4a93a787d38f339757230d441e895422c07aba9"
+	tokenBridgeAddrStrSui := "0xc57508ee0d4595e5a8728974a4a93a787d38f339757230d441e895422c07aba9" //nolint:gosec
 	tokenBridgeAddrSui, err := vaa.StringToAddress(tokenBridgeAddrStrSui)
 	require.NoError(t, err)
 	recipientSui := "0x84a5f374d29fc77e370014dce4fd6a55b58ad608de8074b0be5571701724da31"
 
 	// Data for Solana. Only used to represent the flow cancel asset.
-	tokenBridgeAddrStrSolana := "0x0e0a589e6488147a94dcfa592b90fdd41152bb2ca77bf6016758a6f4df9d21b4" // "wormDTUJ6AWPNvk59vGQbDvGJmqbDTdgWgAqcLBCgUb"
+	// "wormDTUJ6AWPNvk59vGQbDvGJmqbDTdgWgAqcLBCgUb"
+	tokenBridgeAddrStrSolana := "0x0e0a589e6488147a94dcfa592b90fdd41152bb2ca77bf6016758a6f4df9d21b4" //nolint:gosec
 
 	// Add chain entries to `gov`
 	err = gov.setChainForTesting(vaa.ChainIDEthereum, tokenBridgeAddrStrEthereum, 10000, 0)
@@ -1062,10 +1063,10 @@ func TestFlowCancelProcessMsgForTimePartialCancel(t *testing.T) {
 	recipientEthereum := "0x707f9118e33a9b8998bea41dd0d46f38bb963fc8" //nolint:gosec
 
 	// Data for Sui
-	tokenBridgeAddrStrSui := "0xc57508ee0d4595e5a8728974a4a93a787d38f339757230d441e895422c07aba9"
+	tokenBridgeAddrStrSui := "0xc57508ee0d4595e5a8728974a4a93a787d38f339757230d441e895422c07aba9" //nolint:gosec
 	tokenBridgeAddrSui, err := vaa.StringToAddress(tokenBridgeAddrStrSui)
 	require.NoError(t, err)
-	recipientSui := "0x84a5f374d29fc77e370014dce4fd6a55b58ad608de8074b0be5571701724da31"
+	recipientSui := "0x84a5f374d29fc77e370014dce4fd6a55b58ad608de8074b0be5571701724da31" //nolint:gosec
 
 	// Add chain entries to `gov`
 	err = gov.setChainForTesting(vaa.ChainIDEthereum, tokenBridgeAddrStrEthereum, 10000, 0)
@@ -1177,6 +1178,7 @@ func TestFlowCancelProcessMsgForTimePartialCancel(t *testing.T) {
 	sumSui, suiTransfers, err = gov.TrimAndSumValue(chainEntrySui.transfers, time.Unix(int64(transferTime.Unix()-1000), 0))
 	assert.Equal(t, 1, len(suiTransfers)) // A single NEGATIVE transfer
 	assert.Equal(t, int64(-5000), sumSui) // Ensure the inverse (negative) transfer is in the Sui chain Entry
+	require.NoError(t, err)
 	suiGovernorUsage, err := gov.TrimAndSumValueForChain(chainEntrySui, time.Unix(int64(transferTime.Unix()-1000), 0))
 	assert.Zero(t, suiGovernorUsage) // Actual governor usage must not be negative.
 	require.NoError(t, err)

--- a/node/pkg/governor/governor_test.go
+++ b/node/pkg/governor/governor_test.go
@@ -926,10 +926,14 @@ func TestFlowCancelProcessMsgForTime(t *testing.T) {
 	assert.Equal(t, int(1), len(ethTransfers))
 	require.NoError(t, err)
 
-	// Outbound check
+	// Outbound check: 
+	// - ensure that the sum of the transfers is equal to the value of the inverse transfer
+	// - ensure the actual governor usage is Zero (any negative value is converted to zero by TrimAndSumValueForChain)
 	sumSui, suiTransfers, err = gov.TrimAndSumValue(chainEntrySui.transfers, time.Unix(int64(transferTime.Unix()-1000), 0))
 	assert.Equal(t, 1, len(suiTransfers)) // A single NEGATIVE transfer
 	assert.Equal(t, int64(-5000), sumSui) // Ensure the inverse (negative) transfer is in the Sui chain Entry
+	suiGovernorUsage, err := gov.TrimAndSumValueForChain(chainEntrySui, time.Unix(int64(transferTime.Unix()-1000), 0))
+	assert.Zero(t, suiGovernorUsage) // Actual governor usage must not be negative.
 	require.NoError(t, err)
 
 	// Perform a SECOND transfer (Sui --> Ethereum)


### PR DESCRIPTION
There was an issue in the flow cancel mechanism. Tokens were not being indexed correctly (using token Origin and token address) so the logic for cancelling transactions was never triggered.

This got through due to a gap in unit test coverage in #3798. The issue is in the function `ProcessMsgForTime` and while the small component functions were tested, this function was not.

This PR makes the following changes:
- Indexes the tokenEntry for flow cancel tokens properly (using the
  token's origin chain and origin address)
- Adds many more tests and assertions to check flow cancel logic in more detail and at
  the resolution of the ProcessMsgForTime method.

Big thanks to @mdulin2 for helping to debug the issue and the unit tests.