### PR TITLE
docs: update Twitter references to X (formerly Twitter)

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/gateway.yml
+++ b/.github/DISCUSSION_TEMPLATE/gateway.yml
@@ -38,7 +38,7 @@ body:
       value: |
         <!---
         Please include at least the following stats:
-        - <X> Followers on Twitter 
+        - <X> Followers on X (formerly Twitter)
         - <X> Followers on Telegram 
         - <X> Users on Discord
         -->

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -126,7 +126,7 @@ Additionally, ensure:
 
 The Wormhole project maintains a social media monitoring program to stay abreast of important ecosystem developments.
 
-These developments include monitoring services like Twitter for key phrases and patterns such that the Wormhole project is informed of a compromise or vulnerability in a dependency that could negatively affect Wormhole, its users, or the chains that Wormhole is connected to.
+These developments include monitoring services like X (formerly Twitter) for key phrases and patterns such that the Wormhole project is informed of a compromise or vulnerability in a dependency that could negatively affect Wormhole, its users, or the chains that Wormhole is connected to.
 
 In the case of a large ecosystem development that requires response, the Wormhole project will engage its security incident response program.
 


### PR DESCRIPTION
- Update Twitter reference in gateway discussion template
- Update Twitter reference in SECURITY.md
- Add clarification "(formerly Twitter)" for better context

This change reflects the rebranding of Twitter to X and maintains
documentation clarity for users.