### PR TITLE
wormchain: disable ignite

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -817,12 +817,12 @@ if wormchain:
         ignore = ["./wormchain/testing", "./wormchain/ts-sdk", "./wormchain/design", "./wormchain/vue", "./wormchain/build/wormchaind"],
     )
 
-    docker_build(
-        ref = "vue-export",
-        context = ".",
-        dockerfile = "./wormchain/Dockerfile.proto",
-        target = "vue-export",
-    )
+    # docker_build(
+    #     ref = "vue-export",
+    #     context = ".",
+    #     dockerfile = "./wormchain/Dockerfile.proto",
+    #     target = "vue-export",
+    # )
 
     docker_build(
         ref = "wormchain-deploy",

--- a/wormchain/Dockerfile.deploy
+++ b/wormchain/Dockerfile.deploy
@@ -19,7 +19,7 @@ COPY ./ts-sdk/package.json ./ts-sdk/package-lock.json /ts-sdk/
 RUN --mount=type=cache,uid=1000,gid=1000,target=/home/node/.npm \
     npm ci --prefix=/ts-sdk
 COPY ./ts-sdk /ts-sdk
-COPY --from=vue-export /vue /vue
+# COPY --from=vue-export /vue /vue
 RUN npm run build --prefix=/ts-sdk
 
 COPY ./contracts/tools/package.json ./contracts/tools/package-lock.json /app/tools/

--- a/wormchain/Makefile
+++ b/wormchain/Makefile
@@ -26,13 +26,13 @@ build/wormchaind: cmd/wormchaind/main.go $(GO_FILES)
 	go build -v $(BUILD_FLAGS) -tags ledger -o $@ $<
 	cp "$@" "$@"-"$(VERSION)"
 
-proto: $(PROTO_FILES)
-	DOCKER_BUILDKIT=1 docker build --target go-export -f Dockerfile.proto -o type=local,dest=. ..
+# proto: $(PROTO_FILES)
+# 	DOCKER_BUILDKIT=1 docker build --target go-export -f Dockerfile.proto -o type=local,dest=. ..
 
-vue: $(GO_FILES) proto
-	mkdir -p $@
-	touch -m $@
-	DOCKER_BUILDKIT=1 docker build --target vue-export -f Dockerfile.proto -o type=local,dest=. ..
+# vue: $(GO_FILES) proto
+# 	mkdir -p $@
+# 	touch -m $@
+# 	DOCKER_BUILDKIT=1 docker build --target vue-export -f Dockerfile.proto -o type=local,dest=. ..
 
 # For now this is a phony target so we just rebuild it each time instead of
 # tracking dependencies

--- a/wormchain/ts-sdk/package.json
+++ b/wormchain/ts-sdk/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "test": "jest --config jestconfig.json --verbose",
     "build": "npm run genTypes && tsc",
-    "genTypes": "node src/buildHelper.cjs"
+    "genTypes": "echo \"disabled: node src/buildHelper.cjs\""
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Ignite, which is used to generate go and TS code for wormchain / Cosmos, now fails due to a deprecated protobuf dependency. As far as I understand, these files are already committed, but the step was left as the ignite build is non-deterministic, so it was not possible to add enforcement in CI that the committed code matches what would be generate (as with the other pre-compiled sources, such as the node protobuf files).

As soon as the version of Ignite is upgraded, the generation should be moved to a CI check like the others to ensure it matches what is committed. 