### PR TITLE
refactor: unify the error handling methods in the crypto package that are different from the project style

### DIFF
--- a/node/pkg/db/db.go
+++ b/node/pkg/db/db.go
@@ -154,7 +154,7 @@ func (d *Database) HasVAA(id VAAID) (bool, error) {
 	if err == nil {
 		return true, nil
 	}
-	if err == badger.ErrKeyNotFound {
+	if errors.Is(err, badger.ErrKeyNotFound) {
 		return false, nil
 	}
 	return false, err
@@ -173,7 +173,7 @@ func (d *Database) GetSignedVAABytes(id VAAID) (b []byte, err error) {
 		}
 		return nil
 	}); err != nil {
-		if err == badger.ErrKeyNotFound {
+		if errors.Is(err, badger.ErrKeyNotFound) {
 			return nil, ErrVAANotFound
 		}
 		return nil, err

--- a/node/pkg/processor/cleanup.go
+++ b/node/pkg/processor/cleanup.go
@@ -4,6 +4,7 @@ package processor
 import (
 	"context"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"time"
 
@@ -287,7 +288,7 @@ func (p *Processor) signedVaaAlreadyInDB(hash string, s *state) (bool, error) {
 	if v == nil {
 		vb, err := p.db.GetSignedVAABytes(*vaaID)
 		if err != nil {
-			if err == db.ErrVAANotFound {
+			if errors.Is(err, db.ErrVAANotFound) {
 				if p.logger.Level().Enabled(zapcore.DebugLevel) {
 					p.logger.Debug("VAA not in DB",
 						zap.String("message_id", s.ourObservation.MessageID()),

--- a/node/pkg/publicrpc/publicrpcserver.go
+++ b/node/pkg/publicrpc/publicrpcserver.go
@@ -3,6 +3,7 @@ package publicrpc
 import (
 	"context"
 	"encoding/hex"
+	"errors"
 	"fmt"
 
 	"github.com/certusone/wormhole/node/pkg/common"
@@ -93,7 +94,7 @@ func (s *PublicrpcServer) GetSignedVAA(ctx context.Context, req *publicrpcv1.Get
 	})
 
 	if err != nil {
-		if err == db.ErrVAANotFound {
+		if errors.Is(err, db.ErrVAANotFound) {
 			return nil, status.Error(codes.NotFound, err.Error())
 		}
 		s.logger.Error("failed to fetch VAA", zap.Error(err), zap.Any("request", req))


### PR DESCRIPTION
unify the error handling methods in the crypto package that are different from the project style