### PR TITLE
Add coin gecko pro API usage for the governor

### DIFF
--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -245,6 +245,7 @@ var (
 
 	chainGovernorEnabled      *bool
 	governorFlowCancelEnabled *bool
+	coinGeckoApiKey           *string
 
 	ccqEnabled           *bool
 	ccqAllowedRequesters *string
@@ -462,6 +463,7 @@ func init() {
 
 	chainGovernorEnabled = NodeCmd.Flags().Bool("chainGovernorEnabled", false, "Run the chain governor")
 	governorFlowCancelEnabled = NodeCmd.Flags().Bool("governorFlowCancelEnabled", false, "Enable flow cancel on the governor")
+	coinGeckoApiKey = NodeCmd.Flags().String("coinGeckoApiKey", "", "Coin gecko pro API key. Defaults to off via no API key")
 
 	ccqEnabled = NodeCmd.Flags().Bool("ccqEnabled", false, "Enable cross chain query support")
 	ccqAllowedRequesters = NodeCmd.Flags().String("ccqAllowedRequesters", "", "Comma separated list of signers allowed to submit cross chain queries")
@@ -866,6 +868,10 @@ func runNode(cmd *cobra.Command, args []string) {
 
 	if !argsConsistent([]string{*gatewayContract, *gatewayWS, *gatewayLCD}) {
 		logger.Fatal("Either --gatewayContract, --gatewayWS and --gatewayLCD must all be set or all unset")
+	}
+
+	if !*chainGovernorEnabled && *coinGeckoApiKey != "" {
+		logger.Fatal("If coinGeckoApiKey is set, then chainGovernorEnabled must be set")
 	}
 
 	var publicRpcLogDetail common.GrpcLogDetail
@@ -1673,7 +1679,7 @@ func runNode(cmd *cobra.Command, args []string) {
 		node.GuardianOptionDatabase(db),
 		node.GuardianOptionWatchers(watcherConfigs, ibcWatcherConfig),
 		node.GuardianOptionAccountant(*accountantWS, *accountantContract, *accountantCheckEnabled, accountantWormchainConn, *accountantNttContract, accountantNttWormchainConn),
-		node.GuardianOptionGovernor(*chainGovernorEnabled, *governorFlowCancelEnabled),
+		node.GuardianOptionGovernor(*chainGovernorEnabled, *governorFlowCancelEnabled, *coinGeckoApiKey),
 		node.GuardianOptionGatewayRelayer(*gatewayRelayerContract, gatewayRelayerWormchainConn),
 		node.GuardianOptionQueryHandler(*ccqEnabled, *ccqAllowedRequesters),
 		node.GuardianOptionAdminService(*adminSocketPath, ethRPC, ethContract, rpcMap),

--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -463,7 +463,7 @@ func init() {
 
 	chainGovernorEnabled = NodeCmd.Flags().Bool("chainGovernorEnabled", false, "Run the chain governor")
 	governorFlowCancelEnabled = NodeCmd.Flags().Bool("governorFlowCancelEnabled", false, "Enable flow cancel on the governor")
-	coinGeckoApiKey = NodeCmd.Flags().String("coinGeckoApiKey", "", "Coin gecko pro API key. Defaults to off via no API key")
+	coinGeckoApiKey = NodeCmd.Flags().String("coinGeckoApiKey", "", "CoinGecko Pro API key. If no API key is provided, CoinGecko requests may be throttled or blocked.")
 
 	ccqEnabled = NodeCmd.Flags().Bool("ccqEnabled", false, "Enable cross chain query support")
 	ccqAllowedRequesters = NodeCmd.Flags().String("ccqAllowedRequesters", "", "Comma separated list of signers allowed to submit cross chain queries")

--- a/node/pkg/adminrpc/adminserver_test.go
+++ b/node/pkg/adminrpc/adminserver_test.go
@@ -335,7 +335,7 @@ func Test_adminCommands(t *testing.T) {
 }
 
 func newNodePrivilegedServiceForGovernorTests() *nodePrivilegedService {
-	gov := governor.NewChainGovernor(zap.NewNop(), &db.MockGovernorDB{}, wh_common.GoTest, false)
+	gov := governor.NewChainGovernor(zap.NewNop(), &db.MockGovernorDB{}, wh_common.GoTest, false, "")
 
 	return &nodePrivilegedService{
 		db:              nil,

--- a/node/pkg/governor/governor.go
+++ b/node/pkg/governor/governor.go
@@ -211,7 +211,6 @@ func NewChainGovernor(
 	flowCancelEnabled bool,
 	coinGeckoApiKey string,
 ) *ChainGovernor {
-
 	return &ChainGovernor{
 		db:                  db,
 		logger:              logger.With(zap.String("component", "cgov")),

--- a/node/pkg/governor/governor.go
+++ b/node/pkg/governor/governor.go
@@ -211,6 +211,7 @@ func NewChainGovernor(
 	flowCancelEnabled bool,
 	coinGeckoApiKey string,
 ) *ChainGovernor {
+
 	return &ChainGovernor{
 		db:                  db,
 		logger:              logger.With(zap.String("component", "cgov")),

--- a/node/pkg/governor/governor.go
+++ b/node/pkg/governor/governor.go
@@ -201,6 +201,7 @@ type ChainGovernor struct {
 	statusPublishCounter  int64
 	configPublishCounter  int64
 	flowCancelEnabled     bool
+	coinGeckoApiKey       string
 }
 
 func NewChainGovernor(
@@ -208,7 +209,9 @@ func NewChainGovernor(
 	db db.GovernorDB,
 	env common.Environment,
 	flowCancelEnabled bool,
+	coinGeckoApiKey string,
 ) *ChainGovernor {
+
 	return &ChainGovernor{
 		db:                  db,
 		logger:              logger.With(zap.String("component", "cgov")),
@@ -218,6 +221,7 @@ func NewChainGovernor(
 		msgsSeen:            make(map[string]bool),
 		env:                 env,
 		flowCancelEnabled:   flowCancelEnabled,
+		coinGeckoApiKey:     coinGeckoApiKey,
 	}
 }
 

--- a/node/pkg/governor/governor_monitoring_test.go
+++ b/node/pkg/governor/governor_monitoring_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestIsVAAEnqueuedNilMessageID(t *testing.T) {
 	logger, _ := zap.NewProduction()
-	gov := NewChainGovernor(logger, nil, common.GoTest, true)
+	gov := NewChainGovernor(logger, nil, common.GoTest, true, "")
 	enqueued, err := gov.IsVAAEnqueued(nil)
 	require.EqualError(t, err, "no message ID specified")
 	assert.Equal(t, false, enqueued)

--- a/node/pkg/governor/governor_prices.go
+++ b/node/pkg/governor/governor_prices.go
@@ -109,7 +109,7 @@ func createCoinGeckoQuery(ids string, coinGeckoApiKey string) string {
 	} else { // Pro version API key path
 		query = "https://pro-api.coingecko.com/api/v3/simple/price?"
 		params.Add("x_cg_pro_api_key", coinGeckoApiKey)
-		query += "&" + params.Encode()
+		query += params.Encode()
 	}
 
 	return query

--- a/node/pkg/governor/governor_prices.go
+++ b/node/pkg/governor/governor_prices.go
@@ -101,7 +101,7 @@ func createCoinGeckoQuery(ids string, coinGeckoApiKey string) string {
 	params.Add("vs_currencies", "usd")
 
 	// If modifying this code, ensure that the test 'TestCoinGeckoPriceChecks' passes when adding a pro API key to it.
-	// Since the code is requires an API key (which we don't want to publish to git), this
+	// Since the code requires an API key (which we don't want to publish to git), this
 	// part of the test is normally skipped but mods to sensitive places should still be checked
 	query := ""
 	if coinGeckoApiKey == "" {

--- a/node/pkg/governor/governor_prices.go
+++ b/node/pkg/governor/governor_prices.go
@@ -171,7 +171,7 @@ func (gov *ChainGovernor) queryCoinGecko(ctx context.Context) error {
 		query := query + "&" + params.Encode()
 		thisResult, err := gov.queryCoinGeckoChunk(query)
 		if err != nil {
-			gov.logger.Error("CoinGecko query failed", zap.Int("queryIdx", queryIdx), zap.String("query", query), zap.Error(err))
+			gov.logger.Error("CoinGecko query failed", zap.Error(err), zap.Int("queryIdx", queryIdx), zap.String("query", query))
 			gov.revertAllPrices()
 			return err
 		}

--- a/node/pkg/governor/governor_prices.go
+++ b/node/pkg/governor/governor_prices.go
@@ -107,9 +107,8 @@ func createCoinGeckoQuery(ids string, coinGeckoApiKey string) string {
 	if coinGeckoApiKey == "" {
 		query = "https://api.coingecko.com/api/v3/simple/price?" + params.Encode()
 	} else { // Pro version API key path
-		query = "https://pro-api.coingecko.com/api/v3/simple/price?"
 		params.Add("x_cg_pro_api_key", coinGeckoApiKey)
-		query += params.Encode()
+		query = "https://pro-api.coingecko.com/api/v3/simple/price?" + params.Encode()
 	}
 
 	return query

--- a/node/pkg/governor/governor_test.go
+++ b/node/pkg/governor/governor_test.go
@@ -3225,7 +3225,7 @@ func TestCoinGeckoQueryFormat(t *testing.T) {
 	}
 
 	// Create and parse the query
-	queries := createCoinGeckoQueries(ids, 100, "") // Not API key
+	queries := createCoinGeckoQueries(ids, 100, "") // No API key
 	require.Equal(t, len(queries), 1)
 	query_url, err := url.Parse(queries[0])
 	require.Equal(t, err, nil)

--- a/node/pkg/governor/governor_test.go
+++ b/node/pkg/governor/governor_test.go
@@ -666,7 +666,7 @@ func newChainGovernorForTestWithLogger(ctx context.Context, logger *zap.Logger) 
 	}
 
 	var db db.MockGovernorDB
-	gov := NewChainGovernor(logger, &db, common.GoTest, true)
+	gov := NewChainGovernor(logger, &db, common.GoTest, true, "")
 
 	err := gov.Run(ctx)
 	if err != nil {
@@ -2183,7 +2183,7 @@ func TestSmallerPendingTransfersAfterBigOneShouldGetReleased(t *testing.T) {
 func TestMainnetConfigIsValid(t *testing.T) {
 	logger := zap.NewNop()
 	var db db.MockGovernorDB
-	gov := NewChainGovernor(logger, &db, common.GoTest, true)
+	gov := NewChainGovernor(logger, &db, common.GoTest, true, "")
 
 	gov.env = common.TestNet
 	err := gov.initConfig()
@@ -2193,7 +2193,7 @@ func TestMainnetConfigIsValid(t *testing.T) {
 func TestTestnetConfigIsValid(t *testing.T) {
 	logger := zap.NewNop()
 	var db db.MockGovernorDB
-	gov := NewChainGovernor(logger, &db, common.GoTest, true)
+	gov := NewChainGovernor(logger, &db, common.GoTest, true, "")
 
 	gov.env = common.TestNet
 	err := gov.initConfig()
@@ -3187,7 +3187,7 @@ func TestCoinGeckoQueries(t *testing.T) {
 				ids[idx] = fmt.Sprintf("id%d", idx)
 			}
 
-			queries := createCoinGeckoQueries(ids, tc.chunkSize)
+			queries := createCoinGeckoQueries(ids, tc.chunkSize, "")
 			require.Equal(t, tc.expectedQueries, len(queries))
 
 			results := make(map[string]string)
@@ -3213,6 +3213,100 @@ func TestCoinGeckoQueries(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// Test the URL of CoinGecko queries to be correct
+func TestCoinGeckoQueryFormat(t *testing.T) {
+	id_amount := 10
+	ids := make([]string, id_amount)
+	for idx := 0; idx < id_amount; idx++ {
+		ids[idx] = fmt.Sprintf("id%d", idx)
+	}
+
+	// Create and parse the query
+	queries := createCoinGeckoQueries(ids, 100, "") // Not API key
+	require.Equal(t, len(queries), 1)
+	query_url, err := url.Parse(queries[0])
+	require.Equal(t, err, nil)
+	params, err := url.ParseQuery(query_url.RawQuery)
+	require.Equal(t, err, nil)
+
+	// Test the portions of the URL for the non-pro version of the API
+	require.Equal(t, query_url.Scheme, "https")
+	require.Equal(t, query_url.Host, "api.coingecko.com")
+	require.Equal(t, query_url.Path, "/api/v3/simple/price")
+	require.Equal(t, params.Has("x_cg_pro_api_key"), false)
+	require.Equal(t, params.Has("vs_currencies"), true)
+	require.Equal(t, params["vs_currencies"][0], "usd")
+	require.Equal(t, params.Has("ids"), true)
+
+	// Create and parse the query with an API key
+	queries = createCoinGeckoQueries(ids, 100, "FAKE_KEY") // With API key
+	require.Equal(t, len(queries), 1)
+	query_url, err = url.Parse(queries[0])
+	require.Equal(t, err, nil)
+	params, err = url.ParseQuery(query_url.RawQuery)
+	require.Equal(t, err, nil)
+
+	// Test the portions of the URL actually provided
+	require.Equal(t, query_url.Scheme, "https")
+	require.Equal(t, query_url.Host, "pro-api.coingecko.com")
+	require.Equal(t, query_url.Path, "/api/v3/simple/price")
+	require.Equal(t, params.Has("x_cg_pro_api_key"), true)
+	require.Equal(t, params["x_cg_pro_api_key"][0], "FAKE_KEY")
+	require.Equal(t, params.Has("vs_currencies"), true)
+	require.Equal(t, params["vs_currencies"][0], "usd")
+	require.Equal(t, params.Has("ids"), true)
+
+}
+
+// Test that the prices are gathering from the CoinGecko API
+func TestCoinGeckoPriceChecks(t *testing.T) {
+	coinGeckoApiKey := "" // Add API key to test the pro API endpoint. Remove before commit
+	ids := []string{"usd-coin"}
+
+	ctx := context.Background()
+	gov, err := newChainGovernorForTest(ctx)
+	require.Equal(t, err, nil)
+
+	/*
+		The standard governor doesn't have the test suite initiated. Even if it did,
+		the amount of time this takes is too high So, instead of doing that, we're
+		testing at a lower level to ensure that the queries are actually made successfully
+		from the URLs given directly
+	*/
+	coinGeckoQueries := createCoinGeckoQueries(ids, 1, "")
+	require.Equal(t, len(coinGeckoQueries), 1)
+
+	token_map, err := gov.queryCoinGeckoChunk(coinGeckoQueries[0])
+	require.Equal(t, err, nil)
+	token_entry, ok := token_map[ids[0]].(map[string]interface{})
+	require.Equal(t, ok, true)
+
+	token_price, ok := token_entry["usd"]
+	require.Equal(t, ok, true)
+	require.LessOrEqual(t, token_price, 1.5)
+	require.GreaterOrEqual(t, token_price, 0.5)
+
+	// Only run if the key is specified
+	if coinGeckoApiKey != "" {
+		// Pro API key tests
+		coinGeckoQueries = createCoinGeckoQueries(ids, 1, coinGeckoApiKey)
+		require.Equal(t, len(coinGeckoQueries), 1)
+
+		token_map, err = gov.queryCoinGeckoChunk(coinGeckoQueries[0])
+		require.Equal(t, err, nil)
+
+		// Check the price information. Make sure it succeeded.
+		token_entry, ok = token_map[ids[0]].(map[string]interface{})
+		require.Equal(t, ok, true)
+		token_price, ok = token_entry["usd"]
+		require.Equal(t, ok, true)
+		require.LessOrEqual(t, token_price, 1.5)
+		require.GreaterOrEqual(t, token_price, 0.5)
+
+		fmt.Println(coinGeckoQueries)
 	}
 }
 

--- a/node/pkg/governor/governor_test.go
+++ b/node/pkg/governor/governor_test.go
@@ -3258,56 +3258,6 @@ func TestCoinGeckoQueryFormat(t *testing.T) {
 	require.Equal(t, params.Has("vs_currencies"), true)
 	require.Equal(t, params["vs_currencies"][0], "usd")
 	require.Equal(t, params.Has("ids"), true)
-
-}
-
-// Test that the prices are gathering from the CoinGecko API
-func TestCoinGeckoPriceChecks(t *testing.T) {
-	coinGeckoApiKey := "" // Add API key to test the pro API endpoint. Remove before commit
-	ids := []string{"usd-coin"}
-
-	ctx := context.Background()
-	gov, err := newChainGovernorForTest(ctx)
-	require.Equal(t, err, nil)
-
-	/*
-		The standard governor doesn't have the test suite initiated. Even if it did,
-		the amount of time this takes is too high So, instead of doing that, we're
-		testing at a lower level to ensure that the queries are actually made successfully
-		from the URLs given directly
-	*/
-	coinGeckoQueries := createCoinGeckoQueries(ids, 1, "")
-	require.Equal(t, len(coinGeckoQueries), 1)
-
-	token_map, err := gov.queryCoinGeckoChunk(coinGeckoQueries[0])
-	require.Equal(t, err, nil)
-	token_entry, ok := token_map[ids[0]].(map[string]interface{})
-	require.Equal(t, ok, true)
-
-	token_price, ok := token_entry["usd"]
-	require.Equal(t, ok, true)
-	require.LessOrEqual(t, token_price, 1.5)
-	require.GreaterOrEqual(t, token_price, 0.5)
-
-	// Only run if the key is specified
-	if coinGeckoApiKey != "" {
-		// Pro API key tests
-		coinGeckoQueries = createCoinGeckoQueries(ids, 1, coinGeckoApiKey)
-		require.Equal(t, len(coinGeckoQueries), 1)
-
-		token_map, err = gov.queryCoinGeckoChunk(coinGeckoQueries[0])
-		require.Equal(t, err, nil)
-
-		// Check the price information. Make sure it succeeded.
-		token_entry, ok = token_map[ids[0]].(map[string]interface{})
-		require.Equal(t, ok, true)
-		token_price, ok = token_entry["usd"]
-		require.Equal(t, ok, true)
-		require.LessOrEqual(t, token_price, 1.5)
-		require.GreaterOrEqual(t, token_price, 0.5)
-
-		fmt.Println(coinGeckoQueries)
-	}
 }
 
 // setupLogsCapture is a helper function for making a zap logger/observer combination for testing that certain logs have been made

--- a/node/pkg/governor/governor_test.go
+++ b/node/pkg/governor/governor_test.go
@@ -302,7 +302,7 @@ func TestFlowCancelFeatureFlag(t *testing.T) {
 
 	ctx := context.Background()
 	var db db.MockGovernorDB
-	gov := NewChainGovernor(zap.NewNop(), &db, common.GoTest, true)
+	gov := NewChainGovernor(zap.NewNop(), &db, common.GoTest, true, "")
 
 	// Trigger the evaluation of the flow cancelling config
 	err := gov.Run(ctx)
@@ -322,7 +322,7 @@ func TestFlowCancelFeatureFlag(t *testing.T) {
 	assert.NotZero(t, numFlowCancelling)
 
 	// Disable flow cancelling
-	gov = NewChainGovernor(zap.NewNop(), &db, common.GoTest, false)
+	gov = NewChainGovernor(zap.NewNop(), &db, common.GoTest, false, "")
 
 	// Trigger the evaluation of the flow cancelling config
 	err = gov.Run(ctx)

--- a/node/pkg/node/adminServiceRunnable.go
+++ b/node/pkg/node/adminServiceRunnable.go
@@ -77,7 +77,7 @@ func adminServiceRunnable(
 		contract := ethcommon.HexToAddress(*ethContract)
 		evmConnector, err = connectors.NewEthereumBaseConnector(ctx, "eth", *ethRpc, contract, logger)
 		if err != nil {
-			return nil, fmt.Errorf("failed to connecto to ethereum")
+			return nil, fmt.Errorf("failed to connect to ethereum")
 		}
 	}
 

--- a/node/pkg/node/node_test.go
+++ b/node/pkg/node/node_test.go
@@ -188,7 +188,7 @@ func mockGuardianRunnable(t testing.TB, gs []*mockGuardian, mockGuardianIndex ui
 			GuardianOptionDatabase(db),
 			GuardianOptionWatchers(watcherConfigs, nil),
 			GuardianOptionNoAccountant(), // disable accountant
-			GuardianOptionGovernor(true, false),
+			GuardianOptionGovernor(true, false, ""),
 			GuardianOptionGatewayRelayer("", nil), // disable gateway relayer
 			GuardianOptionP2P(gs[mockGuardianIndex].p2pKey, networkID, bootstrapPeers, nodeName, false, false, cfg.p2pPort, "", 0, "", "", func() string { return "" }),
 			GuardianOptionPublicRpcSocket(cfg.publicSocket, publicRpcLogDetail),

--- a/node/pkg/node/options.go
+++ b/node/pkg/node/options.go
@@ -218,7 +218,7 @@ func GuardianOptionAccountant(
 
 // GuardianOptionGovernor enables or disables the governor.
 // Dependencies: db
-func GuardianOptionGovernor(governorEnabled bool, flowCancelEnabled bool) *GuardianOption {
+func GuardianOptionGovernor(governorEnabled bool, flowCancelEnabled bool, coinGeckoApiKey string) *GuardianOption {
 	return &GuardianOption{
 		name:         "governor",
 		dependencies: []string{"db"},
@@ -227,9 +227,13 @@ func GuardianOptionGovernor(governorEnabled bool, flowCancelEnabled bool) *Guard
 				if flowCancelEnabled {
 					logger.Info("chain governor is enabled with flow cancel enabled")
 				} else {
+
 					logger.Info("chain governor is enabled without flow cancel")
 				}
-				g.gov = governor.NewChainGovernor(logger, g.db, g.env, flowCancelEnabled)
+				if coinGeckoApiKey != "" {
+					logger.Info("coingecko pro API key in use")
+				}
+				g.gov = governor.NewChainGovernor(logger, g.db, g.env, flowCancelEnabled, coinGeckoApiKey)
 			} else {
 				logger.Info("chain governor is disabled")
 			}

--- a/node/pkg/publicrpc/publicrpcserver_test.go
+++ b/node/pkg/publicrpc/publicrpcserver_test.go
@@ -69,7 +69,7 @@ func TestGetSignedVAABadAddress(t *testing.T) {
 func TestGovernorIsVAAEnqueuedNoMessage(t *testing.T) {
 	ctx := context.Background()
 	logger, _ := zap.NewProduction()
-	gov := governor.NewChainGovernor(logger, nil, common.GoTest, false)
+	gov := governor.NewChainGovernor(logger, nil, common.GoTest, false, "")
 	server := &PublicrpcServer{logger: logger, gov: gov}
 
 	// A message without the messageId set should not panic but return an error instead.


### PR DESCRIPTION
In case the Guardians want to use API keys for Coin Gecko, support for the API keys has been added. This changes code in the Guardian and adds a command line flag.

Testing this is difficult because we don't want to include a key in here. Prior to this, I don't think we had tests for the query success from CoinGecko anyway. So, I added tests that make requests to coin gecko using the standard and pro APIs. If the API key isn't specified in the test file, the test is just skipped. If there's a better way to do this or relying on external APIs for builds to succeed is bad practice, then please say something and I'm happy to make changes accordingly.
