### PR TITLE
tilt: mac improvements

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -39,6 +39,7 @@ config.define_bool("manual", False, "Set TRIGGER_MODE_MANUAL by default")
 config.define_bool("m1", False, "Use this flag for M-series Macs (e.g. use an arm64 solana-test-validator due to AVX requirement)")
 
 config.define_string("num", False, "Number of guardian nodes to run")
+config.define_string("maxWorkers", False, "Maximum number of workers for sdk-ci-tests. See https://jestjs.io/docs/cli#--maxworkersnumstring")
 
 # You do not usually need to set this argument - this argument is for debugging only. If you do use a different
 # namespace, note that the "wormhole" namespace is hardcoded in tests and don't forget specifying the argument
@@ -78,6 +79,7 @@ config.define_bool("query_server", False, "Enable cross-chain query server")
 
 cfg = config.parse()
 num_guardians = int(cfg.get("num", "1"))
+max_workers = cfg.get("maxWorkers", "50%")
 namespace = cfg.get("namespace", "wormhole")
 webHost = cfg.get("webHost", "localhost")
 ci = cfg.get("ci", False)
@@ -644,8 +646,10 @@ if ci_tests:
     k8s_yaml_with_ns(
         encode_yaml_stream(
             set_env_in_jobs(
-                set_env_in_jobs(read_yaml_stream("devnet/tests.yaml"), "NUM_GUARDIANS", str(num_guardians)),
-                "BOOTSTRAP_PEERS", str(ccqBootstrapPeers)))
+                set_env_in_jobs(
+                    set_env_in_jobs(read_yaml_stream("devnet/tests.yaml"), "NUM_GUARDIANS", str(num_guardians)),
+                    "BOOTSTRAP_PEERS", str(ccqBootstrapPeers)),
+                    "MAX_WORKERS", max_workers))
     )
 
     # separate resources to parallelize docker builds

--- a/Tiltfile
+++ b/Tiltfile
@@ -685,12 +685,14 @@ if terra_classic:
         ref = "terra-image",
         context = "./terra/devnet",
         dockerfile = "terra/devnet/Dockerfile",
+        platform = "linux/amd64",
     )
 
     docker_build(
         ref = "terra-contracts",
         context = "./terra",
         dockerfile = "./terra/Dockerfile",
+        platform = "linux/amd64",
     )
 
     k8s_yaml_with_ns("devnet/terra-devnet.yaml")
@@ -711,6 +713,7 @@ if terra2 or wormchain:
         context = ".",
         dockerfile = "./cosmwasm/Dockerfile",
         target = "artifacts",
+        platform = "linux/amd64",
     )
 
 if terra2:
@@ -718,6 +721,7 @@ if terra2:
         ref = "terra2-image",
         context = "./cosmwasm/deployment/terra2/devnet",
         dockerfile = "./cosmwasm/deployment/terra2/devnet/Dockerfile",
+        platform = "linux/amd64",
     )
 
     docker_build(
@@ -825,6 +829,7 @@ if wormchain:
         ref = "wormchaind-image",
         context = ".",
         dockerfile = "./wormchain/Dockerfile",
+        platform = "linux/amd64",
         build_args = {"num_guardians": str(num_guardians)},
         only = [],
         ignore = ["./wormchain/testing", "./wormchain/ts-sdk", "./wormchain/design", "./wormchain/vue", "./wormchain/build/wormchaind"],

--- a/testing/sdk.sh
+++ b/testing/sdk.sh
@@ -8,4 +8,4 @@ done
 while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' spy:6060/metrics)" != "200" ]]; do sleep 5; done
 while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' ibc-relayer:7597/debug/pprof/)" != "200" ]]; do sleep 5; done
 while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' relayer-engine:3000/metrics)" != "200" ]]; do sleep 5; done
-CI=true npm --prefix ../sdk/js run test-ci
+CI=true npm --prefix ../sdk/js run test-ci -- --maxWorkers=$MAX_WORKERS


### PR DESCRIPTION
The following gets all containers running and relevant tests passing with the exception of

- Near
- Aptos
- Sui

That is because those images require instructions sets that are not supported by Rosetta2 (likely AVX). As far as I can tell, pre-built binaries or images do not exist for linux/arm64, but they could potentially be built, akin to what I did for `solana-test-validator`.

This was tested with 8 CPU / 24 GB memory under Docker resources with the command `tilt up -- --ci --num=2 --m1 --near=false --aptos=false --sui=false`. Fair warning it took nearly 2 hours, but that was with rebuilding nearly all of the images.

Everything should succeed except 

`sdk-ci-tests`
```
FAIL src/token_bridge/__tests__/sui-integration.ts
FAIL src/nft_bridge/__tests__/aptos-integration.ts (10.318 s)
FAIL src/token_bridge/__tests__/aptos-integration.ts (10.902 s)
FAIL src/token_bridge/__tests__/near-integration.ts (241.601 s)
```
`query-sdk-ci-tests` Solana queries testing `rentEpoch` - the arm64 `solana-test-validator` is a different version than the old one. a future PR may attempt to make them the same version (likely updating the amd64 version used, better yet to use the same image)

Additionally, this modifies the `sdk-ci-tests` to set `maxWorkers=50%` and exposes a tilt parameter. While in some instances, this may lead to performance improvements due to reusing workers, this is done here in an effort to save resources. In my benchmarking, the process was consuming up to 16GB of memory (and competing for resources) with the existing default workers, while `--maxWorkers=1` only required 4GB. Here's the test times from CI a run.

```
src/token_bridge/__tests__/terra-integration.ts (123.991 s)
src/token_bridge/__tests__/algorand-integration.ts (122.608 s)
src/cosmwasm/query.testnet.test.ts
src/algorand/__tests__/unit.ts (10.144 s)
src/token_bridge/__tests__/sui-integration.ts (56.435 s)
src/relayer/__tests__/wormhole_relayer.ts (407.135 s)
src/utils/repairVaa.test.ts (9.566 s)
src/token_bridge/__tests__/eth-integration.ts (51.297 s)
src/nft_bridge/__tests__/aptos-integration.ts (106.115 s)
src/token_bridge/__tests__/aptos-integration.ts (54.351 s)
src/token_bridge/__tests__/solana-integration.ts (86.633 s)
src/algorand/__tests__/testHelpers.ts
src/token_bridge/__tests__/terra2-integration.ts (49.393 s)
src/token_bridge/__tests__/near-integration.ts (69.41 s)
src/nft_bridge/__tests__/integration.ts (35.875 s)
src/utils/array.test.ts
src/relayer/__tests__/serde.ts
src/bridge/__tests__/wormhole_ibc_e2e.ts (9.164 s)
src/relayer/__tests__/relay_provider.ts
src/vaa/__tests__/circleUnit.ts
```

The longest test is `wormhole_relayer.ts` at 407s while the rest of the tests cumulatively are about 780s. Yet, here are the results from a few test runs. [[default](https://github.com/wormhole-foundation/wormhole/actions/runs/12164352377/job/34003825424)] [[50%](https://github.com/wormhole-foundation/wormhole/actions/runs/12201034293/job/34038551738?pr=4181)] [[1](https://github.com/wormhole-foundation/wormhole/actions/runs/12188951225/job/34004329560)]

```
# current default (--maxWorkers=CPUs-1)
Time:        483.734 s
# --maxWorkers=50%
Time:        491.606 s
# --runInBand / maxWorkers=1
Time:        1214.48 s
```