### PR TITLE
Update to Move2024

### DIFF
--- a/sui/wormhole/Move.lock
+++ b/sui/wormhole/Move.lock
@@ -2,7 +2,7 @@
 
 [move]
 version = 0
-manifest_digest = "E8C411A83F4F7EF268B73C732B9B6F49F7B204F0C9C2530765365C38B76EF646"
+manifest_digest = "F24DE9952B3B73F37574346F868C342DE75B44914ED8C68274D2F1401E25806F"
 deps_digest = "F8BBB0CCB2491CA29A3DF03D6F92277A4F3574266507ACD77214D37ECA3F3082"
 
 dependencies = [
@@ -11,17 +11,17 @@ dependencies = [
 
 [[move.package]]
 name = "MoveStdlib"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "041c5f2bae2fe52079e44b70514333532d69f4e6", subdir = "crates/sui-framework/packages/move-stdlib" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "framework/testnet", subdir = "crates/sui-framework/packages/move-stdlib" }
 
 [[move.package]]
 name = "Sui"
-source = { git = "https://github.com/MystenLabs/sui.git", rev = "041c5f2bae2fe52079e44b70514333532d69f4e6", subdir = "crates/sui-framework/packages/sui-framework" }
+source = { git = "https://github.com/MystenLabs/sui.git", rev = "framework/testnet", subdir = "crates/sui-framework/packages/sui-framework" }
 
 dependencies = [
   { name = "MoveStdlib" },
 ]
 
 [move.toolchain-version]
-compiler-version = "1.19.0"
-edition = "legacy"
+compiler-version = "1.34.0"
+edition = "2024.beta"
 flavor = "sui"

--- a/sui/wormhole/Move.mainnet.toml
+++ b/sui/wormhole/Move.mainnet.toml
@@ -6,7 +6,7 @@ published-at = "0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb
 [dependencies.Sui]
 git = "https://github.com/MystenLabs/sui.git"
 subdir = "crates/sui-framework/packages/sui-framework"
-rev = "041c5f2bae2fe52079e44b70514333532d69f4e6"
+rev = "framework/mainnet"
 
 [addresses]
 wormhole = "0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a"

--- a/sui/wormhole/Move.testnet.toml
+++ b/sui/wormhole/Move.testnet.toml
@@ -6,7 +6,7 @@ published-at = "0xf47329f4344f3bf0f8e436e2f7b485466cff300f12a166563995d3888c296a
 [dependencies.Sui]
 git = "https://github.com/MystenLabs/sui.git"
 subdir = "crates/sui-framework/packages/sui-framework"
-rev = "041c5f2bae2fe52079e44b70514333532d69f4e6"
+rev = "framework/testnet"
 
 [addresses]
 wormhole = "0xf47329f4344f3bf0f8e436e2f7b485466cff300f12a166563995d3888c296a94"

--- a/sui/wormhole/Move.toml
+++ b/sui/wormhole/Move.toml
@@ -1,1 +1,13 @@
-Move.testnet.toml
+[package]
+name = "Wormhole"
+version = "0.2.0"
+edition = "2024.beta"
+published-at = "0xf47329f4344f3bf0f8e436e2f7b485466cff300f12a166563995d3888c296a94"
+
+[dependencies.Sui]
+git = "https://github.com/MystenLabs/sui.git"
+subdir = "crates/sui-framework/packages/sui-framework"
+rev = "framework/testnet"
+
+[addresses]
+wormhole = "0x123456"

--- a/sui/wormhole/sources/datatypes/external_address.move
+++ b/sui/wormhole/sources/datatypes/external_address.move
@@ -3,7 +3,6 @@
 /// This module implements a custom type for a 32-byte standardized address,
 /// which is meant to represent an address from any other network.
 module wormhole::external_address {
-    use sui::object::{Self, ID};
     use wormhole::bytes32::{Self, Bytes32};
     use wormhole::cursor::{Cursor};
 
@@ -11,7 +10,7 @@ module wormhole::external_address {
     const E_ZERO_ADDRESS: u64 = 0;
 
     /// Container for `Bytes32`.
-    struct ExternalAddress has copy, drop, store {
+    public struct ExternalAddress has copy, drop, store {
         value: Bytes32,
     }
 

--- a/sui/wormhole/sources/datatypes/guardian_signature.move
+++ b/sui/wormhole/sources/datatypes/guardian_signature.move
@@ -4,12 +4,11 @@
 /// with recovery ID of a particular hashed VAA message body. The components of
 /// `GuardianSignature` are used to perform public key recovery using ECDSA.
 module wormhole::guardian_signature {
-    use std::vector::{Self};
 
     use wormhole::bytes32::{Self, Bytes32};
 
     /// Container for elliptic curve signature parameters and Guardian index.
-    struct GuardianSignature has store, drop {
+    public struct GuardianSignature has store, drop {
         r: Bytes32,
         s: Bytes32,
         recovery_id: u8,
@@ -55,10 +54,10 @@ module wormhole::guardian_signature {
     /// consumed by `ecdsa_k1` for public key recovery.
     public fun to_rsv(gs: GuardianSignature): vector<u8> {
         let GuardianSignature { r, s, recovery_id, index: _ } = gs;
-        let out = vector::empty();
-        vector::append(&mut out, bytes32::to_bytes(r));
-        vector::append(&mut out, bytes32::to_bytes(s));
-        vector::push_back(&mut out, recovery_id);
+        let mut out = vector::empty();
+        out.append(bytes32::to_bytes(r));
+        out.append(bytes32::to_bytes(s));
+        out.push_back(recovery_id);
         out
     }
 }

--- a/sui/wormhole/sources/governance/upgrade_contract.move
+++ b/sui/wormhole/sources/governance/upgrade_contract.move
@@ -8,7 +8,6 @@
 /// 3.  Upgrade.
 /// 4.  Commit upgrade.
 module wormhole::upgrade_contract {
-    use sui::object::{ID};
     use sui::package::{UpgradeReceipt, UpgradeTicket};
 
     use wormhole::bytes32::{Self, Bytes32};
@@ -16,7 +15,6 @@ module wormhole::upgrade_contract {
     use wormhole::governance_message::{Self, DecreeTicket, DecreeReceipt};
     use wormhole::state::{Self, State};
 
-    friend wormhole::migrate;
 
     /// Digest is all zeros.
     const E_DIGEST_ZERO_BYTES: u64 = 0;
@@ -25,15 +23,15 @@ module wormhole::upgrade_contract {
     /// contract.
     const ACTION_UPGRADE_CONTRACT: u8 = 1;
 
-    struct GovernanceWitness has drop {}
+    public struct GovernanceWitness has drop {}
 
     // Event reflecting package upgrade.
-    struct ContractUpgraded has drop, copy {
+    public struct ContractUpgraded has drop, copy {
         old_contract: ID,
         new_contract: ID
     }
 
-    struct UpgradeContract {
+    public struct UpgradeContract {
         digest: Bytes32
     }
 
@@ -88,7 +86,7 @@ module wormhole::upgrade_contract {
     ///
     /// During migration, we make sure that the digest equals what we expect by
     /// passing in the same VAA used to upgrade the package.
-    public(friend) fun take_digest(governance_payload: vector<u8>): Bytes32 {
+    public(package) fun take_digest(governance_payload: vector<u8>): Bytes32 {
         // Deserialize the payload as the build digest.
         let UpgradeContract { digest } = deserialize(governance_payload);
 
@@ -103,13 +101,13 @@ module wormhole::upgrade_contract {
     }
 
     fun deserialize(payload: vector<u8>): UpgradeContract {
-        let cur = cursor::new(payload);
+        let mut cur = cursor::new(payload);
 
         // This amount cannot be greater than max u64.
         let digest = bytes32::take_bytes(&mut cur);
         assert!(bytes32::is_nonzero(&digest), E_DIGEST_ZERO_BYTES);
 
-        cursor::destroy_empty(cur);
+        cur.destroy_empty();
 
         UpgradeContract { digest }
     }

--- a/sui/wormhole/sources/governance_message.move
+++ b/sui/wormhole/sources/governance_message.move
@@ -33,7 +33,7 @@ module wormhole::governance_message {
     /// and `authorize_verify_local`) require a witness of type `T`. This is to
     /// ensure that `DecreeTicket`s cannot be mixed up between modules
     /// maliciously.
-    struct DecreeTicket<phantom T> {
+    public struct DecreeTicket<phantom T> {
         governance_chain: u16,
         governance_contract: ExternalAddress,
         module_name: Bytes32,
@@ -41,7 +41,7 @@ module wormhole::governance_message {
         global: bool
     }
 
-    struct DecreeReceipt<phantom T> {
+    public struct DecreeReceipt<phantom T> {
         payload: vector<u8>,
         digest: Bytes32,
         sequence: u64
@@ -173,7 +173,7 @@ module wormhole::governance_message {
     }
 
     fun deserialize(buf: vector<u8>): (Bytes32, u8, u16, vector<u8>) {
-        let cur = cursor::new(buf);
+        let mut cur = cursor::new(buf);
 
         (
             bytes32::take_bytes(&mut cur),
@@ -205,7 +205,6 @@ module wormhole::governance_message {
 #[test_only]
 module wormhole::governance_message_tests {
     use sui::test_scenario::{Self};
-    use sui::tx_context::{Self};
 
     use wormhole::bytes32::{Self};
     use wormhole::consumed_vaas::{Self};
@@ -223,7 +222,7 @@ module wormhole::governance_message_tests {
         take_state
     };
 
-    struct GovernanceWitness has drop {}
+    public struct GovernanceWitness has drop {}
 
     const VAA_UPDATE_GUARDIAN_SET_1: vector<u8> =
         x"010000000001004f74e9596bd8246ef456918594ae16e81365b52c0cf4490b2a029fb101b058311f4a5592baeac014dc58215faad36453467a85a4c3e1c6cf5166e80f6e4dc50b0100bc614e000000000001000000000000000000000000000000000000000000000000000000000000000400000000000000010100000000000000000000000000000000000000000000000000000000436f72650200000000000113befa429d57cd18b7f8a4d91a2da9ab4af05d0fbe88d7d8b32a9105d228100e72dffe2fae0705d31c58076f561cc62a47087b567c86f986426dfcd000bd6e9833490f8fa87c733a183cd076a6cbd29074b853fcf0a5c78c1b56d15fce7a154e6ebe9ed7a2af3503dbd2e37518ab04d7ce78b630f98b15b78a785632dea5609064803b1c8ea8bb2c77a6004bd109a281a698c0f5ba31f158585b41f4f33659e54d3178443ab76a60e21690dbfb17f7f59f09ae3ea1647ec26ae49b14060660504f4da1c2059e1c5ab6810ac3d8e1258bd2f004a94ca0cd4c68fc1c061180610e96d645b12f47ae5cf4546b18538739e90f2edb0d8530e31a218e72b9480202acbaeb06178da78858e5e5c4705cdd4b668ffe3be5bae4867c9d5efe3a05efc62d60e1d19faeb56a80223cdd3472d791b7d32c05abb1cc00b6381fa0c4928f0c56fc14bc029b8809069093d712a3fd4dfab31963597e246ab29fc6ebedf2d392a51ab2dc5c59d0902a03132a84dfd920b35a3d0ba5f7a0635df298f9033e";
@@ -234,7 +233,7 @@ module wormhole::governance_message_tests {
     fun test_global_action() {
         // Set up.
         let caller = person();
-        let my_scenario = test_scenario::begin(caller);
+        let mut my_scenario = test_scenario::begin(caller);
         let scenario = &mut my_scenario;
 
         let wormhole_fee = 350;
@@ -272,7 +271,7 @@ module wormhole::governance_message_tests {
         let receipt =
             governance_message::verify_vaa(&worm_state, verified_vaa, ticket);
 
-        let consumed = consumed_vaas::new(&mut tx_context::dummy());
+        let mut consumed = consumed_vaas::new(&mut tx_context::dummy());
         let payload = governance_message::take_payload(&mut consumed, receipt);
         assert!(payload == expected_payload, 0);
 
@@ -289,7 +288,7 @@ module wormhole::governance_message_tests {
     fun test_local_action() {
         // Set up.
         let caller = person();
-        let my_scenario = test_scenario::begin(caller);
+        let mut my_scenario = test_scenario::begin(caller);
         let scenario = &mut my_scenario;
 
         let wormhole_fee = 350;
@@ -323,7 +322,7 @@ module wormhole::governance_message_tests {
         let receipt =
             governance_message::verify_vaa(&worm_state, verified_vaa, ticket);
 
-        let consumed = consumed_vaas::new(&mut tx_context::dummy());
+        let mut consumed = consumed_vaas::new(&mut tx_context::dummy());
         let payload = governance_message::take_payload(&mut consumed, receipt);
         assert!(payload == expected_payload, 0);
 
@@ -343,7 +342,7 @@ module wormhole::governance_message_tests {
     fun test_cannot_verify_vaa_invalid_governance_chain() {
         // Set up.
         let caller = person();
-        let my_scenario = test_scenario::begin(caller);
+        let mut my_scenario = test_scenario::begin(caller);
         let scenario = &mut my_scenario;
 
         let wormhole_fee = 350;
@@ -388,7 +387,7 @@ module wormhole::governance_message_tests {
     fun test_cannot_verify_vaa_invalid_governance_emitter() {
         // Set up.
         let caller = person();
-        let my_scenario = test_scenario::begin(caller);
+        let mut my_scenario = test_scenario::begin(caller);
         let scenario = &mut my_scenario;
 
         let wormhole_fee = 350;
@@ -433,7 +432,7 @@ module wormhole::governance_message_tests {
     fun test_cannot_verify_vaa_invalid_governance_module() {
         // Set up.
         let caller = person();
-        let my_scenario = test_scenario::begin(caller);
+        let mut my_scenario = test_scenario::begin(caller);
         let scenario = &mut my_scenario;
 
         let wormhole_fee = 350;
@@ -486,7 +485,7 @@ module wormhole::governance_message_tests {
     fun test_cannot_verify_vaa_invalid_governance_action() {
         // Set up.
         let caller = person();
-        let my_scenario = test_scenario::begin(caller);
+        let mut my_scenario = test_scenario::begin(caller);
         let scenario = &mut my_scenario;
 
         let wormhole_fee = 350;
@@ -539,7 +538,7 @@ module wormhole::governance_message_tests {
     fun test_cannot_verify_vaa_governance_target_chain_nonzero() {
         // Set up.
         let caller = person();
-        let my_scenario = test_scenario::begin(caller);
+        let mut my_scenario = test_scenario::begin(caller);
         let scenario = &mut my_scenario;
 
         let wormhole_fee = 350;
@@ -592,7 +591,7 @@ module wormhole::governance_message_tests {
     fun test_cannot_verify_vaa_governance_target_chain_not_sui() {
         // Set up.
         let caller = person();
-        let my_scenario = test_scenario::begin(caller);
+        let mut my_scenario = test_scenario::begin(caller);
         let scenario = &mut my_scenario;
 
         let wormhole_fee = 350;
@@ -647,7 +646,7 @@ module wormhole::governance_message_tests {
     fun test_cannot_verify_vaa_outdated_version() {
         // Set up.
         let caller = person();
-        let my_scenario = test_scenario::begin(caller);
+        let mut my_scenario = test_scenario::begin(caller);
         let scenario = &mut my_scenario;
 
         let wormhole_fee = 350;
@@ -656,7 +655,7 @@ module wormhole::governance_message_tests {
         // Prepare test setting sender to `caller`.
         test_scenario::next_tx(scenario, caller);
 
-        let worm_state = take_state(scenario);
+        let mut worm_state = take_state(scenario);
         let the_clock = take_clock(scenario);
 
         let verified_vaa =

--- a/sui/wormhole/sources/resources/consumed_vaas.move
+++ b/sui/wormhole/sources/resources/consumed_vaas.move
@@ -1,5 +1,4 @@
 module wormhole::consumed_vaas {
-    use sui::tx_context::{TxContext};
 
     use wormhole::bytes32::{Bytes32};
     use wormhole::set::{Self, Set};
@@ -9,7 +8,7 @@ module wormhole::consumed_vaas {
     /// is up to the integrator to have this container live in his contract
     /// in order to take advantage of this no-replay protection. Or an
     /// integrator can implement his own method to prevent replay.
-    struct ConsumedVAAs has store {
+    public struct ConsumedVAAs has store {
         hashes: Set<Bytes32>
     }
 

--- a/sui/wormhole/sources/resources/guardian.move
+++ b/sui/wormhole/sources/resources/guardian.move
@@ -2,7 +2,6 @@
 
 /// This module implements a `Guardian` that warehouses a 20-byte public key.
 module wormhole::guardian {
-    use std::vector::{Self};
     use sui::hash::{Self};
     use sui::ecdsa_k1::{Self};
 
@@ -13,7 +12,7 @@ module wormhole::guardian {
     const E_ZERO_ADDRESS: u64 = 1;
 
     /// Container for 20-byte Guardian public key.
-    struct Guardian has store {
+    public struct Guardian has store {
         pubkey: Bytes20
     }
 
@@ -48,24 +47,23 @@ module wormhole::guardian {
 
     /// Same as 'ecrecover' in EVM.
     fun ecrecover(message: vector<u8>, sig: vector<u8>): vector<u8> {
-        let pubkey =
+        let mut pubkey =
             ecdsa_k1::decompress_pubkey(&ecdsa_k1::secp256k1_ecrecover(&sig, &message, 0));
 
         // `decompress_pubkey` returns 65 bytes. The last 64 bytes are what we
         // need to compute the Guardian's public key.
-        vector::remove(&mut pubkey, 0);
+        pubkey.remove(0);
 
-        let hash = hash::keccak256(&pubkey);
-        let guardian_pubkey = vector::empty<u8>();
-        let (i, n) = (0, bytes20::length());
+        let mut hash = hash::keccak256(&pubkey);
+        let mut guardian_pubkey = vector::empty<u8>();
+        let (mut i, n) = (0, bytes20::length());
         while (i < n) {
-            vector::push_back(
-                &mut guardian_pubkey,
-                vector::pop_back(&mut hash)
+            guardian_pubkey.push_back(
+                hash.pop_back()
             );
             i = i + 1;
         };
-        vector::reverse(&mut guardian_pubkey);
+        guardian_pubkey.reverse();
 
         guardian_pubkey
     }

--- a/sui/wormhole/sources/resources/set.move
+++ b/sui/wormhole/sources/resources/set.move
@@ -6,7 +6,6 @@
 /// NOTE: Items added to this data structure cannot be removed.
 module wormhole::set {
     use sui::table::{Self, Table};
-    use sui::tx_context::{TxContext};
 
     /// Explicit error if key already exists in `Set`.
     const E_KEY_ALREADY_EXISTS: u64 = 0;
@@ -14,11 +13,11 @@ module wormhole::set {
     const E_KEY_NONEXISTENT: u64 = 1;
 
     /// Empty struct. Used as the value type in mappings to encode a set
-    struct Empty has store, drop {}
+    public struct Empty has store, drop {}
 
     /// A set containing elements of type `T` with support for membership
     /// checking.
-    struct Set<phantom T: copy + drop + store> has store {
+    public struct Set<phantom T: copy + drop + store> has store {
         items: Table<T, Empty>
     }
 
@@ -54,35 +53,33 @@ module wormhole::set {
 
 #[test_only]
 module wormhole::set_tests {
-    use sui::tx_context::{Self};
-
     use wormhole::set::{Self};
 
     #[test]
     public fun test_add_and_contains() {
         let ctx = &mut tx_context::dummy();
 
-        let my_set = set::new(ctx);
+        let mut my_set = set::new(ctx);
 
-        let (i, n) = (0, 256);
+        let (mut i, n) = (0, 256);
         while (i < n) {
-            set::add(&mut my_set, i);
+            my_set.add( i);
             i = i + 1;
         };
 
         // Check that the set has the values just added.
-        let i = 0;
+        let mut i = 0;
         while (i < n) {
-            assert!(set::contains(&my_set, i), 0);
+            assert!(my_set.contains(i), 0);
             i = i + 1;
         };
 
         // Check that these values that were not added are not in the set.
         while (i < 2 * n) {
-            assert!(!set::contains(&my_set, i), 0);
+            assert!(!my_set.contains(i), 0);
             i = i + 1;
         };
 
-        set::destroy(my_set);
+        my_set.destroy();
     }
 }

--- a/sui/wormhole/sources/utils/bytes.move
+++ b/sui/wormhole/sources/utils/bytes.move
@@ -6,12 +6,11 @@
 /// argument will be of `&mut Cursor<u8>` (see `wormhole::cursor` for more
 /// details).
 module wormhole::bytes {
-    use std::vector::{Self};
     use std::bcs::{Self};
     use wormhole::cursor::{Self, Cursor};
 
     public fun push_u8(buf: &mut vector<u8>, v: u8) {
-        vector::push_back<u8>(buf, v);
+        buf.push_back<u8>(v);
     }
 
     public fun push_u16_be(buf: &mut vector<u8>, value: u16) {
@@ -39,8 +38,8 @@ module wormhole::bytes {
     }
 
     public fun take_u16_be(cur: &mut Cursor<u8>): u16 {
-        let out = 0;
-        let i = 0;
+        let mut out = 0;
+        let mut i = 0;
         while (i < 2) {
             out = (out << 8) + (cursor::poke(cur) as u16);
             i = i + 1;
@@ -49,8 +48,8 @@ module wormhole::bytes {
     }
 
     public fun take_u32_be(cur: &mut Cursor<u8>): u32 {
-        let out = 0;
-        let i = 0;
+        let mut out = 0;
+        let mut i = 0;
         while (i < 4) {
             out = (out << 8) + (cursor::poke(cur) as u32);
             i = i + 1;
@@ -59,8 +58,8 @@ module wormhole::bytes {
     }
 
     public fun take_u64_be(cur: &mut Cursor<u8>): u64 {
-        let out = 0;
-        let i = 0;
+        let mut out = 0;
+        let mut i = 0;
         while (i < 8) {
             out = (out << 8) + (cursor::poke(cur) as u64);
             i = i + 1;
@@ -69,8 +68,8 @@ module wormhole::bytes {
     }
 
     public fun take_u128_be(cur: &mut Cursor<u8>): u128 {
-        let out = 0;
-        let i = 0;
+        let mut out = 0;
+        let mut i = 0;
         while (i < 16) {
             out = (out << 8) + (cursor::poke(cur) as u128);
             i = i + 1;
@@ -79,8 +78,8 @@ module wormhole::bytes {
     }
 
     public fun take_u256_be(cur: &mut Cursor<u8>): u256 {
-        let out = 0;
-        let i = 0;
+        let mut out = 0;
+        let mut i = 0;
         while (i < 32) {
             out = (out << 8) + (cursor::poke(cur) as u256);
             i = i + 1;
@@ -89,80 +88,79 @@ module wormhole::bytes {
     }
 
     public fun take_bytes(cur: &mut Cursor<u8>, num_bytes: u64): vector<u8> {
-        let out = vector::empty();
-        let i = 0;
+        let mut out = vector::empty();
+        let mut i = 0;
         while (i < num_bytes) {
-            vector::push_back(&mut out, cursor::poke(cur));
+            out.push_back(cursor::poke(cur));
             i = i + 1;
         };
         out
     }
 
     fun push_reverse<T: drop>(buf: &mut vector<u8>, v: T) {
-        let data = bcs::to_bytes(&v);
-        vector::reverse(&mut data);
-        vector::append(buf, data);
+        let mut data = bcs::to_bytes(&v);
+        data.reverse();
+        buf.append(data);
     }
 }
 
 #[test_only]
 module wormhole::bytes_tests {
-    use std::vector::{Self};
     use wormhole::bytes::{Self};
     use wormhole::cursor::{Self};
 
     #[test]
     fun test_push_u8(){
         let u = 0x12;
-        let s = vector::empty();
+        let mut s = vector::empty();
         bytes::push_u8(&mut s, u);
-        let cur = cursor::new(s);
+        let mut cur = cursor::new(s);
         let p = bytes::take_u8(&mut cur);
-        cursor::destroy_empty(cur);
+        cur.destroy_empty();
         assert!(p==u, 0);
     }
 
     #[test]
     fun test_push_u16_be(){
         let u = 0x1234;
-        let s = vector::empty();
+        let mut s = vector::empty();
         bytes::push_u16_be(&mut s, u);
-        let cur = cursor::new(s);
+        let mut cur = cursor::new(s);
         let p = bytes::take_u16_be(&mut cur);
-        cursor::destroy_empty(cur);
+        cur.destroy_empty();
         assert!(p==u, 0);
     }
 
     #[test]
     fun test_push_u32_be(){
         let u = 0x12345678;
-        let s = vector::empty();
+        let mut s = vector::empty();
         bytes::push_u32_be(&mut s, u);
-        let cur = cursor::new(s);
+        let mut cur = cursor::new(s);
         let p = bytes::take_u32_be(&mut cur);
-        cursor::destroy_empty(cur);
+        cur.destroy_empty();
         assert!(p==u, 0);
     }
 
     #[test]
     fun test_push_u64_be(){
         let u = 0x1234567812345678;
-        let s = vector::empty();
+        let mut s = vector::empty();
         bytes::push_u64_be(&mut s, u);
-        let cur = cursor::new(s);
+        let mut cur = cursor::new(s);
         let p = bytes::take_u64_be(&mut cur);
-        cursor::destroy_empty(cur);
+        cur.destroy_empty();
         assert!(p==u, 0);
     }
 
      #[test]
     fun test_push_u128_be(){
         let u = 0x12345678123456781234567812345678;
-        let s = vector::empty();
+        let mut s = vector::empty();
         bytes::push_u128_be(&mut s, u);
-        let cur = cursor::new(s);
+        let mut cur = cursor::new(s);
         let p = bytes::take_u128_be(&mut cur);
-        cursor::destroy_empty(cur);
+        cur.destroy_empty();
         assert!(p==u, 0);
     }
 
@@ -170,7 +168,7 @@ module wormhole::bytes_tests {
     fun test_push_u256_be(){
         let u =
             0x4738691759099793746170047375612500000000000000000000000000009876;
-        let s = vector::empty();
+        let mut s = vector::empty();
         bytes::push_u256_be(&mut s, u);
         assert!(
             s == x"4738691759099793746170047375612500000000000000000000000000009876",
@@ -180,53 +178,53 @@ module wormhole::bytes_tests {
 
     #[test]
     fun test_take_u8() {
-        let cursor = cursor::new(x"99");
+        let mut cursor = cursor::new(x"99");
         let byte = bytes::take_u8(&mut cursor);
         assert!(byte==0x99, 0);
-        cursor::destroy_empty(cursor);
+        cursor.destroy_empty();
     }
 
     #[test]
     fun test_take_u16_be() {
-        let cursor = cursor::new(x"9987");
+        let mut cursor = cursor::new(x"9987");
         let u = bytes::take_u16_be(&mut cursor);
         assert!(u == 0x9987, 0);
-        cursor::destroy_empty(cursor);
+        cursor.destroy_empty();
     }
 
     #[test]
     fun test_take_u32_be() {
-        let cursor = cursor::new(x"99876543");
+        let mut cursor = cursor::new(x"99876543");
         let u = bytes::take_u32_be(&mut cursor);
         assert!(u == 0x99876543, 0);
-        cursor::destroy_empty(cursor);
+        cursor.destroy_empty();
     }
 
     #[test]
     fun test_take_u64_be() {
-        let cursor = cursor::new(x"1300000025000001");
+        let mut cursor = cursor::new(x"1300000025000001");
         let u = bytes::take_u64_be(&mut cursor);
         assert!(u == 0x1300000025000001, 0);
-        cursor::destroy_empty(cursor);
+        cursor.destroy_empty();
     }
 
     #[test]
     fun test_take_u128_be() {
-        let cursor = cursor::new(x"130209AB2500FA0113CD00AE25000001");
+        let mut cursor = cursor::new(x"130209AB2500FA0113CD00AE25000001");
         let u = bytes::take_u128_be(&mut cursor);
         assert!(u == 0x130209AB2500FA0113CD00AE25000001, 0);
-        cursor::destroy_empty(cursor);
+        cursor.destroy_empty();
     }
 
     #[test]
     fun test_to_bytes() {
-        let cursor = cursor::new(b"hello world");
+        let mut cursor = cursor::new(b"hello world");
         let hello = bytes::take_bytes(&mut cursor, 5);
         bytes::take_u8(&mut cursor);
         let world = bytes::take_bytes(&mut cursor, 5);
         assert!(hello == b"hello", 0);
         assert!(world == b"world", 0);
-        cursor::destroy_empty(cursor);
+        cursor.destroy_empty();
     }
 
 }

--- a/sui/wormhole/sources/utils/cursor.move
+++ b/sui/wormhole/sources/utils/cursor.move
@@ -8,17 +8,16 @@
 /// This setup statically guarantees that the parsing methods consume the full
 /// input.
 module wormhole::cursor {
-    use std::vector::{Self};
 
     /// Container for the underlying `vector<u8>` data to be consumed.
-    struct Cursor<T> {
+    public struct Cursor<T> {
         data: vector<T>,
     }
 
     /// Initialises a cursor from a vector.
-    public fun new<T>(data: vector<T>): Cursor<T> {
+    public fun new<T>(mut data: vector<T>): Cursor<T> {
         // reverse the array so we have access to the first element easily
-        vector::reverse(&mut data);
+        data.reverse();
         Cursor<T> { data }
     }
 
@@ -30,13 +29,13 @@ module wormhole::cursor {
     /// Check whether the underlying data is empty. This method is useful for
     /// iterating over a `Cursor` to exhaust its contents.
     public fun is_empty<T>(self: &Cursor<T>): bool {
-        vector::is_empty(&self.data)
+        self.data.is_empty()
     }
 
     /// Destroys an empty cursor. This method aborts if the cursor is not empty.
     public fun destroy_empty<T>(cursor: Cursor<T>) {
         let Cursor { data } = cursor;
-        vector::destroy_empty(data);
+        data.destroy_empty();
     }
 
     /// Consumes the rest of the cursor (thus destroying it) and returns the
@@ -46,15 +45,15 @@ module wormhole::cursor {
     /// bytes. Since the result is a vector, which can be dropped, it is not
     /// possible to statically guarantee that the rest will be used.
     public fun take_rest<T>(cursor: Cursor<T>): vector<T> {
-        let Cursor { data } = cursor;
+        let Cursor { mut data } = cursor;
         // Because the data was reversed in initialization, we need to reverse
         // again so it is in the same order as the original input.
-        vector::reverse(&mut data);
+        data.reverse();
         data
     }
 
     /// Retrieve the first element of the cursor and advances it.
     public fun poke<T>(self: &mut Cursor<T>): T {
-        vector::pop_back(&mut self.data)
+        self.data.pop_back()
     }
 }

--- a/sui/wormhole/sources/version_control.move
+++ b/sui/wormhole/sources/version_control.move
@@ -16,11 +16,11 @@ module wormhole::version_control {
     //
     ////////////////////////////////////////////////////////////////////////////
 
-    public(friend) fun current_version(): V__0_2_0 {
+    public(package) fun current_version(): V__0_2_0 {
        V__0_2_0 {}
     }
 
-    public(friend) fun previous_version(): V__DUMMY {
+    public(package) fun previous_version(): V__DUMMY {
         V__DUMMY {}
     }
 
@@ -39,10 +39,10 @@ module wormhole::version_control {
     ////////////////////////////////////////////////////////////////////////////
 
     /// First published package on Sui mainnet.
-    struct V__0_2_0 has store, drop, copy {}
+    public struct V__0_2_0 has store, drop, copy {}
 
     // Dummy.
-    struct V__DUMMY has store, drop, copy {}
+    public struct V__DUMMY has store, drop, copy {}
 
     ////////////////////////////////////////////////////////////////////////////
     //
@@ -50,10 +50,6 @@ module wormhole::version_control {
     //
     ////////////////////////////////////////////////////////////////////////////
 
-    friend wormhole::state;
-
-    #[test_only]
-    friend wormhole::package_utils_tests;
 
     #[test_only]
     public fun dummy(): V__DUMMY {
@@ -61,7 +57,7 @@ module wormhole::version_control {
     }
 
     #[test_only]
-    struct V__MIGRATED has store, drop, copy {}
+    public struct V__MIGRATED has store, drop, copy {}
 
     #[test_only]
     public fun next_version(): V__MIGRATED {


### PR DESCRIPTION
Updating the code base to Move2024 syntax and change Move.toml edition to 2024.beta
Also changed the Move.toml Sui dependency to point to the latest testnet revision instead of a hardcoded revision that might get too old.