### PR TITLE
tilt: support latest docker desktop

### DIFF
--- a/clients/js/src/consts/networks.ts
+++ b/clients/js/src/consts/networks.ts
@@ -556,7 +556,7 @@ const Testnet = {
 
 const Devnet = {
   Solana: {
-    rpc: "http://localhost:8899",
+    rpc: "http://127.0.0.1:8899",
     key: "J2D4pwDred8P9ioyPEZVLPht885AeYpifsFGUyuzVmiKQosAvmZP4EegaKFrSprBC5vVP1xTvu61vYDWsxBNsYx",
   },
   Terra: {

--- a/ethereum/Dockerfile
+++ b/ethereum/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker.io/docker/dockerfile:1.3@sha256:42399d4635eddd7a9b8a24be879d2f9a930d0ed040a61324cfdf59ef1357b3b2
 FROM const-gen AS const-export
-FROM ghcr.io/foundry-rs/foundry:nightly-55bf41564f605cae3ca4c95ac5d468b1f14447f9@sha256:8c15d322da81a6deaf827222e173f3f81c653136a3518d5eeb41250a0f2e17ea as foundry
+FROM --platform=linux/amd64 ghcr.io/foundry-rs/foundry:nightly-55bf41564f605cae3ca4c95ac5d468b1f14447f9@sha256:8c15d322da81a6deaf827222e173f3f81c653136a3518d5eeb41250a0f2e17ea as foundry
 FROM node:19.6.1-slim@sha256:a1ba21bf0c92931d02a8416f0a54daad66cb36a85d2b73af9d73b044f5f57cfc
 
 # npm wants to clone random Git repositories - lovely.

--- a/relayer/ethereum/ts-scripts/relayer/config/kubernetes/chains.json
+++ b/relayer/ethereum/ts-scripts/relayer/config/kubernetes/chains.json
@@ -7,13 +7,13 @@
       "description": "Ganache is supposed to be 1337, but the on-chain block.chainid returns 1",
       "evmNetworkId": 1,
       "chainId": 2,
-      "rpc": "http://localhost:8545",
+      "rpc": "http://127.0.0.1:8545",
       "wormholeAddress": "0xC89Ce4735882C9F0f0FE26686c53074E09B0D550"
     },
     {
       "evmNetworkId": 1397,
       "chainId": 4,
-      "rpc": "http://localhost:8545",
+      "rpc": "http://127.0.0.1:8545",
       "wormholeAddress": "0xC89Ce4735882C9F0f0FE26686c53074E09B0D550"
     }
   ]

--- a/testing/Dockerfile.sdk.test
+++ b/testing/Dockerfile.sdk.test
@@ -1,4 +1,4 @@
-FROM ghcr.io/foundry-rs/foundry:nightly-ea2eff95b5c17edd3ffbdfc6daab5ce5cc80afc0@sha256:2a774f86765258a0d176366fc46f92bc14f5040faae7a3c3ba59b1c24c5fa7cb as foundry
+FROM --platform=linux/amd64 ghcr.io/foundry-rs/foundry:nightly-ea2eff95b5c17edd3ffbdfc6daab5ce5cc80afc0@sha256:2a774f86765258a0d176366fc46f92bc14f5040faae7a3c3ba59b1c24c5fa7cb as foundry
 FROM node:19.6.1-slim@sha256:a1ba21bf0c92931d02a8416f0a54daad66cb36a85d2b73af9d73b044f5f57cfc
 
 RUN apt-get update && apt-get -y install \


### PR DESCRIPTION
This PR mitigates a bug where `localhost` was not resolving in node.js for Kubernetes (v1.29.2) in Docker Desktop 4.29.0 and later. It also fixes an issue when pulling the amd64 foundry image with sha on aarch64 Macs.