### PR TITLE
sdk/js-query: add signaturesToSolanaArray util

### DIFF
--- a/sdk/js-query/CHANGELOG.md
+++ b/sdk/js-query/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.13
+
+Add signaturesToSolanaArray
+
 ## 0.0.12
 
 Fix SolanaPda mock for bad rentEpoch parsing

--- a/sdk/js-query/package-lock.json
+++ b/sdk/js-query/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wormhole-foundation/wormhole-query-sdk",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@wormhole-foundation/wormhole-query-sdk",
-      "version": "0.0.12",
+      "version": "0.0.13",
       "license": "Apache-2.0",
       "dependencies": {
         "@ethersproject/keccak256": "^5.7.0",

--- a/sdk/js-query/package.json
+++ b/sdk/js-query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wormhole-foundation/wormhole-query-sdk",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "Wormhole cross-chain query SDK",
   "homepage": "https://wormhole.com",
   "main": "./lib/cjs/index.js",

--- a/sdk/js-query/src/query/utils.ts
+++ b/sdk/js-query/src/query/utils.ts
@@ -33,6 +33,16 @@ export function signaturesToEvmStruct(signatures: string[]) {
   }));
 }
 
+// GuardianSetSig expects the guardian index before the signature, the inverse of what the Query Proxy returns.
+// https://docs.rs/wormhole-raw-vaas/0.3.0-alpha.1/src/wormhole_raw_vaas/protocol.rs.html#220
+// https://github.com/wormhole-foundation/wormhole/blob/31b01629087c610c12fa8e84069786139dc0b6bd/node/cmd/ccq/http.go#L191
+export function signaturesToSolanaArray(signatures: string[]) {
+  return signatures.map((s) => [
+    ...Buffer.from(s.substring(130, 132), "hex"),
+    ...Buffer.from(s.substring(0, 130), "hex"),
+  ]);
+}
+
 /**
  * @param key Private key used to sign `data`
  * @param data Data for signing


### PR DESCRIPTION
This PR adds a helper to convert the signatures returned by the Query Proxy into arrays compatible with the [wormhole-raw-vaas](https://docs.rs/wormhole-raw-vaas/0.3.0-alpha.1/src/wormhole_raw_vaas/protocol.rs.html#220) crate struct. Ported from [this example](https://github.com/wormholelabs-xyz/example-queries-solana-verify/blob/20714236eb5420b67181f5c76920da5743357821/tests/helpers/utils/signaturesToSolanaArray.ts)