### PR TITLE
eth: fix unbound variable errors in shell utilities

### DIFF
--- a/ethereum/anvil_fork
+++ b/ethereum/anvil_fork
@@ -5,11 +5,12 @@ set -euo pipefail
 # This script forks a chain using anvil with the mnemonic that is used in the
 # testing environment.
 
-if [ -z "$1" ]; then
+CHAIN_NAME="${1:-}"
+
+if [ -z "$CHAIN_NAME" ]; then
   echo "Usage: $0 <chain name>" >&2
   exit 1
 fi
 
-CHAIN_NAME="$1"
 
 DOCKER_ARGS="-p 8545:8545" ./foundry anvil --host 0.0.0.0 --base-fee 0 --fork-url $(worm info rpc mainnet $CHAIN_NAME) --mnemonic "myth like bonus scare over problem client lizard pioneer submit female collect"

--- a/ethereum/sh/upgrade.sh
+++ b/ethereum/sh/upgrade.sh
@@ -8,14 +8,28 @@
 
 set -euo pipefail
 
-network=$1
-module=$2
-chain=$3
+network="${1:-}"
+module="${2:-}"
+chain="${3:-}"
+
+if [ -z "$network" ] || [ -z "$module" ] || [ -z "$chain" ]; then
+  echo "Usage: MNEMONIC=... $0 <network> <module> <chain name>" >&2
+  exit 1
+fi
+
+if [ -z "${MNEMONIC:-}" ]; then
+  echo "MNEMONIC unset"
+  exit 1
+fi
 
 secret=$MNEMONIC
 guardian_secret=""
 
 if [ "$network" = testnet ]; then
+  if [ -z "${GUARDIAN_MNEMONIC:-}" ]; then
+    echo "GUARDIAN_MNEMONIC unset"
+    exit 1
+  fi
   guardian_secret=$GUARDIAN_MNEMONIC
 fi
 

--- a/ethereum/sh/upgrade_all_testnet.sh
+++ b/ethereum/sh/upgrade_all_testnet.sh
@@ -21,7 +21,7 @@ set -uo pipefail
 network=testnet
 
 for module in ${MODULES[@]}; do
-  for chain in ${chains[@]}; do
+  for chain in ${CHAINS[@]}; do
     echo "Upgrading ${chain} ${module} ********************************************************************"
     ./sh/upgrade.sh "$network" "$module" "$chain"
   done


### PR DESCRIPTION
The `set -u` options in these scripts caused them to fail with 'unbound variable' errors when CLI args or env variables were unset. This commit fixes the validation so that the scripts output usage info or helpful errors instead of exiting with unbound variable errors that the user must read the source to diagnose.

for the script `ethereum/sh/upgrade_all_testnet.sh`, the commit updates a variable name that appears incorrect.