### PR TITLE
Node: Revert #4225 (Double the limits on Ethereum and Solana)

### DIFF
--- a/node/pkg/governor/mainnet_chains.go
+++ b/node/pkg/governor/mainnet_chains.go
@@ -10,8 +10,8 @@ import (
 
 func chainList() []chainConfigEntry {
 	return []chainConfigEntry{
-		{emitterChainID: vaa.ChainIDSolana, dailyLimit: 100_000_000, bigTransactionSize: 5_000_000},
-		{emitterChainID: vaa.ChainIDEthereum, dailyLimit: 200_000_000, bigTransactionSize: 10_000_000},
+		{emitterChainID: vaa.ChainIDSolana, dailyLimit: 50_000_000, bigTransactionSize: 2_500_000},
+		{emitterChainID: vaa.ChainIDEthereum, dailyLimit: 100_000_000, bigTransactionSize: 5_000_000},
 		{emitterChainID: vaa.ChainIDTerra, dailyLimit: 150_000, bigTransactionSize: 15_000},
 		{emitterChainID: vaa.ChainIDBSC, dailyLimit: 5_000_000, bigTransactionSize: 500_000},
 		{emitterChainID: vaa.ChainIDPolygon, dailyLimit: 5_000_000, bigTransactionSize: 500_000},

--- a/node/pkg/governor/mainnet_chains_test.go
+++ b/node/pkg/governor/mainnet_chains_test.go
@@ -31,7 +31,7 @@ func TestChainDailyLimitRange(t *testing.T) {
 	   but setting something sane such that if we accidentally go
 	   too high that the unit tests will make sure it's
 	   intentional */
-	max_daily_limit := uint64(200_000_001)
+	max_daily_limit := uint64(100_000_001)
 
 	// Do not remove this assertion
 	assert.NotEqual(t, max_daily_limit, uint64(0))


### PR DESCRIPTION
Reverts https://github.com/wormhole-foundation/wormhole/pull/4225 as the traffic surge turned out to be very short lived, the higher limit is not needed at this time.