### PR TITLE
clients/js: switch eth rpc

### DIFF
--- a/clients/js/src/consts/networks.ts
+++ b/clients/js/src/consts/networks.ts
@@ -26,7 +26,7 @@ const Mainnet = {
     key: getEnvVar("TERRA_MNEMONIC"),
   },
   Ethereum: {
-    rpc: `https://rpc.ankr.com/eth`,
+    rpc: `https://ethereum-rpc.publicnode.com`,
     key: getEnvVar("ETH_KEY"),
     chain_id: 1,
   },


### PR DESCRIPTION
The ankr RPC was frequently 429'ing the CI tests.