### PR TITLE
node: Fix lint violation in hack/repair_eth/repair_eth.go

### DIFF
--- a/node/hack/repair_eth/repair_eth.go
+++ b/node/hack/repair_eth/repair_eth.go
@@ -366,7 +366,10 @@ func main() {
 	// Press enter to continue if not in dryRun mode
 	if !*dryRun {
 		fmt.Println("Press enter to continue")
-		fmt.Scanln()
+		_, err := fmt.Scanln()
+		if err != nil {
+			log.Printf("Scanln error: %s\n", err)
+		}
 	}
 
 	log.Printf("finding sequences")


### PR DESCRIPTION
Fix error flagged by `errcheck` via `golangci-lint` 