### PR TITLE
Add deprecation warning to the top of SDK readme

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -8,7 +8,8 @@ wormhole.
  * [sdk/](./): Go SDK.  This package must live in this directory so that clients can use the
    `github.com/wormhole-foundation/wormhole/sdk` import path.
  * [vaa/](./vaa/): Go package for using VAAs (Verifiable Action Approval).
- * [js/](./js/README.md): Javascript SDK.
+ * [js/](./js/README.md): Legacy JavaScript SDK (**Deprecated and Unsupported**)
+   * Please use the new Wormhole TypeScript SDK instead: [`@wormhole-foundation/sdk`](https://github.com/wormhole-foundation/wormhole-sdk-ts)
  * [js-proto-node/](./js-proto-node/README.md): NodeJS client protobuf.
  * [js-proto-web/](./js-proto-web/README.md): Web client protobuf.
  * [js-wasm/](./js-wasm/README.md): WebAssembly libraries.

--- a/sdk/js/README.md
+++ b/sdk/js/README.md
@@ -1,6 +1,9 @@
-# Wormhole SDK
+# Wormhole Legacy SDK (Deprecated)
 
-> Note: This is a pre-alpha release and in active development. Function names and signatures are subject to change.
+> [!CAUTION]
+> **This SDK is Deprecated and Unsupported**
+>
+> Please use the new Wormhole TypeScript SDK instead: [`@wormhole-foundation/sdk`](https://github.com/wormhole-foundation/wormhole-sdk-ts)
 
 ## What is Wormhole?
 


### PR DESCRIPTION
It is in fact no longer a pre-alpha release in active development

<img width="1061" alt="image" src="https://github.com/user-attachments/assets/2f47d3c2-8a6b-4dd9-87e5-7b70364e7d25">
