### PR TITLE
cosmwasm: add missing feature flags in Cargo.toml files

### DIFF
--- a/cosmwasm/contracts/ibc-translator/Cargo.toml
+++ b/cosmwasm/contracts/ibc-translator/Cargo.toml
@@ -12,6 +12,9 @@ crate-type = ["cdylib", "rlib"]
 backtraces = ["cosmwasm-std/backtraces"]
 # use library feature to disable all instantiate/execute/query/reply exports
 library = []
+cosmwasm_1_2 = ["cosmwasm-std/cosmwasm_1_2"]
+stargate = ["cosmwasm-std/stargate"]
+staking = ["cosmwasm-std/staking"]
 
 [dependencies]
 anybuf = "0.1.0"

--- a/cosmwasm/contracts/wormchain-ibc-receiver/Cargo.toml
+++ b/cosmwasm/contracts/wormchain-ibc-receiver/Cargo.toml
@@ -9,6 +9,7 @@ crate-type = ["cdylib", "rlib"]
 
 [features]
 backtraces = ["cosmwasm-std/backtraces"]
+library = []
 
 [dependencies]
 cosmwasm-std = { version = "1.0.0", features = ["ibc3"] }

--- a/cosmwasm/contracts/wormchain-ibc-receiver/src/ibc.rs
+++ b/cosmwasm/contracts/wormchain-ibc-receiver/src/ibc.rs
@@ -15,7 +15,7 @@ use crate::msg::WormholeIbcPacketMsg;
 pub const IBC_APP_VERSION: &str = "ibc-wormhole-v1";
 
 /// 1. Opening a channel. Step 1 of handshake. Combines ChanOpenInit and ChanOpenTry from the spec.
-/// The only valid action of the contract is to accept the channel or reject it.
+///    The only valid action of the contract is to accept the channel or reject it.
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn ibc_channel_open(
     _deps: DepsMut,
@@ -150,7 +150,7 @@ fn encode_ibc_error(msg: impl Into<String>) -> Binary {
 }
 
 /// 5. Acknowledging a packet. Called when the other chain successfully receives a packet from us.
-/// Never should be called as this contract never sends packets
+///    Never should be called as this contract never sends packets
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn ibc_packet_ack(
     _deps: DepsMut,
@@ -163,7 +163,7 @@ pub fn ibc_packet_ack(
 }
 
 /// 6. Timing out a packet. Called when the packet was not recieved on the other chain before the timeout.
-/// Never should be called as this contract never sends packets
+///    Never should be called as this contract never sends packets
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn ibc_packet_timeout(
     _deps: DepsMut,

--- a/cosmwasm/contracts/wormhole-ibc/Cargo.toml
+++ b/cosmwasm/contracts/wormhole-ibc/Cargo.toml
@@ -9,6 +9,7 @@ crate-type = ["cdylib", "rlib"]
 
 [features]
 backtraces = ["cosmwasm-std/backtraces"]
+library = []
 
 [dependencies]
 wormhole-cosmwasm = { version = "0.1.0", default-features = false, features = ["library", "full"] }

--- a/cosmwasm/contracts/wormhole-ibc/src/ibc.rs
+++ b/cosmwasm/contracts/wormhole-ibc/src/ibc.rs
@@ -16,7 +16,7 @@ pub const IBC_APP_VERSION: &str = "ibc-wormhole-v1";
 pub const PACKET_LIFETIME: u64 = 31_536_000;
 
 /// 1. Opening a channel. Step 1 of handshake. Combines ChanOpenInit and ChanOpenTry from the spec.
-/// The only valid action of the contract is to accept the channel or reject it.
+///    The only valid action of the contract is to accept the channel or reject it.
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn ibc_channel_open(
     _deps: DepsMut,
@@ -71,7 +71,7 @@ pub fn ibc_channel_close(
 }
 
 /// 4. Receiving a packet.
-/// Never should be called as the other side never sends packets
+///    Never should be called as the other side never sends packets
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn ibc_packet_receive(
     _deps: DepsMut,


### PR DESCRIPTION
These flags were previously not declared, which is now reported by clippy.
Also fixed the docstring indentation, which clippy also complains about now.