### PR TITLE
node/test: fix incorrect control flow in governed assets test

### DIFF
--- a/node/pkg/governor/mainnet_tokens_test.go
+++ b/node/pkg/governor/mainnet_tokens_test.go
@@ -58,7 +58,7 @@ func TestGovernedChainHasGovernedAssets(t *testing.T) {
 	for _, chainConfigEntry := range chainList() {
 		e := chainConfigEntry.emitterChainID
 		if _, ignored := ignoredChains[e]; ignored {
-			return
+			continue
 		}
 		t.Run(e.String(), func(t *testing.T) {
 			found := false


### PR DESCRIPTION
The control flow for this function should be `continue` rather than `return`, otherwise the entire test will exit early when evaluating an ignored chain rather than skip the current iteration as intended.

In practice, this test just so happened to work OK because:
- the only ignored chain is Wormchain with ID 3104
- 3104 is the last entry in the slice
- iteration over slices is deterministic 

And so the test always returned early when hitting Wormchain, but Wormchain is the last item in the list.