### PR TITLE
Input Validation on Generated Token List

### DIFF
--- a/node/hack/governor/src/index.ts
+++ b/node/hack/governor/src/index.ts
@@ -163,9 +163,9 @@ axios
                   continue;
                 }
               }
-
+              
               // If the character list is violated, then skip the coin. The error is logged in the function if something happens to have some sort of check on it.
-              if(!(await safetyCheck(chain, wormholeAddr, data.Symbol, data.CoinGeckoId, data.TokenDecimals, data.TokenPrice, data.Address, notional))){
+              if(!(safetyCheck(chain, wormholeAddr, data.Symbol, data.CoinGeckoId, data.TokenDecimals, data.TokenPrice, data.Address, notional))){
                 failedInputValidationTokens.push(chain + "-" + wormholeAddr + "-" + data.symbol)
                 continue; 
               }
@@ -312,24 +312,24 @@ axios
 
   Example data: 30 000000000000000000000000b5c457ddb4ce3312a6c5a2b056a1652bd542a208 O404 omni404 18 1128.69 0xb5c457ddb4ce3312a6c5a2b056a1652bd542a208 7.4832146999999996
 */
-async function safetyCheck(chain, wormholeAddr, symbol, coinGeckoId, tokenDecimals, tokenPrice, address, notional)  : Promise<boolean>{
+function safetyCheck(chain, wormholeAddr, symbol, coinGeckoId, tokenDecimals, tokenPrice, address, notional)  : boolean{
   
   if(isNaN(chain)){
     console.log("Invalid chain ID ", chain, " provided")
     return false; 
   }
 
-  if(await inputHasInvalidChars(wormholeAddr)){
+  if(inputHasInvalidChars(wormholeAddr)){
     console.log("Invalid wormhole address ", wormholeAddr, " provided")
     return false; 
   }
 
-  if(await inputHasInvalidChars(symbol)){
+  if(inputHasInvalidChars(symbol)){
     console.log("Invalid token symbol ", symbol, " provided")
     return false; 
   }
 
-  if(await inputHasInvalidChars(coinGeckoId)){
+  if(inputHasInvalidChars(coinGeckoId)){
     console.log("Invalid coin gecko id ", coinGeckoId, " provided")
     return false; 
   }
@@ -344,7 +344,7 @@ async function safetyCheck(chain, wormholeAddr, symbol, coinGeckoId, tokenDecima
     return false; 
   }
 
-  if(await inputHasInvalidChars(address)){
+  if(inputHasInvalidChars(address)){
     console.log("Invalid address ", address, " provided")
     return false; 
   }
@@ -358,7 +358,7 @@ async function safetyCheck(chain, wormholeAddr, symbol, coinGeckoId, tokenDecima
 
 // Checks whether an illegal character is present in the provided string
 // If a character is found then return true. Otherwise, return false. 
-async function inputHasInvalidChars(input) : Promise<boolean>{
+function inputHasInvalidChars(input) : boolean{
   var deny_list = ["\"", "%", "\n","\r", "\\","{","}","/","'","[","]","(",")"]
   for(var char of deny_list) {
     if(input.includes(char)){

--- a/node/hack/governor/src/index.ts
+++ b/node/hack/governor/src/index.ts
@@ -94,6 +94,7 @@ axios
     var addedTokens = [];
     var removedTokens = [];
     var changedSymbols = [];
+    var failedInputValidationTokens = [];
     var newTokensCount = 0;
 
     for (let chain in res.data.AllTime) {
@@ -165,6 +166,7 @@ axios
 
               // If the character list is violated, then skip the coin. The error is logged in the function if something happens to have some sort of check on it.
               if(!(await safetyCheck(chain, wormholeAddr, data.Symbol, data.CoinGeckoId, data.TokenDecimals, data.TokenPrice, data.Address, notional))){
+                failedInputValidationTokens.push(chain + "-" + wormholeAddr + "-" + data.symbol)
                 continue; 
               }
             }
@@ -258,7 +260,10 @@ axios
     changedContent += "\n\nTokens removed = " + removedTokens.length + ":\n<WH_chain_id>-<WH_token_addr>-<token_symbol>\n\n";
     changedContent += JSON.stringify(removedTokens, null, 1);
     changedContent += "\n\nTokens with changed symbols = " + changedSymbols.length + ":\n<WH_chain_id>-<WH_token_addr>-<old_token_symbol>-><new_token_symbol>\n\n";
-    changedContent += JSON.stringify(changedSymbols, null, 1);
+
+    changedContent += "\n\nTokens with invalid symbols = " + failedInputValidationTokens.length + ":\n<WH_chain_id>-<WH_token_addr>-<token_symbol>\n\n";
+    changedContent += JSON.stringify(failedInputValidationTokens, null, 1);
+
     changedContent += "\n\nTokens with significant price drops (>" + PriceDeltaTolerance + "%) = " + significantPriceChanges.length + ":\n\n"
     changedContent += JSON.stringify(significantPriceChanges, null, 1);
     changedContent += "\n```";
@@ -354,7 +359,7 @@ async function safetyCheck(chain, wormholeAddr, symbol, coinGeckoId, tokenDecima
 // Checks whether an illegal character is present in the provided string
 // If a character is found then return true. Otherwise, return false. 
 async function inputHasInvalidChars(input) : Promise<boolean>{
-  var deny_list = ["\"", "%", "\n","\r", "\\","{","}","/","'"]
+  var deny_list = ["\"", "%", "\n","\r", "\\","{","}","/","'","[","]","(",")"]
   for(var char of deny_list) {
     if(input.includes(char)){
       return true; 

--- a/node/hack/governor/src/index.ts
+++ b/node/hack/governor/src/index.ts
@@ -351,10 +351,10 @@ async function safetyCheck(chain, wormholeAddr, symbol, coinGeckoId, tokenDecima
   return true; 
 }
 
-// Validates that a list of characters are not in the provided string.
+// Checks whether an illegal character is present in the provided string
 // If a character is found then return true. Otherwise, return false. 
 async function inputHasInvalidChars(input) : Promise<boolean>{
-  var deny_list = ["\"", "%", "\n","\r", "\\"]
+  var deny_list = ["\"", "%", "\n","\r", "\\","{","}","/","'"]
   for(var char of deny_list) {
     if(input.includes(char)){
       return true; 


### PR DESCRIPTION
There's a script that adds a list of tokens into a file called `generated_mainnet_tokens.go` once every two weeks. This adds some input validation on the CoinGecko data before being inserted into the Go code. 

This is meant to be a temporary fix while a more robust mechanism, such as a JSON config file or the usage of a real Go code generation library, is completed. 

I ran this on the production endpoint and this did not violate any tokens in the current list either.