### PR TITLE
solana: Validation of the new spl metadata account

### DIFF
--- a/solana/modules/token_bridge/program/src/accounts.rs
+++ b/solana/modules/token_bridge/program/src/accounts.rs
@@ -106,6 +106,10 @@ impl<'b> Seeded<&SplTokenMetaDerivationData> for SplTokenMeta<'b> {
     }
 }
 
+
+//New data length of spl token metadata account
+pub const NEW_MAX_METADATA_LEN: usize = 607;
+
 /// This method removes code duplication when checking token metadata. When metadata is read for
 /// attestation and transfers, Token Bridge does not invoke Metaplex's Token Metadata program, so
 /// it must validate the account the same way Token Metadata program does to ensure the correct
@@ -128,7 +132,7 @@ pub fn deserialize_and_verify_metadata(
     }
 
     // Account must be the expected Metadata length.
-    if info.data_len() != spl_token_metadata::state::MAX_METADATA_LEN {
+    if info.data_len() != spl_token_metadata::state::MAX_METADATA_LEN && info.data_len() != NEW_MAX_METADATA_LEN {
         return Err(TokenBridgeError::InvalidMetadata.into());
     }
 


### PR DESCRIPTION
**Problem:** Attestation is failing for tokens that were created recently.

**Cause:** Metaplex has resized the SPL token metadata account from **679** bytes to **607** bytes in the commit [(6b2e869)](https://github.com/metaplex-foundation/mpl-token-metadata/commit/6b2e869d92c8aedcbe9c83b06396b7b32e73a679#diff31e646cc5bdf5929f4d60b7c3833f0e976aaa382fe5692a43e973a8451594852)
However, the token-bridge is still using the older version of the SPL token metadata and validating the size based on the older constant. As a result, this check fails to attest tokens that are using the new metadata accounts.

**Solution:** To resolve this, I have added an additional condition with the new metadata length constant, allowing the validation to pass if the SPL token has either of the two metadata account lengths.