### PR TITLE
Node: Enable batching and gossip split in tilt

### DIFF
--- a/node/pkg/p2p/gossip_cutover.go
+++ b/node/pkg/p2p/gossip_cutover.go
@@ -12,7 +12,7 @@ import (
 // The format of this time is very picky. Please use the exact format specified by cutOverFmtStr!
 const mainnetCutOverTimeStr = ""
 const testnetCutOverTimeStr = ""
-const devnetCutOverTimeStr = ""
+const devnetCutOverTimeStr = "2024-08-01T00:00:00-0500"
 const cutOverFmtStr = "2006-01-02T15:04:05-0700"
 
 // gossipCutoverCompleteFlag indicates if the cutover time has passed, meaning we should publish only on the new topics.

--- a/node/pkg/processor/cutover.go
+++ b/node/pkg/processor/cutover.go
@@ -12,7 +12,7 @@ import (
 // The format of this time is very picky. Please use the exact format specified by cutOverFmtStr!
 const mainnetCutOverTimeStr = ""
 const testnetCutOverTimeStr = ""
-const devnetCutOverTimeStr = ""
+const devnetCutOverTimeStr = "2024-08-01T00:00:00-0500"
 const cutOverFmtStr = "2006-01-02T15:04:05-0700"
 
 // batchCutoverCompleteFlag indicates if the cutover time has passed, meaning we should publish observation batches.


### PR DESCRIPTION
This PR enables observation batching and the split of gossip traffic into the new topics in devnet / tilt. It does that by setting the cutover dates for devnet to a time in the past.