### PR TITLE
node: Fix missing support for chains in generated token list due to outdated SDK

### DIFF
--- a/node/hack/governor/package-lock.json
+++ b/node/hack/governor/package-lock.json
@@ -690,11 +690,12 @@
       "dev": true
     },
     "node_modules/@certusone/wormhole-sdk": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk/-/wormhole-sdk-0.10.5.tgz",
-      "integrity": "sha512-wKONuigkakoFx9HplBt2Jh5KPxc7xgtDJVrIb2/SqYWbFrdpiZrMC4H6kTZq2U4+lWtqaCa1aJ1q+3GOTNx2CQ==",
+      "version": "0.10.17",
+      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk/-/wormhole-sdk-0.10.17.tgz",
+      "integrity": "sha512-fFubpGha+2gRuZItPZBJ5PYcKbyoI/DozN3XK2CrK3VXyfHYmaqYKgOK7fhlrrqxCUV3bDYy/Vc6GEUTAh+wDA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@certusone/wormhole-sdk-proto-web": "0.0.6",
+        "@certusone/wormhole-sdk-proto-web": "0.0.7",
         "@certusone/wormhole-sdk-wasm": "^0.0.1",
         "@coral-xyz/borsh": "0.2.6",
         "@mysten/sui.js": "0.32.2",
@@ -720,9 +721,10 @@
       }
     },
     "node_modules/@certusone/wormhole-sdk-proto-web": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk-proto-web/-/wormhole-sdk-proto-web-0.0.6.tgz",
-      "integrity": "sha512-LTyjsrWryefx5WmkoBP6FQ2EjLxhMExAGxLkloHUhufVQZdrbGh0htBBUviP+HaDSJBCMPMtulNFwkBJV6muqQ==",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk-proto-web/-/wormhole-sdk-proto-web-0.0.7.tgz",
+      "integrity": "sha512-GCe1/bcqMS0Mt+hsWp4SE4NLL59pWmK0lhQXO0oqAKl0G9AuuTdudySMDF/sLc7z5H2w34bSuSrIEKvPuuSC+w==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@improbable-eng/grpc-web": "^0.15.0",
         "protobufjs": "^7.0.0",
@@ -732,13 +734,15 @@
     "node_modules/@certusone/wormhole-sdk-proto-web/node_modules/long": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==",
+      "license": "Apache-2.0"
     },
     "node_modules/@certusone/wormhole-sdk-proto-web/node_modules/protobufjs": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.4.tgz",
-      "integrity": "sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.3.2.tgz",
+      "integrity": "sha512-RXyHaACeqXeqAKGLDl68rQKbmObRsTIn4TYVUUug1KfS47YWCo5MacGITEryugIgZqORCvJWEk4l449POg5Txg==",
       "hasInstallScript": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -9914,11 +9918,11 @@
       "dev": true
     },
     "@certusone/wormhole-sdk": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk/-/wormhole-sdk-0.10.5.tgz",
-      "integrity": "sha512-wKONuigkakoFx9HplBt2Jh5KPxc7xgtDJVrIb2/SqYWbFrdpiZrMC4H6kTZq2U4+lWtqaCa1aJ1q+3GOTNx2CQ==",
+      "version": "0.10.17",
+      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk/-/wormhole-sdk-0.10.17.tgz",
+      "integrity": "sha512-fFubpGha+2gRuZItPZBJ5PYcKbyoI/DozN3XK2CrK3VXyfHYmaqYKgOK7fhlrrqxCUV3bDYy/Vc6GEUTAh+wDA==",
       "requires": {
-        "@certusone/wormhole-sdk-proto-web": "0.0.6",
+        "@certusone/wormhole-sdk-proto-web": "0.0.7",
         "@certusone/wormhole-sdk-wasm": "^0.0.1",
         "@coral-xyz/borsh": "0.2.6",
         "@injectivelabs/networks": "1.10.12",
@@ -10015,9 +10019,9 @@
       }
     },
     "@certusone/wormhole-sdk-proto-web": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk-proto-web/-/wormhole-sdk-proto-web-0.0.6.tgz",
-      "integrity": "sha512-LTyjsrWryefx5WmkoBP6FQ2EjLxhMExAGxLkloHUhufVQZdrbGh0htBBUviP+HaDSJBCMPMtulNFwkBJV6muqQ==",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@certusone/wormhole-sdk-proto-web/-/wormhole-sdk-proto-web-0.0.7.tgz",
+      "integrity": "sha512-GCe1/bcqMS0Mt+hsWp4SE4NLL59pWmK0lhQXO0oqAKl0G9AuuTdudySMDF/sLc7z5H2w34bSuSrIEKvPuuSC+w==",
       "requires": {
         "@improbable-eng/grpc-web": "^0.15.0",
         "protobufjs": "^7.0.0",
@@ -10030,9 +10034,9 @@
           "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
         },
         "protobufjs": {
-          "version": "7.2.4",
-          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.4.tgz",
-          "integrity": "sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==",
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.3.2.tgz",
+          "integrity": "sha512-RXyHaACeqXeqAKGLDl68rQKbmObRsTIn4TYVUUug1KfS47YWCo5MacGITEryugIgZqORCvJWEk4l449POg5Txg==",
           "requires": {
             "@protobufjs/aspromise": "^1.1.2",
             "@protobufjs/base64": "^1.1.2",

--- a/node/hack/governor/src/index.ts
+++ b/node/hack/governor/src/index.ts
@@ -153,12 +153,15 @@ axios
                 }
                 if (wormholeAddr === undefined) {
                   console.log(
-                    `Ignoring symbol '${data.Symbol}' on chain ${chainId} because the address '${data.Address}' is undefined`
+                    `Ignoring symbol '${data.Symbol}' on chain ${chainId} because the address '${data.Address}' is undefined`,
+                    data,
+                    `Is the SDK up-to-date?`
                   );
                   continue;
                 } else if (wormholeAddr === "") {
                   console.log(
-                    `Ignoring symbol '${data.Symbol}' on chain ${chainId} because the address '${data.Address}' is invalid`
+                    `Ignoring symbol '${data.Symbol}' on chain ${chainId} because the address '${data.Address}' is invalid`,
+                    data
                   );
                   continue;
                 }


### PR DESCRIPTION
- The script used to generate the updated token list was using an outdated version of the TS SDK. This caused newer chains to return a result of 'undefined' when they were converted to the custom ChainId type as they were not encluded in the enum of valid chain IDs
- Update the local SDK version used by the script via `npm update @certusone/wormhole-sdk`
- Adds additional logging to the script to help troubleshoot similar errors in the future

To test:
- Before this commit: run `node/hack/governor/src/index.ts`, observe error output relating to Scroll. Note that Scroll has no governed tokens in the generated tokens list
- On this commit: do the same. No error and Scroll will be updated to be in the generated token list.