### PR TITLE
Node/Processor: Peg observation metric for us

### DIFF
--- a/node/pkg/processor/message.go
+++ b/node/pkg/processor/message.go
@@ -95,6 +95,10 @@ func (p *Processor) handleMessage(k *common.MessagePublication) {
 	// Broadcast the signature.
 	ourObs, msg := p.broadcastSignature(v.MessageID(), k.TxHash.Bytes(), digest, signature, shouldPublishImmediately)
 
+	// Indicate that we observed this one.
+	observationsReceivedTotal.Inc()
+	observationsReceivedByGuardianAddressTotal.WithLabelValues(p.ourAddr.Hex()).Inc()
+
 	// Get / create our state entry.
 	s := p.state.signatures[hash]
 	if s == nil {


### PR DESCRIPTION
The recent refactoring of the processor included a change to not do all of the `handleObservation` processing on our own observations. This avoids unnecessary work, but the change also caused us to stop pegging `wormhole_observations_signed_by_guardian_total`, which at least one guardian does not like. This PR make it peg that metric for our own observations.