### PR TITLE
Node: Set mainnet gossip cutover time

### DIFF
--- a/node/pkg/p2p/gossip_cutover.go
+++ b/node/pkg/p2p/gossip_cutover.go
@@ -10,7 +10,7 @@ import (
 )
 
 // The format of this time is very picky. Please use the exact format specified by cutOverFmtStr!
-const mainnetCutOverTimeStr = ""
+const mainnetCutOverTimeStr = "2024-10-29T09:00:00-0500"
 const testnetCutOverTimeStr = "2024-09-24T09:00:00-0500"
 const devnetCutOverTimeStr = "2024-08-01T00:00:00-0500"
 const cutOverFmtStr = "2006-01-02T15:04:05-0700"

--- a/node/pkg/processor/cutover.go
+++ b/node/pkg/processor/cutover.go
@@ -10,7 +10,7 @@ import (
 )
 
 // The format of this time is very picky. Please use the exact format specified by cutOverFmtStr!
-const mainnetCutOverTimeStr = ""
+const mainnetCutOverTimeStr = "2024-10-29T09:00:00-0500"
 const testnetCutOverTimeStr = "2024-09-24T09:00:00-0500"
 const devnetCutOverTimeStr = "2024-08-01T00:00:00-0500"
 const cutOverFmtStr = "2006-01-02T15:04:05-0700"


### PR DESCRIPTION
This PR sets the time for the gossip network in mainnet to be cutover to using the split topics and observation batching.

A release containing this PR must be deployed to all guardian nodes before that time (9:00 CDT, October 29th, 2024).