### PR TITLE
chore(node/cmd): replace `fmt.Errorf` without parameters with `errors.New`

### DIFF
--- a/clients/eth/main.go
+++ b/clients/eth/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -183,7 +184,7 @@ func getTransactor(ethC *ethclient.Client) (*abi.AbiTransactor, error) {
 	addr := common.HexToAddress(contractAddress)
 	emptyAddr := common.Address{}
 	if addr == emptyAddr {
-		return nil, fmt.Errorf("invalid contract address")
+		return nil, errors.New("invalid contract address")
 	}
 
 	t, err := abi.NewAbiTransactor(addr, ethC)
@@ -196,7 +197,7 @@ func getTransactor(ethC *ethclient.Client) (*abi.AbiTransactor, error) {
 
 func getGovernanceVaaAction(payload []byte) (uint8, error) {
 	if len(payload) < 32+2+1 {
-		return 0, fmt.Errorf("VAA payload does not contain a governance header")
+		return 0, errors.New("VAA payload does not contain a governance header")
 	}
 
 	return payload[32], nil

--- a/node/cmd/ccq/p2p.go
+++ b/node/cmd/ccq/p2p.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -274,7 +275,7 @@ func runP2P(
 							failedQueriesByUser.WithLabelValues(pendingResponse.userName).Inc()
 							delete(responses, requestSignature)
 							select {
-							case pendingResponse.errCh <- &ErrorEntry{err: fmt.Errorf("quorum not met"), status: http.StatusBadRequest}:
+							case pendingResponse.errCh <- &ErrorEntry{err: errors.New("quorum not met"), status: http.StatusBadRequest}:
 								logger.Info("query failed, quorum not met",
 									zap.String("peerId", peerId),
 									zap.String("userId", pendingResponse.userName),

--- a/node/cmd/ccq/utils.go
+++ b/node/cmd/ccq/utils.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -30,12 +31,12 @@ func FetchCurrentGuardianSet(rpcUrl, coreAddr string) (*common.GuardianSet, erro
 	ethContract := eth_common.HexToAddress(coreAddr)
 	rawClient, err := ethRpc.DialContext(ctx, rpcUrl)
 	if err != nil {
-		return nil, fmt.Errorf("failed to connect to ethereum")
+		return nil, errors.New("failed to connect to ethereum")
 	}
 	client := ethClient.NewClient(rawClient)
 	caller, err := ethAbi.NewAbiCaller(ethContract, client)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create caller")
+		return nil, errors.New("failed to create caller")
 	}
 	currentIndex, err := caller.GetCurrentGuardianSetIndex(&ethBind.CallOpts{Context: ctx})
 	if err != nil {
@@ -57,7 +58,7 @@ func validateRequest(logger *zap.Logger, env common.Environment, perms *Permissi
 	if !exists {
 		logger.Debug("invalid api key", zap.String("apiKey", apiKey))
 		invalidQueryRequestReceived.WithLabelValues("invalid_api_key").Inc()
-		return http.StatusForbidden, nil, fmt.Errorf("invalid api key")
+		return http.StatusForbidden, nil, errors.New("invalid api key")
 	}
 
 	// TODO: Should we verify the signatures?
@@ -70,7 +71,7 @@ func validateRequest(logger *zap.Logger, env common.Environment, perms *Permissi
 				zap.Bool("signerKeyConfigured", signerKey != nil),
 			)
 			invalidQueryRequestReceived.WithLabelValues("request_not_signed").Inc()
-			return http.StatusBadRequest, nil, fmt.Errorf("request not signed")
+			return http.StatusBadRequest, nil, errors.New("request not signed")
 		}
 
 		// Sign the request using our key.
@@ -117,7 +118,7 @@ func validateRequest(logger *zap.Logger, env common.Environment, perms *Permissi
 		default:
 			logger.Debug("unsupported query type", zap.String("userName", permsForUser.userName), zap.Any("type", pcq.Query))
 			invalidQueryRequestReceived.WithLabelValues("unsupported_query_type").Inc()
-			return http.StatusBadRequest, nil, fmt.Errorf("unsupported query type")
+			return http.StatusBadRequest, nil, errors.New("unsupported query type")
 		}
 
 		if err != nil {
@@ -142,7 +143,7 @@ func validateCallData(logger *zap.Logger, permsForUser *permissionEntry, callTag
 		if len(cd.Data) < ETH_CALL_SIG_LENGTH {
 			logger.Debug("eth call data must be at least four bytes", zap.String("userName", permsForUser.userName), zap.String("data", hex.EncodeToString(cd.Data)))
 			invalidQueryRequestReceived.WithLabelValues("bad_call_data").Inc()
-			return http.StatusBadRequest, fmt.Errorf("eth call data must be at least four bytes")
+			return http.StatusBadRequest, errors.New("eth call data must be at least four bytes")
 		}
 		if !permsForUser.allowAnything {
 			call := hex.EncodeToString(cd.Data[0:ETH_CALL_SIG_LENGTH])

--- a/node/cmd/guardiand/adminclient.go
+++ b/node/cmd/guardiand/adminclient.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/csv"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -238,7 +239,7 @@ func runSignWormchainValidatorAddress(cmd *cobra.Command, args []string) error {
 	guardianKeyPath := args[0]
 	wormchainAddress := args[1]
 	if !strings.HasPrefix(wormchainAddress, "wormhole") || strings.HasPrefix(wormchainAddress, "wormholeval") {
-		return fmt.Errorf("must provide a bech32 address that has 'wormhole' prefix")
+		return errors.New("must provide a bech32 address that has 'wormhole' prefix")
 	}
 	gk, err := common.LoadGuardianKey(guardianKeyPath, *unsafeDevnetMode)
 	if err != nil {

--- a/node/cmd/guardiand/admintemplate.go
+++ b/node/cmd/guardiand/admintemplate.go
@@ -2,6 +2,7 @@ package guardiand
 
 import (
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"log"
 	"math/big"
@@ -1214,7 +1215,7 @@ func parseAddress(s string) (string, error) {
 
 func leftPadAddress(a []byte) (string, error) {
 	if len(a) > 32 {
-		return "", fmt.Errorf("address longer than 32 bytes")
+		return "", errors.New("address longer than 32 bytes")
 	}
 	return hex.EncodeToString(common.LeftPadBytes(a, 32)), nil
 }
@@ -1246,7 +1247,7 @@ func isValidUint256(s string) (bool, error) {
 
 	// Check if i is within the range [0, 2^256 - 1]
 	if i.Cmp(big.NewInt(0)) < 0 || i.Cmp(upperLimit) > 0 {
-		return false, fmt.Errorf("value is not a valid uint256")
+		return false, errors.New("value is not a valid uint256")
 	}
 
 	return true, nil


### PR DESCRIPTION
This PR replaces `fmt.Errorf` without parameters with `errors.New`