### PR TITLE
Node/EVM: Batch poller publish initial blocks

### DIFF
--- a/node/pkg/watchers/evm/connectors/batch_poller_test.go
+++ b/node/pkg/watchers/evm/connectors/batch_poller_test.go
@@ -281,12 +281,13 @@ func TestBatchPoller(t *testing.T) {
 		}
 	}()
 
-	// First sleep a bit and make sure there were no start up errors and no blocks got published.
+	// First sleep a bit and make sure there were no start up errors and the initial blocks were published.
 	time.Sleep(10 * time.Millisecond)
 	mutex.Lock()
 	require.NoError(t, publishedErr)
 	require.NoError(t, publishedSubErr)
-	assert.Nil(t, block)
+	batchShouldHaveSafeAndFinalizedButNotLatest(t, block, 0x309a0c, baseConnector.expectedHash())
+	block = nil
 	mutex.Unlock()
 
 	// Post the first new block and verify we get it.


### PR DESCRIPTION
This PR changes the EVM batch poller so that it publishes the current finalized and safe blocks on startup. This is helpful for chains with longer finality times because reobservation requests are not allowed until we have received the first finalized / safe block.