### PR TITLE
Node: Allow no heartbeating in testnet

### DIFF
--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -670,7 +670,7 @@ func runNode(cmd *cobra.Command, args []string) {
 
 	// Verify flags
 
-	if *nodeName == "" {
+	if *nodeName == "" && env == common.MainNet {
 		logger.Fatal("Please specify --nodeName")
 	}
 	if *nodeKeyPath == "" && env != common.UnsafeDevNet { // In devnet mode, keys are deterministically generated.
@@ -778,6 +778,10 @@ func runNode(cmd *cobra.Command, args []string) {
 	if !*disableTelemetry && (env != common.UnsafeDevNet || (env == common.UnsafeDevNet && usingLoki)) {
 		if !usingLoki {
 			logger.Fatal("Please specify --telemetryLokiURL or set --disableTelemetry=false")
+		}
+
+		if *nodeName == "" {
+			logger.Fatal("If telemetry is enabled, --nodeName must be set")
 		}
 
 		// Get libp2p peer ID from private key


### PR DESCRIPTION
Starting and stopping a temporary guardian in testnet causes false alarms in monitoring. This is because monitoring looks for heartbeats from all guardians for which it has seen heartbeats.

This PR allows the running of temporary guardians without heartbeating by omitting the `--nodeName` parameter *in testnet only*. This should prevent these false alarms.