### PR TITLE
node/hack: Update Sui RPC endpoint

### DIFF
--- a/node/hack/governor/src/index.ts
+++ b/node/hack/governor/src/index.ts
@@ -137,7 +137,7 @@ axios
                     const provider = new JsonRpcProvider(
                       new Connection({
                         // fullnode: "https://fullnode.mainnet.sui.io",
-                        fullnode: "https://sui-mainnet-rpc.allthatnode.com",
+                        fullnode: "https://sui-mainnet.g.allthatnode.com/full/json_rpc",
                       })
                     );
                     const result = await getOriginalAssetSui(


### PR DESCRIPTION
The endpoint address for Sui appears to have been changed: https://www.allthatnode.com/sui.dsrv

Previous URL was failing with:

```
FetchError: request to https://sui-mainnet-rpc.allthatnode.com/ failed, reason: getaddrinfo ENOTFOUND sui-mainnet-rpc.allthatnode.com
    at ClientRequest.<anonymous> (/Users/dirk/code/wormhole/node/hack/governor/node_modules/node-fetch/lib/index.js:1491:11)
    at ClientRequest.emit (node:events:517:28)
    at TLSSocket.socketErrorListener (node:_http_client:501:9)
    at TLSSocket.emit (node:events:517:28)
    at emitErrorNT (node:internal/streams/destroy:151:8)
    at emitErrorCloseNT (node:internal/streams/destroy:116:3)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
  type: 'system',
  errno: 'ENOTFOUND',
  code: 'ENOTFOUND'
}
```

when trying to run the token update script.