### PR TITLE
Terra2: Use "docker compose", not "docker-compose"

### DIFF
--- a/cosmwasm/deployment/terra2/Makefile
+++ b/cosmwasm/deployment/terra2/Makefile
@@ -42,10 +42,10 @@ test/node_modules: test/package-lock.json
 ## Run unit and integration tests
 test: artifacts test/node_modules
 	@if pgrep terrad; then echo "Error: terrad already running. Stop it before running tests"; exit 1; fi
-	cd devnet && DOCKER_BUILDKIT=1 docker-compose up --detach
+	cd devnet && DOCKER_BUILDKIT=1 docker compose up --detach
 	sleep 10
-	cd test && npm run test || (cd ../devnet && docker-compose down && exit 1)
-	cd devnet && docker-compose down
+	cd test && npm run test || (cd ../devnet && docker compose down && exit 1)
+	cd devnet && docker compose down
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Recently Terra2 started failing in CI saying "docker-compose: not found". The `docker-compose` command has been replaced by `docker compose`. Although I'm not sure why things suddenly stopped working (Did the docker version in CI get updated?), it works after changing it. 🤷 