### PR TITLE
spy: respect --port if set

### DIFF
--- a/node/cmd/spy/spy.go
+++ b/node/cmd/spy/spy.go
@@ -395,6 +395,7 @@ func runSpy(cmd *cobra.Command, args []string) {
 			gst,
 			rootCtxCancel,
 			p2p.WithSignedVAAListener(signedInC),
+			p2p.WithComponents(components),
 		)
 		if err != nil {
 			return err


### PR DESCRIPTION
`guardiand spy --port` wouldn't be respected and the default port was always used.