### PR TITLE
Node/CCQ: Allow address wildcard

### DIFF
--- a/docs/query_proxy.md
+++ b/docs/query_proxy.md
@@ -143,6 +143,11 @@ The following are the Solana call types. Both require the `chain` parameter plus
 
 The Solana account and and program address can be expressed as either a 32 byte hex string starting with "0x" or as a base 58 value.
 
+#### Wild Card Contract Addresses
+
+For the eth calls, the `contractAddress` field may be set to `"*"` which means the specified call type and call may be made to any
+contract address on the specified chain.
+
 #### Creating New API Keys
 
 Each user must have an API key. These keys only have meaning to the proxy server. They are not passed to the guardians.

--- a/node/cmd/ccq/devnet.permissions.json
+++ b/node/cmd/ccq/devnet.permissions.json
@@ -8,7 +8,7 @@
           "ethCall": {
             "note:": "Name of WETH on Goerli",
             "chain": 2,
-            "contractAddress": "B4FBF271143F4FBf7B91A5ded31805e42b2208d6",
+            "contractAddress": "*",
             "call": "0x06fdde03"
           }
         },

--- a/node/cmd/ccq/permissions.go
+++ b/node/cmd/ccq/permissions.go
@@ -280,9 +280,13 @@ func parseConfig(byteValue []byte, allowAnything bool) (PermissionsMap, error) {
 
 			if callKey == "" {
 				// Convert the contract address into a standard format like "000000000000000000000000b4fbf271143f4fbf7b91a5ded31805e42b2208d6".
-				contractAddress, err := vaa.StringToAddress(contractAddressStr)
-				if err != nil {
-					return nil, fmt.Errorf(`invalid contract address "%s" for user "%s"`, contractAddressStr, user.UserName)
+				contractAddress := contractAddressStr
+				if contractAddressStr != "*" {
+					contractAddr, err := vaa.StringToAddress(contractAddressStr)
+					if err != nil {
+						return nil, fmt.Errorf(`invalid contract address "%s" for user "%s"`, contractAddressStr, user.UserName)
+					}
+					contractAddress = contractAddr.String()
 				}
 
 				// The call should be the ABI four byte hex hash of the function signature. Parse it into a standard form of "06fdde03".

--- a/node/pkg/watchers/evm/blocks_by_timestamp.go
+++ b/node/pkg/watchers/evm/blocks_by_timestamp.go
@@ -166,3 +166,17 @@ func (lhs Block) Cmp(rhs Block) int {
 
 	return 0
 }
+
+// GetRange returns the range covered by the cache for debugging purposes.
+func (bts *BlocksByTimestamp) GetRange() (firstBlockNum, firstBlockTime, lastBlockNum, lastBlockTime uint64) {
+	bts.mutex.Lock()
+	defer bts.mutex.Unlock()
+
+	l := len(bts.cache)
+	if l <= 0 {
+		return 0, 0, 0, 0
+	}
+
+	l = l - 1
+	return bts.cache[0].BlockNum, bts.cache[0].Timestamp, bts.cache[l].BlockNum, bts.cache[l].Timestamp
+}

--- a/node/pkg/watchers/evm/ccq.go
+++ b/node/pkg/watchers/evm/ccq.go
@@ -220,9 +220,11 @@ func (w *Watcher) ccqHandleEthCallByTimestampQueryRequest(ctx context.Context, q
 		}
 
 		// Look the timestamp up in the cache. Note that the cache uses native EVM time, which is seconds, but CCQ uses microseconds, so we have to convert.
-		blockNum, nextBlockNum, found := w.ccqTimestampCache.LookUp(req.TargetTimestamp / 1000000)
+		timestampForCache := req.TargetTimestamp / 1000000
+		blockNum, nextBlockNum, found := w.ccqTimestampCache.LookUp(timestampForCache)
 		if !found {
 			status := query.QueryRetryNeeded
+			firstBlockNum, firstBlockTime, lastBlockNum, lastBlockTime := w.ccqTimestampCache.GetRange()
 			if nextBlockNum == 0 {
 				w.ccqLogger.Warn("block look up failed in eth_call_by_timestamp query request, timestamp beyond the end of the cache, will wait and retry",
 					zap.String("requestId", requestId),
@@ -231,6 +233,11 @@ func (w *Watcher) ccqHandleEthCallByTimestampQueryRequest(ctx context.Context, q
 					zap.String("nextBlock", nextBlock),
 					zap.Uint64("blockNum", blockNum),
 					zap.Uint64("nextBlockNum", nextBlockNum),
+					zap.Uint64("timestampForCache", timestampForCache),
+					zap.Uint64("firstBlockNum", firstBlockNum),
+					zap.Uint64("firstBlockTime", firstBlockTime),
+					zap.Uint64("lastBlockNum", lastBlockNum),
+					zap.Uint64("lastBlockTime", lastBlockTime),
 				)
 			} else if blockNum == 0 {
 				w.ccqLogger.Error("block look up failed in eth_call_by_timestamp query request, timestamp too old, failing request",
@@ -240,6 +247,11 @@ func (w *Watcher) ccqHandleEthCallByTimestampQueryRequest(ctx context.Context, q
 					zap.String("nextBlock", nextBlock),
 					zap.Uint64("blockNum", blockNum),
 					zap.Uint64("nextBlockNum", nextBlockNum),
+					zap.Uint64("timestampForCache", timestampForCache),
+					zap.Uint64("firstBlockNum", firstBlockNum),
+					zap.Uint64("firstBlockTime", firstBlockTime),
+					zap.Uint64("lastBlockNum", lastBlockNum),
+					zap.Uint64("lastBlockTime", lastBlockTime),
 				)
 				status = query.QueryFatalError
 			} else if w.ccqBackfillCache {
@@ -250,6 +262,11 @@ func (w *Watcher) ccqHandleEthCallByTimestampQueryRequest(ctx context.Context, q
 					zap.String("nextBlock", nextBlock),
 					zap.Uint64("blockNum", blockNum),
 					zap.Uint64("nextBlockNum", nextBlockNum),
+					zap.Uint64("timestampForCache", timestampForCache),
+					zap.Uint64("firstBlockNum", firstBlockNum),
+					zap.Uint64("firstBlockTime", firstBlockTime),
+					zap.Uint64("lastBlockNum", lastBlockNum),
+					zap.Uint64("lastBlockTime", lastBlockTime),
 				)
 				w.ccqRequestBackfill(req.TargetTimestamp / 1000000)
 			} else {
@@ -260,6 +277,11 @@ func (w *Watcher) ccqHandleEthCallByTimestampQueryRequest(ctx context.Context, q
 					zap.String("nextBlock", nextBlock),
 					zap.Uint64("blockNum", blockNum),
 					zap.Uint64("nextBlockNum", nextBlockNum),
+					zap.Uint64("timestampForCache", timestampForCache),
+					zap.Uint64("firstBlockNum", firstBlockNum),
+					zap.Uint64("firstBlockTime", firstBlockTime),
+					zap.Uint64("lastBlockNum", lastBlockNum),
+					zap.Uint64("lastBlockTime", lastBlockTime),
 				)
 				status = query.QueryFatalError
 			}

--- a/node/pkg/watchers/evm/ccq.go
+++ b/node/pkg/watchers/evm/ccq.go
@@ -268,7 +268,7 @@ func (w *Watcher) ccqHandleEthCallByTimestampQueryRequest(ctx context.Context, q
 					zap.Uint64("lastBlockNum", lastBlockNum),
 					zap.Uint64("lastBlockTime", lastBlockTime),
 				)
-				w.ccqRequestBackfill(req.TargetTimestamp / 1000000)
+				w.ccqRequestBackfill(timestampForCache)
 			} else {
 				w.ccqLogger.Error("block look up failed in eth_call_by_timestamp query request, timestamp is in a gap in the cache, failing request",
 					zap.String("requestId", requestId),


### PR DESCRIPTION
This PR allows the permissions in the queries proxy server to use a wildcard in the contract address field.

It also makes some logging changes in the guardian CCQ code to help debug problems.

To specify a wildcard on an eth call type, the `contractAddress` should be set to `"*"` rather than a specific address.