### PR TITLE
Fix typos across multiple files

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -148,7 +148,7 @@ The role of the incident commander for Wormhole includes the following minimum o
 
 ## Emergency Shutdown
 
-The Wormhole project has evaluated the concept of having an safety feature, which could allow Wormhole smart contracts to be paused during a state of existential crisis without contract upgrades.  However, after careful consideration the project has chosen to not introduce such a feature at this time.
+The Wormhole project has evaluated the concept of having a safety feature, which could allow Wormhole smart contracts to be paused during a state of existential crisis without contract upgrades.  However, after careful consideration the project has chosen to not introduce such a feature at this time.
 
 The rationale for this decision included the following considerations:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -75,7 +75,7 @@ Consensus on Wormhole is achieved by two subset groups of Guardians (aka: valida
 - **Super Minority** (any 1/3+ quorum of Guardians - 7 of 19)
   * Can censor messages or governance
     - Refusing to sign observed message(s)
-    - Refusing to observe the block chain
+    - Refusing to observe the blockchain
     - Refusing to run guardian software
 
 There are 19 Guardians in the current Guardian Set, made up of some of the largest and most reputable staking providers in crypto.  This level of operational security diversity is a useful property in preventing wholesale compromise of the Guardian Set due to operational failures of a single or small number of organizations.

--- a/ethereum/README.md
+++ b/ethereum/README.md
@@ -5,7 +5,7 @@ These smart contracts allow to use Ethereum as foreign chain in the Wormhole pro
 The `Wormhole` contract is the bridge contract and allows tokens to be transferred out of ETH and VAAs to be submitted
 to transfer tokens in or change configuration settings.
 
-The `WrappedAsset` is a ERC-20 token contract that holds metadata about a wormhole asset on ETH. Wormhole assets are all
+The `WrappedAsset` is an ERC-20 token contract that holds metadata about a wormhole asset on ETH. Wormhole assets are all
 wrapped non-ETH assets that are currently held on ETH.
 
 ### Building

--- a/node/pkg/watchers/near/README.md
+++ b/node/pkg/watchers/near/README.md
@@ -30,7 +30,7 @@ Determining finality of blocks:
 *Do we really have to parse every single NEAR transaction?*
 
 Unfortunately NEAR does not (yet?) provide a mechanism to subscribe to a particular contract.
-There is a RPC API EXPERIMENTAL_changes_in_block which would tell you if the block contained any receipts that touch your account, but there is no way of knowing in which block the transaction started. Even if there was, you'd still need to process all transactions in the block and we are expecting there to be a Wormhole transaction in most blocks.
+There is an RPC API EXPERIMENTAL_changes_in_block which would tell you if the block contained any receipts that touch your account, but there is no way of knowing in which block the transaction started. Even if there was, you'd still need to process all transactions in the block and we are expecting there to be a Wormhole transaction in most blocks.
 
 ## Logging
 * log_msg_type (enum)

--- a/whitepapers/0003_token_bridge.md
+++ b/whitepapers/0003_token_bridge.md
@@ -110,7 +110,7 @@ Any chains implementation must make sure that of any token only ever MaxUint64 u
 Token "dust" that can not be transferred due to truncation during a deposit needs to be refunded back to the user.
 
 **Examples:**
-- The amount "1" of a 18 decimal Ethereum token is originally represented as: `1000000000000000000`, over the wormhole it is passed as: `100000000`.
+- The amount "1" of an 18 decimal Ethereum token is originally represented as: `1000000000000000000`, over the wormhole it is passed as: `100000000`.
 - The amount "2" of a 4 decimal token is represented as `20000` and is passed over the wormhole without a decimal shift.
 
 **Handling on the target Chains:**

--- a/whitepapers/0004_message_publishing.md
+++ b/whitepapers/0004_message_publishing.md
@@ -62,7 +62,7 @@ anyone sending a transaction is already required to hold such assets in order to
 message, and that the fee will therefore not negatively affect usability of the bridge.
 
 The fee is defined by governance using the `SetMessageFee` VAA. The fees set are denominated in the respective chains
-native currency. Each chain's Wormhole program is supposed to use an on-chain price oracle (e.g. a uniswap pool TWAP or
+native currency. Each chain's Wormhole program is supposed to use an on-chain price oracle (e.g. an uniswap pool TWAP or
 Pyth price feed)
 Fees are set per chain to allow the protocol to take into consideration the effort required to keep the chain's nodes
 online and account for spam attacks.


### PR DESCRIPTION
This pull request resolves typographical issues across various documentation files to enhance clarity and consistency:  

- **SECURITY.md:**  
  - Corrected "block chain" to "blockchain" and refined phrasing for improved readability.  

- **README.md:**  
  - Adjusted indefinite articles from "a" to "an" before words beginning with vowel sounds.  

- **0003_token_bridge.md:**  
  - Corrected improper use of "a" to "an" where necessary.  

- **0004_message_publishing.md:**  
  - Fixed similar article-related typos for consistent style.  

These updates improve the overall quality of the project's documentation.
