### PR TITLE
Node / Solana: Fix reobservation ID in log msg

### DIFF
--- a/node/pkg/watchers/solana/client.go
+++ b/node/pkg/watchers/solana/client.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"encoding/base64"
-	"encoding/hex"
 	"encoding/json"
 
 	"github.com/certusone/wormhole/node/pkg/common"
@@ -409,13 +408,13 @@ func (s *SolanaWatcher) Run(ctx context.Context) error {
 				if err != nil {
 					logger.Error("failed to process observation request",
 						zap.Uint32("chainID", m.ChainId),
-						zap.String("txID", hex.EncodeToString(m.TxHash)),
+						zap.String("identifier", base58.Encode(m.TxHash)),
 						zap.Error(err),
 					)
 				} else {
 					logger.Info("reobserved transactions",
 						zap.Uint32("chainID", m.ChainId),
-						zap.String("txID", hex.EncodeToString(m.TxHash)),
+						zap.String("identifier", base58.Encode(m.TxHash)),
 						zap.Uint32("numObservations", numObservations),
 					)
 				}


### PR DESCRIPTION
The log messages showing the result of a solana reobservation request (both success and failure) are logging the identifier as a hex string when it is really a base58 encoded string. This means that the result message does not have the same identifier as the request. This PR makes them consistent.

Also changed `txID` to a more generic `identifier` since it can be either an account ID or a transaction signature.