### PR TITLE
fix: make devcontainer valid JSON

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,5 +16,5 @@
         "files.insertFinalNewline": true
       }
     }
-  },
+  }
 }


### PR DESCRIPTION
Currently, this file is not a valid JSON file. This PR fixes that by removing the trailing comma.