### PR TITLE
refactor: using slices.Contains to simplify the code

### DIFF
--- a/node/pkg/node/url_verification.go
+++ b/node/pkg/node/url_verification.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net"
 	"net/url"
+	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -33,12 +34,7 @@ func validateURL(urlStr string, validSchemes []string) bool {
 		return false
 	}
 
-	for _, scheme := range validSchemes {
-		if parsedURL.Scheme == scheme {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(validSchemes, parsedURL.Scheme)
 }
 
 func generateFormatString(schemes []string) string {


### PR DESCRIPTION
This is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.