### PR TITLE
Node/EVM: Berachain not instant finality

### DIFF
--- a/node/pkg/watchers/evm/chain_config.go
+++ b/node/pkg/watchers/evm/chain_config.go
@@ -89,7 +89,7 @@ var (
 		// As of 9/06/2024 Linea supports polling for finalized but not safe.
 		vaa.ChainIDLinea: {Finalized: true, Safe: false, EvmChainID: 59144, PublicRPC: "https://rpc.linea.build"},
 
-		vaa.ChainIDBerachain: {InstantFinality: true, Finalized: true, Safe: true, EvmChainID: 80094, PublicRPC: "https://berachain-rpc.publicnode.com"},
+		vaa.ChainIDBerachain: {Finalized: true, Safe: true, EvmChainID: 80094, PublicRPC: "https://berachain-rpc.publicnode.com"},
 		// vaa.ChainIDSeiEVM:     Not in Mainnet yet.
 		// vaa.ChainIDEclipse:    Not supported in the guardian.
 		// vaa.ChainIDBOB:        Not supported in the guardian.
@@ -139,7 +139,7 @@ var (
 		// As of 9/06/2024 Linea supports polling for finalized but not safe.
 		vaa.ChainIDLinea: {Finalized: true, Safe: false, EvmChainID: 59141, PublicRPC: "https://rpc.sepolia.linea.build"},
 
-		vaa.ChainIDBerachain: {InstantFinality: true, Finalized: true, Safe: true, EvmChainID: 80084, PublicRPC: "https://berachain-testnet-rpc.publicnode.com"},
+		vaa.ChainIDBerachain: {Finalized: true, Safe: true, EvmChainID: 80084, PublicRPC: "https://berachain-testnet-rpc.publicnode.com"},
 		vaa.ChainIDSeiEVM:    {Finalized: true, Safe: true, EvmChainID: 1328, PublicRPC: "https://evm-rpc-testnet.sei-apis.com/"},
 		// vaa.ChainIDEclipse:     Not supported in the guardian.
 		// vaa.ChainIDBOB:         Not supported in the guardian.

--- a/node/pkg/watchers/evm/chain_config_test.go
+++ b/node/pkg/watchers/evm/chain_config_test.go
@@ -128,6 +128,7 @@ func getFinalityForTest(env common.Environment, chainID vaa.ChainID) (instantFin
 		chainID == vaa.ChainIDArbitrumSepolia ||
 		chainID == vaa.ChainIDBase ||
 		chainID == vaa.ChainIDBaseSepolia ||
+		chainID == vaa.ChainIDBerachain || // Berachain really isn't instant finality, despite what this doc says: https://docs.berachain.com/faq/
 		chainID == vaa.ChainIDBlast ||
 		chainID == vaa.ChainIDBSC ||
 		chainID == vaa.ChainIDEthereum ||
@@ -171,7 +172,6 @@ func getFinalityForTest(env common.Environment, chainID vaa.ChainID) (instantFin
 
 		// The following chains support instant finality.
 	} else if chainID == vaa.ChainIDAvalanche ||
-		chainID == vaa.ChainIDBerachain || // Berachain supports instant finality: https://docs.berachain.com/faq/
 		chainID == vaa.ChainIDOasis ||
 		chainID == vaa.ChainIDAurora ||
 		chainID == vaa.ChainIDFantom ||


### PR DESCRIPTION
We noticed recently that Berachain reports different block numbers for latest and finalized / safe. This PR updates it to use the batch poller rather than the instant finality poller.