### PR TITLE
ci: bump foundry to 2024-08-04 nightly

### DIFF
--- a/ethereum/Dockerfile
+++ b/ethereum/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker.io/docker/dockerfile:1.3@sha256:42399d4635eddd7a9b8a24be879d2f9a930d0ed040a61324cfdf59ef1357b3b2
 FROM const-gen AS const-export
-FROM ghcr.io/foundry-rs/foundry:nightly-ea2eff95b5c17edd3ffbdfc6daab5ce5cc80afc0@sha256:2a774f86765258a0d176366fc46f92bc14f5040faae7a3c3ba59b1c24c5fa7cb as foundry
+FROM ghcr.io/foundry-rs/foundry:nightly-55bf41564f605cae3ca4c95ac5d468b1f14447f9@sha256:8c15d322da81a6deaf827222e173f3f81c653136a3518d5eeb41250a0f2e17ea as foundry
 FROM node:19.6.1-slim@sha256:a1ba21bf0c92931d02a8416f0a54daad66cb36a85d2b73af9d73b044f5f57cfc
 
 # npm wants to clone random Git repositories - lovely.


### PR DESCRIPTION
We have seen [some instances](https://github.com/wormholelabs-xyz/wormhole/actions/runs/10162658975/job/28103791466#step:6:9835) in CI where anvil returns a block number which doesn't match the one queried. Perhaps this issue has been fixed since the [nightly currently being used (2024-05-26)](https://github.com/foundry-rs/foundry/commit/ea2eff95b5c17edd3ffbdfc6daab5ce5cc80afc0). Confirmed that the forge output is still the same by exec-ing into the container and running the following before and after the change then diffing the result.
```bash
cd ~/app/ethereum/build-forge
find . -type f -exec sha256sum {} \;
cd ~/app/relayer/ethereum/build-forge
find . -type f -exec sha256sum {} \;
```