### PR TITLE
ethereum: fix tests after forge 1.0 release

### DIFF
--- a/ethereum/forge-test/Implementation.t.sol
+++ b/ethereum/forge-test/Implementation.t.sol
@@ -184,6 +184,7 @@ contract TestImplementation is TestUtils {
         );
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testPublishMessage_Revert_OutOfFunds(
         bytes32 storageSlot,
         uint256 messageFee,

--- a/ethereum/forge-test/TokenImplementation.t.sol
+++ b/ethereum/forge-test/TokenImplementation.t.sol
@@ -392,7 +392,7 @@ contract TestTokenImplementation is TokenImplementation, Test {
         );
     }
 
-    function testFailPermitWithSameSignature(
+    function test_Revert_PermitWithSameSignature(
         bytes32 walletPrivateKey,
         uint256 amount,
         address spender
@@ -424,10 +424,8 @@ contract TestTokenImplementation is TokenImplementation, Test {
             signature.s
         );
 
-        // try again... you shall not pass
-        // NOTE: using "testFail" instead of "test" because
-        // vm.expectRevert("ERC20Permit: invalid signature") does not work
-        permit(
+        vm.expectRevert("ERC20Permit: invalid signature");
+        this.permit(
             signature.allower,
             spender,
             amount,
@@ -438,7 +436,7 @@ contract TestTokenImplementation is TokenImplementation, Test {
         );
     }
 
-    function testFailPermitWithBadSignature(
+    function test_Revert_PermitWithBadSignature(
         bytes32 walletPrivateKey,
         uint256 amount,
         address spender
@@ -466,9 +464,8 @@ contract TestTokenImplementation is TokenImplementation, Test {
         );
 
         // you shall not pass!
-        // NOTE: using "testFail" instead of "test" because
-        // vm.expectRevert("ERC20Permit: invalid signature") does not work
-        permit(
+        vm.expectRevert("ERC20Permit: invalid signature");
+        this.permit(
             signature.allower,
             spender,
             amount,
@@ -505,7 +502,7 @@ contract TestTokenImplementation is TokenImplementation, Test {
 
         // and fail
         vm.expectRevert("ERC20Permit: expired deadline");
-        permit(
+        this.permit(
             signature.allower,
             spender,
             amount,

--- a/relayer/ethereum/forge-test/relayer/WormholeRelayer.t.sol
+++ b/relayer/ethereum/forge-test/relayer/WormholeRelayer.t.sol
@@ -2108,6 +2108,7 @@ contract WormholeRelayerTests is Test {
         checkMessageKey(WormholeRelayerSerde.encodeMessageKey(newMessageKey), 0, messageKey);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testRevertEncodeAndDecodeTooLongMessageKeyArray() public {
         uint256 len = uint256(type(uint8).max) + 1;
         MessageKey[] memory messageKeys = new MessageKey[](len);


### PR DESCRIPTION
Forge 1.0 changed the meaning of expectRevert, by no longer considering internal calls by default:
https://book.getfoundry.sh/guides/v1.0-migration#expect-revert-cheatcode-disabled-on-internal-calls-by-default

We work around this by overriding the default config in places that rely on this expectation, and simply by invoking external calls in places that just incidentally relied on this.