### PR TITLE
editVaa:  Fix Guardian address comparison 

### DIFF
--- a/clients/js/src/cmds/editVaa.ts
+++ b/clients/js/src/cmds/editVaa.ts
@@ -262,7 +262,7 @@ const getSigsFromWormscanData = (
       const normalizedGuardianFromSet = new UniversalAddress(guardianSet[idx], platformToAddressFormat("Evm"));
       const normalizedGuardianAddr = new UniversalAddress(guardianAddr, platformToAddressFormat("Evm"));
 
-      if (normalizedGuardianAddr.toString() === normalizedGuardianFromSet.toString()) {
+      if (normalizedGuardianAddr.equals(normalizedGuardianFromSet)) {
         gsi = idx;
         break;
       }

--- a/clients/js/src/cmds/editVaa.ts
+++ b/clients/js/src/cmds/editVaa.ts
@@ -23,8 +23,9 @@ import { ethers } from "ethers";
 import yargs from "yargs";
 import { NETWORK_OPTIONS, NETWORKS } from "../consts";
 import { parse, Payload, serialiseVAA, sign, Signature, VAA } from "../vaa";
-import { contracts, Network } from "@wormhole-foundation/sdk-base";
+import { contracts, Network, platformToAddressFormat } from "@wormhole-foundation/sdk-base";
 import { getNetwork } from "../utils";
+import { UniversalAddress } from "@wormhole-foundation/sdk";
 
 export const command = "edit-vaa";
 export const desc = "Edits or generates a VAA";
@@ -256,8 +257,12 @@ const getSigsFromWormscanData = (
   for (let data in wormscanData) {
     let guardianAddr = wormscanData[data].guardianAddr;
     let gsi = -1;
+    
     for (let idx = 0; idx < guardianSet.length; idx++) {
-      if (guardianSet[idx] === guardianAddr) {
+      const normalizedGuardianFromSet = new UniversalAddress(guardianSet[idx], platformToAddressFormat("Evm"));
+      const normalizedGuardianAddr = new UniversalAddress(guardianAddr, platformToAddressFormat("Evm"));
+
+      if (normalizedGuardianAddr.toString() === normalizedGuardianFromSet.toString()) {
         gsi = idx;
         break;
       }


### PR DESCRIPTION
I experienced the following result from a edit-vaa command:

```
 worm edit-vaa --vaa 010000000400000000000b8a8215000100000000000000000000000000000000000000000000000000000000000000040e2f9f6967ce40c620000000000000000000000000000000000000000000546f6b656e427269646765010000002d000000000000000000000000c309275443519adca74c9136b02a38ef96e3a1f6 --network mainnet --wormscanurl  https://api.wormholescan.io/api/v1/observations/1/0000000000000000000000000000000000000000000000000000000000000004/1022210915498344646
Failed to look up guardian address 0x5893b5a76c3f739645648885bdccc06cd70a3cd3. Skipping.
Failed to look up guardian address 0x107a0086b32d7a0977926a205131d8731d39cbeb. Skipping.
Failed to look up guardian address 0x178e21ad2e77ae06711549cfbb1f9c7a9d8096e8. Skipping.
Failed to look up guardian address 0x000ac0076727b35fbea2dac28fee5ccb0fea768e. Skipping.
Failed to look up guardian address 0xaf45ced136b9d9e24903464ae889f5c8a723fc14. Skipping.
Failed to look up guardian address 0x71aa1be1d36cafe3867910f99c09e347899c19c3. Skipping.
Failed to look up guardian address 0x11b39756c042441be6d8650b69b54ebe715e2343. Skipping.
Failed to look up guardian address 0xda798f6896a3331f64b48c12d1d57fd9cbe70811. Skipping.
Failed to look up guardian address 0x54ce5b4d348fb74b958e8966e2ec3dbd4958a7cd. Skipping.
Failed to look up guardian address 0xf93124b7c738843cbb89e864c862c38cddcccf95. Skipping.
Failed to look up guardian address 0x8192b6e7387ccd768277c17dab1b7a5027c0b3cf. Skipping.
Failed to look up guardian address 0x5e1487f35515d02a92753504a8d75471b9f49edb. Skipping.
Failed to look up guardian address 0x15e7caf07c4e3dc8e7c469f92c8cd88fb8005a20. Skipping.
010000000400000000000b8a8215000100000000000000000000000000000000000000000000000000000000000000040e2f9f6967ce40c620000000000000000000000000000000000000000000546f6b656e427269646765010000002d000000000000000000000000c309275443519adca74c9136b02a38ef96e3a1f6
```

The problem was that casing was different between the guardian addresses contained in set  and the guardian addresses read from WormholeScan results.

This fix uses UniversalAddress to normalize both strings and compare them via equals method.