### PR TITLE
Update bug bounty reward limit in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -54,7 +54,7 @@ The Wormhole project operates a bug bounty program to financially incentivize in
 
 - [Immunefi-Hosted Program](https://immunefi.com/bounty/wormhole/)
   - **Scopes**: Guardian and Smart Contracts
-  - **Rewards**: Up to $2,500,000 USDC
+  - **Rewards**: Up to $5,000,000 USDC
   - **KYC**: Required
 
 If you find a security issue in Wormhole, please report the issue immediately using the bug bounty program above.


### PR DESCRIPTION
The max reward on immunefi is $5M as shown in the screenshot here 
![image](https://github.com/user-attachments/assets/5dd89a43-a3c2-4ad0-9133-d3fa79cf0d83)

Also is there a hard upper limit at $5M? or are critical issues paid using the W token and then $5M is just an estimate of how much 20M W tokens would convert to, at the current price of W?