### PR TITLE
go-sdk: Add xLabs public RPC

### DIFF
--- a/sdk/mainnet_consts.go
+++ b/sdk/mainnet_consts.go
@@ -15,6 +15,7 @@ var PublicRPCEndpoints = []string{
 	"https://wormhole-v2-mainnet-api.mcf.rocks",
 	"https://wormhole-v2-mainnet-api.chainlayer.network",
 	"https://wormhole-v2-mainnet-api.staking.fund",
+	"https://guardian.mainnet.xlabs.xyz",
 }
 
 type (


### PR DESCRIPTION
[Here's](https://guardian.mainnet.xlabs.xyz/v1/governor/enqueued_vaas) proof that the endpoint works.