### PR TITLE
tilt: m1 flag

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -36,6 +36,7 @@ update_settings(max_parallel_updates = 10)
 # Runtime configuration
 config.define_bool("ci", False, "We are running in CI")
 config.define_bool("manual", False, "Set TRIGGER_MODE_MANUAL by default")
+config.define_bool("m1", False, "Use this flag for M-series Macs (e.g. use an arm64 solana-test-validator due to AVX requirement)")
 
 config.define_string("num", False, "Number of guardian nodes to run")
 
@@ -100,6 +101,7 @@ btc = cfg.get("btc", False)
 redis = cfg.get('redis', ci)
 generic_relayer = cfg.get("generic_relayer", ci)
 query_server = cfg.get("query_server", ci)
+m1 = cfg.get("m1", False)
 
 if ci:
     guardiand_loglevel = cfg.get("guardiand_loglevel", "warn")
@@ -484,6 +486,17 @@ if solana or pythnet:
     )
 
     # solana local devnet
+
+    build_args = {}
+    if m1:
+        build_args = {"BASE_IMAGE": "ghcr.io/wormholelabs-xyz/solana-test-validator-m1:1.17.29@sha256:c5a43c0762f2dab4873a9e632a389029b6d5f706be7dfb89a42a66cc65a3dd24"}
+
+    docker_build(
+        ref = "solana-test-validator",
+        context = "solana",
+        dockerfile = "solana/Dockerfile.test-validator",
+        build_args = build_args
+    )
 
     k8s_yaml_with_ns("devnet/solana-devnet.yaml")
 

--- a/devnet/solana-devnet.yaml
+++ b/devnet/solana-devnet.yaml
@@ -35,9 +35,9 @@ spec:
       terminationGracePeriodSeconds: 1
       containers:
         - name: devnet
-          image: solana-contract
+          image: solana-test-validator
           command:
-            - /root/.local/share/solana/install/active_release/bin/solana-test-validator
+            - solana-test-validator
             - --bpf-program
             - Bridge1p5gheXUvJ6jGWGeCsgPKgnE3YgdGKRVCMY9o
             - /opt/solana/deps/bridge.so

--- a/solana/Dockerfile.test-validator
+++ b/solana/Dockerfile.test-validator
@@ -1,0 +1,3 @@
+ARG BASE_IMAGE=solana-contract
+FROM ${BASE_IMAGE}
+COPY --from=solana-contract /opt/solana/deps/ /opt/solana/deps/

--- a/wormchain/.dockerignore
+++ b/wormchain/.dockerignore
@@ -1,0 +1,6 @@
+target
+bin
+**/target
+**/node_modules
+
+build/config/gentx/

--- a/wormchain/Dockerfile.deploy
+++ b/wormchain/Dockerfile.deploy
@@ -7,7 +7,7 @@ FROM const-gen AS const-export
 FROM cosmwasm_artifacts AS artifacts
 
 # Contract deployment stage
-FROM node:16-buster-slim@sha256:93c9fc3550f5f7d159f282027228e90e3a7f8bf38544758024f005e82607f546
+FROM node:20.13.1-buster-slim@sha256:8916ca78cc94933fdaef715531141c8a658bea61b89d7d88a1b2dcc0a1ae92f6
 
 RUN apt update && apt install netcat curl jq -y
 


### PR DESCRIPTION
This PR adds support for `solana-test-validator` within Docker / Tilt for M-series Macs. This is useful for downstream projects such as NTT which rely on a subset of the tilt setup for e2e testing. It may also benefit contributors who wish to run a minimal tilt setup on their Macs.

The key hold up was Rosetta 2 lacking AVX instruction support, which `solana-test-validator` relies upon. Everything would compile as `amd64` but would not run. Further complicating efforts, there is not a pre-built binary for linux/aarch64. Unlike prior attempts to build the entire solana dependency under `aarch64`, this simply swaps out the binary used.

This same shortcoming may also prevent some other chains from running, such as Near. Further work could be done to provide `aarch64` alternative dockerfiles for the relevant images which do not run properly as `amd64` with Rosetta 2.

This PR also includes a change for the `wormhole-deploy` image, as the existing node image did not build.