### PR TITLE
fix clippy::needless-lifetimes warnings

### DIFF
--- a/cosmwasm/packages/accountant/src/state/account.rs
+++ b/cosmwasm/packages/accountant/src/state/account.rs
@@ -81,7 +81,7 @@ impl KeyDeserialize for Key {
     }
 }
 
-impl<'a> PrimaryKey<'a> for Key {
+impl PrimaryKey<'_> for Key {
     type Prefix = (u16, u16);
     type SubPrefix = u16;
     type Suffix = TokenAddress;

--- a/cosmwasm/packages/accountant/src/state/addr.rs
+++ b/cosmwasm/packages/accountant/src/state/addr.rs
@@ -110,7 +110,7 @@ impl KeyDeserialize for TokenAddress {
     }
 }
 
-impl<'a> PrimaryKey<'a> for TokenAddress {
+impl PrimaryKey<'_> for TokenAddress {
     type Prefix = ();
     type SubPrefix = ();
     type Suffix = Self;
@@ -121,7 +121,7 @@ impl<'a> PrimaryKey<'a> for TokenAddress {
     }
 }
 
-impl<'a> Prefixer<'a> for TokenAddress {
+impl Prefixer<'_> for TokenAddress {
     fn prefix(&self) -> Vec<Key> {
         vec![Key::Ref(&**self)]
     }

--- a/cosmwasm/packages/accountant/src/state/transfer.rs
+++ b/cosmwasm/packages/accountant/src/state/transfer.rs
@@ -109,7 +109,7 @@ impl KeyDeserialize for Key {
     }
 }
 
-impl<'a> PrimaryKey<'a> for Key {
+impl PrimaryKey<'_> for Key {
     type Prefix = (u16, TokenAddress);
     type SubPrefix = u16;
     type Suffix = u64;

--- a/cosmwasm/packages/cw_transcode/src/ser.rs
+++ b/cosmwasm/packages/cw_transcode/src/ser.rs
@@ -266,7 +266,7 @@ pub struct Transcoder<'a> {
     event: Event,
 }
 
-impl<'a> Transcoder<'a> {
+impl Transcoder<'_> {
     fn serialize_field<T>(&mut self, k: &'static str, v: &T) -> Result<(), Error>
     where
         T: ?Sized + Serialize,
@@ -285,7 +285,7 @@ impl<'a> Transcoder<'a> {
     }
 }
 
-impl<'a> SerializeStruct for Transcoder<'a> {
+impl SerializeStruct for Transcoder<'_> {
     type Ok = ();
     type Error = Error;
 
@@ -303,7 +303,7 @@ impl<'a> SerializeStruct for Transcoder<'a> {
     }
 }
 
-impl<'a> SerializeStructVariant for Transcoder<'a> {
+impl SerializeStructVariant for Transcoder<'_> {
     type Ok = ();
     type Error = Error;
 

--- a/sdk/rust/serde_wormhole/src/de.rs
+++ b/sdk/rust/serde_wormhole/src/de.rs
@@ -46,7 +46,7 @@ macro_rules! deserialize_be_number {
     }};
 }
 
-impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
+impl<'de> de::Deserializer<'de> for &mut Deserializer<'de> {
     type Error = Error;
 
     fn deserialize_any<V>(self, _: V) -> Result<V::Value, Self::Error>
@@ -338,7 +338,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     }
 }
 
-impl<'de, 'a> VariantAccess<'de> for &'a mut Deserializer<'de> {
+impl<'de> VariantAccess<'de> for &mut Deserializer<'de> {
     type Error = Error;
 
     #[inline]
@@ -386,7 +386,7 @@ impl<'de, 'a> BoundedSequence<'de, 'a> {
     }
 }
 
-impl<'de, 'a> SeqAccess<'de> for BoundedSequence<'de, 'a> {
+impl<'de> SeqAccess<'de> for BoundedSequence<'de, '_> {
     type Error = Error;
 
     fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>, Self::Error>
@@ -407,7 +407,7 @@ impl<'de, 'a> SeqAccess<'de> for BoundedSequence<'de, 'a> {
     }
 }
 
-impl<'de, 'a> MapAccess<'de> for BoundedSequence<'de, 'a> {
+impl<'de> MapAccess<'de> for BoundedSequence<'de, '_> {
     type Error = Error;
 
     fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>

--- a/sdk/rust/serde_wormhole/src/ser.rs
+++ b/sdk/rust/serde_wormhole/src/ser.rs
@@ -18,7 +18,7 @@ impl<W: Write> Serializer<W> {
     }
 }
 
-impl<'a, W: Write> ser::Serializer for &'a mut Serializer<W> {
+impl<W: Write> ser::Serializer for &mut Serializer<W> {
     type Ok = ();
     type Error = Error;
 
@@ -270,7 +270,7 @@ impl<'a, W: Write> ser::Serializer for &'a mut Serializer<W> {
     }
 }
 
-impl<'a, W: Write> ser::SerializeSeq for &'a mut Serializer<W> {
+impl<W: Write> ser::SerializeSeq for &mut Serializer<W> {
     type Ok = ();
     type Error = Error;
 
@@ -288,7 +288,7 @@ impl<'a, W: Write> ser::SerializeSeq for &'a mut Serializer<W> {
     }
 }
 
-impl<'a, W: Write> ser::SerializeTuple for &'a mut Serializer<W> {
+impl<W: Write> ser::SerializeTuple for &mut Serializer<W> {
     type Ok = ();
     type Error = Error;
 
@@ -306,7 +306,7 @@ impl<'a, W: Write> ser::SerializeTuple for &'a mut Serializer<W> {
     }
 }
 
-impl<'a, W: Write> ser::SerializeTupleStruct for &'a mut Serializer<W> {
+impl<W: Write> ser::SerializeTupleStruct for &mut Serializer<W> {
     type Ok = ();
     type Error = Error;
 
@@ -324,7 +324,7 @@ impl<'a, W: Write> ser::SerializeTupleStruct for &'a mut Serializer<W> {
     }
 }
 
-impl<'a, W: Write> ser::SerializeTupleVariant for &'a mut Serializer<W> {
+impl<W: Write> ser::SerializeTupleVariant for &mut Serializer<W> {
     type Ok = ();
     type Error = Error;
 
@@ -342,7 +342,7 @@ impl<'a, W: Write> ser::SerializeTupleVariant for &'a mut Serializer<W> {
     }
 }
 
-impl<'a, W: Write> ser::SerializeStruct for &'a mut Serializer<W> {
+impl<W: Write> ser::SerializeStruct for &mut Serializer<W> {
     type Ok = ();
     type Error = Error;
 
@@ -360,7 +360,7 @@ impl<'a, W: Write> ser::SerializeStruct for &'a mut Serializer<W> {
     }
 }
 
-impl<'a, W: Write> ser::SerializeStructVariant for &'a mut Serializer<W> {
+impl<W: Write> ser::SerializeStructVariant for &mut Serializer<W> {
     type Ok = ();
     type Error = Error;
 
@@ -378,7 +378,7 @@ impl<'a, W: Write> ser::SerializeStructVariant for &'a mut Serializer<W> {
     }
 }
 
-impl<'a, W: Write> ser::SerializeMap for &'a mut Serializer<W> {
+impl<W: Write> ser::SerializeMap for &mut Serializer<W> {
     type Ok = ();
     type Error = Error;
 


### PR DESCRIPTION
by removing the binders for inferrable lifetimes