### PR TITLE
node: add keyprint command

### DIFF
--- a/node/cmd/guardiand/keyprint.go
+++ b/node/cmd/guardiand/keyprint.go
@@ -9,7 +9,7 @@ import (
 
 	nodev1 "github.com/certusone/wormhole/node/pkg/proto/node/v1"
 	"github.com/spf13/cobra"
-	"golang.org/x/crypto/openpgp/armor"
+	"golang.org/x/crypto/openpgp/armor" //nolint
 	"google.golang.org/protobuf/proto"
 )
 

--- a/node/cmd/guardiand/keyprint.go
+++ b/node/cmd/guardiand/keyprint.go
@@ -1,0 +1,52 @@
+package guardiand
+
+import (
+	"encoding/hex"
+	"fmt"
+	"io"
+	"log"
+	"os"
+
+	nodev1 "github.com/certusone/wormhole/node/pkg/proto/node/v1"
+	"github.com/spf13/cobra"
+	"golang.org/x/crypto/openpgp/armor"
+	"google.golang.org/protobuf/proto"
+)
+
+var KeyprintCmd = &cobra.Command{
+	Use:   "keyprint [KEYFILE]",
+	Short: "Unmarshal and print armored guardian key in hex format",
+	Run:   runKeyprint,
+	Args:  cobra.ExactArgs(1),
+}
+
+func runKeyprint(cmd *cobra.Command, args []string) {
+	keyFile := args[0]
+
+	fmt.Println("Reading key from", keyFile)
+
+	f, err := os.Open(keyFile)
+	if err != nil {
+		log.Fatalf("failed to open keyfile: %w", err)
+	}
+
+	p, err := armor.Decode(f)
+	if err != nil {
+		log.Fatalf("failed to read armored file: %w", err)
+	}
+
+	b, err := io.ReadAll(p.Body)
+	if err != nil {
+		log.Fatalf("failed to read file: %w", err)
+	}
+
+	var m nodev1.GuardianKey
+	err = proto.Unmarshal(b, &m)
+	if err != nil {
+		log.Fatalf("failed to deserialize protobuf: %w", err)
+	}
+
+	fmt.Printf("Guardian key:\n")
+	fmt.Printf("\tType: %s\n", p.Type)
+	fmt.Printf("\tPrivatekey: %s\n", hex.EncodeToString(m.Data))
+}

--- a/node/cmd/guardiand/keyprint.go
+++ b/node/cmd/guardiand/keyprint.go
@@ -27,23 +27,23 @@ func runKeyprint(cmd *cobra.Command, args []string) {
 
 	f, err := os.Open(keyFile)
 	if err != nil {
-		log.Fatalf("failed to open keyfile: %w", err)
+		log.Fatalf("failed to open keyfile: %v", err)
 	}
 
 	p, err := armor.Decode(f)
 	if err != nil {
-		log.Fatalf("failed to read armored file: %w", err)
+		log.Fatalf("failed to read armored file: %v", err)
 	}
 
 	b, err := io.ReadAll(p.Body)
 	if err != nil {
-		log.Fatalf("failed to read file: %w", err)
+		log.Fatalf("failed to read file: %v", err)
 	}
 
 	var m nodev1.GuardianKey
 	err = proto.Unmarshal(b, &m)
 	if err != nil {
-		log.Fatalf("failed to deserialize protobuf: %w", err)
+		log.Fatalf("failed to deserialize protobuf: %v", err)
 	}
 
 	fmt.Printf("Guardian key:\n")

--- a/node/cmd/root.go
+++ b/node/cmd/root.go
@@ -53,6 +53,7 @@ func init() {
 	rootCmd.AddCommand(guardiand.KeygenCmd)
 	rootCmd.AddCommand(guardiand.AdminCmd)
 	rootCmd.AddCommand(guardiand.TemplateCmd)
+	rootCmd.AddCommand(guardiand.KeyprintCmd)
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(debug.DebugCmd)
 }


### PR DESCRIPTION
This PR adds a new `keyprint` command, which unmarshals a guardian-generated key file and prints out the private key as a hex string. With KMS incoming (along with other potential signing mechanisms) it might be desirable to reuse/import an existing key into the key management solution.

Usage: `guardiand keyprint <path-to-keyfile>`