### PR TITLE
Deploy Ink mainnet

### DIFF
--- a/node/hack/repair_eth/repair_eth.go
+++ b/node/hack/repair_eth/repair_eth.go
@@ -53,6 +53,7 @@ var etherscanAPIMap = map[vaa.ChainID]string{
 	vaa.ChainIDBerachain:  "https://api.berascan.com/",
 	vaa.ChainIDUnichain:   "https://api.uniscan.xyz/",
 	vaa.ChainIDWorldchain: "https://api.worldscan.org",
+	vaa.ChainIDInk:        "", // TODO: Does Ink have an etherscan API endpoint?
 }
 
 var coreContractMap = map[vaa.ChainID]string{
@@ -78,6 +79,7 @@ var coreContractMap = map[vaa.ChainID]string{
 	vaa.ChainIDBerachain:  strings.ToLower("0xCa1D5a146B03f6303baF59e5AD5615ae0b9d146D"),
 	vaa.ChainIDUnichain:   strings.ToLower("0xCa1D5a146B03f6303baF59e5AD5615ae0b9d146D"),
 	vaa.ChainIDWorldchain: strings.ToLower("0xcbcEe4e081464A15d8Ad5f58BB493954421eB506"),
+	vaa.ChainIDInk:        strings.ToLower("0xCa1D5a146B03f6303baF59e5AD5615ae0b9d146D"),
 }
 
 var (

--- a/node/pkg/governor/mainnet_chains.go
+++ b/node/pkg/governor/mainnet_chains.go
@@ -44,5 +44,6 @@ func chainList() []chainConfigEntry {
 		{emitterChainID: vaa.ChainIDSnaxchain, dailyLimit: 500_000, bigTransactionSize: 50_000},
 		{emitterChainID: vaa.ChainIDUnichain, dailyLimit: 500_000, bigTransactionSize: 50_000},
 		{emitterChainID: vaa.ChainIDWorldchain, dailyLimit: 500_000, bigTransactionSize: 50_000},
+		{emitterChainID: vaa.ChainIDInk, dailyLimit: 500_000, bigTransactionSize: 50_000},
 	}
 }

--- a/node/pkg/governor/mainnet_tokens_test.go
+++ b/node/pkg/governor/mainnet_tokens_test.go
@@ -44,6 +44,8 @@ func TestGovernedChainHasGovernedAssets(t *testing.T) {
 		vaa.ChainIDSnaxchain: true,
 		// Wormchain is an abstraction over IBC-connected chains so no assets are "native" to it
 		vaa.ChainIDWormchain: true,
+		// TODO: Remove this once we have governed tokens for Ink.
+		vaa.ChainIDInk: true,
 	}
 	if len(ignoredChains) > 0 {
 		ignoredOutput := []string{}

--- a/node/pkg/watchers/evm/chain_config.go
+++ b/node/pkg/watchers/evm/chain_config.go
@@ -96,7 +96,7 @@ var (
 		vaa.ChainIDSnaxchain:  {Finalized: true, Safe: true, EvmChainID: 2192, PublicRPC: "https://mainnet.snaxchain.io"},
 		vaa.ChainIDUnichain:   {Finalized: true, Safe: true, EvmChainID: 130, PublicRPC: "https://unichain-rpc.publicnode.com"},
 		vaa.ChainIDWorldchain: {Finalized: true, Safe: true, EvmChainID: 480, PublicRPC: "https://worldchain-mainnet.g.alchemy.com/public"},
-		// vaa.ChainIDInk:        Not in Mainnet yet.
+		vaa.ChainIDInk:        {Finalized: true, Safe: true, EvmChainID: 57073, PublicRPC: "https://rpc-qnd.inkonchain.com"},
 		// vaa.ChainIDHyperEVM:   Not in Mainnet yet.
 		// vaa.ChainIDMonad:      Not in Mainnet yet.
 	}

--- a/sdk/mainnet_consts.go
+++ b/sdk/mainnet_consts.go
@@ -128,6 +128,7 @@ var knownTokenbridgeEmitters = map[vaa.ChainID]string{
 	vaa.ChainIDSei:        "86c5fd957e2db8389553e1728f9c27964b22a8154091ccba54d75f4b10c61f5e",
 	vaa.ChainIDWormchain:  "aeb534c45c3049d380b9d9b966f9895f53abd4301bfaff407fa09dea8ae7a924",
 	vaa.ChainIDWorldchain: "000000000000000000000000c309275443519adca74c9136b02A38eF96E3a1f6",
+	vaa.ChainIDInk:        "0000000000000000000000003Ff72741fd67D6AD0668d93B41a09248F4700560",
 }
 
 // KnownNFTBridgeEmitters is a list of well-known mainnet emitters for the NFT bridge.


### PR DESCRIPTION
This PR enabled Ink in mainnet.

- The core is available [here](https://explorer.inkonchain.com/address/0xCa1D5a146B03f6303baF59e5AD5615ae0b9d146D).
- The token bridge is available [here](https://explorer.inkonchain.com/address/0x3Ff72741fd67D6AD0668d93B41a09248F4700560).

Due to a bug in the explorer, both are labeled as `TokenBridge`. See the "Read/Write Proxy" tab to confirm each is the correct contract.

Here is the output from the command to confirm that the EVM chain ID and Finalized / Safe flags are correct.

```
verify_chain_config (main *)$ go run verify.go --env mainnet
<snip>
EVM chain ID match for prod ink: value: 57073
verify_chain_config (main *)$
```