### PR TITLE
Node: Gateway relayer can ignore already attested return

### DIFF
--- a/node/pkg/gwrelayer/gwrelayer.go
+++ b/node/pkg/gwrelayer/gwrelayer.go
@@ -424,7 +424,7 @@ func SubmitVAAToContract(
 		return txResp, fmt.Errorf("out of gas: %s", txResp.TxResponse.RawLog)
 	}
 
-	if strings.Contains(txResp.TxResponse.RawLog, "failed") && !strings.Contains(txResp.TxResponse.RawLog, "VaaAlreadyExecuted") {
+	if strings.Contains(txResp.TxResponse.RawLog, "failed") && !canIgnoreFailure(txResp.TxResponse.RawLog) {
 		return txResp, fmt.Errorf("submit failed: %s", txResp.TxResponse.RawLog)
 	}
 
@@ -440,4 +440,9 @@ func SubmitVAAToContract(
 	logger.Debug("in SubmitVAAToContract, done sending broadcast", zap.String("resp", wormchainConn.BroadcastTxResponseToString(txResp)))
 
 	return txResp, nil
+}
+
+// canIgnoreFailure checks for returns from the contract that aren't really errors.
+func canIgnoreFailure(rawLog string) bool {
+	return strings.Contains(rawLog, "VaaAlreadyExecuted") || strings.Contains(rawLog, "this asset has already been attested")
 }

--- a/node/pkg/gwrelayer/gwrelayer_test.go
+++ b/node/pkg/gwrelayer/gwrelayer_test.go
@@ -180,3 +180,9 @@ func Test_shouldPublishToIbcTranslatorShouldIgnoreUnknownEmitter(t *testing.T) {
 	assert.NoError(t, err)
 	assert.False(t, shouldPub)
 }
+
+func Test_canIgnoreFailure(t *testing.T) {
+	assert.True(t, canIgnoreFailure("failed to execute message; message index: 0: Generic error: VaaAlreadyExecuted: execute wasm contract failed"))
+	assert.True(t, canIgnoreFailure("failed to execute message; message index: 0: Generic error: this asset has already been attested: execute wasm contract failed"))
+	assert.False(t, canIgnoreFailure("failed to execute message; message index: 0: Generic error: some other failure: execute wasm contract failed"))
+}


### PR DESCRIPTION
We are occasionally seeing the gateway relayer logging an error when the contract returns "this asset has already been attested". This should not be logged as an error.