### PR TITLE
Node/EVM: Add instant finality to chain config

### DIFF
--- a/node/pkg/watchers/evm/chain_config.go
+++ b/node/pkg/watchers/evm/chain_config.go
@@ -68,7 +68,7 @@ var (
 		vaa.ChainIDFantom:   {InstantFinality: true, Finalized: false, Safe: false, EvmChainID: 250, PublicRPC: "https://fantom-rpc.publicnode.com"},
 		vaa.ChainIDKarura:   {Finalized: true, Safe: true, EvmChainID: 686, PublicRPC: "https://eth-rpc-karura.aca-api.network/"},
 		vaa.ChainIDAcala:    {Finalized: true, Safe: true, EvmChainID: 787, PublicRPC: "https://eth-rpc-acala.aca-api.network/"},
-		vaa.ChainIDKlaytn:   {InstantFinality: true, Finalized: true, Safe: true, EvmChainID: 8217}, // As of Feb 2025, can't find a working public node.
+		vaa.ChainIDKlaytn:   {InstantFinality: true, Finalized: false, Safe: false, EvmChainID: 8217, PublicRPC: "https://public-en.node.kaia.io"},
 		vaa.ChainIDCelo:     {Finalized: true, Safe: false, EvmChainID: 42220, PublicRPC: "https://celo-rpc.publicnode.com"},
 		vaa.ChainIDMoonbeam: {Finalized: true, Safe: true, EvmChainID: 1284, PublicRPC: "https://moonbeam-rpc.publicnode.com"},
 		vaa.ChainIDArbitrum: {Finalized: true, Safe: true, EvmChainID: 42161, PublicRPC: "https://arbitrum-one-rpc.publicnode.com"},
@@ -118,7 +118,7 @@ var (
 		vaa.ChainIDFantom:   {InstantFinality: true, Finalized: false, Safe: false, EvmChainID: 4002, PublicRPC: "https://fantom-testnet-rpc.publicnode.com"},
 		vaa.ChainIDKarura:   {Finalized: true, Safe: true, EvmChainID: 596, PublicRPC: "https://eth-rpc-karura-testnet.aca-staging.network"},
 		vaa.ChainIDAcala:    {Finalized: true, Safe: true, EvmChainID: 597, PublicRPC: "https://eth-rpc-acala-testnet.aca-staging.network"},
-		vaa.ChainIDKlaytn:   {InstantFinality: true, Finalized: true, Safe: true, EvmChainID: 1001}, // As of Feb 2025, can't find a working public node.
+		vaa.ChainIDKlaytn:   {InstantFinality: true, Finalized: false, Safe: false, EvmChainID: 1001, PublicRPC: "https://public-en-kairos.node.kaia.io"},
 		vaa.ChainIDCelo:     {Finalized: true, Safe: true, EvmChainID: 44787, PublicRPC: "https://alfajores-forno.celo-testnet.org"},
 		vaa.ChainIDMoonbeam: {Finalized: true, Safe: true, EvmChainID: 1287, PublicRPC: "https://rpc.api.moonbase.moonbeam.network"},
 		vaa.ChainIDArbitrum: {Finalized: true, Safe: true, EvmChainID: 421613}, // Arbitrum Goerli is deprecated.
@@ -147,7 +147,7 @@ var (
 		vaa.ChainIDUnichain:        {Finalized: true, Safe: true, EvmChainID: 1301, PublicRPC: "https://unichain-sepolia-rpc.publicnode.com"},
 		vaa.ChainIDWorldchain:      {Finalized: true, Safe: true, EvmChainID: 4801, PublicRPC: "https://worldchain-sepolia.g.alchemy.com/public"},
 		vaa.ChainIDInk:             {Finalized: true, Safe: true, EvmChainID: 763373, PublicRPC: "https://rpc-qnd-sepolia.inkonchain.com"},
-		vaa.ChainIDHyperEVM:        {Finalized: true, Safe: true, EvmChainID: 998}, // As of Feb 2025, this does not work: "https://api.hyperliquid-testnet.xyz/evm"
+		vaa.ChainIDHyperEVM:        {Finalized: true, Safe: true, EvmChainID: 998, PublicRPC: "https://rpc.hyperliquid-testnet.xyz/evm"},
 		vaa.ChainIDMonad:           {Finalized: true, Safe: true, EvmChainID: 10143, PublicRPC: "https://testnet-rpc.monad.xyz"},
 		vaa.ChainIDSepolia:         {Finalized: true, Safe: true, EvmChainID: 11155111, PublicRPC: "https://ethereum-sepolia-rpc.publicnode.com"},
 		vaa.ChainIDArbitrumSepolia: {Finalized: true, Safe: true, EvmChainID: 421614, PublicRPC: "https://arbitrum-sepolia-rpc.publicnode.com"},

--- a/node/pkg/watchers/evm/chain_config.go
+++ b/node/pkg/watchers/evm/chain_config.go
@@ -139,7 +139,7 @@ var (
 		// As of 9/06/2024 Linea supports polling for finalized but not safe.
 		vaa.ChainIDLinea: {Finalized: true, Safe: false, EvmChainID: 59141, PublicRPC: "https://rpc.sepolia.linea.build"},
 
-		vaa.ChainIDBerachain: {InstantFinality: true, Finalized: true, Safe: true, EvmChainID: 80084, PublicRPC: "https://bartio.rpc.berachain.com"},
+		vaa.ChainIDBerachain: {InstantFinality: true, Finalized: true, Safe: true, EvmChainID: 80084, PublicRPC: "https://berachain-testnet-rpc.publicnode.com"},
 		vaa.ChainIDSeiEVM:    {Finalized: true, Safe: true, EvmChainID: 1328, PublicRPC: "https://evm-rpc-testnet.sei-apis.com/"},
 		// vaa.ChainIDEclipse:     Not supported in the guardian.
 		// vaa.ChainIDBOB:         Not supported in the guardian.

--- a/node/pkg/watchers/evm/chain_config.go
+++ b/node/pkg/watchers/evm/chain_config.go
@@ -27,6 +27,10 @@ import (
 type (
 	// EnvEntry specifies the config data for a given chain / environment.
 	EnvEntry struct {
+		// InstantFinality indicates that the chain has instant finality, meaning finalized and safe blocks can be generated along with the latest block.
+		// Note that if InstantFinality is set to true, Finalized and Safe are for documentation purposes only.
+		InstantFinality bool
+
 		// Finalized indicates if the chain supports querying for finalized blocks.
 		Finalized bool
 
@@ -58,13 +62,13 @@ var (
 		// Polygon supports polling for finalized but not safe: https://forum.polygon.technology/t/optimizing-decentralized-apps-ux-with-milestones-a-significantly-accelerated-finality-solution/13154
 		vaa.ChainIDPolygon: {Finalized: true, Safe: false, EvmChainID: 137, PublicRPC: "https://polygon-bor-rpc.publicnode.com"},
 
-		vaa.ChainIDAvalanche: {Finalized: false, Safe: false, EvmChainID: 43114, PublicRPC: "https://avalanche-c-chain-rpc.publicnode.com"},
-		vaa.ChainIDOasis:     {Finalized: false, Safe: false, EvmChainID: 42262, PublicRPC: "https://emerald.oasis.dev/"},
+		vaa.ChainIDAvalanche: {InstantFinality: true, Finalized: true, Safe: true, EvmChainID: 43114, PublicRPC: "https://avalanche-c-chain-rpc.publicnode.com"},
+		vaa.ChainIDOasis:     {InstantFinality: true, Finalized: false, Safe: false, EvmChainID: 42262, PublicRPC: "https://emerald.oasis.dev/"},
 		// vaa.ChainIDAurora:    Not supported in the guardian.
-		vaa.ChainIDFantom:   {Finalized: false, Safe: false, EvmChainID: 250, PublicRPC: "https://fantom-rpc.publicnode.com"},
+		vaa.ChainIDFantom:   {InstantFinality: true, Finalized: false, Safe: false, EvmChainID: 250, PublicRPC: "https://fantom-rpc.publicnode.com"},
 		vaa.ChainIDKarura:   {Finalized: true, Safe: true, EvmChainID: 686, PublicRPC: "https://eth-rpc-karura.aca-api.network/"},
 		vaa.ChainIDAcala:    {Finalized: true, Safe: true, EvmChainID: 787, PublicRPC: "https://eth-rpc-acala.aca-api.network/"},
-		vaa.ChainIDKlaytn:   {Finalized: false, Safe: false, EvmChainID: 8217}, // As of Feb 2025, can't find a working public node.
+		vaa.ChainIDKlaytn:   {InstantFinality: true, Finalized: true, Safe: true, EvmChainID: 8217}, // As of Feb 2025, can't find a working public node.
 		vaa.ChainIDCelo:     {Finalized: true, Safe: false, EvmChainID: 42220, PublicRPC: "https://celo-rpc.publicnode.com"},
 		vaa.ChainIDMoonbeam: {Finalized: true, Safe: true, EvmChainID: 1284, PublicRPC: "https://moonbeam-rpc.publicnode.com"},
 		vaa.ChainIDArbitrum: {Finalized: true, Safe: true, EvmChainID: 42161, PublicRPC: "https://arbitrum-one-rpc.publicnode.com"},
@@ -83,9 +87,9 @@ var (
 		vaa.ChainIDXLayer: {Finalized: true, Safe: true, EvmChainID: 196, PublicRPC: "https://xlayerrpc.okx.com"},
 
 		// As of 9/06/2024 Linea supports polling for finalized but not safe.
-		vaa.ChainIDLinea: {Finalized: true, Safe: false, EvmChainID: 59144, PublicRPC: "https://linea-rpc.publicnode.com"},
+		vaa.ChainIDLinea: {Finalized: true, Safe: false, EvmChainID: 59144, PublicRPC: "https://rpc.linea.build"},
 
-		vaa.ChainIDBerachain: {Finalized: false, Safe: false, EvmChainID: 80094, PublicRPC: "https://berachain-rpc.publicnode.com"},
+		vaa.ChainIDBerachain: {InstantFinality: true, Finalized: true, Safe: true, EvmChainID: 80094, PublicRPC: "https://berachain-rpc.publicnode.com"},
 		// vaa.ChainIDSeiEVM:     Not in Mainnet yet.
 		// vaa.ChainIDEclipse:    Not supported in the guardian.
 		// vaa.ChainIDBOB:        Not supported in the guardian.
@@ -102,19 +106,19 @@ var (
 	// NOTE: If you change this data, be sure and run the tests described at the top of this file!
 	testnetChainConfig = EnvMap{
 		// For Ethereum testnet we actually use Holeksy since Goerli is deprecated.
-		vaa.ChainIDEthereum: {Finalized: true, Safe: true, EvmChainID: 17000, PublicRPC: "https://ethereum-holesky-rpc.publicnode.com"},
+		vaa.ChainIDEthereum: {Finalized: true, Safe: true, EvmChainID: 17000, PublicRPC: "https://1rpc.io/holesky"},
 		vaa.ChainIDBSC:      {Finalized: true, Safe: true, EvmChainID: 97, PublicRPC: "https://bsc-testnet-rpc.publicnode.com"},
 
 		// Polygon supports polling for finalized but not safe: https://forum.polygon.technology/t/optimizing-decentralized-apps-ux-with-milestones-a-significantly-accelerated-finality-solution/13154
 		vaa.ChainIDPolygon: {Finalized: true, Safe: false, EvmChainID: 80001}, // Polygon Mumbai is deprecated.
 
-		vaa.ChainIDAvalanche: {Finalized: false, Safe: false, EvmChainID: 43113, PublicRPC: "https://avalanche-fuji-c-chain-rpc.publicnode.com"},
-		vaa.ChainIDOasis:     {Finalized: false, Safe: false, EvmChainID: 42261, PublicRPC: "https://testnet.emerald.oasis.dev"},
+		vaa.ChainIDAvalanche: {InstantFinality: true, Finalized: true, Safe: true, EvmChainID: 43113, PublicRPC: "https://avalanche-fuji-c-chain-rpc.publicnode.com"},
+		vaa.ChainIDOasis:     {InstantFinality: true, Finalized: false, Safe: false, EvmChainID: 42261, PublicRPC: "https://testnet.emerald.oasis.dev"},
 		// vaa.ChainIDAurora:    Not supported in the guardian.
-		vaa.ChainIDFantom:   {Finalized: false, Safe: false, EvmChainID: 4002, PublicRPC: "https://fantom-testnet-rpc.publicnode.com"},
+		vaa.ChainIDFantom:   {InstantFinality: true, Finalized: false, Safe: false, EvmChainID: 4002, PublicRPC: "https://fantom-testnet-rpc.publicnode.com"},
 		vaa.ChainIDKarura:   {Finalized: true, Safe: true, EvmChainID: 596, PublicRPC: "https://eth-rpc-karura-testnet.aca-staging.network"},
 		vaa.ChainIDAcala:    {Finalized: true, Safe: true, EvmChainID: 597, PublicRPC: "https://eth-rpc-acala-testnet.aca-staging.network"},
-		vaa.ChainIDKlaytn:   {Finalized: false, Safe: false, EvmChainID: 1001}, // As of Feb 2025, can't find a working public node.
+		vaa.ChainIDKlaytn:   {InstantFinality: true, Finalized: true, Safe: true, EvmChainID: 1001}, // As of Feb 2025, can't find a working public node.
 		vaa.ChainIDCelo:     {Finalized: true, Safe: true, EvmChainID: 44787, PublicRPC: "https://alfajores-forno.celo-testnet.org"},
 		vaa.ChainIDMoonbeam: {Finalized: true, Safe: true, EvmChainID: 1287, PublicRPC: "https://rpc.api.moonbase.moonbeam.network"},
 		vaa.ChainIDArbitrum: {Finalized: true, Safe: true, EvmChainID: 421613}, // Arbitrum Goerli is deprecated.
@@ -128,14 +132,14 @@ var (
 		// As of 11/10/2023 Scroll supports polling for finalized but not safe.
 		vaa.ChainIDScroll: {Finalized: true, Safe: false, EvmChainID: 534351, PublicRPC: "https://scroll-sepolia-rpc.publicnode.com"},
 
-		vaa.ChainIDMantle: {Finalized: true, Safe: true, EvmChainID: 5003, PublicRPC: "https://mantle-sepolia.drpc.org"},
-		vaa.ChainIDBlast:  {Finalized: true, Safe: true, EvmChainID: 168587773, PublicRPC: "https://blast-sepolia.drpc.org"},
+		vaa.ChainIDMantle: {Finalized: true, Safe: true, EvmChainID: 5003, PublicRPC: "https://rpc.sepolia.mantle.xyz"},
+		vaa.ChainIDBlast:  {Finalized: true, Safe: true, EvmChainID: 168587773, PublicRPC: "https://sepolia.blast.io"},
 		vaa.ChainIDXLayer: {Finalized: true, Safe: true, EvmChainID: 195, PublicRPC: "https://xlayertestrpc.okx.com"},
 
 		// As of 9/06/2024 Linea supports polling for finalized but not safe.
-		vaa.ChainIDLinea: {Finalized: true, Safe: false, EvmChainID: 59141, PublicRPC: "https://linea-sepolia-rpc.publicnode.com"},
+		vaa.ChainIDLinea: {Finalized: true, Safe: false, EvmChainID: 59141, PublicRPC: "https://rpc.sepolia.linea.build"},
 
-		vaa.ChainIDBerachain: {Finalized: false, Safe: false, EvmChainID: 80084, PublicRPC: "https://bartio.rpc.berachain.com"},
+		vaa.ChainIDBerachain: {InstantFinality: true, Finalized: true, Safe: true, EvmChainID: 80084, PublicRPC: "https://bartio.rpc.berachain.com"},
 		vaa.ChainIDSeiEVM:    {Finalized: true, Safe: true, EvmChainID: 1328, PublicRPC: "https://evm-rpc-testnet.sei-apis.com/"},
 		// vaa.ChainIDEclipse:     Not supported in the guardian.
 		// vaa.ChainIDBOB:         Not supported in the guardian.
@@ -149,7 +153,7 @@ var (
 		vaa.ChainIDArbitrumSepolia: {Finalized: true, Safe: true, EvmChainID: 421614, PublicRPC: "https://arbitrum-sepolia-rpc.publicnode.com"},
 		vaa.ChainIDBaseSepolia:     {Finalized: true, Safe: true, EvmChainID: 84532, PublicRPC: "https://base-sepolia-rpc.publicnode.com"},
 		vaa.ChainIDOptimismSepolia: {Finalized: true, Safe: true, EvmChainID: 11155420, PublicRPC: "https://optimism-sepolia-rpc.publicnode.com"},
-		vaa.ChainIDHolesky:         {Finalized: true, Safe: true, EvmChainID: 17000, PublicRPC: "https://ethereum-holesky-rpc.publicnode.com"},
+		vaa.ChainIDHolesky:         {Finalized: true, Safe: true, EvmChainID: 17000, PublicRPC: "https://1rpc.io/holesky"},
 		vaa.ChainIDPolygonSepolia:  {Finalized: true, Safe: false, EvmChainID: 80002, PublicRPC: "https://polygon-amoy-bor-rpc.publicnode.com"},
 	}
 )
@@ -175,6 +179,10 @@ func GetFinality(env common.Environment, chainID vaa.ChainID) (finalized bool, s
 	entry, exists := m[chainID]
 	if !exists {
 		return false, false, ErrNotFound
+	}
+
+	if entry.InstantFinality {
+		return false, false, nil
 	}
 
 	return entry.Finalized, entry.Safe, nil

--- a/node/pkg/watchers/evm/chain_config_test.go
+++ b/node/pkg/watchers/evm/chain_config_test.go
@@ -102,17 +102,21 @@ func testFinalityValuesForEnvironment(t *testing.T, env common.Environment) {
 
 	for chainID, entry := range m {
 		t.Run(chainID.String(), func(t *testing.T) {
-			finalized, safe, err := getFinalityForTest(env, chainID)
+			instantFinality, finalized, safe, err := getFinalityForTest(env, chainID)
 			require.NoError(t, err)
-			assert.Equal(t, finalized, entry.Finalized)
-			assert.Equal(t, safe, entry.Safe)
+			require.Equal(t, instantFinality, entry.InstantFinality)
+			// For instant finality, the values for finalized and safe are for documentation only, so we can't audit them.
+			if !instantFinality {
+				assert.Equal(t, finalized, entry.Finalized)
+				assert.Equal(t, safe, entry.Safe)
+			}
 		})
 	}
 }
 
 // getFinalityForTest was lifted from the old `getFinality` watcher function so we could validate our config data.
 // TODO: Once this code is merged and verified to be stable, this function can be deleted so we don't have to maintain it.
-func getFinalityForTest(env common.Environment, chainID vaa.ChainID) (finalized bool, safe bool, err error) {
+func getFinalityForTest(env common.Environment, chainID vaa.ChainID) (instantFinality bool, finalized bool, safe bool, err error) {
 	// Tilt supports polling for both finalized and safe.
 	if env == common.UnsafeDevNet {
 		finalized = true
@@ -172,11 +176,11 @@ func getFinalityForTest(env common.Environment, chainID vaa.ChainID) (finalized 
 		chainID == vaa.ChainIDAurora ||
 		chainID == vaa.ChainIDFantom ||
 		chainID == vaa.ChainIDKlaytn {
-		return false, false, nil
+		return true, false, false, nil
 
 		// Anything else is undefined / not supported.
 	} else {
-		return false, false, fmt.Errorf("unsupported chain: %s", chainID.String())
+		return false, false, false, fmt.Errorf("unsupported chain: %s", chainID.String())
 	}
 
 	return


### PR DESCRIPTION
The old code that determined the finality values for creating the appropriate poller reported that instant finality chains did not support finalized or safe. This was okay because the finalized / safe flags were not used for instant finality chains. However, now that we have this chain config, which can also be used as a way to document chain behavior, it would be useful to have the correct finalized / safe values for instant finality chains, just for documentation purposes. 

This PR adds an `InstantFinality` flag to the chain config tables and also sets the correct values for `Finalized` and `Safe` for instant finality chains. Additionally, this PR enhances the `verify_chain_config` tool to validate the values for `Finalized` and `Safe` against the public RPC endpoints.

Here is the output from the verify tool to confirm that everything passes.
```
verify_chain_config (node/evm_add_instant_finality_to_chain_config +)$ go run verify.go 
EVM chain ID match for prod ethereum: value: 1
EVM chain ID match for prod bsc: value: 56
EVM chain ID match for prod polygon: value: 137
EVM chain ID match for prod avalanche: value: 43114
EVM chain ID match for prod oasis: value: 42262
EVM chain ID match for prod fantom: value: 250
EVM chain ID match for prod karura: value: 686
EVM chain ID match for prod acala: value: 787
Skipping prod klaytn because the rpc is null
EVM chain ID match for prod celo: value: 42220
EVM chain ID match for prod moonbeam: value: 1284
EVM chain ID match for prod arbitrum: value: 42161
EVM chain ID match for prod optimism: value: 10
EVM chain ID match for prod base: value: 8453
EVM chain ID match for prod scroll: value: 534352
EVM chain ID match for prod mantle: value: 5000
EVM chain ID match for prod blast: value: 81457
EVM chain ID match for prod xlayer: value: 196
EVM chain ID match for prod linea: value: 59144
EVM chain ID match for prod berachain: value: 80094
EVM chain ID match for prod snaxchain: value: 2192
EVM chain ID match for prod unichain: value: 130
EVM chain ID match for prod worldchain: value: 480
EVM chain ID match for test ethereum: value: 17000
EVM chain ID match for test bsc: value: 97
Skipping test polygon because the rpc is null
EVM chain ID match for test avalanche: value: 43113
EVM chain ID match for test oasis: value: 42261
EVM chain ID match for test fantom: value: 4002
EVM chain ID match for test karura: value: 596
EVM chain ID match for test acala: value: 597
Skipping test klaytn because the rpc is null
EVM chain ID match for test celo: value: 44787
EVM chain ID match for test moonbeam: value: 1287
Skipping test arbitrum because the rpc is null
Skipping test optimism because the rpc is null
Skipping test base because the rpc is null
EVM chain ID match for test scroll: value: 534351
EVM chain ID match for test mantle: value: 5003
EVM chain ID match for test blast: value: 168587773
EVM chain ID match for test xlayer: value: 195
EVM chain ID match for test linea: value: 59141
EVM chain ID match for test berachain: value: 80084
EVM chain ID match for test seievm: value: 1328
EVM chain ID match for test snaxchain: value: 13001
EVM chain ID match for test unichain: value: 1301
EVM chain ID match for test worldchain: value: 4801
EVM chain ID match for test ink: value: 763373
Skipping test hyperevm because the rpc is null
EVM chain ID match for test monad: value: 10143
EVM chain ID match for test sepolia: value: 11155111
EVM chain ID match for test arbitrum_sepolia: value: 421614
EVM chain ID match for test base_sepolia: value: 84532
EVM chain ID match for test optimism_sepolia: value: 11155420
EVM chain ID match for test holesky: value: 17000
EVM chain ID match for test polygon_sepolia: value: 80002
verify_chain_config (node/evm_add_instant_finality_to_chain_config)$
```