### PR TITLE
Node/EVM: Add more cases to canRetryGetBlockTime

### DIFF
--- a/node/pkg/watchers/evm/watcher.go
+++ b/node/pkg/watchers/evm/watcher.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
-	ethereum "github.com/ethereum/go-ethereum"
 	eth_common "github.com/ethereum/go-ethereum/common"
 	eth_hexutil "github.com/ethereum/go-ethereum/common/hexutil"
 	"go.uber.org/zap"
@@ -895,9 +894,19 @@ func (w *Watcher) postMessage(logger *zap.Logger, ev *ethabi.AbiLogMessagePublis
 	w.pendingMu.Unlock()
 }
 
+// blockNotFoundErrors is used by `canRetryGetBlockTime`. It is a map of the error returns from `getBlockTime` that can trigger a retry.
+var blockNotFoundErrors = map[string]struct{}{
+	"not found":                     {},
+	"Unknown block":                 {},
+	"cannot query unfinalized data": {}, // Seen on Avalanche
+}
+
 // canRetryGetBlockTime returns true if the error returned by getBlockTime warrants doing a retry.
 func canRetryGetBlockTime(err error) bool {
-	return err == ethereum.NotFound /* go-ethereum */ || err.Error() == "cannot query unfinalized data" /* avalanche */
+	if _, exists := blockNotFoundErrors[err.Error()]; exists {
+		return true
+	}
+	return false
 }
 
 // waitForBlockTime is a go routine that repeatedly attempts to read the block time for a single log event. It is used when the initial attempt to read

--- a/node/pkg/watchers/evm/watcher.go
+++ b/node/pkg/watchers/evm/watcher.go
@@ -903,10 +903,8 @@ var blockNotFoundErrors = map[string]struct{}{
 
 // canRetryGetBlockTime returns true if the error returned by getBlockTime warrants doing a retry.
 func canRetryGetBlockTime(err error) bool {
-	if _, exists := blockNotFoundErrors[err.Error()]; exists {
-		return true
-	}
-	return false
+	_, exists := blockNotFoundErrors[err.Error()]
+	return exists
 }
 
 // waitForBlockTime is a go routine that repeatedly attempts to read the block time for a single log event. It is used when the initial attempt to read

--- a/node/pkg/watchers/evm/watcher_test.go
+++ b/node/pkg/watchers/evm/watcher_test.go
@@ -2,9 +2,11 @@ package evm
 
 import (
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/certusone/wormhole/node/pkg/watchers/evm/connectors/ethabi"
+	ethereum "github.com/ethereum/go-ethereum"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wormhole-foundation/wormhole/sdk/vaa"
@@ -39,4 +41,12 @@ func TestMsgIdFromLogEvent(t *testing.T) {
 	require.NoError(t, err)
 	msgId := msgIdFromLogEvent(vaa.ChainIDSepolia, &ev)
 	assert.Equal(t, "10002/00000000000000000000000045c140dd2526e4bfd1c2a5bb0aa6aa1db00b1744/3685", msgId)
+}
+
+func Test_canRetryGetBlockTime(t *testing.T) {
+	assert.True(t, canRetryGetBlockTime(ethereum.NotFound))
+	assert.True(t, canRetryGetBlockTime(errors.New("not found")))
+	assert.True(t, canRetryGetBlockTime(errors.New("Unknown block")))
+	assert.True(t, canRetryGetBlockTime(errors.New("cannot query unfinalized data")))
+	assert.False(t, canRetryGetBlockTime(errors.New("Hello, World!")))
 }


### PR DESCRIPTION
Noticed a few additional error returns in the log that we could retry on.