### PR TITLE
Deploy Berachain V2 testnet

### DIFF
--- a/clients/js/src/consts/networks.ts
+++ b/clients/js/src/consts/networks.ts
@@ -418,9 +418,9 @@ const TESTNET = {
     chain_id: 59141,
   },
   berachain: {
-    rpc: "https://artio.rpc.berachain.com/",
+    rpc: "https://bartio.rpc.berachain.com/",
     key: getEnvVar("ETH_KEY_TESTNET"),
-    chain_id: 80085,
+    chain_id: 80084,
   },
   seievm: {
     rpc: "https://evm-rpc-arctic-1.sei-apis.com/",

--- a/ethereum/env/.env.berachain.testnet
+++ b/ethereum/env/.env.berachain.testnet
@@ -2,19 +2,20 @@
 # ethereum$ ln -s env/.env.berachain.testnet .env
 
 # Common config for forge deployment
-RPC_URL=https://artio.rpc.berachain.com/
+RPC_URL=https://bartio.rpc.berachain.com/
+FORGE_ARGS="--legacy"
 
 # Wormhole Core Migrations
 INIT_SIGNERS=["0x13947Bd48b18E53fdAeEe77F3473391aC727C638"]
 INIT_CHAIN_ID=39
 INIT_GOV_CHAIN_ID=0x1
 INIT_GOV_CONTRACT=0x0000000000000000000000000000000000000000000000000000000000000004
-INIT_EVM_CHAIN_ID=80085
+INIT_EVM_CHAIN_ID=80084
 
 # Bridge Migrations
 BRIDGE_INIT_CHAIN_ID=39
 BRIDGE_INIT_GOV_CHAIN_ID=0x1
 BRIDGE_INIT_GOV_CONTRACT=0x0000000000000000000000000000000000000000000000000000000000000004
-# Wrapped BERA: https://docs.berachain.com/developers/precompile-addresses#deployment-addresses
-BRIDGE_INIT_WETH=0x5806E416dA447b267cEA759358cF22Cc41FAE80F
+# Wrapped BERA: https://docs.berachain.com/developers/deployed-contracts#deployment-contract-addresses
+BRIDGE_INIT_WETH=0x7507c1dc16935B82698e4C63f2746A2fCf994dF8
 BRIDGE_INIT_FINALITY=1


### PR DESCRIPTION
We originally deployed to Berachain testnet in April 2024.

Recently Berachain deprecated V1 (Artio) in favor of V2 (bArtio).

Although we deployed the contracts and updated the SDK, it was never actually enabled in testnet, so no integrators ever used it. For that reason, we are able to use the same chain ID as before.

Additionally, when the contracts were deployed to the new network, the addresses were the same, so the SDK does not need to be updated.

This PR makes the couple of minor changes needed to reflect the new deployment.

The core is deployed [here](https://bartio.beratrail.io/address/0xBB73cB66C26740F31d1FabDC6b7A46a038A300dd/contract/80084/code), the token bridge is deployed [here](https://bartio.beratrail.io/address/0xa10f2eF61dE1f19f586ab8B6F2EbA89bACE63F7a/contract/80084/code) and the WETH (WBERA) is deployed [here](https://bartio.beratrail.io/token/0x7507c1dc16935B82698e4C63f2746A2fCf994dF8?chainid=80084).
