### PR TITLE
txverifier: fix bugs and improve error handling

### DIFF
--- a/cspell-custom-words.txt
+++ b/cspell-custom-words.txt
@@ -181,6 +181,7 @@ trustlessly
 tsig
 tsproto
 TWAP
+txverifier
 uatom
 uluna
 unbond

--- a/node/cmd/txverifier/README.md
+++ b/node/cmd/txverifier/README.md
@@ -1,0 +1,25 @@
+# Transfer Verifier - CLI tool
+
+This package can be used to run the Transfer Verifier as a standalone tool. This allows for quick iteration: a developer can
+modify the package code at `node/pkg/txverifier/` and run this tool to test the changes against either mainnet or a local network.
+
+## Usage
+
+### Ethereum
+
+Ensure that you have a valid API key connected with a **WebSockets** URL. 
+
+The following command runs the Transfer Verifier against mainnet.
+
+```sh
+# Run from the root of the Wormhole monorepo. This script uses the mainnet values for the core contracts.
+./build/bin/guardiand transfer-verifier evm \
+    --rpcUrl $RPC_URL \
+    --coreContract 0x98f3c9e6E3fAce36bAAd05FE09d375Ef1464288B \
+    --tokenContract 0x3ee18B2214AFF97000D974cf647E7C347E8fa585 \
+    --wrappedNativeContract 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2 \
+    --logLevel debug
+```
+
+To test against a forked local network, change the RPC URL to anvil's default (also used by the Tilt network), and update
+the contract addresses.

--- a/node/pkg/txverifier/evm.go
+++ b/node/pkg/txverifier/evm.go
@@ -86,10 +86,18 @@ func (tv *TransferVerifier[ethClient, Connector]) ProcessEvent(
 
 	// Parse raw transaction receipt into high-level struct containing transfer details.
 	transferReceipt, parseErr := tv.ParseReceipt(receipt)
-	if parseErr != nil || transferReceipt == nil {
-		tv.logger.Warn("error when parsing receipt. skipping validation",
-			zap.String("receipt hash", receipt.TxHash.String()),
-			zap.Error(parseErr))
+	if transferReceipt == nil {
+		if parseErr != nil {
+			tv.logger.Warn("error when parsing receipt. skipping validation",
+				zap.String("receipt hash", receipt.TxHash.String()),
+				zap.Error(parseErr))
+		} else {
+			tv.logger.Debug("parsed receipt did not contain any LogMessagePublished events",
+				zap.String("receipt hash", receipt.TxHash.String()))
+		}
+		// Return true regardless of parsing errors. False is reserved
+		// for confirmed bad scenarios (arbitrary message
+		// publications), not parsing errors or irrelevant receipts.
 		return true
 	}
 
@@ -156,6 +164,18 @@ func (tv *TransferVerifier[ethClient, Connector]) UpdateReceiptDetails(
 	receipt *TransferReceipt,
 ) (updateErr error) {
 
+	if receipt == nil {
+		return errors.New("UpdateReceiptDetails was called with a nil Transfer Receipt")
+	}
+
+	invalidErr := receipt.Validate()
+	if invalidErr != nil {
+		return errors.Join(
+			errors.New("ProcessReceipt was called with an invalid Transfer Receipt:"),
+			invalidErr,
+		)
+	}
+
 	tv.logger.Debug(
 		"updating details for receipt",
 		zap.String("receiptRaw", receipt.String()),
@@ -195,7 +215,7 @@ func (tv *TransferVerifier[ethClient, Connector]) UpdateReceiptDetails(
 	// Populate the native asset information and token decimals for assets
 	// recorded in LogMessagePublished events for this receipt.
 	tv.logger.Debug("populating native data for LogMessagePublished assets")
-	for _, message := range *receipt.MessagePublicatons {
+	for _, message := range *receipt.MessagePublications {
 		newDetails, logFetchErr := tv.fetchLogMessageDetails(message.TransferDetails)
 		if logFetchErr != nil {
 			// The unwrapped address and the denormalized amount are necessary for checking
@@ -267,13 +287,13 @@ func (tv *TransferVerifier[evmClient, connector]) ParseReceipt(
 ) (*TransferReceipt, error) {
 	// Sanity checks. Shouldn't be necessary but no harm
 	if receipt == nil {
-		return &TransferReceipt{}, errors.New("receipt parameter is nil")
+		return nil, errors.New("receipt parameter is nil")
 	}
 	if receipt.Status != 1 {
-		return &TransferReceipt{}, errors.New("non-success transaction status")
+		return nil, errors.New("non-success transaction status")
 	}
 	if len(receipt.Logs) == 0 {
-		return &TransferReceipt{}, errors.New("no logs in receipt")
+		return nil, errors.New("no logs in receipt")
 	}
 
 	var deposits []*NativeDeposit
@@ -300,6 +320,7 @@ func (tv *TransferVerifier[evmClient, connector]) ParseReceipt(
 			tv.logger.Debug("adding deposit", zap.String("deposit", deposit.String()))
 			deposits = append(deposits, deposit)
 		case common.HexToHash(EVENTHASH_ERC20_TRANSFER):
+
 			transfer, transferErr := ERC20TransferFromLog(log, tv.chainIds.wormholeChainId)
 
 			if transferErr != nil {
@@ -311,11 +332,22 @@ func (tv *TransferVerifier[evmClient, connector]) ParseReceipt(
 				continue
 			}
 
+			// Log when the zero address is used in non-obvious ways.
+			if transfer.From == ZERO_ADDRESS {
+				tv.logger.Info("transfer's From field is the zero address. This is likely a mint operation",
+					zap.String("txHash", log.TxHash.String()),
+				)
+			}
+			if transfer.To == ZERO_ADDRESS {
+				tv.logger.Info("transfer's To field is the zero address. This is likely a burn operation",
+					zap.String("txHash", log.TxHash.String()),
+				)
+			}
+
 			tv.logger.Debug("adding transfer", zap.String("transfer", transfer.String()))
 			transfers = append(transfers, transfer)
 		case common.HexToHash(EVENTHASH_WORMHOLE_LOG_MESSAGE_PUBLISHED):
 			if len(log.Data) == 0 {
-				// tv.logger.Error("receipt data has length 0")
 				receiptErr = errors.Join(receiptErr, errors.New("receipt data has length 0"))
 				continue
 			}
@@ -362,6 +394,12 @@ func (tv *TransferVerifier[evmClient, connector]) ParseReceipt(
 				continue
 			}
 
+			if transferDetails == nil {
+				tv.logger.Debug("skip: parsed successfully but no relevant transfer found",
+					zap.String("txhash", log.TxHash.String()))
+				continue
+			}
+
 			// If everything went well, append the message publication
 			messagePublications = append(messagePublications, &LogMessagePublished{
 				EventEmitter:    log.Address,
@@ -373,17 +411,24 @@ func (tv *TransferVerifier[evmClient, connector]) ParseReceipt(
 	}
 
 	if len(messagePublications) == 0 {
-		receiptErr = errors.Join(receiptErr, errors.New("parsed receipts but received no LogMessagePublished events"))
+		if receiptErr == nil {
+			// There are no valid message publications, but also no recorded errors.
+			// This occurs when the core bridge emits a LogMessagePublished event but it is not sent by
+			// the Token Bridge. In this case, just return nil for both values.
+			return nil, nil
+		}
+		// If other errors occurred, also mention that there were no valid LogMessagePublished events.
+		receiptErr = errors.Join(receiptErr, errors.New("parsed receipt but received no LogMessagePublished events"))
 	}
 
 	if receiptErr != nil {
-		return &TransferReceipt{}, receiptErr
+		return nil, receiptErr
 	}
 
 	return &TransferReceipt{
-			Deposits:           &deposits,
-			Transfers:          &transfers,
-			MessagePublicatons: &messagePublications},
+			Deposits:            &deposits,
+			Transfers:           &transfers,
+			MessagePublications: &messagePublications},
 		nil
 }
 
@@ -412,17 +457,26 @@ func (tv *TransferVerifier[evmClient, connector]) ProcessReceipt(
 	receipt *TransferReceipt,
 ) (summary *ReceiptSummary, err error) {
 
+	// Sanity checks.
+	if receipt == nil {
+		return summary, errors.New("got nil transfer receipt")
+	}
+
+	invalidErr := receipt.Validate()
+	if invalidErr != nil {
+		return nil, errors.Join(
+			errors.New("ProcessReceipt was called with an invalid Transfer Receipt:"),
+			invalidErr,
+		)
+	}
+
 	tv.logger.Debug("beginning to process receipt",
 		zap.String("receipt", receipt.String()),
 	)
 
 	summary = NewReceiptSummary()
 
-	// Sanity checks.
-	if receipt == nil {
-		return summary, errors.New("got nil transfer receipt")
-	}
-	if len(*receipt.MessagePublicatons) == 0 {
+	if len(*receipt.MessagePublications) == 0 {
 		return summary, errors.New("no message publications in receipt")
 	}
 
@@ -483,7 +537,7 @@ func (tv *TransferVerifier[evmClient, connector]) ProcessReceipt(
 	}
 
 	// Process LogMessagePublished events.
-	for _, message := range *receipt.MessagePublicatons {
+	for _, message := range *receipt.MessagePublications {
 		td := message.TransferDetails
 
 		validateErr := validate[*LogMessagePublished](message)
@@ -552,17 +606,15 @@ func parseLogMessagePublishedPayload(
 	// Corresponds to LogMessagePublished.Payload as returned by the ABI parsing operation in the ethConnector.
 	data []byte,
 ) (*TransferDetails, error) {
-	// This method is already called by DecodeTransferPayloadHdr but the
-	// error message is unclear. Doing a manual check here lets us return a
-	// more helpful error message.
+	// If the payload type is neither Transfer nor Transfer With Payload, just return.
 	if !vaa.IsTransfer(data) {
-		return nil, errors.New("payload is not a transfer type. no need to process")
+		return nil, nil
 	}
 
 	// Note: vaa.DecodeTransferPayloadHdr performs validation on data, e.g. length checks.
 	hdr, err := vaa.DecodeTransferPayloadHdr(data)
 	if err != nil {
-		return nil, err
+		return nil, errors.Join(errors.New("could not parse LogMessagePublished payload:"), err)
 	}
 	return &TransferDetails{
 		PayloadType:      VAAPayloadType(hdr.Type),

--- a/node/pkg/txverifier/evm_test.go
+++ b/node/pkg/txverifier/evm_test.go
@@ -168,7 +168,7 @@ func TestParseReceiptHappyPath(t *testing.T) {
 						Amount:       big.NewInt(1),
 					},
 				},
-				MessagePublicatons: &[]*LogMessagePublished{
+				MessagePublications: &[]*LogMessagePublished{
 					{
 						EventEmitter: coreBridgeAddr,
 						MsgSender:    tokenBridgeAddr,
@@ -205,9 +205,9 @@ func TestParseReceiptHappyPath(t *testing.T) {
 				assert.Zero(t, ret.Amount.Cmp(expectedTransfers[0].Amount))
 			}
 
-			expectedMessages := *test.expected.MessagePublicatons
-			assert.Equal(t, len(expectedMessages), len(*transferReceipt.MessagePublicatons))
-			for _, ret := range *transferReceipt.MessagePublicatons {
+			expectedMessages := *test.expected.MessagePublications
+			assert.Equal(t, len(expectedMessages), len(*transferReceipt.MessagePublications))
+			for _, ret := range *transferReceipt.MessagePublications {
 				// TODO: switch argument order to (expected, actual)
 				assert.Equal(t, ret.MsgSender, expectedMessages[0].MsgSender)
 				assert.Equal(t, ret.EventEmitter, expectedMessages[0].EventEmitter)
@@ -320,7 +320,7 @@ func TestParseReceiptErrors(t *testing.T) {
 
 			receipt, err := mocks.transferVerifier.ParseReceipt(test.receipt)
 			require.Error(t, err)
-			assert.Equal(t, TransferReceipt{}, *receipt)
+			assert.Nil(t, receipt)
 		})
 	}
 }
@@ -464,7 +464,7 @@ func TestProcessReceipt(t *testing.T) {
 					},
 				},
 				Transfers: &[]*ERC20Transfer{},
-				MessagePublicatons: &[]*LogMessagePublished{
+				MessagePublications: &[]*LogMessagePublished{
 					{
 						EventEmitter: coreBridgeAddr,
 						MsgSender:    tokenBridgeAddr,
@@ -495,7 +495,7 @@ func TestProcessReceipt(t *testing.T) {
 						Amount:       big.NewInt(456),
 					},
 				},
-				MessagePublicatons: &[]*LogMessagePublished{
+				MessagePublications: &[]*LogMessagePublished{
 					{
 						EventEmitter: coreBridgeAddr,
 						MsgSender:    tokenBridgeAddr,
@@ -525,7 +525,7 @@ func TestProcessReceipt(t *testing.T) {
 					},
 				},
 				Transfers: &[]*ERC20Transfer{},
-				MessagePublicatons: &[]*LogMessagePublished{
+				MessagePublications: &[]*LogMessagePublished{
 					{
 						EventEmitter: coreBridgeAddr,
 						MsgSender:    tokenBridgeAddr,
@@ -556,7 +556,7 @@ func TestProcessReceipt(t *testing.T) {
 						Amount:       big.NewInt(999),
 					},
 				},
-				MessagePublicatons: &[]*LogMessagePublished{
+				MessagePublications: &[]*LogMessagePublished{
 					{
 						EventEmitter: coreBridgeAddr,
 						MsgSender:    tokenBridgeAddr,
@@ -586,7 +586,7 @@ func TestProcessReceipt(t *testing.T) {
 					},
 				},
 				Transfers: &[]*ERC20Transfer{},
-				MessagePublicatons: &[]*LogMessagePublished{
+				MessagePublications: &[]*LogMessagePublished{
 					{
 						EventEmitter: coreBridgeAddr,
 						MsgSender:    tokenBridgeAddr,
@@ -617,7 +617,7 @@ func TestProcessReceipt(t *testing.T) {
 						Amount:       big.NewInt(1),
 					},
 				},
-				MessagePublicatons: &[]*LogMessagePublished{
+				MessagePublications: &[]*LogMessagePublished{
 					{
 						EventEmitter: coreBridgeAddr,
 						MsgSender:    tokenBridgeAddr,
@@ -648,7 +648,7 @@ func TestProcessReceipt(t *testing.T) {
 						Amount:       big.NewInt(2),
 					},
 				},
-				MessagePublicatons: &[]*LogMessagePublished{
+				MessagePublications: &[]*LogMessagePublished{
 					{
 						EventEmitter: coreBridgeAddr,
 						MsgSender:    tokenBridgeAddr,
@@ -685,6 +685,39 @@ func TestProcessReceipt(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestTransferReceiptValidate(t *testing.T) {
+	transferReceipt := &TransferReceipt{
+		Deposits:            &[]*NativeDeposit{},
+		Transfers:           &[]*ERC20Transfer{},
+		MessagePublications: &[]*LogMessagePublished{},
+	}
+	err := transferReceipt.Validate()
+	require.Error(t, err, "Validate must return error when its fields are nil")
+
+	transferReceipt.MessagePublications = &[]*LogMessagePublished{
+		{
+			EventEmitter:    [20]byte{},
+			MsgSender:       [20]byte{},
+			TransferDetails: &TransferDetails{},
+		},
+	}
+
+	err = transferReceipt.Validate()
+	require.NoError(t, err, "Validate must not return an error when it has a non-zero Message Publication slice")
+}
+
+func TestNoPanics(t *testing.T) {
+	mocks := setup()
+	require.NotPanics(t, func() {
+		_, err := mocks.transferVerifier.ProcessReceipt(nil)
+		require.Error(t, err, "ProcessReceipt must return an error on nil input")
+	}, "ProcessReceipt should handle nil without panicking")
+	require.NotPanics(t, func() {
+		err := mocks.transferVerifier.UpdateReceiptDetails(nil)
+		require.Error(t, err, "UpdateReceiptDetails must return an error on nil input")
+	}, "UpdateReceiptDetails should handle nil without panicking")
 }
 
 func receiptData(payloadAmount *big.Int) (data []byte) {

--- a/node/pkg/txverifier/evmtypes.go
+++ b/node/pkg/txverifier/evmtypes.go
@@ -525,9 +525,15 @@ type TransferReceipt struct {
 	MessagePublications *[]*LogMessagePublished
 }
 
-// Validate ensures that a parsed TransferReceipt struct is well-formed. Its fields must not be nil, though they can be empty,
-// with the exception of MessagePublications. There should always be at least one relevant Message Publication by the
-// time this function is called.
+// Validate ensures that a parsed TransferReceipt struct is well-formed (i.e.
+// structurally valid, even if the semantic contents of the TransferReceipt
+// would be evaluated as "bad" from a security perspective.
+//
+// Well-formed means:
+// - The structs fields must not be nil.
+// - The MessagePublications fields must have at least one element.
+// As as result, this function should only be used near the end of parsing and processing
+// when all the logs have been parsed and used to populate the TransferReceipt instance.
 func (r *TransferReceipt) Validate() (err error) {
 	if r.Deposits == nil {
 		return errors.Join(err, errors.New("parsed receipt's Deposits field is nil"))
@@ -539,7 +545,7 @@ func (r *TransferReceipt) Validate() (err error) {
 		return errors.Join(err, errors.New("parsed receipt's MessagePublications field is nil"))
 	}
 	if len(*r.MessagePublications) == 0 {
-		return errors.Join(err, errors.New("parsed receipt' has no Message Publications"))
+		return errors.Join(err, errors.New("parsed receipt has no Message Publications"))
 	}
 
 	return

--- a/node/pkg/txverifier/evmtypes_test.go
+++ b/node/pkg/txverifier/evmtypes_test.go
@@ -830,7 +830,7 @@ func TestParseERC20TransferFrom(t *testing.T) {
 	invalidTests := map[string]struct {
 		log types.Log
 	}{
-		"invalid transfer: From is zero address": {
+		"invalid transfer: From and To are both equal to the zero address": {
 			log: types.Log{
 				Address: usdcAddr,
 				Topics: []common.Hash{
@@ -838,7 +838,7 @@ func TestParseERC20TransferFrom(t *testing.T) {
 					// From
 					common.HexToHash(ZERO_ADDRESS.String()),
 					// To
-					common.HexToHash(tokenBridgeAddr.String()),
+					common.HexToHash(ZERO_ADDRESS.String()),
 				},
 				TxHash: common.BytesToHash([]byte{0x01}),
 				Data:   common.LeftPadBytes(big.NewInt(100).Bytes(), EVM_WORD_LENGTH),


### PR DESCRIPTION
- Sometimes From _can_ be set to the zero address when a token is minted. This restriction has been removed
- Made error handling around irrelevant receipts less noisy. Now there will not be any WARN logs when a receipt contains a LogMessagePublished event that was sent by someone other than the token bridge.
- Changed functions that process receipts to always return nil rather than the empty struct
- Added more unit tests to ensure that functions don't panic in nil input
- Added Validation function for TransferReceipts
- Add README for running the Transfer Verifier CLI tool
- Fix typo in variable name