### PR TITLE
Eth: Make registerAllChainsOnTokenBridge not require worm support

### DIFF
--- a/ethereum/README.md
+++ b/ethereum/README.md
@@ -71,7 +71,7 @@ ethereum$ MNEMONIC= ./sh/upgrade.sh testnet TokenBridge blast
 #### Registering Other Chains on a New TokenBridge
 
 ```shell
-ethereum$ MNEMONIC= ./sh/registerAllChainsOnTokenBridge.sh.sh testnet blast
+ethereum$ MNEMONIC= ./sh/registerAllChainsOnTokenBridge.sh <network> <chainName> <tokenBridgeAddress>
 ```
 
 ### Deploying using Truffle (deprecated)

--- a/ethereum/sh/registerAllChainsOnTokenBridge.sh
+++ b/ethereum/sh/registerAllChainsOnTokenBridge.sh
@@ -6,10 +6,10 @@
 # find a VAA for that chain in the CSV file (as a sanity check). Please be sure to generate
 # the registation VAA for this chain and add it to the file before running this script.
 
-# MNEMONIC=<redacted> ./sh/registerAllChainsOnTokenBridge.sh testnet blast
+# MNEMONIC=<redacted> ./sh/registerAllChainsOnTokenBridge.sh <network> <chainName> <tokenBridgeAddress>
 
-if [ $# != 2 ]; then
-	echo "Usage: $0 testnet blast" >&2
+if [ $# != 3 ]; then
+	echo "Usage: $0 <network> <chainName> <tokenBridgeAddress>" >&2
 	exit 1
 fi
 
@@ -17,14 +17,18 @@ fi
 
 network=$1
 chain=$2
+token_bridge_address=$3
 
-# Figure out which file of VAAs to use.
+# Figure out which env file and VAA files to use.
+env_file=""
 input_file=""
 case "$network" in
     mainnet)
+				env_file="env/.env.${chain}"
         input_file="../deployments/mainnet/tokenBridgeVAAs.csv"
     ;;
     testnet)
+				env_file="env/.env.${chain}.testnet"
         input_file="../deployments/testnet/tokenBridgeVAAs.csv"
 		;;
 		*) echo "unknown network $network, must be testnet or mainnet" >&2
@@ -32,30 +36,10 @@ case "$network" in
     ;;
 esac
 
-# Use the worm cli to get the chain parameters.
-if ! command -v worm &> /dev/null
-then
-	echo "worm binary could not be found. See installation instructions in clients/js/README.md"
-	exit 1
-fi
+# Source in the env file to get the RPC and forge arguments.
+. ${env_file}
 
-chain_id=$(worm info chain-id "$chain")
-if [ $? != 0 ]; then
-	echo -e "\nERROR: failed to look up the chain id for ${chain}, please make sure the worm binary is current!" >&2
-	exit 1
-fi
-
-rpc_url=$(worm info rpc "$network" "$chain")
-if [ $? != 0 ]; then
-	echo -e "\nERROR: failed to look up the RPC for ${chain}, please make sure the worm binary is current!" >&2
-	exit 1
-fi
-
-token_bridge_address=$(worm info contract "$network" "$chain" TokenBridge)
-if [ $? != 0 ]; then
-	echo -e "\nERROR: failed to look up the token bridge address for ${chain}, please make sure the worm binary is current!" >&2
-	exit 1
-fi
+[[ -z $RPC_URL ]] && { echo "Missing RPC_URL"; exit 1; }
 
 # Build one long string of all the vaas in the input file.
 vaas=""
@@ -73,7 +57,7 @@ do
 	vaa=`echo $line | cut -d, -f2`
 
 	# Skip this chain. (We don't want to register this chain on itself.)
-	echo $tag | grep "(${chain_id})" > /dev/null
+	echo $tag | grep -i ${chain} > /dev/null
 	if [ $? == 0 ]; then
 		found_us=1
 		continue
@@ -89,7 +73,7 @@ do
 done < "$input_file"
 
 if [ $found_us == 0 ]; then
-	echo "ERROR: failed to find chain id ${chain_id} in ${input_file}, something is not right!" >&2
+	echo "ERROR: failed to find chain ${chain} in ${input_file}, something is not right!" >&2
 	exit 1
 fi
 
@@ -97,9 +81,9 @@ fi
 vaas="[${vaas}]"
 echo $vaas
 
-echo "Submitting ${count} VAAs to ${network} ${chain} token bridge at address ${token_bridge_address} and rpc ${rpc_url}"
+echo "Submitting ${count} VAAs to ${network} ${chain} token bridge at address ${token_bridge_address} and rpc ${RPC_URL}"
 forge script ./forge-scripts/RegisterChainsTokenBridge.s.sol:RegisterChainsTokenBridge \
 	--sig "run(address,bytes[])" $token_bridge_address $vaas \
-	--rpc-url $rpc_url \
+	--rpc-url $RPC_URL \
 	--private-key $MNEMONIC \
-	--broadcast
+	--broadcast ${FORGE_ARGS}


### PR DESCRIPTION
This script is used to register all existing chains on a new chain. It currently requires that the new chain be supported by the `worm` cli, which can make it difficult to use for newly added chains. This PR removes the dependency on the `worm` cli in favor of reading parameters from the command line and then `.env` file.