### PR TITLE
node: Integrate Transfer Verifier into the Ethereum watcher

### DIFF
--- a/devnet/node.yaml
+++ b/devnet/node.yaml
@@ -146,6 +146,7 @@ spec:
             - --ccqEnabled=true
             - --ccqAllowedRequesters=beFA429d57cD18b7F8A4d91A2da9AB4AF05d0FBe,25021A4FCAf61F2EADC8202D3833Df48B2Fa0D54
             - --ccqAllowedPeers=12D3KooWSnju8zhywCYVi2JwTqky1sySPnmtYLsHHzc4WerMnDQH,12D3KooWM6WqedfR6ehtTd1y6rJu3ZUrEkTjcJJnJZYesjd89zj8
+            - --transferVerifierEnabledChains=2
             # - --logLevel=debug
           securityContext:
             capabilities:

--- a/devnet/node.yaml
+++ b/devnet/node.yaml
@@ -146,7 +146,7 @@ spec:
             - --ccqEnabled=true
             - --ccqAllowedRequesters=beFA429d57cD18b7F8A4d91A2da9AB4AF05d0FBe,25021A4FCAf61F2EADC8202D3833Df48B2Fa0D54
             - --ccqAllowedPeers=12D3KooWSnju8zhywCYVi2JwTqky1sySPnmtYLsHHzc4WerMnDQH,12D3KooWM6WqedfR6ehtTd1y6rJu3ZUrEkTjcJJnJZYesjd89zj8
-            - --transferVerifierEnabledChains=2
+            # - --transferVerifierEnabledChains=1
             # - --logLevel=debug
           securityContext:
             capabilities:

--- a/devnet/node.yaml
+++ b/devnet/node.yaml
@@ -146,7 +146,7 @@ spec:
             - --ccqEnabled=true
             - --ccqAllowedRequesters=beFA429d57cD18b7F8A4d91A2da9AB4AF05d0FBe,25021A4FCAf61F2EADC8202D3833Df48B2Fa0D54
             - --ccqAllowedPeers=12D3KooWSnju8zhywCYVi2JwTqky1sySPnmtYLsHHzc4WerMnDQH,12D3KooWM6WqedfR6ehtTd1y6rJu3ZUrEkTjcJJnJZYesjd89zj8
-            # - --transferVerifierEnabledChains=1
+            # - --transferVerifierEnabledChainIDs=2
             # - --logLevel=debug
           securityContext:
             capabilities:

--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -286,7 +286,10 @@ var (
 
 	subscribeToVAAs *bool
 
+	// CLI parameter value
 	transferVerifierEnabledChains *string
+	// CLI parameter value
+	txVerifierChains []vaa.ChainID
 )
 
 func init() {
@@ -938,10 +941,12 @@ func runNode(cmd *cobra.Command, args []string) {
 	}
 
 	if cmd.Flags().Changed("transferVerifierEnabledChains") {
-		txVerifierChains, err := parseTxVerifierChains(*transferVerifierEnabledChains)
-		logger.Info("parsed txVerifierChains", zap.Any("chains", txVerifierChains))
-		if err != nil {
-			logger.Fatal("Could not parse transferVerifierEnabledChains", zap.Error(err))
+		var parseErr error
+		// NOTE: avoid shadowing txVerifierChains here. It should refer to the global variable.
+		txVerifierChains, parseErr = parseTxVerifierChains(*transferVerifierEnabledChains)
+		logger.Debug("parsed txVerifierChains", zap.Any("chains", txVerifierChains))
+		if parseErr != nil {
+			logger.Fatal("Could not parse transferVerifierEnabledChains", zap.Error(parseErr))
 		}
 	}
 

--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -937,10 +937,12 @@ func runNode(cmd *cobra.Command, args []string) {
 		logger.Fatal("If coinGeckoApiKey is set, then chainGovernorEnabled must be set")
 	}
 
-	txVerifierChains, err := parseTxVerifierChains(*transferVerifierEnabledChains)
-	logger.Info("parsed txVerifierChains", zap.Any("chains", txVerifierChains))
-	if err != nil {
-		logger.Fatal("Could not parse transferVerifierEnabledChains", zap.Error(err))
+	if cmd.Flags().Changed("transferVerifierEnabledChains") {
+		txVerifierChains, err := parseTxVerifierChains(*transferVerifierEnabledChains)
+		logger.Info("parsed txVerifierChains", zap.Any("chains", txVerifierChains))
+		if err != nil {
+			logger.Fatal("Could not parse transferVerifierEnabledChains", zap.Error(err))
+		}
 	}
 
 	var publicRpcLogDetail common.GrpcLogDetail
@@ -1938,7 +1940,7 @@ func argsConsistent(args []string) bool {
 	return true
 }
 
-// Parse a list of chainIds from a comma separated string and validate that they have a Transfer Verifier implementation
+// Parse a list of chainIds from a comma separated string and validate that they have a Transfer Verifier implementation.
 func parseTxVerifierChains(
 	// A comma-separated list of Wormhole ChainIDs.
 	input string,

--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -1925,21 +1925,18 @@ func parseTxVerifierChains(
 	if len(input) == 0 {
 		return nil, errors.New("could not parse input to parseTxVerifierChains: input empty")
 	}
-	// These are the only supported chains. The argument to this function must only include elements
-	// that are members of this slice.
-	// TODO should this be a utility function in the Transfer Verifier package?
 	supported := txverifier.SupportedChains()
 	parsed := strings.Split(input, ",")
 	enabled := make([]vaa.ChainID, 0)
-	for _, c := range parsed {
-		cid, err := vaa.ChainIDFromString(c)
+	for _, chain := range parsed {
+		chainId, err := vaa.ChainIDFromString(chain)
 		if err != nil {
-			return nil, fmt.Errorf("%s is not a valid chainId. input: %s", c, input)
+			return nil, fmt.Errorf("%s is not a valid chainId: %w. input: %s", chain, err, input)
 		}
-		if !slices.Contains(supported, cid) {
-			return nil, fmt.Errorf("chainId %d is not supported by Transfer Verifier", cid)
+		if !slices.Contains(supported, chainId) {
+			return nil, fmt.Errorf("chainId %d is not supported by Transfer Verifier", chainId)
 		}
-		enabled = append(enabled, cid)
+		enabled = append(enabled, chainId)
 	}
 
 	return enabled, nil

--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -285,9 +285,9 @@ var (
 	subscribeToVAAs *bool
 
 	// A list of chain IDs that should enable the Transfer Verifier. If empty, Transfer Verifier will not be enabled.
-	transferVerifierEnabledChains *[]uint
+	transferVerifierEnabledChainIDs *[]uint
 	// Global variable used to store enabled Chain IDs for Transfer Verification. Contents are parsed from
-	// transferVerifierEnabledChains.
+	// transferVerifierEnabledChainIDs.
 	txVerifierChains []vaa.ChainID
 )
 
@@ -519,7 +519,7 @@ func init() {
 
 	subscribeToVAAs = NodeCmd.Flags().Bool("subscribeToVAAs", false, "Guardiand should subscribe to incoming signed VAAs, set to true if running a public RPC node")
 
-	transferVerifierEnabledChains = NodeCmd.Flags().UintSlice("transferVerifierEnabledChains", make([]uint, 0), "Transfer Verifier will be enabled for these chain IDs (comma-separated)")
+	transferVerifierEnabledChainIDs = NodeCmd.Flags().UintSlice("transferVerifierEnabledChainIDs", make([]uint, 0), "Transfer Verifier will be enabled for these chain IDs (comma-separated)")
 }
 
 var (
@@ -940,14 +940,14 @@ func runNode(cmd *cobra.Command, args []string) {
 	}
 
 	// NOTE: If this flag isn't set, or the list is empty, Transfer Verifier should not be enabled.
-	if cmd.Flags().Changed("transferVerifierEnabledChains") {
+	if len(*transferVerifierEnabledChainIDs) != 0 {
 		var parseErr error
 		// NOTE: avoid shadowing txVerifierChains here. It should refer to the global variable.
-		txVerifierChains, parseErr = txverifier.ValidateChains(*transferVerifierEnabledChains)
+		txVerifierChains, parseErr = txverifier.ValidateChains(*transferVerifierEnabledChainIDs)
 
 		logger.Debug("validated txVerifierChains", zap.Any("chains", txVerifierChains))
 		if parseErr != nil {
-			logger.Fatal("transferVerifierEnabledChains input is invalid", zap.Error(parseErr))
+			logger.Fatal("transferVerifierEnabledChainIDs input is invalid", zap.Error(parseErr))
 		}
 	}
 

--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -11,6 +11,7 @@ import (
 	"path"
 	"runtime"
 	"slices"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -937,6 +938,7 @@ func runNode(cmd *cobra.Command, args []string) {
 	}
 
 	txVerifierChains, err := parseTxVerifierChains(*transferVerifierEnabledChains)
+	logger.Info("parsed txVerifierChains", zap.Any("chains", txVerifierChains))
 	if err != nil {
 		logger.Fatal("Could not parse transferVerifierEnabledChains", zap.Error(err))
 	}
@@ -1751,6 +1753,7 @@ func runNode(cmd *cobra.Command, args []string) {
 				Rpc:              *sepoliaRPC,
 				Contract:         *sepoliaContract,
 				CcqBackfillCache: *ccqBackfillCache,
+				TxVerifier:       slices.Contains(txVerifierChains, vaa.ChainIDSepolia),
 			}
 
 			watcherConfigs = append(watcherConfigs, wc)
@@ -1763,6 +1766,7 @@ func runNode(cmd *cobra.Command, args []string) {
 				Rpc:              *holeskyRPC,
 				Contract:         *holeskyContract,
 				CcqBackfillCache: *ccqBackfillCache,
+				TxVerifier:       slices.Contains(txVerifierChains, vaa.ChainIDHolesky),
 			}
 
 			watcherConfigs = append(watcherConfigs, wc)
@@ -1775,6 +1779,7 @@ func runNode(cmd *cobra.Command, args []string) {
 				Rpc:              *arbitrumSepoliaRPC,
 				Contract:         *arbitrumSepoliaContract,
 				CcqBackfillCache: *ccqBackfillCache,
+				TxVerifier:       slices.Contains(txVerifierChains, vaa.ChainIDArbitrumSepolia),
 			}
 
 			watcherConfigs = append(watcherConfigs, wc)
@@ -1787,6 +1792,7 @@ func runNode(cmd *cobra.Command, args []string) {
 				Rpc:              *baseSepoliaRPC,
 				Contract:         *baseSepoliaContract,
 				CcqBackfillCache: *ccqBackfillCache,
+				TxVerifier:       slices.Contains(txVerifierChains, vaa.ChainIDBaseSepolia),
 			}
 
 			watcherConfigs = append(watcherConfigs, wc)
@@ -1799,6 +1805,7 @@ func runNode(cmd *cobra.Command, args []string) {
 				Rpc:              *optimismSepoliaRPC,
 				Contract:         *optimismSepoliaContract,
 				CcqBackfillCache: *ccqBackfillCache,
+				TxVerifier:       slices.Contains(txVerifierChains, vaa.ChainIDOptimismSepolia),
 			}
 
 			watcherConfigs = append(watcherConfigs, wc)
@@ -1811,6 +1818,20 @@ func runNode(cmd *cobra.Command, args []string) {
 				Rpc:              *polygonSepoliaRPC,
 				Contract:         *polygonSepoliaContract,
 				CcqBackfillCache: *ccqBackfillCache,
+				TxVerifier:       slices.Contains(txVerifierChains, vaa.ChainIDPolygonSepolia),
+			}
+
+			watcherConfigs = append(watcherConfigs, wc)
+		}
+
+		if shouldStart(monadDevnetRPC) {
+			wc := &evm.WatcherConfig{
+				NetworkID:        "monad_devnet",
+				ChainID:          vaa.ChainIDMonadDevnet,
+				Rpc:              *monadDevnetRPC,
+				Contract:         *monadDevnetContract,
+				CcqBackfillCache: *ccqBackfillCache,
+				TxVerifier:       slices.Contains(txVerifierChains, vaa.ChainIDMonadDevnet),
 			}
 
 			watcherConfigs = append(watcherConfigs, wc)
@@ -1928,12 +1949,13 @@ func parseTxVerifierChains(
 	supported := txverifier.SupportedChains()
 	parsed := strings.Split(input, ",")
 	enabled := make([]vaa.ChainID, 0)
-	for _, chain := range parsed {
-		chainId, err := vaa.ChainIDFromString(chain)
-		if err != nil {
-			return nil, fmt.Errorf("%s is not a valid chainId: %w. input: %s", chain, err, input)
+	for _, chainStr := range parsed {
+		chain, parseErr := strconv.Atoi(chainStr)
+		if parseErr != nil {
+			return nil, fmt.Errorf("could not parse chainId from string %s: %w", chainStr, parseErr)
 		}
-		if !slices.Contains(supported, chainId) {
+		chainId := vaa.ChainID(chain)
+		if !slices.Contains(supported, vaa.ChainID(chainId)) {
 			return nil, fmt.Errorf("chainId %d is not supported by Transfer Verifier", chainId)
 		}
 		enabled = append(enabled, chainId)

--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -1831,18 +1831,6 @@ func runNode(cmd *cobra.Command, args []string) {
 			watcherConfigs = append(watcherConfigs, wc)
 		}
 
-		if shouldStart(monadDevnetRPC) {
-			wc := &evm.WatcherConfig{
-				NetworkID:        "monad_devnet",
-				ChainID:          vaa.ChainIDMonadDevnet,
-				Rpc:              *monadDevnetRPC,
-				Contract:         *monadDevnetContract,
-				CcqBackfillCache: *ccqBackfillCache,
-				TxVerifier:       slices.Contains(txVerifierChains, vaa.ChainIDMonadDevnet),
-			}
-
-			watcherConfigs = append(watcherConfigs, wc)
-		}
 	}
 
 	var ibcWatcherConfig *node.IbcWatcherConfig = nil

--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -521,7 +521,7 @@ func init() {
 
 	subscribeToVAAs = NodeCmd.Flags().Bool("subscribeToVAAs", false, "Guardiand should subscribe to incoming signed VAAs, set to true if running a public RPC node")
 
-	transferVerifierEnabledChains = NodeCmd.Flags().UintSlice("transferVerifierEnabledChains", make([]uint, 2), "Transfer Verifier will be enabled for these chain IDs (comma-separated)")
+	transferVerifierEnabledChains = NodeCmd.Flags().UintSlice("transferVerifierEnabledChains", make([]uint, 0), "Transfer Verifier will be enabled for these chain IDs (comma-separated)")
 }
 
 var (

--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -937,6 +937,9 @@ func runNode(cmd *cobra.Command, args []string) {
 	}
 
 	txVerifierChains, err := parseTxVerifierChains(*transferVerifierEnabledChains)
+	if err != nil {
+		logger.Fatal("Could not parse transferVerifierEnabledChains", zap.Error(err))
+	}
 
 	var publicRpcLogDetail common.GrpcLogDetail
 	switch *publicRpcLogDetailStr {

--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -1948,7 +1948,7 @@ func parseTxVerifierChains(
 	supportedChains := txverifier.SupportedChains()
 
 	// NOTE: Using a known capacity and counter here avoids unnecessary reallocations compared to using `append()`.
-	enabled := make([]vaa.ChainID, 0, len(parsed))
+	enabled := make([]vaa.ChainID, len(parsed))
 	i := uint8(0)
 	for _, chainStr := range parsed {
 		chain, parseErr := strconv.Atoi(chainStr)

--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -1238,7 +1238,7 @@ func runNode(cmd *cobra.Command, args []string) {
 			Contract:               *ethContract,
 			GuardianSetUpdateChain: true,
 			CcqBackfillCache:       *ccqBackfillCache,
-			TxVerifier:             slices.Contains(txVerifierChains, vaa.ChainIDEthereum),
+			TxVerifierEnabled:      slices.Contains(txVerifierChains, vaa.ChainIDEthereum),
 		}
 
 		watcherConfigs = append(watcherConfigs, wc)
@@ -1246,12 +1246,12 @@ func runNode(cmd *cobra.Command, args []string) {
 
 	if shouldStart(bscRPC) {
 		wc := &evm.WatcherConfig{
-			NetworkID:        "bsc",
-			ChainID:          vaa.ChainIDBSC,
-			Rpc:              *bscRPC,
-			Contract:         *bscContract,
-			CcqBackfillCache: *ccqBackfillCache,
-			TxVerifier:       slices.Contains(txVerifierChains, vaa.ChainIDBSC),
+			NetworkID:         "bsc",
+			ChainID:           vaa.ChainIDBSC,
+			Rpc:               *bscRPC,
+			Contract:          *bscContract,
+			CcqBackfillCache:  *ccqBackfillCache,
+			TxVerifierEnabled: slices.Contains(txVerifierChains, vaa.ChainIDBSC),
 		}
 
 		watcherConfigs = append(watcherConfigs, wc)
@@ -1259,12 +1259,12 @@ func runNode(cmd *cobra.Command, args []string) {
 
 	if shouldStart(polygonRPC) {
 		wc := &evm.WatcherConfig{
-			NetworkID:        "polygon",
-			ChainID:          vaa.ChainIDPolygon,
-			Rpc:              *polygonRPC,
-			Contract:         *polygonContract,
-			CcqBackfillCache: *ccqBackfillCache,
-			TxVerifier:       slices.Contains(txVerifierChains, vaa.ChainIDPolygon),
+			NetworkID:         "polygon",
+			ChainID:           vaa.ChainIDPolygon,
+			Rpc:               *polygonRPC,
+			Contract:          *polygonContract,
+			CcqBackfillCache:  *ccqBackfillCache,
+			TxVerifierEnabled: slices.Contains(txVerifierChains, vaa.ChainIDPolygon),
 		}
 
 		watcherConfigs = append(watcherConfigs, wc)
@@ -1272,12 +1272,12 @@ func runNode(cmd *cobra.Command, args []string) {
 
 	if shouldStart(avalancheRPC) {
 		wc := &evm.WatcherConfig{
-			NetworkID:        "avalanche",
-			ChainID:          vaa.ChainIDAvalanche,
-			Rpc:              *avalancheRPC,
-			Contract:         *avalancheContract,
-			CcqBackfillCache: *ccqBackfillCache,
-			TxVerifier:       slices.Contains(txVerifierChains, vaa.ChainIDAvalanche),
+			NetworkID:         "avalanche",
+			ChainID:           vaa.ChainIDAvalanche,
+			Rpc:               *avalancheRPC,
+			Contract:          *avalancheContract,
+			CcqBackfillCache:  *ccqBackfillCache,
+			TxVerifierEnabled: slices.Contains(txVerifierChains, vaa.ChainIDAvalanche),
 		}
 
 		watcherConfigs = append(watcherConfigs, wc)
@@ -1285,12 +1285,12 @@ func runNode(cmd *cobra.Command, args []string) {
 
 	if shouldStart(oasisRPC) {
 		wc := &evm.WatcherConfig{
-			NetworkID:        "oasis",
-			ChainID:          vaa.ChainIDOasis,
-			Rpc:              *oasisRPC,
-			Contract:         *oasisContract,
-			CcqBackfillCache: *ccqBackfillCache,
-			TxVerifier:       slices.Contains(txVerifierChains, vaa.ChainIDOasis),
+			NetworkID:         "oasis",
+			ChainID:           vaa.ChainIDOasis,
+			Rpc:               *oasisRPC,
+			Contract:          *oasisContract,
+			CcqBackfillCache:  *ccqBackfillCache,
+			TxVerifierEnabled: slices.Contains(txVerifierChains, vaa.ChainIDOasis),
 		}
 
 		watcherConfigs = append(watcherConfigs, wc)
@@ -1298,12 +1298,12 @@ func runNode(cmd *cobra.Command, args []string) {
 
 	if shouldStart(fantomRPC) {
 		wc := &evm.WatcherConfig{
-			NetworkID:        "fantom",
-			ChainID:          vaa.ChainIDFantom,
-			Rpc:              *fantomRPC,
-			Contract:         *fantomContract,
-			CcqBackfillCache: *ccqBackfillCache,
-			TxVerifier:       slices.Contains(txVerifierChains, vaa.ChainIDFantom),
+			NetworkID:         "fantom",
+			ChainID:           vaa.ChainIDFantom,
+			Rpc:               *fantomRPC,
+			Contract:          *fantomContract,
+			CcqBackfillCache:  *ccqBackfillCache,
+			TxVerifierEnabled: slices.Contains(txVerifierChains, vaa.ChainIDFantom),
 		}
 
 		watcherConfigs = append(watcherConfigs, wc)
@@ -1311,12 +1311,12 @@ func runNode(cmd *cobra.Command, args []string) {
 
 	if shouldStart(karuraRPC) {
 		wc := &evm.WatcherConfig{
-			NetworkID:        "karura",
-			ChainID:          vaa.ChainIDKarura,
-			Rpc:              *karuraRPC,
-			Contract:         *karuraContract,
-			CcqBackfillCache: *ccqBackfillCache,
-			TxVerifier:       slices.Contains(txVerifierChains, vaa.ChainIDKarura),
+			NetworkID:         "karura",
+			ChainID:           vaa.ChainIDKarura,
+			Rpc:               *karuraRPC,
+			Contract:          *karuraContract,
+			CcqBackfillCache:  *ccqBackfillCache,
+			TxVerifierEnabled: slices.Contains(txVerifierChains, vaa.ChainIDKarura),
 		}
 
 		watcherConfigs = append(watcherConfigs, wc)
@@ -1324,12 +1324,12 @@ func runNode(cmd *cobra.Command, args []string) {
 
 	if shouldStart(acalaRPC) {
 		wc := &evm.WatcherConfig{
-			NetworkID:        "acala",
-			ChainID:          vaa.ChainIDAcala,
-			Rpc:              *acalaRPC,
-			Contract:         *acalaContract,
-			CcqBackfillCache: *ccqBackfillCache,
-			TxVerifier:       slices.Contains(txVerifierChains, vaa.ChainIDAcala),
+			NetworkID:         "acala",
+			ChainID:           vaa.ChainIDAcala,
+			Rpc:               *acalaRPC,
+			Contract:          *acalaContract,
+			CcqBackfillCache:  *ccqBackfillCache,
+			TxVerifierEnabled: slices.Contains(txVerifierChains, vaa.ChainIDAcala),
 		}
 
 		watcherConfigs = append(watcherConfigs, wc)
@@ -1337,12 +1337,12 @@ func runNode(cmd *cobra.Command, args []string) {
 
 	if shouldStart(klaytnRPC) {
 		wc := &evm.WatcherConfig{
-			NetworkID:        "klaytn",
-			ChainID:          vaa.ChainIDKlaytn,
-			Rpc:              *klaytnRPC,
-			Contract:         *klaytnContract,
-			CcqBackfillCache: *ccqBackfillCache,
-			TxVerifier:       slices.Contains(txVerifierChains, vaa.ChainIDKlaytn),
+			NetworkID:         "klaytn",
+			ChainID:           vaa.ChainIDKlaytn,
+			Rpc:               *klaytnRPC,
+			Contract:          *klaytnContract,
+			CcqBackfillCache:  *ccqBackfillCache,
+			TxVerifierEnabled: slices.Contains(txVerifierChains, vaa.ChainIDKlaytn),
 		}
 
 		watcherConfigs = append(watcherConfigs, wc)
@@ -1350,12 +1350,12 @@ func runNode(cmd *cobra.Command, args []string) {
 
 	if shouldStart(celoRPC) {
 		wc := &evm.WatcherConfig{
-			NetworkID:        "celo",
-			ChainID:          vaa.ChainIDCelo,
-			Rpc:              *celoRPC,
-			Contract:         *celoContract,
-			CcqBackfillCache: *ccqBackfillCache,
-			TxVerifier:       slices.Contains(txVerifierChains, vaa.ChainIDCelo),
+			NetworkID:         "celo",
+			ChainID:           vaa.ChainIDCelo,
+			Rpc:               *celoRPC,
+			Contract:          *celoContract,
+			CcqBackfillCache:  *ccqBackfillCache,
+			TxVerifierEnabled: slices.Contains(txVerifierChains, vaa.ChainIDCelo),
 		}
 
 		watcherConfigs = append(watcherConfigs, wc)
@@ -1363,12 +1363,12 @@ func runNode(cmd *cobra.Command, args []string) {
 
 	if shouldStart(moonbeamRPC) {
 		wc := &evm.WatcherConfig{
-			NetworkID:        "moonbeam",
-			ChainID:          vaa.ChainIDMoonbeam,
-			Rpc:              *moonbeamRPC,
-			Contract:         *moonbeamContract,
-			CcqBackfillCache: *ccqBackfillCache,
-			TxVerifier:       slices.Contains(txVerifierChains, vaa.ChainIDMoonbeam),
+			NetworkID:         "moonbeam",
+			ChainID:           vaa.ChainIDMoonbeam,
+			Rpc:               *moonbeamRPC,
+			Contract:          *moonbeamContract,
+			CcqBackfillCache:  *ccqBackfillCache,
+			TxVerifierEnabled: slices.Contains(txVerifierChains, vaa.ChainIDMoonbeam),
 		}
 
 		watcherConfigs = append(watcherConfigs, wc)
@@ -1381,7 +1381,7 @@ func runNode(cmd *cobra.Command, args []string) {
 			Rpc:                 *arbitrumRPC,
 			Contract:            *arbitrumContract,
 			L1FinalizerRequired: "eth",
-			TxVerifier:          slices.Contains(txVerifierChains, vaa.ChainIDArbitrum),
+			TxVerifierEnabled:   slices.Contains(txVerifierChains, vaa.ChainIDArbitrum),
 			CcqBackfillCache:    *ccqBackfillCache,
 		}
 
@@ -1390,12 +1390,12 @@ func runNode(cmd *cobra.Command, args []string) {
 
 	if shouldStart(optimismRPC) {
 		wc := &evm.WatcherConfig{
-			NetworkID:        "optimism",
-			ChainID:          vaa.ChainIDOptimism,
-			Rpc:              *optimismRPC,
-			Contract:         *optimismContract,
-			CcqBackfillCache: *ccqBackfillCache,
-			TxVerifier:       slices.Contains(txVerifierChains, vaa.ChainIDOptimism),
+			NetworkID:         "optimism",
+			ChainID:           vaa.ChainIDOptimism,
+			Rpc:               *optimismRPC,
+			Contract:          *optimismContract,
+			CcqBackfillCache:  *ccqBackfillCache,
+			TxVerifierEnabled: slices.Contains(txVerifierChains, vaa.ChainIDOptimism),
 		}
 
 		watcherConfigs = append(watcherConfigs, wc)
@@ -1403,12 +1403,12 @@ func runNode(cmd *cobra.Command, args []string) {
 
 	if shouldStart(baseRPC) {
 		wc := &evm.WatcherConfig{
-			NetworkID:        "base",
-			ChainID:          vaa.ChainIDBase,
-			Rpc:              *baseRPC,
-			Contract:         *baseContract,
-			CcqBackfillCache: *ccqBackfillCache,
-			TxVerifier:       slices.Contains(txVerifierChains, vaa.ChainIDBase),
+			NetworkID:         "base",
+			ChainID:           vaa.ChainIDBase,
+			Rpc:               *baseRPC,
+			Contract:          *baseContract,
+			CcqBackfillCache:  *ccqBackfillCache,
+			TxVerifierEnabled: slices.Contains(txVerifierChains, vaa.ChainIDBase),
 		}
 
 		watcherConfigs = append(watcherConfigs, wc)
@@ -1416,12 +1416,12 @@ func runNode(cmd *cobra.Command, args []string) {
 
 	if shouldStart(scrollRPC) {
 		wc := &evm.WatcherConfig{
-			NetworkID:        "scroll",
-			ChainID:          vaa.ChainIDScroll,
-			Rpc:              *scrollRPC,
-			Contract:         *scrollContract,
-			CcqBackfillCache: *ccqBackfillCache,
-			TxVerifier:       slices.Contains(txVerifierChains, vaa.ChainIDScroll),
+			NetworkID:         "scroll",
+			ChainID:           vaa.ChainIDScroll,
+			Rpc:               *scrollRPC,
+			Contract:          *scrollContract,
+			CcqBackfillCache:  *ccqBackfillCache,
+			TxVerifierEnabled: slices.Contains(txVerifierChains, vaa.ChainIDScroll),
 		}
 
 		watcherConfigs = append(watcherConfigs, wc)
@@ -1429,12 +1429,12 @@ func runNode(cmd *cobra.Command, args []string) {
 
 	if shouldStart(mantleRPC) {
 		wc := &evm.WatcherConfig{
-			NetworkID:        "mantle",
-			ChainID:          vaa.ChainIDMantle,
-			Rpc:              *mantleRPC,
-			Contract:         *mantleContract,
-			CcqBackfillCache: *ccqBackfillCache,
-			TxVerifier:       slices.Contains(txVerifierChains, vaa.ChainIDMantle),
+			NetworkID:         "mantle",
+			ChainID:           vaa.ChainIDMantle,
+			Rpc:               *mantleRPC,
+			Contract:          *mantleContract,
+			CcqBackfillCache:  *ccqBackfillCache,
+			TxVerifierEnabled: slices.Contains(txVerifierChains, vaa.ChainIDMantle),
 		}
 
 		watcherConfigs = append(watcherConfigs, wc)
@@ -1442,12 +1442,12 @@ func runNode(cmd *cobra.Command, args []string) {
 
 	if shouldStart(blastRPC) {
 		wc := &evm.WatcherConfig{
-			NetworkID:        "blast",
-			ChainID:          vaa.ChainIDBlast,
-			Rpc:              *blastRPC,
-			Contract:         *blastContract,
-			CcqBackfillCache: *ccqBackfillCache,
-			TxVerifier:       slices.Contains(txVerifierChains, vaa.ChainIDBlast),
+			NetworkID:         "blast",
+			ChainID:           vaa.ChainIDBlast,
+			Rpc:               *blastRPC,
+			Contract:          *blastContract,
+			CcqBackfillCache:  *ccqBackfillCache,
+			TxVerifierEnabled: slices.Contains(txVerifierChains, vaa.ChainIDBlast),
 		}
 
 		watcherConfigs = append(watcherConfigs, wc)
@@ -1455,12 +1455,12 @@ func runNode(cmd *cobra.Command, args []string) {
 
 	if shouldStart(xlayerRPC) {
 		wc := &evm.WatcherConfig{
-			NetworkID:        "xlayer",
-			ChainID:          vaa.ChainIDXLayer,
-			Rpc:              *xlayerRPC,
-			Contract:         *xlayerContract,
-			CcqBackfillCache: *ccqBackfillCache,
-			TxVerifier:       slices.Contains(txVerifierChains, vaa.ChainIDXLayer),
+			NetworkID:         "xlayer",
+			ChainID:           vaa.ChainIDXLayer,
+			Rpc:               *xlayerRPC,
+			Contract:          *xlayerContract,
+			CcqBackfillCache:  *ccqBackfillCache,
+			TxVerifierEnabled: slices.Contains(txVerifierChains, vaa.ChainIDXLayer),
 		}
 
 		watcherConfigs = append(watcherConfigs, wc)
@@ -1468,12 +1468,12 @@ func runNode(cmd *cobra.Command, args []string) {
 
 	if shouldStart(lineaRPC) {
 		wc := &evm.WatcherConfig{
-			NetworkID:        "linea",
-			ChainID:          vaa.ChainIDLinea,
-			Rpc:              *lineaRPC,
-			Contract:         *lineaContract,
-			CcqBackfillCache: *ccqBackfillCache,
-			TxVerifier:       slices.Contains(txVerifierChains, vaa.ChainIDLinea),
+			NetworkID:         "linea",
+			ChainID:           vaa.ChainIDLinea,
+			Rpc:               *lineaRPC,
+			Contract:          *lineaContract,
+			CcqBackfillCache:  *ccqBackfillCache,
+			TxVerifierEnabled: slices.Contains(txVerifierChains, vaa.ChainIDLinea),
 		}
 
 		watcherConfigs = append(watcherConfigs, wc)
@@ -1481,12 +1481,12 @@ func runNode(cmd *cobra.Command, args []string) {
 
 	if shouldStart(berachainRPC) {
 		wc := &evm.WatcherConfig{
-			NetworkID:        "berachain",
-			ChainID:          vaa.ChainIDBerachain,
-			Rpc:              *berachainRPC,
-			Contract:         *berachainContract,
-			CcqBackfillCache: *ccqBackfillCache,
-			TxVerifier:       slices.Contains(txVerifierChains, vaa.ChainIDBerachain),
+			NetworkID:         "berachain",
+			ChainID:           vaa.ChainIDBerachain,
+			Rpc:               *berachainRPC,
+			Contract:          *berachainContract,
+			CcqBackfillCache:  *ccqBackfillCache,
+			TxVerifierEnabled: slices.Contains(txVerifierChains, vaa.ChainIDBerachain),
 		}
 
 		watcherConfigs = append(watcherConfigs, wc)
@@ -1494,12 +1494,12 @@ func runNode(cmd *cobra.Command, args []string) {
 
 	if shouldStart(snaxchainRPC) {
 		wc := &evm.WatcherConfig{
-			NetworkID:        "snaxchain",
-			ChainID:          vaa.ChainIDSnaxchain,
-			Rpc:              *snaxchainRPC,
-			Contract:         *snaxchainContract,
-			CcqBackfillCache: *ccqBackfillCache,
-			TxVerifier:       slices.Contains(txVerifierChains, vaa.ChainIDSnaxchain),
+			NetworkID:         "snaxchain",
+			ChainID:           vaa.ChainIDSnaxchain,
+			Rpc:               *snaxchainRPC,
+			Contract:          *snaxchainContract,
+			CcqBackfillCache:  *ccqBackfillCache,
+			TxVerifierEnabled: slices.Contains(txVerifierChains, vaa.ChainIDSnaxchain),
 		}
 
 		watcherConfigs = append(watcherConfigs, wc)
@@ -1507,12 +1507,12 @@ func runNode(cmd *cobra.Command, args []string) {
 
 	if shouldStart(unichainRPC) {
 		wc := &evm.WatcherConfig{
-			NetworkID:        "unichain",
-			ChainID:          vaa.ChainIDUnichain,
-			Rpc:              *unichainRPC,
-			Contract:         *unichainContract,
-			CcqBackfillCache: *ccqBackfillCache,
-			TxVerifier:       slices.Contains(txVerifierChains, vaa.ChainIDUnichain),
+			NetworkID:         "unichain",
+			ChainID:           vaa.ChainIDUnichain,
+			Rpc:               *unichainRPC,
+			Contract:          *unichainContract,
+			CcqBackfillCache:  *ccqBackfillCache,
+			TxVerifierEnabled: slices.Contains(txVerifierChains, vaa.ChainIDUnichain),
 		}
 
 		watcherConfigs = append(watcherConfigs, wc)
@@ -1520,12 +1520,12 @@ func runNode(cmd *cobra.Command, args []string) {
 
 	if shouldStart(worldchainRPC) {
 		wc := &evm.WatcherConfig{
-			NetworkID:        "worldchain",
-			ChainID:          vaa.ChainIDWorldchain,
-			Rpc:              *worldchainRPC,
-			Contract:         *worldchainContract,
-			CcqBackfillCache: *ccqBackfillCache,
-			TxVerifier:       slices.Contains(txVerifierChains, vaa.ChainIDWorldchain),
+			NetworkID:         "worldchain",
+			ChainID:           vaa.ChainIDWorldchain,
+			Rpc:               *worldchainRPC,
+			Contract:          *worldchainContract,
+			CcqBackfillCache:  *ccqBackfillCache,
+			TxVerifierEnabled: slices.Contains(txVerifierChains, vaa.ChainIDWorldchain),
 		}
 
 		watcherConfigs = append(watcherConfigs, wc)
@@ -1533,12 +1533,12 @@ func runNode(cmd *cobra.Command, args []string) {
 
 	if shouldStart(inkRPC) {
 		wc := &evm.WatcherConfig{
-			NetworkID:        "ink",
-			ChainID:          vaa.ChainIDInk,
-			Rpc:              *inkRPC,
-			Contract:         *inkContract,
-			CcqBackfillCache: *ccqBackfillCache,
-			TxVerifier:       slices.Contains(txVerifierChains, vaa.ChainIDInk),
+			NetworkID:         "ink",
+			ChainID:           vaa.ChainIDInk,
+			Rpc:               *inkRPC,
+			Contract:          *inkContract,
+			CcqBackfillCache:  *ccqBackfillCache,
+			TxVerifierEnabled: slices.Contains(txVerifierChains, vaa.ChainIDInk),
 		}
 
 		watcherConfigs = append(watcherConfigs, wc)
@@ -1546,12 +1546,12 @@ func runNode(cmd *cobra.Command, args []string) {
 
 	if shouldStart(hyperEvmRPC) {
 		wc := &evm.WatcherConfig{
-			NetworkID:        "hyperevm",
-			ChainID:          vaa.ChainIDHyperEVM,
-			Rpc:              *hyperEvmRPC,
-			Contract:         *hyperEvmContract,
-			CcqBackfillCache: *ccqBackfillCache,
-			TxVerifier:       slices.Contains(txVerifierChains, vaa.ChainIDHyperEVM),
+			NetworkID:         "hyperevm",
+			ChainID:           vaa.ChainIDHyperEVM,
+			Rpc:               *hyperEvmRPC,
+			Contract:          *hyperEvmContract,
+			CcqBackfillCache:  *ccqBackfillCache,
+			TxVerifierEnabled: slices.Contains(txVerifierChains, vaa.ChainIDHyperEVM),
 		}
 
 		watcherConfigs = append(watcherConfigs, wc)
@@ -1559,12 +1559,12 @@ func runNode(cmd *cobra.Command, args []string) {
 
 	if shouldStart(monadRPC) {
 		wc := &evm.WatcherConfig{
-			NetworkID:        "monad",
-			ChainID:          vaa.ChainIDMonad,
-			Rpc:              *monadRPC,
-			Contract:         *monadContract,
-			CcqBackfillCache: *ccqBackfillCache,
-			TxVerifier:       slices.Contains(txVerifierChains, vaa.ChainIDMonad),
+			NetworkID:         "monad",
+			ChainID:           vaa.ChainIDMonad,
+			Rpc:               *monadRPC,
+			Contract:          *monadContract,
+			CcqBackfillCache:  *ccqBackfillCache,
+			TxVerifierEnabled: slices.Contains(txVerifierChains, vaa.ChainIDMonad),
 		}
 
 		watcherConfigs = append(watcherConfigs, wc)
@@ -1572,12 +1572,12 @@ func runNode(cmd *cobra.Command, args []string) {
 
 	if shouldStart(seiEvmRPC) {
 		wc := &evm.WatcherConfig{
-			NetworkID:        "seievm",
-			ChainID:          vaa.ChainIDSeiEVM,
-			Rpc:              *seiEvmRPC,
-			Contract:         *seiEvmContract,
-			CcqBackfillCache: *ccqBackfillCache,
-			TxVerifier:       slices.Contains(txVerifierChains, vaa.ChainIDSeiEVM),
+			NetworkID:         "seievm",
+			ChainID:           vaa.ChainIDSeiEVM,
+			Rpc:               *seiEvmRPC,
+			Contract:          *seiEvmContract,
+			CcqBackfillCache:  *ccqBackfillCache,
+			TxVerifierEnabled: slices.Contains(txVerifierChains, vaa.ChainIDSeiEVM),
 		}
 
 		watcherConfigs = append(watcherConfigs, wc)
@@ -1756,12 +1756,12 @@ func runNode(cmd *cobra.Command, args []string) {
 	if env == common.TestNet || env == common.UnsafeDevNet {
 		if shouldStart(sepoliaRPC) {
 			wc := &evm.WatcherConfig{
-				NetworkID:        "sepolia",
-				ChainID:          vaa.ChainIDSepolia,
-				Rpc:              *sepoliaRPC,
-				Contract:         *sepoliaContract,
-				CcqBackfillCache: *ccqBackfillCache,
-				TxVerifier:       slices.Contains(txVerifierChains, vaa.ChainIDSepolia),
+				NetworkID:         "sepolia",
+				ChainID:           vaa.ChainIDSepolia,
+				Rpc:               *sepoliaRPC,
+				Contract:          *sepoliaContract,
+				CcqBackfillCache:  *ccqBackfillCache,
+				TxVerifierEnabled: slices.Contains(txVerifierChains, vaa.ChainIDSepolia),
 			}
 
 			watcherConfigs = append(watcherConfigs, wc)
@@ -1769,12 +1769,12 @@ func runNode(cmd *cobra.Command, args []string) {
 
 		if shouldStart(holeskyRPC) {
 			wc := &evm.WatcherConfig{
-				NetworkID:        "holesky",
-				ChainID:          vaa.ChainIDHolesky,
-				Rpc:              *holeskyRPC,
-				Contract:         *holeskyContract,
-				CcqBackfillCache: *ccqBackfillCache,
-				TxVerifier:       slices.Contains(txVerifierChains, vaa.ChainIDHolesky),
+				NetworkID:         "holesky",
+				ChainID:           vaa.ChainIDHolesky,
+				Rpc:               *holeskyRPC,
+				Contract:          *holeskyContract,
+				CcqBackfillCache:  *ccqBackfillCache,
+				TxVerifierEnabled: slices.Contains(txVerifierChains, vaa.ChainIDHolesky),
 			}
 
 			watcherConfigs = append(watcherConfigs, wc)
@@ -1782,12 +1782,12 @@ func runNode(cmd *cobra.Command, args []string) {
 
 		if shouldStart(arbitrumSepoliaRPC) {
 			wc := &evm.WatcherConfig{
-				NetworkID:        "arbitrum_sepolia",
-				ChainID:          vaa.ChainIDArbitrumSepolia,
-				Rpc:              *arbitrumSepoliaRPC,
-				Contract:         *arbitrumSepoliaContract,
-				CcqBackfillCache: *ccqBackfillCache,
-				TxVerifier:       slices.Contains(txVerifierChains, vaa.ChainIDArbitrumSepolia),
+				NetworkID:         "arbitrum_sepolia",
+				ChainID:           vaa.ChainIDArbitrumSepolia,
+				Rpc:               *arbitrumSepoliaRPC,
+				Contract:          *arbitrumSepoliaContract,
+				CcqBackfillCache:  *ccqBackfillCache,
+				TxVerifierEnabled: slices.Contains(txVerifierChains, vaa.ChainIDArbitrumSepolia),
 			}
 
 			watcherConfigs = append(watcherConfigs, wc)
@@ -1795,12 +1795,12 @@ func runNode(cmd *cobra.Command, args []string) {
 
 		if shouldStart(baseSepoliaRPC) {
 			wc := &evm.WatcherConfig{
-				NetworkID:        "base_sepolia",
-				ChainID:          vaa.ChainIDBaseSepolia,
-				Rpc:              *baseSepoliaRPC,
-				Contract:         *baseSepoliaContract,
-				CcqBackfillCache: *ccqBackfillCache,
-				TxVerifier:       slices.Contains(txVerifierChains, vaa.ChainIDBaseSepolia),
+				NetworkID:         "base_sepolia",
+				ChainID:           vaa.ChainIDBaseSepolia,
+				Rpc:               *baseSepoliaRPC,
+				Contract:          *baseSepoliaContract,
+				CcqBackfillCache:  *ccqBackfillCache,
+				TxVerifierEnabled: slices.Contains(txVerifierChains, vaa.ChainIDBaseSepolia),
 			}
 
 			watcherConfigs = append(watcherConfigs, wc)
@@ -1808,12 +1808,12 @@ func runNode(cmd *cobra.Command, args []string) {
 
 		if shouldStart(optimismSepoliaRPC) {
 			wc := &evm.WatcherConfig{
-				NetworkID:        "optimism_sepolia",
-				ChainID:          vaa.ChainIDOptimismSepolia,
-				Rpc:              *optimismSepoliaRPC,
-				Contract:         *optimismSepoliaContract,
-				CcqBackfillCache: *ccqBackfillCache,
-				TxVerifier:       slices.Contains(txVerifierChains, vaa.ChainIDOptimismSepolia),
+				NetworkID:         "optimism_sepolia",
+				ChainID:           vaa.ChainIDOptimismSepolia,
+				Rpc:               *optimismSepoliaRPC,
+				Contract:          *optimismSepoliaContract,
+				CcqBackfillCache:  *ccqBackfillCache,
+				TxVerifierEnabled: slices.Contains(txVerifierChains, vaa.ChainIDOptimismSepolia),
 			}
 
 			watcherConfigs = append(watcherConfigs, wc)
@@ -1821,12 +1821,12 @@ func runNode(cmd *cobra.Command, args []string) {
 
 		if shouldStart(polygonSepoliaRPC) {
 			wc := &evm.WatcherConfig{
-				NetworkID:        "polygon_sepolia",
-				ChainID:          vaa.ChainIDPolygonSepolia,
-				Rpc:              *polygonSepoliaRPC,
-				Contract:         *polygonSepoliaContract,
-				CcqBackfillCache: *ccqBackfillCache,
-				TxVerifier:       slices.Contains(txVerifierChains, vaa.ChainIDPolygonSepolia),
+				NetworkID:         "polygon_sepolia",
+				ChainID:           vaa.ChainIDPolygonSepolia,
+				Rpc:               *polygonSepoliaRPC,
+				Contract:          *polygonSepoliaContract,
+				CcqBackfillCache:  *ccqBackfillCache,
+				TxVerifierEnabled: slices.Contains(txVerifierChains, vaa.ChainIDPolygonSepolia),
 			}
 
 			watcherConfigs = append(watcherConfigs, wc)

--- a/node/cmd/txverifier/evm.go
+++ b/node/cmd/txverifier/evm.go
@@ -151,7 +151,7 @@ func runTransferVerifierEvm(cmd *cobra.Command, args []string) {
 
 		// Process observed LogMessagePublished events
 		case vLog := <-sub.Events():
-			transferVerifier.ProcessEvent(ctx, vLog, nil)
+			transferVerifier.ProcessEvent(ctx, vLog.Raw.TxHash, nil)
 		}
 	}
 }

--- a/node/go.mod
+++ b/node/go.mod
@@ -384,3 +384,5 @@ replace github.com/wormhole-foundation/wormchain => ../wormchain
 replace github.com/CosmWasm/wasmd v0.30.0 => github.com/wormhole-foundation/wasmd v0.30.0-wormchain-2
 
 replace github.com/cosmos/cosmos-sdk => github.com/wormhole-foundation/cosmos-sdk v0.45.9-wormhole
+
+replace github.com/certusone/wormhole/node/pkg/txverifier => ./pkg/txverifier

--- a/node/hack/parse_eth_tx/parse_eth_tx.go
+++ b/node/hack/parse_eth_tx/parse_eth_tx.go
@@ -46,7 +46,7 @@ func main() {
 
 	transactionHash := ethCommon.HexToHash(*flagTx)
 
-	block, msgs, err := evm.MessageEventsForTransaction(ctx, ethIntf, contractAddr, chainID, transactionHash)
+	_, block, msgs, err := evm.MessageEventsForTransaction(ctx, ethIntf, contractAddr, chainID, transactionHash)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/node/pkg/common/chainlock.go
+++ b/node/pkg/common/chainlock.go
@@ -18,24 +18,40 @@ import (
 const HashLength = 32
 const AddressLength = 32
 
-// This type represents whether a message has been verified for some definition of verification. This may mean different things
-// on a per-application or per-chain basis.
-// NOTE: This status is currently used only by the Transfer Verifier for supported chains.
+// The `VerificationState` is the result of applying transfer verification to the transaction associated with the `MessagePublication`.
+// While this could likely be extended to additional security controls in the future, it is only used for `txverifier` at present.
+// Consequently, its status should be set to `NotVerified` or `NotApplicable` for all messages that aren't token transfers.
 type VerificationState uint8
 
 const (
 	// The default state for a message. This can be used before verification occurs. If no verification is required, `NotApplicable` should be used instead.
-	// NOTE: this value is used as the default, zero-value for the type, so this field should not be re-ordered among other variants.
 	NotVerified VerificationState = iota
 	// Represents a "known bad" status where a Message has been validated and the result indicates an erroneous or invalid message. The message should be discarded.
 	Rejected
 	// Represents an unusual state after validation, neither confirmed to be good or bad.
 	Anomalous
-	// Represents a "known good" status where a Message has been validated and the result is good. The message should be process normally.
+	// Represents a "known good" status where a Message has been validated and the result is good. The message should be processed normally.
 	Valid
 	// Indicates that no verification is necessary.
 	NotApplicable
 )
+
+func (v VerificationState) String() string {
+	switch v {
+	case NotVerified:
+		return "NotVerified"
+	case Valid:
+		return "Valid"
+	case Anomalous:
+		return "Anomalous"
+	case Rejected:
+		return "Rejected"
+	case NotApplicable:
+		return "NotApplicable"
+	default:
+		return ""
+	}
+}
 
 type MessagePublication struct {
 	TxID      []byte
@@ -52,8 +68,10 @@ type MessagePublication struct {
 	// Unreliable indicates if this message can be reobserved. If a message is considered unreliable it cannot be
 	// reobserved.
 	Unreliable bool
-	// This type represents whether a message has been verified for some definition of verification. This may mean different things
-	// on a per-application or per-chain basis.
+
+	// The `VerificationState` is the result of applying transfer verification to the transaction associated with the `MessagePublication`.
+	// While this could likely be extended to additional security controls in the future, it is only used for `txverifier` at present.
+	// Consequently, its status should be set to `NotVerified` or `NotApplicable` for all messages that aren't token transfers.
 	verificationState VerificationState
 }
 
@@ -297,21 +315,4 @@ func (msg *MessagePublication) ZapFields(fields ...zap.Field) []zap.Field {
 		zap.Bool("unreliable", msg.Unreliable),
 		zap.String("verificationState", msg.verificationState.String()),
 	)
-}
-
-func (v VerificationState) String() string {
-	switch v {
-	case NotVerified:
-		return "NotVerified"
-	case Valid:
-		return "Valid"
-	case Anomalous:
-		return "Anomalous"
-	case Rejected:
-		return "Rejected"
-	case NotApplicable:
-		return "NotApplicable"
-	default:
-		return ""
-	}
 }

--- a/node/pkg/common/chainlock.go
+++ b/node/pkg/common/chainlock.go
@@ -70,9 +70,16 @@ type MessagePublication struct {
 	// This field is not marshalled/serialized.
 	Unreliable bool
 
-	// The `VerificationState` is the result of applying transfer verification to the transaction associated with the `MessagePublication`.
-	// While this could likely be extended to additional security controls in the future, it is only used for `txverifier` at present.
-	// Consequently, its status should be set to `NotVerified` or `NotApplicable` for all messages that aren't token transfers.
+	// The `VerificationState` is the result of applying transfer
+	// verification to the transaction associated with the
+	// `MessagePublication`. While this could likely be extended to
+	// additional security controls in the future, it is only used for
+	// `txverifier` at present. Consequently, its status should be set to
+	// `NotVerified` or `NotApplicable` for all messages that aren't token
+	// transfers.
+	// This field is intentionally private so that it must be
+	// updated using the setter, which performs verification on the new
+	// state.
 	// This field is not marshalled/serialized.
 	verificationState VerificationState
 }

--- a/node/pkg/common/chainlock.go
+++ b/node/pkg/common/chainlock.go
@@ -67,11 +67,13 @@ type MessagePublication struct {
 
 	// Unreliable indicates if this message can be reobserved. If a message is considered unreliable it cannot be
 	// reobserved.
+	// This field is not marshalled/serialized.
 	Unreliable bool
 
 	// The `VerificationState` is the result of applying transfer verification to the transaction associated with the `MessagePublication`.
 	// While this could likely be extended to additional security controls in the future, it is only used for `txverifier` at present.
 	// Consequently, its status should be set to `NotVerified` or `NotApplicable` for all messages that aren't token transfers.
+	// This field is not marshalled/serialized.
 	verificationState VerificationState
 }
 
@@ -128,6 +130,8 @@ func (msg *MessagePublication) Marshal() ([]byte, error) {
 	vaa.MustWrite(buf, binary.BigEndian, msg.EmitterChain)
 	buf.Write(msg.EmitterAddress[:])
 	vaa.MustWrite(buf, binary.BigEndian, msg.IsReobservation)
+	// Unreliable and verificationState are not marshalled because they are not used in the Governor code,
+	// which is currently the only place in the node where marshalling this struct is done.
 	buf.Write(msg.Payload)
 
 	return buf.Bytes(), nil
@@ -243,6 +247,9 @@ func UnmarshalMessagePublication(data []byte) (*MessagePublication, error) {
 	if err := binary.Read(reader, binary.BigEndian, &msg.IsReobservation); err != nil {
 		return nil, fmt.Errorf("failed to read isReobservation: %w", err)
 	}
+
+	// Unreliable and verificationState are not unmarshalled because they are not used in the Governor code,
+	// which is currently the only place in the node where unmarshalling this struct is done.
 
 	payload := make([]byte, reader.Len())
 	n, err := reader.Read(payload)

--- a/node/pkg/common/chainlock_test.go
+++ b/node/pkg/common/chainlock_test.go
@@ -59,6 +59,10 @@ func TestSerializeAndDeserializeOfMessagePublication(t *testing.T) {
 		EmitterAddress:   tokenBridgeAddress,
 		Payload:          payloadBytes1,
 		ConsistencyLevel: 32,
+		// NOTE: these fields are not marshalled or unmarshalled. They are set to non-default values
+		// here to prove that they will be unmarshalled into their defaults.
+		Unreliable:        true,
+		verificationState: Anomalous,
 	}
 
 	bytes, err := msg1.Marshal()
@@ -66,7 +70,18 @@ func TestSerializeAndDeserializeOfMessagePublication(t *testing.T) {
 
 	msg2, err := UnmarshalMessagePublication(bytes)
 	require.NoError(t, err)
-	assert.Equal(t, msg1, msg2)
+
+	require.Equal(t, msg1.TxID, msg2.TxID)
+	require.Equal(t, msg1.Timestamp, msg2.Timestamp)
+	require.Equal(t, msg1.Nonce, msg2.Nonce)
+	require.Equal(t, msg1.Sequence, msg2.Sequence)
+	require.Equal(t, msg1.EmitterChain, msg2.EmitterChain)
+	require.Equal(t, msg1.EmitterAddress, msg2.EmitterAddress)
+	require.Equal(t, msg1.ConsistencyLevel, msg2.ConsistencyLevel)
+	// These fields are not currently marshalled or unmarshalled. Ensure that the unmarshalled values are equal
+	// to the defaults for the types, even if the original struct instance had non-default values.
+	require.Equal(t, NotVerified, msg2.verificationState)
+	require.Equal(t, false, msg2.Unreliable)
 
 	payload2, err := vaa.DecodeTransferPayloadHdr(msg2.Payload)
 	require.NoError(t, err)

--- a/node/pkg/common/chainlock_test.go
+++ b/node/pkg/common/chainlock_test.go
@@ -398,3 +398,47 @@ func TestTxIDStringMatchesHashToString(t *testing.T) {
 
 	assert.Equal(t, expectedHashID, msg.TxIDString())
 }
+
+func TestMessagePublication_SetVerificationState(t *testing.T) {
+	tests := []struct {
+		name    string
+		initial VerificationState
+		arg     VerificationState
+		wantErr bool
+	}{
+		{
+			"can't overwrite existing status with default value",
+			Valid,
+			NotVerified,
+			true,
+		},
+		{
+			"can't overwrite with the same value",
+			Valid,
+			Valid,
+			true,
+		},
+		{
+			"happy path: default status to non-default",
+			NotVerified,
+			Valid,
+			false,
+		},
+		{
+			"happy path: non-default status to non-default",
+			Rejected,
+			Valid,
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := &MessagePublication{
+				verificationState: tt.initial,
+			}
+			if err := msg.SetVerificationState(tt.arg); (err != nil) != tt.wantErr {
+				t.Errorf("MessagePublication.SetVerificationState() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/node/pkg/node/node.go
+++ b/node/pkg/node/node.go
@@ -64,13 +64,14 @@ type G struct {
 	guardianSigner guardiansigner.GuardianSigner
 
 	// components
-	db              *db.Database
-	gst             *common.GuardianSetState
-	acct            *accountant.Accountant
-	gov             *governor.ChainGovernor
-	gatewayRelayer  *gwrelayer.GatewayRelayer
-	queryHandler    *query.QueryHandler
-	publicrpcServer *grpc.Server
+	db               *db.Database
+	gst              *common.GuardianSetState
+	acct             *accountant.Accountant
+	gov              *governor.ChainGovernor
+	txVerifierChains *[]vaa.ChainID
+	gatewayRelayer   *gwrelayer.GatewayRelayer
+	queryHandler     *query.QueryHandler
+	publicrpcServer  *grpc.Server
 
 	// runnables
 	runnablesWithScissors map[string]supervisor.Runnable

--- a/node/pkg/node/node.go
+++ b/node/pkg/node/node.go
@@ -64,14 +64,13 @@ type G struct {
 	guardianSigner guardiansigner.GuardianSigner
 
 	// components
-	db               *db.Database
-	gst              *common.GuardianSetState
-	acct             *accountant.Accountant
-	gov              *governor.ChainGovernor
-	txVerifierChains *[]vaa.ChainID
-	gatewayRelayer   *gwrelayer.GatewayRelayer
-	queryHandler     *query.QueryHandler
-	publicrpcServer  *grpc.Server
+	db              *db.Database
+	gst             *common.GuardianSetState
+	acct            *accountant.Accountant
+	gov             *governor.ChainGovernor
+	gatewayRelayer  *gwrelayer.GatewayRelayer
+	queryHandler    *query.QueryHandler
+	publicrpcServer *grpc.Server
 
 	// runnables
 	runnablesWithScissors map[string]supervisor.Runnable

--- a/node/pkg/node/node_test.go
+++ b/node/pkg/node/node_test.go
@@ -855,7 +855,7 @@ type testCaseGuardianConfig struct {
 	err  string
 }
 
-// TestWatcherConfigs tries to instantiate a guardian with various invlid []watchers.WatcherConfig and asserts that it errors
+// TestWatcherConfigs tries to instantiate a guardian with various invalid []watchers.WatcherConfig and asserts that it errors
 func TestWatcherConfigs(t *testing.T) {
 	tc := []testCaseGuardianConfig{
 		{

--- a/node/pkg/node/options.go
+++ b/node/pkg/node/options.go
@@ -327,7 +327,7 @@ type IbcWatcherConfig struct {
 	Contract       string
 }
 
-// GuardianOptionWatchers configues all normal watchers and all IBC watchers. They need to be all configured at the same time because they may depend on each other.
+// GuardianOptionWatchers configures all normal watchers and all IBC watchers. They need to be all configured at the same time because they may depend on each other.
 // TODO: currently, IBC watchers are partially statically configured in ibc.ChainConfig. It might make sense to refactor this to instead provide this as a parameter here.
 // Dependencies: none
 func GuardianOptionWatchers(watcherConfigs []watchers.WatcherConfig, ibcWatcherConfig *IbcWatcherConfig) *GuardianOption {

--- a/node/pkg/txverifier/evm.go
+++ b/node/pkg/txverifier/evm.go
@@ -41,6 +41,7 @@ const (
 // If the return value is false, it implies that something serious has gone wrong.
 func (tv *TransferVerifier[ethClient, Connector]) ProcessEvent(
 	ctx context.Context,
+	// If nil, only the receipt argument will be used
 	vLog *ethabi.AbiLogMessagePublished,
 	// If nil, this code will fetch the receipt using the TransferVerifier's connector.
 	receipt *geth.Receipt,
@@ -48,6 +49,12 @@ func (tv *TransferVerifier[ethClient, Connector]) ProcessEvent(
 
 	// Use this opportunity to prune old transaction information from the cache.
 	tv.pruneCache()
+
+	// TODO there's probably a better way to structure the functions so that this isn't necessary
+	if receipt == nil && vLog == nil {
+		tv.logger.Error("one of receipt or vLog must not be nil")
+		return false
+	}
 
 	tv.logger.Debug("detected LogMessagePublished event",
 		zap.String("txHash", vLog.Raw.TxHash.String()))

--- a/node/pkg/txverifier/evm.go
+++ b/node/pkg/txverifier/evm.go
@@ -48,7 +48,7 @@ func (tv *TransferVerifier[ethClient, Connector]) ProcessEvent(
 	// Use this opportunity to prune old transaction information from the cache.
 	tv.pruneCache()
 
-	if cmp(txHash, ZERO_ADDRESS) == 0 {
+	if Cmp(txHash, ZERO_ADDRESS) == 0 {
 		tv.logger.Error("txHash is the zero address")
 		return false
 	}
@@ -265,7 +265,7 @@ func (tv *TransferVerifier[ethClient, Connector]) fetchNativeInfo(
 	}
 
 	// Asset is wrapped but not in wrappedAsset map for the Token Bridge.
-	if cmp(unwrapped, ZERO_ADDRESS) == 0 {
+	if Cmp(unwrapped, ZERO_ADDRESS) == 0 {
 		return 0, ZERO_ADDRESS, errors.New("asset is wrapped but unwrapping gave the zero address. this is an unusual asset or there is a bug in the program")
 	}
 
@@ -663,7 +663,7 @@ func (tv *TransferVerifier[ethClient, connector]) fetchLogMessageDetails(details
 			return newDetails, unwrapErr
 		}
 
-		if cmp(unwrappedAddress, ZERO_ADDRESS) == 0 {
+		if Cmp(unwrappedAddress, ZERO_ADDRESS) == 0 {
 			// If the unwrap function returns the zero address, that means
 			// it has no knowledge of this token. In this case set the
 			// OriginAddress to OriginAddressRaw rather than to the zero

--- a/node/pkg/txverifier/evm.go
+++ b/node/pkg/txverifier/evm.go
@@ -12,7 +12,6 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/certusone/wormhole/node/pkg/watchers/evm/connectors/ethabi"
 	"github.com/ethereum/go-ethereum/common"
 	geth "github.com/ethereum/go-ethereum/core/types"
 	"github.com/wormhole-foundation/wormhole/sdk/vaa"
@@ -32,7 +31,7 @@ const (
 
 // ProcessEvent processes a LogMessagePublished event, and is either called
 // from a watcher or from the transfer verifier standalone process. It fetches
-// the full transaction receipt associated with the log, and parses all
+// the full transaction receipt associated with the txHash, and parses all
 // events emitted in the transaction, tracking LogMessagePublished events as outbound
 // transfers and token deposits into the token bridge as inbound transfers. It then
 // verifies that the sum of the inbound transfers is at least as much as the sum of
@@ -41,8 +40,7 @@ const (
 // If the return value is false, it implies that something serious has gone wrong.
 func (tv *TransferVerifier[ethClient, Connector]) ProcessEvent(
 	ctx context.Context,
-	// If nil, only the receipt argument will be used
-	vLog *ethabi.AbiLogMessagePublished,
+	txHash common.Hash,
 	// If nil, this code will fetch the receipt using the TransferVerifier's connector.
 	receipt *geth.Receipt,
 ) bool {
@@ -50,37 +48,30 @@ func (tv *TransferVerifier[ethClient, Connector]) ProcessEvent(
 	// Use this opportunity to prune old transaction information from the cache.
 	tv.pruneCache()
 
-	// TODO there's probably a better way to structure the functions so that this isn't necessary
-	if receipt == nil && vLog == nil {
-		tv.logger.Error("one of receipt or vLog must not be nil")
+	if cmp(txHash, ZERO_ADDRESS) == 0 {
+		tv.logger.Error("txHash is the zero address")
+		return false
+	}
+	if len(txHash) == 0 {
+		tv.logger.Error("txHash has zero length")
 		return false
 	}
 
 	tv.logger.Debug("detected LogMessagePublished event",
-		zap.String("txHash", vLog.Raw.TxHash.String()))
+		zap.String("txHash", txHash.String()))
 
 	// Caching: record used/inspected tx hash.
-	if _, exists := tv.processedTransactions[vLog.Raw.TxHash]; exists {
+	if _, exists := tv.processedTransactions[txHash]; exists {
 		tv.logger.Debug("skip: transaction hash already processed",
-			zap.String("txHash", vLog.Raw.TxHash.String()))
+			zap.String("txHash", txHash.String()))
 		return true
 	}
 
-	// This check also occurs when processing a receipt but skipping here avoids unnecessary
-	// processing.
-	if cmp(vLog.Sender, tv.Addresses.TokenBridgeAddr) != 0 {
-		tv.logger.Debug("skip: sender is not token bridge",
-			zap.String("txHash", vLog.Raw.TxHash.String()),
-			zap.String("sender", vLog.Sender.String()),
-			zap.String("tokenBridge", tv.Addresses.TokenBridgeAddr.String()))
-		return true
-	}
-
+	// Get the full transaction receipt for this txHash if it was not provided as an argument.
 	if receipt == nil {
 		tv.logger.Debug("receipt was not passed as an argument. fetching it using the connector")
-		// Get the full transaction receipt for this log if it was not provided as an argument.
 		var txReceiptErr error
-		receipt, txReceiptErr = tv.evmConnector.TransactionReceipt(ctx, vLog.Raw.TxHash)
+		receipt, txReceiptErr = tv.evmConnector.TransactionReceipt(ctx, txHash)
 		if txReceiptErr != nil {
 			tv.logger.Warn("could not find core bridge receipt", zap.Error(txReceiptErr))
 			return true
@@ -89,7 +80,7 @@ func (tv *TransferVerifier[ethClient, Connector]) ProcessEvent(
 
 	// Caching: record a new lastBlockNumber.
 	tv.lastBlockNumber = receipt.BlockNumber.Uint64()
-	tv.processedTransactions[vLog.Raw.TxHash] = receipt
+	tv.processedTransactions[txHash] = receipt
 
 	// Parse raw transaction receipt into high-level struct containing transfer details.
 	transferReceipt, parseErr := tv.ParseReceipt(receipt)
@@ -137,13 +128,13 @@ func (tv *TransferVerifier[ethClient, Connector]) ProcessEvent(
 		// transfer verifier is monitoring is broken.
 		tv.logger.Error("error when processing receipt. can't continue processing",
 			zap.Error(processErr),
-			zap.String("txHash", vLog.Raw.TxHash.String()))
+			zap.String("txHash", txHash.String()))
 		return false
 	}
 
 	// Update statistics
 	if summary.logsProcessed == 0 {
-		tv.logger.Warn("receipt logs empty for tx", zap.String("txHash", vLog.Raw.TxHash.Hex()))
+		tv.logger.Warn("receipt logs empty for tx", zap.String("txHash", txHash.Hex()))
 		return true
 	}
 
@@ -681,11 +672,11 @@ func (tv *TransferVerifier[ethClient, connector]) fetchLogMessageDetails(details
 			//
 			// This case can occur if a token is transferred when the wrapped asset hasn't been set-up yet.
 			// https://github.com/wormhole-foundation/wormhole/blob/main/whitepapers/0003_token_bridge.md#setup-of-wrapped-assets
-			tv.logger.Warn("unwrap call for foreign asset returned the zero address. Either token has not been registered or there is a bug in the program. .",
+			tv.logger.Warn("unwrap call for foreign asset returned the zero address. Either token has not been registered or there is a bug in the program.",
 				zap.String("originAddressRaw", details.OriginAddress.String()),
 				zap.String("tokenChain", details.TokenChain.String()),
 			)
-			return newDetails, errors.New("unwrap call for foreign asset returned the zero address. Either token has not been registered or there is a bug in the program")
+			return newDetails, errors.New("unwrap call for foreign asset returned the zero address. Either token has not been registered or there is a bug in the program.")
 		} else {
 			originAddress = unwrappedAddress
 		}

--- a/node/pkg/txverifier/evm.go
+++ b/node/pkg/txverifier/evm.go
@@ -49,11 +49,7 @@ func (tv *TransferVerifier[ethClient, Connector]) ProcessEvent(
 	tv.pruneCache()
 
 	if Cmp(txHash, ZERO_ADDRESS) == 0 {
-		tv.logger.Error("txHash is the zero address")
-		return false
-	}
-	if len(txHash) == 0 {
-		tv.logger.Error("txHash has zero length")
+		tv.logger.Error("txHash is all zeroes")
 		return false
 	}
 

--- a/node/pkg/txverifier/evmtypes.go
+++ b/node/pkg/txverifier/evmtypes.go
@@ -1018,7 +1018,7 @@ func (tv *TransferVerifier[evmClient, connector]) getDecimals(
 	}
 
 	if len(result) < EVM_WORD_LENGTH {
-		tv.logger.Warn("failed to get decimals for token: result has insufficient length",
+		tv.logger.Warn("failed to get decimals for token: decimals() result has insufficient length",
 			zap.String("tokenAddress", tokenAddress.String()),
 			zap.ByteString("result", result))
 		return 0, err

--- a/node/pkg/txverifier/evmtypes.go
+++ b/node/pkg/txverifier/evmtypes.go
@@ -85,6 +85,10 @@ type chainIds struct {
 	wormholeChainId vaa.ChainID
 }
 
+type TransferVerifierInterface interface {
+	ProcessEvent(ctx context.Context, txHash common.Hash, receipt *types.Receipt) bool
+}
+
 // TransferVerifier contains configuration values for verifying transfers.
 type TransferVerifier[E evmClient, C connector] struct {
 	Addresses *TVAddresses

--- a/node/pkg/txverifier/evmtypes_test.go
+++ b/node/pkg/txverifier/evmtypes_test.go
@@ -666,20 +666,20 @@ func TestCmp(t *testing.T) {
 	// in that format.
 
 	// Test identity
-	assert.Zero(t, cmp(ZERO_ADDRESS, ZERO_ADDRESS))
-	assert.Zero(t, cmp(ZERO_ADDRESS_VAA, ZERO_ADDRESS))
+	assert.Zero(t, Cmp(ZERO_ADDRESS, ZERO_ADDRESS))
+	assert.Zero(t, Cmp(ZERO_ADDRESS_VAA, ZERO_ADDRESS))
 
 	// Test mixed types
-	assert.Zero(t, cmp(ZERO_ADDRESS, ZERO_ADDRESS_VAA))
-	assert.Zero(t, cmp(ZERO_ADDRESS_VAA, ZERO_ADDRESS_VAA))
+	assert.Zero(t, Cmp(ZERO_ADDRESS, ZERO_ADDRESS_VAA))
+	assert.Zero(t, Cmp(ZERO_ADDRESS_VAA, ZERO_ADDRESS_VAA))
 
 	vaaAddr, err := vaa.BytesToAddress([]byte{0x01})
 	require.NoError(t, err)
-	assert.Zero(t, cmp(vaaAddr, common.BytesToAddress([]byte{0x01})))
+	assert.Zero(t, Cmp(vaaAddr, common.BytesToAddress([]byte{0x01})))
 
 	vaaAddr, err = vaa.BytesToAddress([]byte{0xff, 0x02})
 	require.NoError(t, err)
-	assert.Zero(t, cmp(common.BytesToAddress([]byte{0xff, 0x02}), vaaAddr))
+	assert.Zero(t, Cmp(common.BytesToAddress([]byte{0xff, 0x02}), vaaAddr))
 }
 
 func TestVAAFromAddr(t *testing.T) {

--- a/node/pkg/txverifier/utils.go
+++ b/node/pkg/txverifier/utils.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"math/big"
 	"strings"
+
+	"github.com/wormhole-foundation/wormhole/sdk/vaa"
 )
 
 // Constants
@@ -95,4 +97,12 @@ func denormalize(
 	}
 
 	return denormalizedAmount
+}
+
+// SupportedChains returns a slice of Wormhole Chain IDs that have a Transfer Verifier implementation.
+func SupportedChains() []vaa.ChainID {
+	return []vaa.ChainID{
+		vaa.ChainIDEthereum,
+		vaa.ChainIDSui,
+	}
 }

--- a/node/pkg/txverifier/utils.go
+++ b/node/pkg/txverifier/utils.go
@@ -2,8 +2,11 @@ package txverifier
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"math"
 	"math/big"
+	"slices"
 	"strings"
 
 	"github.com/wormhole-foundation/wormhole/sdk/vaa"
@@ -108,4 +111,41 @@ func SupportedChains() []vaa.ChainID {
 		vaa.ChainIDSepolia,
 		vaa.ChainIDHolesky,
 	}
+}
+
+// ValidateChains validates that a slice of uints correspond to chain IDs with a Transfer Verifier implementation.
+// Returns a slice of the input values converted into valid, known ChainIDs.
+// Returns nil when an error occurs.
+func ValidateChains(
+	// Uints to be validated. This type is selected because it can be used with Cobra's `UintSlice()` function.
+	input []uint,
+) ([]vaa.ChainID, error) {
+	if len(input) == 0 {
+		return nil, errors.New("no chain IDs provided for transfer verification")
+	}
+	knownChains := vaa.GetAllNetworkIDs()
+	supportedChains := SupportedChains()
+
+	// NOTE: Using a known capacity and counter here avoids unnecessary reallocations compared to using `append()`.
+	enabled := make([]vaa.ChainID, len(input))
+	i := uint8(0)
+	for _, chain := range input {
+		if chain > uint(math.MaxUint16) {
+			return nil, fmt.Errorf("uint %d exceeds MaxUint16", chain)
+		}
+		chainId := vaa.ChainID(chain)
+
+		if !slices.Contains(knownChains, chainId) {
+			return nil, fmt.Errorf("chainId %d is not a known Chain ID", chainId)
+		}
+
+		if !slices.Contains(supportedChains, chainId) {
+			return nil, fmt.Errorf("chainId %d does not have a Transfer Verifier implementation", chainId)
+		}
+
+		enabled[i] = chainId
+		i++
+	}
+
+	return enabled, nil
 }

--- a/node/pkg/txverifier/utils.go
+++ b/node/pkg/txverifier/utils.go
@@ -102,6 +102,10 @@ func denormalize(
 // SupportedChains returns a slice of Wormhole Chain IDs that have a Transfer Verifier implementation.
 func SupportedChains() []vaa.ChainID {
 	return []vaa.ChainID{
+		// Mainnets
 		vaa.ChainIDEthereum,
+		// Testnets
+		vaa.ChainIDSepolia,
+		vaa.ChainIDHolesky,
 	}
 }

--- a/node/pkg/txverifier/utils.go
+++ b/node/pkg/txverifier/utils.go
@@ -103,6 +103,5 @@ func denormalize(
 func SupportedChains() []vaa.ChainID {
 	return []vaa.ChainID{
 		vaa.ChainIDEthereum,
-		vaa.ChainIDSui,
 	}
 }

--- a/node/pkg/txverifier/utils_test.go
+++ b/node/pkg/txverifier/utils_test.go
@@ -3,7 +3,10 @@ package txverifier
 import (
 	"encoding/json"
 	"math/big"
+	"reflect"
 	"testing"
+
+	"github.com/wormhole-foundation/wormhole/sdk/vaa"
 )
 
 func TestExtractFromJsonPath(t *testing.T) {
@@ -216,6 +219,63 @@ func TestDenormalize(t *testing.T) {
 				)
 			}
 
+		})
+	}
+}
+
+func TestValidateChains(t *testing.T) {
+	type args struct {
+		input []uint
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []vaa.ChainID
+		wantErr bool
+	}{
+		{
+			name: "invalid chainId",
+			args: args{
+				input: []uint{65535},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "unsupported chainId",
+			args: args{
+				input: []uint{22},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "empty input",
+			args: args{
+				input: []uint{},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "happy path",
+			args: args{
+				input: []uint{2},
+			},
+			want:    []vaa.ChainID{vaa.ChainIDEthereum},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ValidateChains(tt.args.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateChains() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ValidateChains() = %v, want %v", got, tt.want)
+			}
 		})
 	}
 }

--- a/node/pkg/watchers/evm/by_transaction.go
+++ b/node/pkg/watchers/evm/by_transaction.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/certusone/wormhole/node/pkg/common"
 	eth_common "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/wormhole-foundation/wormhole/sdk/vaa"
 )
 
@@ -26,12 +27,12 @@ func MessageEventsForTransaction(
 	ethConn connectors.Connector,
 	contract eth_common.Address,
 	chainId vaa.ChainID,
-	tx eth_common.Hash) (uint64, []*common.MessagePublication, error) {
+	tx eth_common.Hash) (*types.Receipt, uint64, []*common.MessagePublication, error) {
 
 	// Get transactions logs from transaction
 	receipt, err := ethConn.TransactionReceipt(ctx, tx)
 	if err != nil {
-		return 0, nil, fmt.Errorf("failed to get transaction receipt: %w", err)
+		return nil, 0, nil, fmt.Errorf("failed to get transaction receipt: %w", err)
 	}
 
 	// Bail early when the transaction receipt status is anything other than
@@ -43,13 +44,13 @@ func MessageEventsForTransaction(
 	// EVM-compatible chains which might accidentally break this API contract
 	// and return logs for failed transactions. Check explicitly instead.
 	if receipt.Status != 1 {
-		return 0, nil, fmt.Errorf("non-success transaction status: %d", receipt.Status)
+		return nil, 0, nil, fmt.Errorf("non-success transaction status: %d", receipt.Status)
 	}
 
 	// Get block
 	blockTime, err := ethConn.TimeOfBlockByHash(ctx, receipt.BlockHash)
 	if err != nil {
-		return 0, nil, fmt.Errorf("failed to get block time: %w", err)
+		return nil, 0, nil, fmt.Errorf("failed to get block time: %w", err)
 	}
 
 	msgs := make([]*common.MessagePublication, 0, len(receipt.Logs))
@@ -71,7 +72,7 @@ func MessageEventsForTransaction(
 
 		ev, err := ethConn.ParseLogMessagePublished(*l)
 		if err != nil {
-			return 0, nil, fmt.Errorf("failed to parse log: %w", err)
+			return nil, 0, nil, fmt.Errorf("failed to parse log: %w", err)
 		}
 
 		message := &common.MessagePublication{
@@ -88,5 +89,5 @@ func MessageEventsForTransaction(
 		msgs = append(msgs, message)
 	}
 
-	return receipt.BlockNumber.Uint64(), msgs, nil
+	return receipt, receipt.BlockNumber.Uint64(), msgs, nil
 }

--- a/node/pkg/watchers/evm/config.go
+++ b/node/pkg/watchers/evm/config.go
@@ -20,7 +20,7 @@ type WatcherConfig struct {
 	L1FinalizerRequired    watchers.NetworkID // (optional)
 	l1Finalizer            interfaces.L1Finalizer
 	CcqBackfillCache       bool
-	TxVerifier             bool
+	TxVerifierEnabled      bool
 }
 
 func (wc *WatcherConfig) GetNetworkID() watchers.NetworkID {
@@ -66,7 +66,7 @@ func (wc *WatcherConfig) Create(
 		queryResponseC,
 		env,
 		wc.CcqBackfillCache,
-		wc.TxVerifier,
+		wc.TxVerifierEnabled,
 	)
 	watcher.SetL1Finalizer(wc.l1Finalizer)
 	return watcher, watcher.Run, watcher, nil

--- a/node/pkg/watchers/evm/config.go
+++ b/node/pkg/watchers/evm/config.go
@@ -20,6 +20,7 @@ type WatcherConfig struct {
 	L1FinalizerRequired    watchers.NetworkID // (optional)
 	l1Finalizer            interfaces.L1Finalizer
 	CcqBackfillCache       bool
+	TxVerifier             bool
 }
 
 func (wc *WatcherConfig) GetNetworkID() watchers.NetworkID {
@@ -53,7 +54,20 @@ func (wc *WatcherConfig) Create(
 		setWriteC = setC
 	}
 
-	watcher := NewEthWatcher(wc.Rpc, eth_common.HexToAddress(wc.Contract), string(wc.NetworkID), wc.ChainID, msgC, setWriteC, obsvReqC, queryReqC, queryResponseC, env, wc.CcqBackfillCache)
+	watcher := NewEthWatcher(
+		wc.Rpc,
+		eth_common.HexToAddress(wc.Contract),
+		string(wc.NetworkID),
+		wc.ChainID,
+		msgC,
+		setWriteC,
+		obsvReqC,
+		queryReqC,
+		queryResponseC,
+		env,
+		wc.CcqBackfillCache,
+		wc.TxVerifier,
+	)
 	watcher.SetL1Finalizer(wc.l1Finalizer)
 	return watcher, watcher.Run, watcher, nil
 }

--- a/node/pkg/watchers/evm/msg_verifier.go
+++ b/node/pkg/watchers/evm/msg_verifier.go
@@ -1,0 +1,63 @@
+package evm
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/certusone/wormhole/node/pkg/common"
+	"github.com/certusone/wormhole/node/pkg/txverifier"
+	eth_common "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// verify evaluates a MessagePublication using the Transfer Verifier.
+// On success, this function returns a copy of the MessagePublication with its verificationState set to the result of
+// the transfer verifier's evaluation.
+// On error, it returns an empty MessagePublication struct.
+func verify(
+	ctx context.Context,
+	msg *common.MessagePublication,
+	txHash eth_common.Hash,
+	receipt *types.Receipt,
+	txVerifier txverifier.TransferVerifierInterface,
+) (common.MessagePublication, error) {
+
+	// Create a local copy of the MessagePublication so that the original isn't modified.
+	localMsg := msg
+
+	if localMsg.VerificationState() != common.NotVerified {
+		return common.MessagePublication{}, fmt.Errorf("message publication already has a verification status")
+	}
+
+	if txVerifier == nil {
+		return common.MessagePublication{}, fmt.Errorf("transfer verifier is nil")
+	}
+
+	var verificationState common.VerificationState
+
+	// Only involve the transfer verifier for core messages sent
+	// from the token bridge. This check is also done in the
+	// transfer verifier package, but this helps us skip useless
+	// computation.
+	if txverifier.Cmp(localMsg.EmitterAddress, txVerifier.Addrs().TokenBridgeAddr) != 0 {
+		verificationState = common.NotApplicable
+	} else {
+		// Verify the transfer by analyzing the transaction receipt. This is a defense-in-depth mechanism
+		// to protect against fraudulent message emissions.
+		valid := txVerifier.ProcessEvent(ctx, txHash, receipt)
+		if !valid {
+			verificationState = common.Rejected
+		} else {
+			verificationState = common.Valid
+		}
+	}
+
+	// Update the state of the message.
+	updateErr := localMsg.SetVerificationState(verificationState)
+	if updateErr != nil {
+		errMsg := fmt.Sprintf("could not set verification state for message with txID %s", localMsg.TxIDString())
+		return common.MessagePublication{}, fmt.Errorf("%s %w", errMsg, updateErr)
+	}
+
+	return *localMsg, nil
+}

--- a/node/pkg/watchers/evm/reobserve.go
+++ b/node/pkg/watchers/evm/reobserve.go
@@ -79,6 +79,8 @@ func (w *Watcher) handleReobservationRequest(ctx context.Context, chainId vaa.Ch
 
 				if pubErr != nil {
 					w.logger.Error("Error when publishing message", zap.Error(err))
+					// Avoid increasing the observations metrics for messages that weren't published.
+					continue
 				}
 
 				numObservations++

--- a/node/pkg/watchers/evm/reobserve.go
+++ b/node/pkg/watchers/evm/reobserve.go
@@ -52,9 +52,10 @@ func (w *Watcher) handleReobservationRequest(ctx context.Context, chainId vaa.Ch
 
 			if pubErr != nil {
 				w.logger.Error("Error when publishing message", zap.Error(err))
+			} else {
+				numObservations++
 			}
 
-			numObservations++
 			continue
 		}
 
@@ -125,9 +126,9 @@ func (w *Watcher) handleReobservationRequest(ctx context.Context, chainId vaa.Ch
 
 			if pubErr != nil {
 				w.logger.Error("Error when publishing message", zap.Error(err))
+			} else {
+				numObservations++
 			}
-
-			numObservations++
 		} else {
 			w.logger.Info("ignoring re-observed message publication transaction",
 				zap.String("msgId", msg.MessageIDString()),

--- a/node/pkg/watchers/evm/reobserve.go
+++ b/node/pkg/watchers/evm/reobserve.go
@@ -52,7 +52,6 @@ func (w *Watcher) handleReobservationRequest(ctx context.Context, chainId vaa.Ch
 
 			if pubErr != nil {
 				w.logger.Error("Error when publishing message", zap.Error(err))
-				continue
 			}
 
 			numObservations++
@@ -80,7 +79,6 @@ func (w *Watcher) handleReobservationRequest(ctx context.Context, chainId vaa.Ch
 
 				if pubErr != nil {
 					w.logger.Error("Error when publishing message", zap.Error(err))
-					continue
 				}
 
 				numObservations++
@@ -125,7 +123,6 @@ func (w *Watcher) handleReobservationRequest(ctx context.Context, chainId vaa.Ch
 
 			if pubErr != nil {
 				w.logger.Error("Error when publishing message", zap.Error(err))
-				continue
 			}
 
 			numObservations++

--- a/node/pkg/watchers/evm/reobserve.go
+++ b/node/pkg/watchers/evm/reobserve.go
@@ -31,7 +31,7 @@ func (w *Watcher) handleReobservationRequest(ctx context.Context, chainId vaa.Ch
 	// by relying on the same websocket connection).
 
 	timeout, cancel := context.WithTimeout(ctx, 5*time.Second)
-	blockNumber, msgs, err := MessageEventsForTransaction(timeout, ethConn, w.contract, w.chainID, tx)
+	receipt, blockNumber, msgs, err := MessageEventsForTransaction(timeout, ethConn, w.contract, w.chainID, tx)
 	cancel()
 
 	if err != nil {
@@ -47,7 +47,14 @@ func (w *Watcher) handleReobservationRequest(ctx context.Context, chainId vaa.Ch
 				zap.Uint64("current_block", finalizedBlockNum),
 				zap.Uint64("observed_block", blockNumber),
 			)
-			w.msgC <- msg
+
+			pubErr := w.publishIfSafe(msg, ctx, eth_common.BytesToHash(msg.TxID), receipt)
+
+			if pubErr != nil {
+				w.logger.Error("Error when publishing message", zap.Error(err))
+				continue
+			}
+
 			numObservations++
 			continue
 		}
@@ -68,7 +75,14 @@ func (w *Watcher) handleReobservationRequest(ctx context.Context, chainId vaa.Ch
 					zap.Uint64("current_safe_block", safeBlockNum),
 					zap.Uint64("observed_block", blockNumber),
 				)
-				w.msgC <- msg
+
+				pubErr := w.publishIfSafe(msg, ctx, eth_common.BytesToHash(msg.TxID), receipt)
+
+				if pubErr != nil {
+					w.logger.Error("Error when publishing message", zap.Error(err))
+					continue
+				}
+
 				numObservations++
 			} else {
 				w.logger.Info("ignoring re-observed message publication transaction",
@@ -106,7 +120,14 @@ func (w *Watcher) handleReobservationRequest(ctx context.Context, chainId vaa.Ch
 				zap.Uint64("current_block", finalizedBlockNum),
 				zap.Uint64("observed_block", blockNumber),
 			)
-			w.msgC <- msg
+
+			pubErr := w.publishIfSafe(msg, ctx, eth_common.BytesToHash(msg.TxID), receipt)
+
+			if pubErr != nil {
+				w.logger.Error("Error when publishing message", zap.Error(err))
+				continue
+			}
+
 			numObservations++
 		} else {
 			w.logger.Info("ignoring re-observed message publication transaction",

--- a/node/pkg/watchers/evm/reobserve.go
+++ b/node/pkg/watchers/evm/reobserve.go
@@ -48,7 +48,7 @@ func (w *Watcher) handleReobservationRequest(ctx context.Context, chainId vaa.Ch
 				zap.Uint64("observed_block", blockNumber),
 			)
 
-			pubErr := w.publishIfSafe(msg, ctx, eth_common.BytesToHash(msg.TxID), receipt)
+			pubErr := w.verifyAndPublish(msg, ctx, eth_common.BytesToHash(msg.TxID), receipt)
 
 			if pubErr != nil {
 				w.logger.Error("Error when publishing message", zap.Error(err))
@@ -76,7 +76,7 @@ func (w *Watcher) handleReobservationRequest(ctx context.Context, chainId vaa.Ch
 					zap.Uint64("observed_block", blockNumber),
 				)
 
-				pubErr := w.publishIfSafe(msg, ctx, eth_common.BytesToHash(msg.TxID), receipt)
+				pubErr := w.verifyAndPublish(msg, ctx, eth_common.BytesToHash(msg.TxID), receipt)
 
 				if pubErr != nil {
 					w.logger.Error("Error when publishing message", zap.Error(err))
@@ -121,7 +121,7 @@ func (w *Watcher) handleReobservationRequest(ctx context.Context, chainId vaa.Ch
 				zap.Uint64("observed_block", blockNumber),
 			)
 
-			pubErr := w.publishIfSafe(msg, ctx, eth_common.BytesToHash(msg.TxID), receipt)
+			pubErr := w.verifyAndPublish(msg, ctx, eth_common.BytesToHash(msg.TxID), receipt)
 
 			if pubErr != nil {
 				w.logger.Error("Error when publishing message", zap.Error(err))

--- a/node/pkg/watchers/evm/watcher.go
+++ b/node/pkg/watchers/evm/watcher.go
@@ -85,18 +85,20 @@ var (
 
 type (
 	Watcher struct {
-		// Ethereum RPC url
+		// EVM RPC url.
 		url string
-		// Address of the Eth contract
+		// Address of the EVM contract
 		contract eth_common.Address
-		// Human-readable name of the Eth network, for logging and monitoring.
+		// Human-readable name of the EVM network, for logging and monitoring.
 		networkName string
 		// Readiness component
 		readinessSync readiness.Component
-		// VAA ChainID of the network we're connecting to.
+		// VAA ChainID of the network monitored by this watcher.
 		chainID vaa.ChainID
 
-		// Channel to send new messages to. Should be wrapped be a call to `publishIfSafe()`
+		// Channel for sending new MesssagePublications. Messages should not be sent
+		// to this channel directly. Instead, they should be wrapped by
+		// a call to `publishIfSafe()`.
 		msgC chan<- *common.MessagePublication
 
 		// Channel to send guardian set changes to.

--- a/node/pkg/watchers/evm/watcher.go
+++ b/node/pkg/watchers/evm/watcher.go
@@ -149,7 +149,6 @@ type (
 		txVerifierEnabled bool
 		// Transfer Verifier instance
 		txVerifier txverifier.TransferVerifierInterface
-		// txVerifier *txverifier.TransferVerifier[*eth_client.Client, connectors.Connector]
 	}
 
 	pendingKey struct {
@@ -856,12 +855,12 @@ func (w *Watcher) publishIfSafe(
 	if w.txVerifierEnabled {
 		// This should have already been initialized.
 		if w.txVerifier == nil {
-			return errors.New("transfer verifier should be enabled but is nil")
+			return errors.New("transfer verifier should be instantiated but is nil")
 		}
 		// Verify the transfer by analyzing the transaction receipt. This is a defense-in-depth mechanism
 		// to protect against fraudulent message emissions.
 		if !w.txVerifier.ProcessEvent(ctx, txHash, receipt) {
-			return errors.New("transfer verification failed")
+			return fmt.Errorf("transfer verification failed for txHash %s", txHash)
 		}
 	}
 

--- a/node/pkg/watchers/evm/watcher.go
+++ b/node/pkg/watchers/evm/watcher.go
@@ -620,8 +620,9 @@ func (w *Watcher) Run(parentCtx context.Context) error {
 								zap.String("txHash", txHash.String()),
 								zap.Error(pubErr),
 							)
+						} else {
+							ethMessagesConfirmed.WithLabelValues(w.networkName).Inc()
 						}
-						ethMessagesConfirmed.WithLabelValues(w.networkName).Inc()
 					}
 				}
 
@@ -811,9 +812,9 @@ func (w *Watcher) postMessage(
 				zap.String("txHash", msg.TxIDString()),
 				zap.Error(pubErr),
 			)
+		} else {
+			ethMessagesConfirmed.WithLabelValues(w.networkName).Inc()
 		}
-
-		ethMessagesConfirmed.WithLabelValues(w.networkName).Inc()
 		return
 	}
 

--- a/node/pkg/watchers/evm/watcher.go
+++ b/node/pkg/watchers/evm/watcher.go
@@ -164,8 +164,15 @@ type (
 	}
 )
 
-// MaxWaitConfirmations is the maximum number of confirmations to wait before declaring a transaction abandoned.
-const MaxWaitConfirmations = 60
+const (
+	// MaxWaitConfirmations is the maximum number of confirmations to wait before declaring a transaction abandoned.
+	MaxWaitConfirmations = 60
+
+	// pruneHeightDelta is the block height difference between the latest block and the oldest block to keep in memory.
+	// It is used as a parameter for the Transfer Verifier.
+	// Value is arbitrary and can be adjusted if it helps performance.
+	PruneHeightDelta = uint64(20)
+)
 
 func NewEthWatcher(
 	url string,
@@ -294,14 +301,11 @@ func (w *Watcher) Run(parentCtx context.Context) error {
 				WrappedNativeAddr: eth_common.HexToAddress(weth),
 			}
 
-			// The block height difference between the latest block and the oldest block to keep in memory.
-			// Value is arbitrary and can be adjusted if it helps performance.
-			pruneHeightDelta := uint64(20)
 			var tvErr error
 			w.txVerifier, tvErr = txverifier.NewTransferVerifier(
 				w.ethConn,
 				&addrs,
-				pruneHeightDelta,
+				PruneHeightDelta,
 				logger,
 			)
 			if tvErr != nil {

--- a/node/pkg/watchers/evm/watcher.go
+++ b/node/pkg/watchers/evm/watcher.go
@@ -97,7 +97,7 @@ type (
 
 		// Channel for sending new MesssagePublications. Messages should not be sent
 		// to this channel directly. Instead, they should be wrapped by
-		// a call to `publishIfSafe()`.
+		// a call to `verifyAndPublish()`.
 		msgC chan<- *common.MessagePublication
 
 		// Channel to send guardian set changes to.
@@ -281,24 +281,26 @@ func (w *Watcher) Run(parentCtx context.Context) error {
 			}
 
 			// Fetch the constants for the Token Bridge and the WETH address from the SDK.
+			// Token Bridge address
 			var tbridge []byte
-			var weth string
+			// Address of wrapped native asset, e.g. WETH for Ethereum.
+			var wnative string
+
 			switch w.env {
 			case common.UnsafeDevNet:
 				tbridge = sdk.KnownDevnetTokenbridgeEmitters[w.chainID]
-				weth = sdk.KnownDevnetWrappedNativeAddresses[w.chainID]
+				wnative = sdk.KnownDevnetWrappedNativeAddresses[w.chainID]
 			case common.TestNet:
 				tbridge = sdk.KnownTestnetTokenbridgeEmitters[w.chainID]
-				weth = sdk.KnownTestnetWrappedNativeAddresses[w.chainID]
+				wnative = sdk.KnownTestnetWrappedNativeAddresses[w.chainID]
 			case common.MainNet:
 				tbridge = sdk.KnownTokenbridgeEmitters[w.chainID]
-				// https://etherscan.io/token/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2
-				weth = sdk.KnownWrappedNativeAddress[w.chainID]
+				wnative = sdk.KnownWrappedNativeAddress[w.chainID]
 			}
 			addrs := txverifier.TVAddresses{
 				CoreBridgeAddr:    w.contract,
 				TokenBridgeAddr:   eth_common.BytesToAddress(tbridge[:]),
-				WrappedNativeAddr: eth_common.HexToAddress(weth),
+				WrappedNativeAddr: eth_common.HexToAddress(wnative),
 			}
 
 			var tvErr error

--- a/node/pkg/watchers/evm/watcher.go
+++ b/node/pkg/watchers/evm/watcher.go
@@ -589,7 +589,7 @@ func (w *Watcher) Run(parentCtx context.Context) error {
 						if pubErr != nil {
 							logger.Error("could not publish message: transfer verification failed",
 								zap.String("msgId", pLock.message.MessageIDString()),
-								zap.String("txHash",txHash.String()),
+								zap.String("txHash", txHash.String()),
 								zap.Error(pubErr),
 							)
 						}

--- a/node/pkg/watchers/evm/watcher.go
+++ b/node/pkg/watchers/evm/watcher.go
@@ -177,9 +177,9 @@ func NewEthWatcher(
 	queryResponseC chan<- *query.PerChainQueryResponseInternal,
 	env common.Environment,
 	ccqBackfillCache bool,
-	txVerifier bool,
+	txVerifierEnabled bool,
 ) *Watcher {
-	// Note: the Transfer Verifier is not added to the struct here because it requires a Connector instance.
+	// Note: the watcher's txVerifier field is not set here because it requires a Connector as an argument.
 	// Instead, it will be populated in `Run()`.
 	return &Watcher{
 		url:                url,
@@ -198,6 +198,8 @@ func NewEthWatcher(
 		ccqMaxBlockNumber:  big.NewInt(0).SetUint64(math.MaxUint64),
 		ccqBackfillCache:   ccqBackfillCache,
 		ccqBackfillChannel: make(chan *ccqBackfillRequest, 50),
+		// Signals that a transfer Verifier should be instantiated in Run()
+		txVerifierEnabled: txVerifierEnabled,
 	}
 }
 
@@ -214,6 +216,7 @@ func (w *Watcher) Run(parentCtx context.Context) error {
 		zap.String("networkName", w.networkName),
 		zap.String("chainID", w.chainID.String()),
 		zap.String("env", string(w.env)),
+		zap.Bool("txVerifier", w.txVerifierEnabled),
 	)
 
 	// later on we will spawn multiple go-routines through `RunWithScissors`, i.e. catching panics.

--- a/node/pkg/watchers/evm/watcher.go
+++ b/node/pkg/watchers/evm/watcher.go
@@ -147,7 +147,7 @@ type (
 		ccqLogger          *zap.Logger
 		// Whether the Transfer Verifier should be initialized for this watcher.
 		txVerifierEnabled bool
-		// Transfer Verifier instance
+		// Transfer Verifier instance. If nil, transfer verification is disabled.
 		txVerifier txverifier.TransferVerifierInterface
 	}
 
@@ -875,16 +875,11 @@ func (w *Watcher) verifyAndPublish(
 		return errors.New("verifyAndPublish: message publication already has a verification status")
 	}
 
-	if w.txVerifierEnabled {
+	if w.txVerifier != nil {
 		// Setting a custom verification state is only required when
 		// Transfer Verification is enabled. If disabled, the message
 		// will be emitted with the default value `NotVerified`.
 		var verificationState common.VerificationState
-
-		// This should have already been initialized by the constructor.
-		if w.txVerifier == nil {
-			return errors.New("verifyAndPublish: transfer verifier should be instantiated but is nil")
-		}
 
 		// Only involve the transfer verifier for core messages sent
 		// from the token bridge. This check is also done in the

--- a/node/pkg/watchers/evm/watcher.go
+++ b/node/pkg/watchers/evm/watcher.go
@@ -838,7 +838,8 @@ func canRetryGetBlockTime(err error) bool {
 	return exists
 }
 
-// publishIfSafe validates a MessagePublication to ensure that it's safe. If so, it broadcasts the message.
+// publishIfSafe validates a MessagePublication to ensure that it's safe. If so, it broadcasts the message. This function
+// should be the only location where the watcher's msgC channel is written to.
 // The MessagePulication is checked against either its corresponding raw message publication event log or else a transaction receipt.
 func (w *Watcher) publishIfSafe(
 	msg *common.MessagePublication,

--- a/node/pkg/watchers/evm/watcher_test.go
+++ b/node/pkg/watchers/evm/watcher_test.go
@@ -50,3 +50,6 @@ func Test_canRetryGetBlockTime(t *testing.T) {
 	assert.True(t, canRetryGetBlockTime(errors.New("cannot query unfinalized data")))
 	assert.False(t, canRetryGetBlockTime(errors.New("Hello, World!")))
 }
+
+// Add test for publishIFSafe
+// requires creating a watcher object

--- a/node/pkg/watchers/evm/watcher_test.go
+++ b/node/pkg/watchers/evm/watcher_test.go
@@ -131,7 +131,7 @@ func TestVerifyAndPublish(t *testing.T) {
 	require.NotNil(t, w.txVerifier)
 
 	err = w.verifyAndPublish(&msg, ctx, eth_common.Hash{}, &types.Receipt{})
-	require.ErrorContains(t, err, "message publication already has a verification status")
+	require.ErrorContains(t, err, "MessagePublication already has a non-default verification state")
 	require.Equal(t, 0, len(msgC))
 	require.Equal(t, common.Anomalous.String(), msg.VerificationState().String())
 

--- a/node/pkg/watchers/evm/watcher_test.go
+++ b/node/pkg/watchers/evm/watcher_test.go
@@ -97,7 +97,8 @@ func TestVerifyAndPublish(t *testing.T) {
 
 	// Check scenario where the message already has a verification status.
 	msg = common.MessagePublication{}
-	msg.SetVerificationState(common.Anomalous)
+	setErr := msg.SetVerificationState(common.Anomalous)
+	require.NoError(t, setErr)
 
 	err = w.verifyAndPublish(&msg, ctx, eth_common.Hash{}, &types.Receipt{})
 	require.ErrorContains(t, err, "message publication already has a verification status")

--- a/node/pkg/watchers/evm/watcher_test.go
+++ b/node/pkg/watchers/evm/watcher_test.go
@@ -69,12 +69,12 @@ func TestVerifyAndPublish(t *testing.T) {
 
 	// Check preconditions
 	require.Equal(t, 0, len(w.msgC))
-	require.Equal(t, common.NotVerified, msg.VerificationState())
+	require.Equal(t, common.NotVerified.String(), msg.VerificationState().String())
 
 	// Check nil message
 	err := w.verifyAndPublish(nil, ctx, eth_common.Hash{}, &types.Receipt{})
 	require.ErrorContains(t, err, "message publication cannot be nil")
-	require.Equal(t, common.NotVerified, msg.VerificationState())
+	require.Equal(t, common.NotVerified.String(), msg.VerificationState().String())
 
 	// Check transfer verifier not enabled case. The message should be published normally
 	msg = common.MessagePublication{}
@@ -84,7 +84,7 @@ func TestVerifyAndPublish(t *testing.T) {
 	publishedMsg := <-msgC
 	require.NotNil(t, publishedMsg)
 	require.Equal(t, 0, len(msgC))
-	require.Equal(t, common.NotApplicable, publishedMsg.VerificationState())
+	require.Equal(t, common.NotVerified.String(), publishedMsg.VerificationState().String())
 
 	// Check scenario where transfer verifier is enabled but isn't initialized.
 	msg = common.MessagePublication{}
@@ -93,7 +93,7 @@ func TestVerifyAndPublish(t *testing.T) {
 	err = w.verifyAndPublish(&msg, ctx, eth_common.Hash{}, &types.Receipt{})
 	require.ErrorContains(t, err, "transfer verifier should be instantiated but is nil")
 	require.Equal(t, 0, len(msgC))
-	require.Equal(t, common.NotVerified, publishedMsg.VerificationState())
+	require.Equal(t, common.NotVerified.String(), publishedMsg.VerificationState().String())
 
 	// Check scenario where the message already has a verification status.
 	msg = common.MessagePublication{}
@@ -103,7 +103,7 @@ func TestVerifyAndPublish(t *testing.T) {
 	err = w.verifyAndPublish(&msg, ctx, eth_common.Hash{}, &types.Receipt{})
 	require.ErrorContains(t, err, "message publication already has a verification status")
 	require.Equal(t, 0, len(msgC))
-	require.Equal(t, common.Anomalous, msg.VerificationState())
+	require.Equal(t, common.Anomalous.String(), msg.VerificationState().String())
 
 	// Check case where Transfer Verifier finds a dangerous transaction. Note that this case does
 	// not return an error, but the published message should be marked as Rejected.
@@ -117,7 +117,7 @@ func TestVerifyAndPublish(t *testing.T) {
 	publishedMsg = <-msgC
 	require.NotNil(t, publishedMsg)
 	require.Equal(t, 0, len(msgC))
-	require.Equal(t, common.Rejected, publishedMsg.VerificationState())
+	require.Equal(t, common.Rejected.String(), publishedMsg.VerificationState().String())
 
 	// Check happy path where txverifier is enabled and initialized
 	msg = common.MessagePublication{}
@@ -130,7 +130,7 @@ func TestVerifyAndPublish(t *testing.T) {
 	publishedMsg = <-msgC
 	require.NotNil(t, publishedMsg)
 	require.Equal(t, 0, len(msgC))
-	require.Equal(t, common.Valid, publishedMsg.VerificationState())
+	require.Equal(t, common.Valid.String(), publishedMsg.VerificationState().String())
 }
 
 // Helper function to set up a test Ethereum Watcher

--- a/node/pkg/watchers/evm/watcher_test.go
+++ b/node/pkg/watchers/evm/watcher_test.go
@@ -84,7 +84,7 @@ func TestPublishIfSafe(t *testing.T) {
 	// Check scenario where transfer verifier is enabled but isn't initialized.
 	w.txVerifierEnabled = true
 	err = w.publishIfSafe(&msg, ctx, eth_common.Hash{}, &types.Receipt{})
-	require.ErrorContains(t, err, "transfer verifier should be enabled but is nil")
+	require.ErrorContains(t, err, "transfer verifier should be instantiated but is nil")
 	require.Equal(t, 0, len(msgC))
 
 	// Check case where Transfer Verifier finds a dangerous transaction

--- a/sdk/devnet_consts.go
+++ b/sdk/devnet_consts.go
@@ -2,6 +2,7 @@ package sdk
 
 import (
 	"github.com/wormhole-foundation/wormhole/sdk/vaa"
+	"github.com/ethereum/go-ethereum/common"
 )
 
 // KnownDevnetEmitters is a list of known emitters used during development.
@@ -40,4 +41,10 @@ var KnownDevnetAutomaticRelayerEmitters = []struct {
 	// NTT end to end testing uses special emitters in local dev and CI.
 	{ChainId: vaa.ChainIDEthereum, Addr: "000000000000000000000000cc680d088586c09c3e0e099a676fa4b6e42467b4"},
 	{ChainId: vaa.ChainIDBSC, Addr: "000000000000000000000000cc680d088586c09c3e0e099a676fa4b6e42467b4"},
+}
+
+// KnownDevnetWrappedNativeAddress is a map of wrapped native addresses by chain ID, e.g. WETH for Ethereum
+var KnownDevnetWrappedNativeAddresses = map[vaa.ChainID]common.Address{
+	// WETH deployed by the Tilt devnet configuration.
+	vaa.ChainIDEthereum: common.HexToAddress("0xDDb64fE46a91D46ee29420539FC25FD07c5FEa3E"),
 }

--- a/sdk/devnet_consts.go
+++ b/sdk/devnet_consts.go
@@ -1,8 +1,8 @@
 package sdk
 
 import (
-	"github.com/wormhole-foundation/wormhole/sdk/vaa"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/wormhole-foundation/wormhole/sdk/vaa"
 )
 
 // KnownDevnetEmitters is a list of known emitters used during development.

--- a/sdk/devnet_consts.go
+++ b/sdk/devnet_consts.go
@@ -1,7 +1,6 @@
 package sdk
 
 import (
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/wormhole-foundation/wormhole/sdk/vaa"
 )
 
@@ -44,7 +43,7 @@ var KnownDevnetAutomaticRelayerEmitters = []struct {
 }
 
 // KnownDevnetWrappedNativeAddress is a map of wrapped native addresses by chain ID, e.g. WETH for Ethereum
-var KnownDevnetWrappedNativeAddresses = map[vaa.ChainID]common.Address{
+var KnownDevnetWrappedNativeAddresses = map[vaa.ChainID]string{
 	// WETH deployed by the Tilt devnet configuration.
-	vaa.ChainIDEthereum: common.HexToAddress("0xDDb64fE46a91D46ee29420539FC25FD07c5FEa3E"),
+	vaa.ChainIDEthereum: "0xDDb64fE46a91D46ee29420539FC25FD07c5FEa3E",
 }

--- a/sdk/mainnet_consts.go
+++ b/sdk/mainnet_consts.go
@@ -199,5 +199,5 @@ var KnownAutomaticRelayerEmitters = []struct {
 // KnownWrappedNativeAddress is a map of wrapped native addresses by chain ID, e.g. WETH for Ethereum
 var KnownWrappedNativeAddress = map[vaa.ChainID]string{
 	// WETH
-	vaa.ChainIDEthereum: "0xc8f93d9738e7Ad5f3aF8c548DB2f6B7F8082B5e8",
+	vaa.ChainIDEthereum: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
 }

--- a/sdk/mainnet_consts.go
+++ b/sdk/mainnet_consts.go
@@ -4,7 +4,6 @@ import (
 	"encoding/hex"
 	"fmt"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/wormhole-foundation/wormhole/sdk/vaa"
 )
 
@@ -198,7 +197,7 @@ var KnownAutomaticRelayerEmitters = []struct {
 }
 
 // KnownWrappedNativeAddress is a map of wrapped native addresses by chain ID, e.g. WETH for Ethereum
-var KnownWrappedNativeAddress = map[vaa.ChainID]common.Address{
+var KnownWrappedNativeAddress = map[vaa.ChainID]string{
 	// WETH
-	vaa.ChainIDEthereum: common.HexToAddress("0xc8f93d9738e7Ad5f3aF8c548DB2f6B7F8082B5e8"),
+	vaa.ChainIDEthereum: "0xc8f93d9738e7Ad5f3aF8c548DB2f6B7F8082B5e8",
 }

--- a/sdk/mainnet_consts.go
+++ b/sdk/mainnet_consts.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"fmt"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/wormhole-foundation/wormhole/sdk/vaa"
 )
 
@@ -194,4 +195,10 @@ var KnownAutomaticRelayerEmitters = []struct {
 	{ChainId: vaa.ChainIDXLayer, Addr: "00000000000000000000000027428dd2d3dd32a4d7f7c497eaaa23130d894911"},
 	{ChainId: vaa.ChainIDSnaxchain, Addr: "00000000000000000000000027428DD2d3DD32A4D7f7C497eAaa23130d894911"},
 	{ChainId: vaa.ChainIDWorldchain, Addr: "0000000000000000000000001520cc9e779c56dab5866bebfb885c86840c33d3"},
+}
+
+// KnownWrappedNativeAddress is a map of wrapped native addresses by chain ID, e.g. WETH for Ethereum
+var KnownWrappedNativeAddress = map[vaa.ChainID]common.Address{
+	// WETH
+	vaa.ChainIDEthereum: common.HexToAddress("0xc8f93d9738e7Ad5f3aF8c548DB2f6B7F8082B5e8"),
 }

--- a/sdk/testnet_consts.go
+++ b/sdk/testnet_consts.go
@@ -1,6 +1,9 @@
 package sdk
 
-import "github.com/wormhole-foundation/wormhole/sdk/vaa"
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/wormhole-foundation/wormhole/sdk/vaa"
+)
 
 // KnownTestnetEmitters is a list of known emitters on the various L1 testnets.
 var KnownTestnetEmitters = buildKnownEmitters(knownTestnetTokenbridgeEmitters, knownTestnetNFTBridgeEmitters)
@@ -102,4 +105,12 @@ var KnownTestnetAutomaticRelayerEmitters = []struct {
 	{ChainId: vaa.ChainIDArbitrumSepolia, Addr: "0000000000000000000000007B1bD7a6b4E61c2a123AC6BC2cbfC614437D0470"},
 	{ChainId: vaa.ChainIDOptimismSepolia, Addr: "00000000000000000000000093BAD53DDfB6132b0aC8E37f6029163E63372cEE"},
 	{ChainId: vaa.ChainIDBaseSepolia, Addr: "00000000000000000000000093BAD53DDfB6132b0aC8E37f6029163E63372cEE"},
+}
+
+// KnownTestnetWrappedNativeAddresses is a list of addresses for deployments of wrapped native asssets (e.g. WETH) on various testnets.
+var KnownTestnetWrappedNativeAddresses = map[vaa.ChainID]common.Address {
+	// WETH
+	vaa.ChainIDSepolia: common.HexToAddress("0x7b79995e5f793a07bc00c21412e50ecae098e7f9"),
+	// WETH
+	vaa.ChainIDHolesky: common.HexToAddress("0xc8f93d9738e7Ad5f3aF8c548DB2f6B7F8082B5e8"),
 }

--- a/sdk/testnet_consts.go
+++ b/sdk/testnet_consts.go
@@ -1,7 +1,6 @@
 package sdk
 
 import (
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/wormhole-foundation/wormhole/sdk/vaa"
 )
 
@@ -108,9 +107,9 @@ var KnownTestnetAutomaticRelayerEmitters = []struct {
 }
 
 // KnownTestnetWrappedNativeAddresses is a list of addresses for deployments of wrapped native asssets (e.g. WETH) on various testnets.
-var KnownTestnetWrappedNativeAddresses = map[vaa.ChainID]common.Address{
+var KnownTestnetWrappedNativeAddresses = map[vaa.ChainID]string{
 	// WETH
-	vaa.ChainIDSepolia: common.HexToAddress("0x7b79995e5f793a07bc00c21412e50ecae098e7f9"),
+	vaa.ChainIDSepolia: "0x7b79995e5f793a07bc00c21412e50ecae098e7f9",
 	// WETH
-	vaa.ChainIDHolesky: common.HexToAddress("0xc8f93d9738e7Ad5f3aF8c548DB2f6B7F8082B5e8"),
+	vaa.ChainIDHolesky: "0xc8f93d9738e7Ad5f3aF8c548DB2f6B7F8082B5e8",
 }

--- a/sdk/testnet_consts.go
+++ b/sdk/testnet_consts.go
@@ -108,7 +108,7 @@ var KnownTestnetAutomaticRelayerEmitters = []struct {
 }
 
 // KnownTestnetWrappedNativeAddresses is a list of addresses for deployments of wrapped native asssets (e.g. WETH) on various testnets.
-var KnownTestnetWrappedNativeAddresses = map[vaa.ChainID]common.Address {
+var KnownTestnetWrappedNativeAddresses = map[vaa.ChainID]common.Address{
 	// WETH
 	vaa.ChainIDSepolia: common.HexToAddress("0x7b79995e5f793a07bc00c21412e50ecae098e7f9"),
 	// WETH


### PR DESCRIPTION
# New Features
* Create a TxVerifier instance in the Run function of the EVM watcher
* Wrap all instances where a message would be published to the broadcasting msg channel with a new function,  `verifyAndPublish`
* Messages are published with a new status: `VerificationState`. 
* Modified the Transfer Verifier pkg API so that we can call the method with either an existing Receipt or a txHash.
* Added unit test in the watcher for new functionality

## If Transfer Verifier is enabled

- Messages that are token transfers will undergo Transfer Verification
- Message will be published with a status of Valid or Rejected depending on the result
- The calling code can then decide what to do based on this status

## If Transfer Verifier is not enabled
- Existing behaviour will be preserved, but messages will be published with a status of NotVerified. No further actions are taken when a Message Publication has this status

# Design Considerations

## Modifying MessagePublication

This PR modifies `MessagePublication` to add a new status based on whether the Message Publication is verified. This decision was made to handle Transfer Verification cases across many chains. For example, the EVM logs are reliable enough that we can confidently rule a message as Valid or Rejected. Other ecosystems (i.e. Sui, but perhaps also Solana, etc.) are not so clear cut. In this case, we may want to mark a transaction as Anomalous rather than outright rejecting it. 

Using this new enum allow us to do this.

Other potential benefits:
* Decouples the Verification of a Message from whether or not this can be published.
* Avoids scope-creep for the Watchers: they only watch messages, but do not need to reject them. (Instead this could be handled by the processor or some other security mechanism akin to the Governor or Accountant.)
* Allows configuring targeted action on a per-chain and per-status basis. For example, we may want to delay Anomalous messages but drop Rejected ones.
* Preserves a NotApplicable state that can be used as a fallback mechanism if the Transfer Verifier is disabled outright or on a particular chain
* This status could be used in other cases beyond Transfer Verification, but should not interfere with existing message handling.

## Scope of this PR

The idea with this PR is to test the modifications to the Ethereum watcher _without enabling the transfer verifier yet_. We can release this in testnet or mainnet to be sure that the changes here are stable. 

Once we're confident that the underlying mechanism is working well, we can add some logic in the Guardian to actually react when a MessagePublication has a status like Rejected or Anomalous. For now, changing the reaction of the watcher to a "bad" message is out of scope. 

# Questions

- Is it necessary to update the Protobuf files somewhere in order to capture the changes to Message Publication?


# Related Work
- [x] Note: #4277 should be merged before this PR.
- [x] #4280 extends the integration test coverage of the underlying package