### PR TITLE
node: devcontainer support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+{
+  "name": "Guardian Development",
+  "build": {
+    "context": "..",
+    "dockerfile": "../node/Dockerfile",
+    "target": "dev"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "golang.go",
+        "ms-azuretools.vscode-docker",
+        "ms-vscode.makefile-tools"
+      ],
+      "settings": {
+        "files.insertFinalNewline": true
+      }
+    }
+  },
+}

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -1,6 +1,8 @@
 # syntax=docker.io/docker/dockerfile:1.3@sha256:42399d4635eddd7a9b8a24be879d2f9a930d0ed040a61324cfdf59ef1357b3b2
-FROM --platform=linux/amd64 docker.io/golang:1.21.9-bullseye@sha256:311468bffa9fa4747a334b94e6ce3681b564126d653675a6adc46698b2b88d35 AS build
+FROM --platform=linux/amd64 docker.io/golang:1.21.9-bullseye@sha256:311468bffa9fa4747a334b94e6ce3681b564126d653675a6adc46698b2b88d35 AS dev
 # libwasmvm.so is not compatible with arm
+
+FROM dev AS build
 
 WORKDIR /app
 

--- a/scripts/check-docker-pin.sh
+++ b/scripts/check-docker-pin.sh
@@ -13,7 +13,7 @@
 #   - We ignore cosmwasm_artifacts AS artifacts because it's a local reference only, is built in tilt
 #   - We ignore base AS (ignite-go-build|ignite-vue-build) because the base image is already pinned in wormchain/Dockerfile.proto
 #
-git ls-files -z | grep -z "Dockerfile*" | xargs -r -0 grep -s "FROM" | egrep -v 'sha256|scratch|solana|aptos|sui|base|cosmwasm_artifacts|cli-gen|const-gen AS (application|base|builder|ci_tests|tests|artifacts|ignite-go-build|ignite-vue-build|cli-export|const-export)'
+git ls-files -z | grep -z "Dockerfile*" | xargs -r -0 grep -s "FROM" | egrep -v 'sha256|scratch|solana|aptos|sui|base|cosmwasm_artifacts|cli-gen|const-gen|dev AS (application|base|builder|ci_tests|tests|artifacts|ignite-go-build|ignite-vue-build|cli-export|const-export|build)'
 if [ $? -eq 0 ]; then
    echo "[!] Unpinned docker files" >&2
    exit 1


### PR DESCRIPTION
This PR adds a [devcontainer.json](https://code.visualstudio.com/docs/devcontainers/containers) to aid in the development of node / guardian code. While development is currently possible in Linux (including WSL on Windows), providing this container adds an option for non-WSL Windows and ARM (M-series) Mac users which only requires Docker and VS Code. It also shares the same dockerfile used in CI for added assurance of compatibility. Relevant to #4031. Please note, this dockerfile _explicitly_ specifies amd64, which means it will run via qemu or rosetta (depending on your Docker settings) - as far as I understand, the cosmwasm dependency (and possibly others) requires this and there will be a slight performance hit, but it is useable. 