### PR TITLE
sdk: Add functions for type-safe conversions from integers to ChainID

### DIFF
--- a/sdk/vaa/structs.go
+++ b/sdk/vaa/structs.go
@@ -136,10 +136,6 @@ func (a SignatureData) String() string {
 	return hex.EncodeToString(a[:])
 }
 
-// func ToChainID() string {
-// 	return hex.EncodeToString(a[:])
-// }
-
 func (c ChainID) String() string {
 	switch c {
 	case ChainIDUnset:


### PR DESCRIPTION
In many places in the Guardian, the following is done:

```go
// equivalent to `cid := uint16(x)`
cid := vaa.ChainID(x)
```

As `ChainID()` is just a custom type around `uint16`, this is equivalent to doing an unchecked type-conversion to uint16, which could result in edge-case truncation/overflow/sign-change issues.

The motivation for this change is to provide a clear way to go from any integer type to a ChainID in a type-safe way. With this PR, someone could instead write the following:

```go
// just type-safe
cid, err := vaa.ChainIDFromNumber(x)
// type-safe + corresponds to a real chain
cid, err := vaa.KnownChainIDFromNumber(x)
```

If the general idea seems good, I will merge this work with #4239 in the future so that the function introduced in that PR will use `KnownChainIDFromNumber` in the numeric string context.