### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,7 +15,7 @@
 /solana/ @kcsongor @a5-pickle
 /sui/ @kcsongor @a5-pickle @gator-boi
 /terra/ @kcsongor @a5-pickle
-/wormchain/ @nik-suri @johnsaigle @mdulin2 @jtieri
+/wormchain/ @nik-suri @johnsaigle @mdulin2 @joelsmith-2019
 
 # Utilities
 


### PR DESCRIPTION
Transitions the Strangelove Codeowner from Justin Tieri to Joel Smith.