### PR TITLE
tilt: more multi-platform support

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -36,7 +36,6 @@ update_settings(max_parallel_updates = 10)
 # Runtime configuration
 config.define_bool("ci", False, "We are running in CI")
 config.define_bool("manual", False, "Set TRIGGER_MODE_MANUAL by default")
-config.define_bool("m1", False, "Use this flag for M-series Macs (e.g. use an arm64 solana-test-validator due to AVX requirement)")
 
 config.define_string("num", False, "Number of guardian nodes to run")
 config.define_string("maxWorkers", False, "Maximum number of workers for sdk-ci-tests. See https://jestjs.io/docs/cli#--maxworkersnumstring")
@@ -103,7 +102,6 @@ btc = cfg.get("btc", False)
 redis = cfg.get('redis', ci)
 generic_relayer = cfg.get("generic_relayer", ci)
 query_server = cfg.get("query_server", ci)
-m1 = cfg.get("m1", False)
 
 if ci:
     guardiand_loglevel = cfg.get("guardiand_loglevel", "warn")
@@ -489,15 +487,10 @@ if solana or pythnet:
 
     # solana local devnet
 
-    build_args = {}
-    if m1:
-        build_args = {"BASE_IMAGE": "ghcr.io/wormholelabs-xyz/solana-test-validator-m1:1.17.29@sha256:c5a43c0762f2dab4873a9e632a389029b6d5f706be7dfb89a42a66cc65a3dd24"}
-
     docker_build(
         ref = "solana-test-validator",
         context = "solana",
         dockerfile = "solana/Dockerfile.test-validator",
-        build_args = build_args
     )
 
     k8s_yaml_with_ns("devnet/solana-devnet.yaml")

--- a/aptos/Docker.md
+++ b/aptos/Docker.md
@@ -1,12 +1,15 @@
-# first build the image
+# build the image and tag it appropriately
 
-<!-- cspell:disable-next-line -->
-(cd ..; DOCKER_BUILDKIT=1 docker buildx build --platform linux/amd64 -f aptos/Dockerfile.base -t aptos .)
+<!-- cspell:disable -->
 
-# tag the image with the appropriate version
+```bash
+cd .. && docker buildx build --platform linux/amd64,linux/arm64 -f aptos/Dockerfile.base -t ghcr.io/wormhole-foundation/aptos:3.1.0 .
+```
 
-docker tag aptos:latest ghcr.io/wormhole-foundation/aptos:3.1.0
+<!-- cspell:enable -->
 
 # push to ghcr
 
+```bash
 docker push ghcr.io/wormhole-foundation/aptos:3.1.0
+```

--- a/aptos/Dockerfile
+++ b/aptos/Dockerfile
@@ -1,6 +1,6 @@
 FROM cli-gen AS cli-export
 FROM const-gen AS const-export
-FROM ghcr.io/wormhole-foundation/aptos:3.1.0@sha256:c359f25cd6b2cd9edb2634504756a3b179cd416fd73fda59f66c48168e3b69da as aptos
+FROM ghcr.io/wormhole-foundation/aptos:3.1.0@sha256:f66c2b5fea4a75050d051a5260ef643f52f5048d473877f1760be39d9e460d6b AS aptos
 
 # Install nodejs
 # todo(aki): move this into base image?

--- a/aptos/Dockerfile.base
+++ b/aptos/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM rust:1.62@sha256:5777f201f507075309c4d2d1c1e8d8219e654ae1de154c844341050016a64a0c as aptos-node
+FROM rust:1.62@sha256:2cd5c8517d0640bd287b2cfb4c0e62f1a8ed86174764d88280bc2a106d6835db AS aptos-node
 
 RUN apt-get update && apt-get -y install libclang-dev libudev-dev libdw-dev jq cmake curl npm gcc g++ make lld
 
@@ -11,5 +11,5 @@ WORKDIR /tmp/aptos-core
 RUN git reset --hard 6f83bc6d02207298b2dee91133d75538789bf582
 RUN cargo build -p aptos --profile cli
 
-FROM rust:1.62@sha256:5777f201f507075309c4d2d1c1e8d8219e654ae1de154c844341050016a64a0c as export-stage
+FROM rust:1.62@sha256:2cd5c8517d0640bd287b2cfb4c0e62f1a8ed86174764d88280bc2a106d6835db AS export-stage
 COPY --from=aptos-node /tmp/aptos-core/target/cli/aptos /usr/local/cargo/bin/aptos

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -1,6 +1,5 @@
 # syntax=docker.io/docker/dockerfile:1.3@sha256:42399d4635eddd7a9b8a24be879d2f9a930d0ed040a61324cfdf59ef1357b3b2
-FROM --platform=linux/amd64 docker.io/golang:1.23.3-bullseye@sha256:bc1b90c2a8eb0ffb62325e02a85d51031ad3afae15b3df4b6a48b7929b00badb AS dev
-# libwasmvm.so is not compatible with arm
+FROM docker.io/golang:1.23.3-bullseye@sha256:9e53abacfc22cd3df3e4ebcc04ac64951b71d2a38c52b690f3807af6a2000ed2 AS dev
 
 FROM dev AS build
 
@@ -22,7 +21,7 @@ RUN --mount=type=cache,target=/root/.cache --mount=type=cache,target=/go \
   cd node && \
   go build ${GO_BUILD_ARGS} -gcflags="all=-N -l" --ldflags '-extldflags "-Wl,--allow-multiple-definition" -X "github.com/certusone/wormhole/node/cmd/guardiand.Build=dev"' -mod=readonly -o /guardiand github.com/certusone/wormhole/node && \
   go get github.com/CosmWasm/wasmvm@v1.1.1 && \
-  cp /go/pkg/mod/github.com/!cosm!wasm/wasmvm@v1.1.1/internal/api/libwasmvm.x86_64.so /usr/lib/
+  cp /go/pkg/mod/github.com/!cosm!wasm/wasmvm@v1.1.1/internal/api/libwasmvm.*.so /usr/lib/
 
 # Only export the final binary (+ shared objects). This reduces the image size
 # from ~1GB to ~150MB.
@@ -32,7 +31,7 @@ FROM scratch as export
 # have to copy all the dynamic libraries
 COPY --from=build /lib/* /lib/
 COPY --from=build /lib64/* /lib64/
-COPY --from=build /usr/lib/libwasmvm.x86_64.so /usr/lib/
+COPY --from=build /usr/lib/libwasmvm.*.so /usr/lib/
 
 # Copy the shells as entrypoints, but no utilities are necessary
 COPY --from=build /bin/bash /bin/dash /bin/sh /bin/

--- a/sdk/js-query/src/query/solana.test.ts
+++ b/sdk/js-query/src/query/solana.test.ts
@@ -204,7 +204,9 @@ describe("solana", () => {
     expect(sar.results[0].lamports.toString()).toEqual(
       BigInt(1461600).toString()
     );
-    expect(sar.results[0].rentEpoch.toString()).toEqual(BigInt(0).toString());
+    expect(sar.results[0].rentEpoch.toString()).toEqual(
+      BigInt("18446744073709551615").toString()
+    );
     expect(sar.results[0].executable).toEqual(false);
     expect(base58.encode(Buffer.from(sar.results[0].owner))).toEqual(
       "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
@@ -216,7 +218,9 @@ describe("solana", () => {
     expect(sar.results[0].lamports.toString()).toEqual(
       BigInt(1461600).toString()
     );
-    expect(sar.results[0].rentEpoch.toString()).toEqual(BigInt(0).toString());
+    expect(sar.results[0].rentEpoch.toString()).toEqual(
+      BigInt("18446744073709551615").toString()
+    );
     expect(sar.results[1].executable).toEqual(false);
     expect(base58.encode(Buffer.from(sar.results[1].owner))).toEqual(
       "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
@@ -268,7 +272,9 @@ describe("solana", () => {
     expect(sar.results[0].lamports.toString()).toEqual(
       BigInt(1461600).toString()
     );
-    expect(sar.results[0].rentEpoch.toString()).toEqual(BigInt(0).toString());
+    expect(sar.results[0].rentEpoch.toString()).toEqual(
+      BigInt("18446744073709551615").toString()
+    );
     expect(sar.results[0].executable).toEqual(false);
     expect(base58.encode(Buffer.from(sar.results[0].owner))).toEqual(
       "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
@@ -280,7 +286,9 @@ describe("solana", () => {
     expect(sar.results[0].lamports.toString()).toEqual(
       BigInt(1461600).toString()
     );
-    expect(sar.results[0].rentEpoch.toString()).toEqual(BigInt(0).toString());
+    expect(sar.results[0].rentEpoch.toString()).toEqual(
+      BigInt("18446744073709551615").toString()
+    );
     expect(sar.results[1].executable).toEqual(false);
     expect(base58.encode(Buffer.from(sar.results[1].owner))).toEqual(
       "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
@@ -398,7 +406,9 @@ describe("solana", () => {
     expect(sar.results[0].lamports.toString()).not.toEqual(
       BigInt(0).toString()
     );
-    expect(sar.results[0].rentEpoch.toString()).toEqual(BigInt(0).toString());
+    expect(sar.results[0].rentEpoch.toString()).toEqual(
+      BigInt("18446744073709551615").toString()
+    );
     expect(sar.results[0].executable).toEqual(false);
     expect(Buffer.from(sar.results[0].owner).toString("hex")).toEqual(
       "02c806312cbe5b79ef8aa6c17e3f423d8fdfe1d46909fb1f6cdf65ee8e2e6faa"
@@ -455,7 +465,9 @@ describe("solana", () => {
     expect(sar.results[0].lamports.toString()).not.toEqual(
       BigInt(0).toString()
     );
-    expect(sar.results[0].rentEpoch.toString()).toEqual(BigInt(0).toString());
+    expect(sar.results[0].rentEpoch.toString()).toEqual(
+      BigInt("18446744073709551615").toString()
+    );
     expect(sar.results[0].executable).toEqual(false);
     expect(Buffer.from(sar.results[0].owner).toString("hex")).toEqual(
       "02c806312cbe5b79ef8aa6c17e3f423d8fdfe1d46909fb1f6cdf65ee8e2e6faa"
@@ -519,7 +531,9 @@ describe("solana", () => {
       expect(sar.results[0].lamports.toString()).toEqual(
         BigInt(1461600).toString()
       );
-      expect(sar.results[0].rentEpoch.toString()).toEqual(BigInt(0).toString());
+      expect(sar.results[0].rentEpoch.toString()).toEqual(
+        BigInt("18446744073709551615").toString()
+      );
       expect(sar.results[0].executable).toEqual(false);
       expect(base58.encode(Buffer.from(sar.results[0].owner))).toEqual(
         "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
@@ -531,7 +545,9 @@ describe("solana", () => {
       expect(sar.results[0].lamports.toString()).toEqual(
         BigInt(1461600).toString()
       );
-      expect(sar.results[0].rentEpoch.toString()).toEqual(BigInt(0).toString());
+      expect(sar.results[0].rentEpoch.toString()).toEqual(
+        BigInt("18446744073709551615").toString()
+      );
       expect(sar.results[1].executable).toEqual(false);
       expect(base58.encode(Buffer.from(sar.results[1].owner))).toEqual(
         "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
@@ -584,7 +600,9 @@ describe("solana", () => {
     expect(sar.results[0].lamports.toString()).toEqual(
       BigInt(1461600).toString()
     );
-    expect(sar.results[0].rentEpoch.toString()).toEqual(BigInt(0).toString());
+    expect(sar.results[0].rentEpoch.toString()).toEqual(
+      BigInt("18446744073709551615").toString()
+    );
     expect(sar.results[0].executable).toEqual(false);
     expect(base58.encode(Buffer.from(sar.results[0].owner))).toEqual(
       "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
@@ -596,7 +614,9 @@ describe("solana", () => {
     expect(sar.results[0].lamports.toString()).toEqual(
       BigInt(1461600).toString()
     );
-    expect(sar.results[0].rentEpoch.toString()).toEqual(BigInt(0).toString());
+    expect(sar.results[0].rentEpoch.toString()).toEqual(
+      BigInt("18446744073709551615").toString()
+    );
     expect(sar.results[1].executable).toEqual(false);
     expect(base58.encode(Buffer.from(sar.results[1].owner))).toEqual(
       "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
@@ -654,7 +674,9 @@ describe("solana", () => {
     expect(sar.results[0].lamports.toString()).not.toEqual(
       BigInt(0).toString()
     );
-    expect(sar.results[0].rentEpoch.toString()).toEqual(BigInt(0).toString());
+    expect(sar.results[0].rentEpoch.toString()).toEqual(
+      BigInt("18446744073709551615").toString()
+    );
     expect(sar.results[0].executable).toEqual(false);
     expect(Buffer.from(sar.results[0].owner).toString("hex")).toEqual(
       "02c806312cbe5b79ef8aa6c17e3f423d8fdfe1d46909fb1f6cdf65ee8e2e6faa"

--- a/solana/Dockerfile.test-validator
+++ b/solana/Dockerfile.test-validator
@@ -1,3 +1,2 @@
-ARG BASE_IMAGE=solana-contract
-FROM ${BASE_IMAGE}
+FROM ghcr.io/wormholelabs-xyz/solana-test-validator:1.17.29@sha256:b1f85eed2d33a2bd0378204ab4d1e16537de35407cdcfeedbd021b31636618bc
 COPY --from=solana-contract /opt/solana/deps/ /opt/solana/deps/

--- a/sui/Docker.md
+++ b/sui/Docker.md
@@ -1,13 +1,15 @@
-# first build the image
+# build the image and tag it appropriately
 
-cd ..; DOCKER_BUILDKIT=1 docker build --no-cache --progress plain -f sui/Dockerfile.base -t sui .
+<!-- cspell:disable -->
 
-# tag the image with the appropriate version
+```bash
+cd .. && docker buildx build --platform linux/amd64,linux/arm64 -f sui/Dockerfile.base -t ghcr.io/wormhole-foundation/sui:1.19.1-mainnet .
+```
 
-docker tag sui:latest ghcr.io/wormhole-foundation/sui:1.19.1-mainnet
+<!-- cspell:enable -->
 
 # push to ghcr
 
+```bash
 docker push ghcr.io/wormhole-foundation/sui:1.19.1-mainnet
-
-echo remember to update both Dockerfile and Dockerfile.export
+```

--- a/sui/Dockerfile
+++ b/sui/Dockerfile
@@ -1,6 +1,6 @@
 FROM cli-gen AS cli-export
 FROM const-gen AS const-export
-FROM ghcr.io/wormhole-foundation/sui:1.19.1-mainnet@sha256:ad490b9c8c237b6b44d84feacfa45df3d0adeef55fcbec9586c0d9951e3dce95 AS sui
+FROM ghcr.io/wormhole-foundation/sui:1.19.1-mainnet@sha256:97e2e62d43262883b7a5bed5c9a9dd83d766a00a9476473eb275948fb53d376e AS sui
 
 # initial run
 # COPY sui/devnet/genesis_config genesis_config

--- a/sui/Dockerfile
+++ b/sui/Dockerfile
@@ -1,6 +1,6 @@
 FROM cli-gen AS cli-export
 FROM const-gen AS const-export
-FROM ghcr.io/wormhole-foundation/sui:1.19.1-mainnet@sha256:544a1b2aa5701fae25a19aed3c5e8c24e0caf7d1c9f511b6844d339a8f0b2a00 as sui
+FROM ghcr.io/wormhole-foundation/sui:1.19.1-mainnet@sha256:ad490b9c8c237b6b44d84feacfa45df3d0adeef55fcbec9586c0d9951e3dce95 AS sui
 
 # initial run
 # COPY sui/devnet/genesis_config genesis_config

--- a/sui/Dockerfile.base
+++ b/sui/Dockerfile.base
@@ -1,19 +1,14 @@
-FROM rust:1.62@sha256:5777f201f507075309c4d2d1c1e8d8219e654ae1de154c844341050016a64a0c as sui-node
+FROM rust:1.79.0@sha256:9b2689d6f99ff381f178fa4361db745c8c355faecde73aa5b18b0efa84f03e62 AS sui-node
 
 WORKDIR /tmp
 
-RUN curl -L https://github.com/MystenLabs/sui/releases/download/mainnet-v1.19.1/sui-mainnet-v1.19.1-ubuntu-x86_64.tgz > sui-mainnet-v1.19.1-ubuntu-x86_64.tgz
-RUN echo "6a8cc96759760293143a00fe7031a5fea70d2dff5b98d18c0470c09555da63e0  sui-mainnet-v1.19.1-ubuntu-x86_64.tgz" | sha256sum -c --status
+# https://github.com/MystenLabs/sui/blob/041c5f2bae2fe52079e44b70514333532d69f4e6/docs/content/guides/developer/getting-started/sui-install.mdx#all-linux-prerequisites
+RUN apt-get update && apt-get install -y curl git-all cmake gcc libssl-dev pkg-config libclang-dev libpq-dev build-essential
 
-RUN tar -xvf sui-mainnet-v1.19.1-ubuntu-x86_64.tgz
-RUN mv target/release/sui-ubuntu-x86_64 /bin/sui
-RUN mv target/release/sui-faucet-ubuntu-x86_64 /bin/sui-faucet
-RUN mv target/release/sui-node-ubuntu-x86_64 /bin/sui-node
+# https://github.com/MystenLabs/sui/releases/tag/mainnet-v1.19.1
+RUN cargo install --locked --git https://github.com/MystenLabs/sui.git --rev 041c5f2bae2fe52079e44b70514333532d69f4e6 sui
 
-RUN rm sui-mainnet-v1.19.1-ubuntu-x86_64.tgz
-
-RUN apt-get update
-RUN apt-get install -y ca-certificates curl gnupg
+RUN apt-get install -y ca-certificates gnupg
 RUN mkdir -p /etc/apt/keyrings
 RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
 

--- a/sui/Dockerfile.base
+++ b/sui/Dockerfile.base
@@ -1,6 +1,4 @@
-FROM rust:1.79.0@sha256:9b2689d6f99ff381f178fa4361db745c8c355faecde73aa5b18b0efa84f03e62 AS sui-node
-
-WORKDIR /tmp
+FROM rust:1.79.0@sha256:9b2689d6f99ff381f178fa4361db745c8c355faecde73aa5b18b0efa84f03e62 AS sui-build
 
 # https://github.com/MystenLabs/sui/blob/041c5f2bae2fe52079e44b70514333532d69f4e6/docs/content/guides/developer/getting-started/sui-install.mdx#all-linux-prerequisites
 RUN apt-get update && apt-get install -y curl git-all cmake gcc libssl-dev pkg-config libclang-dev libpq-dev build-essential
@@ -8,7 +6,13 @@ RUN apt-get update && apt-get install -y curl git-all cmake gcc libssl-dev pkg-c
 # https://github.com/MystenLabs/sui/releases/tag/mainnet-v1.19.1
 RUN cargo install --locked --git https://github.com/MystenLabs/sui.git --rev 041c5f2bae2fe52079e44b70514333532d69f4e6 sui
 
-RUN apt-get install -y ca-certificates gnupg
+FROM rust:1.79.0@sha256:9b2689d6f99ff381f178fa4361db745c8c355faecde73aa5b18b0efa84f03e62 AS sui-node
+
+WORKDIR /tmp
+
+COPY --from=sui-build /usr/local/cargo/bin/sui /bin/sui
+
+RUN apt-get install -y ca-certificates curl gnupg
 RUN mkdir -p /etc/apt/keyrings
 RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
 


### PR DESCRIPTION
This PR removes the m1 flag in favor of the multi-platform `solana-test-validator` image [[src](https://github.com/wormholelabs-xyz/solana-test-validator), [image](https://github.com/orgs/wormholelabs-xyz/packages/container/package/solana-test-validator)]. It also uses the newly rebuilt multi-image aptos and sui images and makes the guardian image compatible with an arm64 or amd64 build.

With this PR, Near should now be the only container and test that fails on M-series Macs, which I tested via `tilt up -- --ci --num=2 --near=false`.

It is important to note that, when available, images should pin the *index* digest, which identifies the registry entry, not the manifext digest, which identifies a single platform image. See https://docs.docker.com/build/building/multi-platform/.

Reviewers: I wasn't able to build Sui from source with rust:1.62 but it appears to work with 1.79. Not sure if that would cause any other issues but it appears to work.