### PR TITLE
Node/CCQ: Solana should retry block read

### DIFF
--- a/node/pkg/watchers/solana/ccq_test.go
+++ b/node/pkg/watchers/solana/ccq_test.go
@@ -101,3 +101,37 @@ func TestCcqIsMinContextSlotErrorContextSlotIsNotUint64(t *testing.T) {
 	require.True(t, isMinContext)
 	assert.Equal(t, uint64(0), currentSlot)
 }
+
+func TestCcqIsBlockNotAvailableSuccess(t *testing.T) {
+	myErr := &jsonrpc.RPCError{
+		Code:    -32004,
+		Message: "Block not available for slot 282135928",
+		Data:    nil,
+	}
+
+	assert.True(t, ccqIsBlockNotAvailable(error(myErr)))
+}
+
+func TestCcqIsBlockNotAvailableWrongErrorNumberFailure(t *testing.T) {
+	myErr := &jsonrpc.RPCError{
+		Code:    -32016,
+		Message: "Minimum context slot has not been reached",
+		Data: map[string]interface{}{
+			"contextSlot": json.Number("13526"),
+		},
+	}
+
+	assert.False(t, ccqIsBlockNotAvailable(error(myErr)))
+}
+
+func TestCcqIsBlockNotAvailableWrongTextFailure(t *testing.T) {
+	myErr := &jsonrpc.RPCError{
+		Code:    -32004,
+		Message: "Minimum context slot has not been reached",
+		Data: map[string]interface{}{
+			"contextSlot": json.Number("13526"),
+		},
+	}
+
+	assert.False(t, ccqIsBlockNotAvailable(error(myErr)))
+}


### PR DESCRIPTION
We are seeing quite a few cases where the Solana watcher is able to read the desired slot, but then fails to look up the block associated with that slot (to get the block time). This is most likely due to load balancing. This PR adds a retry mechanism for that case.