### PR TITLE
sdk: add StringToKnownChainID function for VAAs

### DIFF
--- a/sdk/vaa/structs.go
+++ b/sdk/vaa/structs.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"math"
 	"math/big"
+	"strconv"
 	"strings"
 	"time"
 
@@ -319,6 +320,28 @@ func KnownChainIDFromNumber[N number](n N) (ChainID, error) {
 
 }
 
+// StringToKnownChainID converts from a string representation of a chain into a ChainID that is registered in the SDK.
+// The argument can be either a numeric string representation of a number or a known chain name such as "solana".
+// Inputs of unknown ChainIDs, including 0, will result in an error.
+func StringToKnownChainID(s string) (ChainID, error) {
+
+	// Try to convert from chain name first, and return early if it's found.
+	id, err := ChainIDFromString(s)
+	if err == nil {
+		return id, nil
+	}
+
+	// Ensure that the string can be parsed into a uint16 in order to avoid overflow issues when converting
+	// to ChainID (which is a uint16).
+	u16, err := strconv.ParseUint(s, 10, 16)
+	if err != nil {
+		return ChainIDUnset, err
+	}
+
+	return KnownChainIDFromNumber(u16)
+}
+
+// ChainIDFromString converts from a chain's full name (e.g. "solana") to its corresponding ChainID.
 func ChainIDFromString(s string) (ChainID, error) {
 	s = strings.ToLower(s)
 

--- a/sdk/vaa/structs_test.go
+++ b/sdk/vaa/structs_test.go
@@ -1183,3 +1183,85 @@ func TestChainIDFromNumber(t *testing.T) {
 		})
 	}
 }
+
+func TestStringToKnownChainID(t *testing.T) {
+
+	happy := []struct {
+		name     string
+		input    string
+		expected ChainID
+	}{
+		{
+			name:     "simple int 1",
+			input:    "1",
+			expected: ChainIDSolana,
+		},
+		{
+			name:     "simple int 2",
+			input:    "3104",
+			expected: ChainIDWormchain,
+		},
+		{
+			name:     "chain name 1",
+			input:    "solana",
+			expected: ChainIDSolana,
+		},
+	}
+	for _, tt := range happy {
+		// Avoid "loop variable capture".
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, err := StringToKnownChainID(tt.input)
+			require.Equal(t, tt.expected, actual)
+			require.NoError(t, err)
+		})
+	}
+
+	// Check error cases
+	sad := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "zero is not a valid ChainID",
+			input: "0",
+		},
+		{
+			name:  "negative value",
+			input: "-1",
+		},
+		{
+			name:  "NaN",
+			input: "garbage",
+		},
+		{
+			name:  "overflow",
+			input: "65536",
+		},
+		{
+			name:  "not a real chain",
+			input: "12345",
+		},
+		{
+			name:  "empty string",
+			input: "",
+		},
+		{
+			name:  "no hex inputs",
+			input: "0x10",
+		},
+	}
+	for _, tt := range sad {
+		// Avoid "loop variable capture".
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, err := StringToKnownChainID(tt.input)
+			require.Equal(t, ChainIDUnset, actual)
+			require.Error(t, err)
+		})
+	}
+}


### PR DESCRIPTION
Adds a function to the SDK's vaa structs that parses known ChainIDs from string representations of ints or chain names.

I've found myself wishing that this function exists in the context of working with ChainIDs. It's nice to have this parsing and validation provided by the SDK.