### PR TITLE
Node/Solana: Watcher updates

### DIFF
--- a/node/go.mod
+++ b/node/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/dgraph-io/badger/v3 v3.2103.1
 	github.com/ethereum/go-ethereum v1.10.21
-	github.com/gagliardetto/solana-go v1.8.4
+	github.com/gagliardetto/solana-go v1.12.0
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
@@ -144,7 +144,7 @@ require (
 	github.com/flynn/noise v1.1.0 // indirect
 	github.com/francoispqt/gojay v1.2.13 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
-	github.com/gagliardetto/binary v0.7.7 // indirect
+	github.com/gagliardetto/binary v0.8.0 // indirect
 	github.com/gagliardetto/treeout v0.1.4 // indirect
 	github.com/go-kit/log v0.2.1 // indirect
 	github.com/go-logfmt/logfmt v0.6.0 // indirect
@@ -327,7 +327,7 @@ require (
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/strangelove-ventures/packet-forward-middleware/v4 v4.0.4 // indirect
-	github.com/streamingfast/logging v0.0.0-20220813175024-b4fbb0e893df // indirect
+	github.com/streamingfast/logging v0.0.0-20230608130331-f22c91403091 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/subosito/gotenv v1.4.1 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 // indirect

--- a/node/go.sum
+++ b/node/go.sum
@@ -1330,9 +1330,13 @@ github.com/fzipp/gocyclo v0.5.1/go.mod h1:rXPyn8fnlpa0R2csP/31uerbiVBugk5whMdlya
 github.com/fzipp/gocyclo v0.6.0/go.mod h1:rXPyn8fnlpa0R2csP/31uerbiVBugk5whMdlyaLkLoA=
 github.com/gagliardetto/binary v0.7.7 h1:QZpT38+sgoPg+TIQjH94sLbl/vX+nlIRA37pEyOsjfY=
 github.com/gagliardetto/binary v0.7.7/go.mod h1:mUuay5LL8wFVnIlecHakSZMvcdqfs+CsotR5n77kyjM=
+github.com/gagliardetto/binary v0.8.0 h1:U9ahc45v9HW0d15LoN++vIXSJyqR/pWw8DDlhd7zvxg=
+github.com/gagliardetto/binary v0.8.0/go.mod h1:2tfj51g5o9dnvsc+fL3Jxr22MuWzYXwx9wEoN0XQ7/c=
 github.com/gagliardetto/gofuzz v1.2.2/go.mod h1:bkH/3hYLZrMLbfYWA0pWzXmi5TTRZnu4pMGZBkqMKvY=
 github.com/gagliardetto/solana-go v1.8.4 h1:vmD/JmTlonyXGy39bAo0inMhmbdAwV7rXZtLDMZeodE=
 github.com/gagliardetto/solana-go v1.8.4/go.mod h1:i+7aAyNDTHG0jK8GZIBSI4OVvDqkt2Qx+LklYclRNG8=
+github.com/gagliardetto/solana-go v1.12.0 h1:rzsbilDPj6p+/DOPXBMLhwMZeBgeRuXjm5zQFCoXgsg=
+github.com/gagliardetto/solana-go v1.12.0/go.mod h1:l/qqqIN6qJJPtxW/G1PF4JtcE3Zg2vD2EliZrr9Gn5k=
 github.com/gagliardetto/treeout v0.1.4 h1:ozeYerrLCmCubo1TcIjFiOWTTGteOOHND1twdFpgwaw=
 github.com/gagliardetto/treeout v0.1.4/go.mod h1:loUefvXTrlRG5rYmJmExNryyBRh8f89VZhmMOyCyqok=
 github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
@@ -3010,6 +3014,8 @@ github.com/streadway/handy v0.0.0-20200128134331-0f66f006fb2e/go.mod h1:qNTQ5P5J
 github.com/streamingfast/logging v0.0.0-20220405224725-2755dab2ce75/go.mod h1:VlduQ80JcGJSargkRU4Sg9Xo63wZD/l8A5NC/Uo1/uU=
 github.com/streamingfast/logging v0.0.0-20220813175024-b4fbb0e893df h1:P4pTLzwgd6bO3nnlIPnfQ/9Swnx3kSWxItgfkyDFoWo=
 github.com/streamingfast/logging v0.0.0-20220813175024-b4fbb0e893df/go.mod h1:VlduQ80JcGJSargkRU4Sg9Xo63wZD/l8A5NC/Uo1/uU=
+github.com/streamingfast/logging v0.0.0-20230608130331-f22c91403091 h1:RN5mrigyirb8anBEtdjtHFIufXdacyTi6i4KBfeNXeo=
+github.com/streamingfast/logging v0.0.0-20230608130331-f22c91403091/go.mod h1:VlduQ80JcGJSargkRU4Sg9Xo63wZD/l8A5NC/Uo1/uU=
 github.com/stretchr/objx v0.0.0-20180129172003-8a3f7159479f/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/node/pkg/watchers/solana/ccq.go
+++ b/node/pkg/watchers/solana/ccq.go
@@ -225,7 +225,7 @@ func (w *SolanaWatcher) ccqBaseHandleSolanaAccountQueryRequest(
 		}
 		results = append(results, query.SolanaAccountResult{
 			Lamports:   val.Lamports,
-			RentEpoch:  val.RentEpoch,
+			RentEpoch:  val.RentEpoch.Uint64(),
 			Executable: val.Executable,
 			Owner:      val.Owner,
 			Data:       val.Data.GetBinary(),

--- a/node/pkg/watchers/solana/client.go
+++ b/node/pkg/watchers/solana/client.go
@@ -137,7 +137,7 @@ const (
 	// SolanaAccountLen is the expected length of an account identifier, which is a public key. Using the number here because that's what the admin client will populate.
 	SolanaAccountLen = 32
 
-	// SolanaSignatureLen is the expected length of a signature. As of v1.11.0, solana-go does not have a const for this.
+	// SolanaSignatureLen is the expected length of a signature. As of v1.12.0, solana-go does not have a const for this.
 	SolanaSignatureLen = 64
 )
 

--- a/node/pkg/watchers/solana/client_test.go
+++ b/node/pkg/watchers/solana/client_test.go
@@ -13,3 +13,158 @@ func TestVerifyConstants(t *testing.T) {
 	assert.Equal(t, SolanaAccountLen, solana.PublicKeyLength)
 	assert.Equal(t, SolanaSignatureLen, len(solana.Signature{}))
 }
+
+var whLogPrefixForMainnet = createWhLogPrefix("worm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMTth")
+var whLogPrefixForTestnet = createWhLogPrefix("3u8hJUVTA4jH1wYAyUur7FFZVQ8H635K3tSHHF4ssjQ5")
+
+func TestIsPossibleWormholeMessageSuccess(t *testing.T) {
+	// These are actual logs see in mainnet on 8/29/2024.
+	logs := []string{
+		"Program 3vxKRPwUTiEkeUVyoZ9MXFe1V71sRLbLqu1gRYaWmehQ invoke [1]",
+		"Program log: Instruction: TransferWrappedTokensWithRelay",
+		"Program 11111111111111111111111111111111 invoke [2]",
+		"Program 11111111111111111111111111111111 success",
+		"Program 11111111111111111111111111111111 invoke [2]",
+		"Program 11111111111111111111111111111111 success",
+		"Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [2]",
+		"Program log: Instruction: InitializeAccount3",
+		"Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 4214 of 189385 compute units",
+		"Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success",
+		"Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [2]",
+		"Program log: Instruction: Transfer",
+		"Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 4645 of 162844 compute units",
+		"Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success",
+		"Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [2]",
+		"Program log: Instruction: Approve",
+		"Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 2904 of 153570 compute units",
+		"Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success",
+		"Program wormDTUJ6AWPNvk59vGQbDvGJmqbDTdgWgAqcLBCgUb invoke [2]",
+		"Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [3]",
+		"Program log: Instruction: Burn",
+		"Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 4790 of 91730 compute units",
+		"Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success",
+		"Program 11111111111111111111111111111111 invoke [3]",
+		"Program 11111111111111111111111111111111 success",
+		"Program worm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMTth invoke [3]",
+		"Program log: Sequence: 937184",
+		"Program 11111111111111111111111111111111 invoke [4]",
+		"Program 11111111111111111111111111111111 success",
+		"Program 11111111111111111111111111111111 invoke [4]",
+		"Program 11111111111111111111111111111111 success",
+		"Program 11111111111111111111111111111111 invoke [4]",
+		"Program 11111111111111111111111111111111 success",
+		"Program worm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMTth consumed 27141 of 74067 compute units",
+		"Program worm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMTth success",
+		"Program wormDTUJ6AWPNvk59vGQbDvGJmqbDTdgWgAqcLBCgUb consumed 87537 of 133116 compute units",
+		"Program wormDTUJ6AWPNvk59vGQbDvGJmqbDTdgWgAqcLBCgUb success",
+		"Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [2]",
+		"Program log: Instruction: CloseAccount",
+		"Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 3015 of 42346 compute units",
+		"Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success",
+		"Program 3vxKRPwUTiEkeUVyoZ9MXFe1V71sRLbLqu1gRYaWmehQ consumed 186778 of 224134 compute units",
+		"Program 3vxKRPwUTiEkeUVyoZ9MXFe1V71sRLbLqu1gRYaWmehQ success",
+		"Program ComputeBudget111111111111111111111111111111 invoke [1]",
+		"Program ComputeBudget111111111111111111111111111111 success",
+		"Program ComputeBudget111111111111111111111111111111 invoke [1]",
+		"Program ComputeBudget111111111111111111111111111111 success",
+	}
+
+	assert.True(t, isPossibleWormholeMessage(whLogPrefixForMainnet, logs))
+}
+
+func TestIsPossibleWormholeMessageFailNoLogs(t *testing.T) {
+	// These are actual logs see in mainnet on 8/29/2024.
+	logs := []string{}
+
+	assert.False(t, isPossibleWormholeMessage(whLogPrefixForMainnet, logs))
+}
+
+func TestIsPossibleWormholeMessageFailNoWormhole(t *testing.T) {
+	// These are actual logs see in mainnet on 8/29/2024.
+	logs := []string{
+		"Program 11111111111111111111111111111111 invoke [2]",
+		"Program 11111111111111111111111111111111 success",
+		"Program 11111111111111111111111111111111 invoke [2]",
+		"Program 11111111111111111111111111111111 success",
+		"Program 11111111111111111111111111111111 invoke [2]",
+		"Program 11111111111111111111111111111111 success",
+		"Program ComputeBudget111111111111111111111111111111 invoke [1]",
+		"Program ComputeBudget111111111111111111111111111111 success",
+		"Program ComputeBudget111111111111111111111111111111 invoke [1]",
+		"Program ComputeBudget111111111111111111111111111111 success",
+	}
+
+	assert.False(t, isPossibleWormholeMessage(whLogPrefixForMainnet, logs))
+}
+
+func TestIsPossibleWormholeMessageFailNoSequence(t *testing.T) {
+	// These are actual logs see in mainnet on 8/29/2024.
+	logs := []string{
+		"Program worm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMTth invoke [1]",
+		"Program 11111111111111111111111111111111 invoke [2]",
+		"Program 11111111111111111111111111111111 success",
+		"Program 11111111111111111111111111111111 invoke [2]",
+		"Program 11111111111111111111111111111111 success",
+		"Program 11111111111111111111111111111111 invoke [2]",
+		"Program 11111111111111111111111111111111 success",
+		"Program worm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMTth consumed 37058 of 500000 compute units",
+		"Program worm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMTth success",
+		"Program ComputeBudget111111111111111111111111111111 invoke [1]",
+		"Program ComputeBudget111111111111111111111111111111 success",
+		"Program ComputeBudget111111111111111111111111111111 invoke [1]",
+		"Program ComputeBudget111111111111111111111111111111 success",
+	}
+
+	assert.False(t, isPossibleWormholeMessage(whLogPrefixForMainnet, logs))
+}
+
+func TestIsPossibleWormholeMessageFailAtEnd(t *testing.T) {
+	// Note: I altered these logs to create this test. I don't know if this could ever happen.
+	logs := []string{
+		"Program 11111111111111111111111111111111 invoke [2]",
+		"Program 11111111111111111111111111111111 success",
+		"Program 11111111111111111111111111111111 invoke [2]",
+		"Program 11111111111111111111111111111111 success",
+		"Program 11111111111111111111111111111111 invoke [2]",
+		"Program 11111111111111111111111111111111 success",
+		"Program worm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMTth consumed 37058 of 500000 compute units",
+		"Program worm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMTth success",
+		"Program ComputeBudget111111111111111111111111111111 invoke [1]",
+		"Program ComputeBudget111111111111111111111111111111 success",
+		"Program ComputeBudget111111111111111111111111111111 invoke [1]",
+		"Program ComputeBudget111111111111111111111111111111 success",
+		"Program worm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMTth invoke [1]",
+	}
+
+	assert.False(t, isPossibleWormholeMessage(whLogPrefixForMainnet, logs))
+}
+
+func TestIsPossibleWormholeMessageForSolanaRewriteSuccess(t *testing.T) {
+	// These are actual logs see in testnet on 8/30/2024.
+	logs := []string{
+		"Program 4cmLyfxkgj2rGkPnXXJG8uroGvoSqsgigAsB3ACci2x7 invoke [1]",
+		"Program log: Instruction: WithdrawNative",
+		"Program 11111111111111111111111111111111 invoke [2]",
+		"Program 11111111111111111111111111111111 success",
+		"Program log: ctx.accounts.wormhole_program : 3u8hJUVTA4jH1wYAyUur7FFZVQ8H635K3tSHHF4ssjQ5",
+		"Program log: ctx.accounts.wormhole_bridge : 6bi4JGDoRwUs9TYBuvoA7dUVyikTJDrJsJU1ew6KVLiu",
+		"Program log: ctx.accounts.wormhole_message : DzKjuonZWoBjc9VcrtBBXwnEXA248Ma6fjUp1hgez9yg",
+		"Program log: ctx.accounts.custom_wormhole_emitter : F7thxxU2rLuXBj8xxzA39K63oZALrFuYRkCPUpQVhRb3",
+		"Program log: ctx.accounts.custom_wormhole_sequence : FEDW1vsFoGbQkaw9gbwuEZEsSwXLHcAKBVesXnmYNQnU",
+		"Program log: ctx.accounts.depositor : 3X1PnDdoyMdzLEoEy2TAhw8i1zC1F4ipNsxJHotnzCKK",
+		"Program log: ctx.accounts.wormhole_fee_collector : 7s3a1ycs16d6SNDumaRtjcoyMaTDZPavzgsmS3uUZYWX",
+		"Program 3u8hJUVTA4jH1wYAyUur7FFZVQ8H635K3tSHHF4ssjQ5 invoke [2]",
+		"Program log: Instruction: LegacyPostMessage",
+		"Program 11111111111111111111111111111111 invoke [3]",
+		"Program 11111111111111111111111111111111 success",
+		"Program 11111111111111111111111111111111 invoke [3]",
+		"Program 11111111111111111111111111111111 success",
+		"Program log: Sequence: 26",
+		"Program 3u8hJUVTA4jH1wYAyUur7FFZVQ8H635K3tSHHF4ssjQ5 consumed 36772 of 68261 compute units",
+		"Program 3u8hJUVTA4jH1wYAyUur7FFZVQ8H635K3tSHHF4ssjQ5 success",
+		"Program 4cmLyfxkgj2rGkPnXXJG8uroGvoSqsgigAsB3ACci2x7 consumed 169398 of 200000 compute units",
+		"Program 4cmLyfxkgj2rGkPnXXJG8uroGvoSqsgigAsB3ACci2x7 success",
+	}
+
+	assert.True(t, isPossibleWormholeMessage(whLogPrefixForTestnet, logs))
+}

--- a/node/pkg/watchers/solana/client_test.go
+++ b/node/pkg/watchers/solana/client_test.go
@@ -1,0 +1,15 @@
+package solana
+
+import (
+	"testing"
+
+	"github.com/gagliardetto/solana-go"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVerifyConstants(t *testing.T) {
+	// If either of these ever change, message publication and reobservation may break.
+	assert.Equal(t, SolanaAccountLen, solana.PublicKeyLength)
+	assert.Equal(t, SolanaSignatureLen, len(solana.Signature{}))
+}


### PR DESCRIPTION
This PR updates the Solana watcher to do the following:

- Updates `solana-go` to the latest version (v1.12.0, released 11/14/2024). This is required for future work.
- Updates the watcher to support reobserving by transaction ID in addition to by account ID.

This PR changes the code to use `GetParsedTransaction` which processes the account look up table so we no longer have to.