### PR TITLE
Node: Set cutover date for testnet

### DIFF
--- a/node/pkg/p2p/gossip_cutover.go
+++ b/node/pkg/p2p/gossip_cutover.go
@@ -11,7 +11,7 @@ import (
 
 // The format of this time is very picky. Please use the exact format specified by cutOverFmtStr!
 const mainnetCutOverTimeStr = ""
-const testnetCutOverTimeStr = ""
+const testnetCutOverTimeStr = "2024-09-24T09:00:00-0500"
 const devnetCutOverTimeStr = "2024-08-01T00:00:00-0500"
 const cutOverFmtStr = "2006-01-02T15:04:05-0700"
 

--- a/node/pkg/processor/cutover.go
+++ b/node/pkg/processor/cutover.go
@@ -11,7 +11,7 @@ import (
 
 // The format of this time is very picky. Please use the exact format specified by cutOverFmtStr!
 const mainnetCutOverTimeStr = ""
-const testnetCutOverTimeStr = ""
+const testnetCutOverTimeStr = "2024-09-24T09:00:00-0500"
 const devnetCutOverTimeStr = "2024-08-01T00:00:00-0500"
 const cutOverFmtStr = "2006-01-02T15:04:05-0700"
 


### PR DESCRIPTION
This PR sets the date to cutover to the new gossip topics and observation batching on testnet. This PR will have no effect until the cutover date (September 24th, 2024, 9am Central Daylight Time).