### PR TITLE
Node/EVM: Add contract address to chain config

### DIFF
--- a/node/hack/repair_eth/repair_eth.go
+++ b/node/hack/repair_eth/repair_eth.go
@@ -15,6 +15,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/certusone/wormhole/node/pkg/common"
+	"github.com/certusone/wormhole/node/pkg/watchers/evm"
 	"github.com/certusone/wormhole/node/pkg/watchers/evm/connectors/ethabi"
 
 	"github.com/certusone/wormhole/node/pkg/db"
@@ -55,33 +57,6 @@ var etherscanAPIMap = map[vaa.ChainID]string{
 	vaa.ChainIDUnichain:   "https://api.uniscan.xyz/",
 	vaa.ChainIDWorldchain: "https://api.worldscan.org",
 	vaa.ChainIDInk:        "", // TODO: Does Ink have an etherscan API endpoint?
-}
-
-var coreContractMap = map[vaa.ChainID]string{
-	vaa.ChainIDEthereum:   "0x98f3c9e6E3fAce36bAAd05FE09d375Ef1464288B",
-	vaa.ChainIDBSC:        "0x98f3c9e6E3fAce36bAAd05FE09d375Ef1464288B",
-	vaa.ChainIDAvalanche:  "0x54a8e5f9c4CbA08F9943965859F6c34eAF03E26c",
-	vaa.ChainIDPolygon:    "0x7A4B5a56256163F07b2C80A7cA55aBE66c4ec4d7",
-	vaa.ChainIDOasis:      "0xfe8cd454b4a1ca468b57d79c0cc77ef5b6f64585", // <- converted to all lower case for easy compares
-	vaa.ChainIDAurora:     "0xa321448d90d4e5b0a732867c18ea198e75cac48e",
-	vaa.ChainIDFantom:     strings.ToLower("0x126783A6Cb203a3E35344528B26ca3a0489a1485"),
-	vaa.ChainIDKarura:     strings.ToLower("0xa321448d90d4e5b0A732867c18eA198e75CAC48E"),
-	vaa.ChainIDAcala:      strings.ToLower("0xa321448d90d4e5b0A732867c18eA198e75CAC48E"),
-	vaa.ChainIDKlaytn:     strings.ToLower("0x0C21603c4f3a6387e241c0091A7EA39E43E90bb7"),
-	vaa.ChainIDCelo:       strings.ToLower("0xa321448d90d4e5b0A732867c18eA198e75CAC48E"),
-	vaa.ChainIDMoonbeam:   strings.ToLower("0xC8e2b0cD52Cf01b0Ce87d389Daa3d414d4cE29f3"),
-	vaa.ChainIDArbitrum:   strings.ToLower("0xa5f208e072434bC67592E4C49C1B991BA79BCA46"),
-	vaa.ChainIDOptimism:   strings.ToLower("0xEe91C335eab126dF5fDB3797EA9d6aD93aeC9722"),
-	vaa.ChainIDBase:       strings.ToLower("0xbebdb6C8ddC678FfA9f8748f85C815C556Dd8ac6"),
-	vaa.ChainIDScroll:     strings.ToLower("0xbebdb6C8ddC678FfA9f8748f85C815C556Dd8ac6"),
-	vaa.ChainIDMantle:     strings.ToLower("0xbebdb6C8ddC678FfA9f8748f85C815C556Dd8ac6"),
-	vaa.ChainIDBlast:      strings.ToLower("0xbebdb6C8ddC678FfA9f8748f85C815C556Dd8ac6"),
-	vaa.ChainIDXLayer:     strings.ToLower("0x194B123c5E96B9b2E49763619985790Dc241CAC0"),
-	vaa.ChainIDBerachain:  strings.ToLower("0xCa1D5a146B03f6303baF59e5AD5615ae0b9d146D"),
-	vaa.ChainIDSeiEVM:     strings.ToLower("0xCa1D5a146B03f6303baF59e5AD5615ae0b9d146D"),
-	vaa.ChainIDUnichain:   strings.ToLower("0xCa1D5a146B03f6303baF59e5AD5615ae0b9d146D"),
-	vaa.ChainIDWorldchain: strings.ToLower("0xcbcEe4e081464A15d8Ad5f58BB493954421eB506"),
-	vaa.ChainIDInk:        strings.ToLower("0xCa1D5a146B03f6303baF59e5AD5615ae0b9d146D"),
 }
 
 var (
@@ -285,8 +260,8 @@ func main() {
 		log.Fatalf("Unsupported chain: %v", err)
 	}
 
-	coreContract, ok := coreContractMap[chainID]
-	if !ok {
+	coreContract, err := evm.GetContractAddrString(common.MainNet, chainID)
+	if err != nil {
 		panic("no core contract")
 	}
 	ctx := context.Background()

--- a/node/pkg/watchers/evm/chain_config.go
+++ b/node/pkg/watchers/evm/chain_config.go
@@ -8,8 +8,6 @@ package evm
 //    node/pkg/watcher/evm$ go test
 //    node/pkg/watcher/evm/verify_chain_config$ go run verify.go
 
-// TODO: In a future PR we could consider merging the data in `node/hack/repair_eth/repair_eth.go` into here.
-
 import (
 	"context"
 	"errors"
@@ -19,6 +17,7 @@ import (
 	"time"
 
 	"github.com/certusone/wormhole/node/pkg/common"
+	ethCommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/wormhole-foundation/wormhole/sdk/vaa"
 	"go.uber.org/zap"
@@ -42,6 +41,10 @@ type (
 
 		// PublicRPC is not actually used by the watcher. It's used to verify that the EvmChainID specified here is correct.
 		PublicRPC string
+
+		// ContractAddr specifies the Wormhole core contract address for this chain (starting with 0x).
+		// SECURITY: This is for documentation and validation only. Allowing it as a default would provide a single point attack vector.
+		ContractAddr string
 	}
 
 	// EnvMap defines the config data for a given environment (mainet or testnet).
@@ -56,47 +59,44 @@ var (
 	// NOTE: Only add a chain here if the watcher should allow it in Mainnet!
 	// NOTE: If you change this data, be sure and run the tests described at the top of this file!
 	mainnetChainConfig = EnvMap{
-		vaa.ChainIDEthereum: {Finalized: true, Safe: true, EvmChainID: 1, PublicRPC: "https://ethereum-rpc.publicnode.com"},
-		vaa.ChainIDBSC:      {Finalized: true, Safe: true, EvmChainID: 56, PublicRPC: "https://bsc-rpc.publicnode.com"},
+		vaa.ChainIDEthereum: {Finalized: true, Safe: true, EvmChainID: 1, PublicRPC: "https://ethereum-rpc.publicnode.com", ContractAddr: "0x98f3c9e6E3fAce36bAAd05FE09d375Ef1464288B"},
+		vaa.ChainIDBSC:      {Finalized: true, Safe: true, EvmChainID: 56, PublicRPC: "https://bsc-rpc.publicnode.com", ContractAddr: "0x98f3c9e6E3fAce36bAAd05FE09d375Ef1464288B"},
 
 		// Polygon supports polling for finalized but not safe: https://forum.polygon.technology/t/optimizing-decentralized-apps-ux-with-milestones-a-significantly-accelerated-finality-solution/13154
-		vaa.ChainIDPolygon: {Finalized: true, Safe: false, EvmChainID: 137, PublicRPC: "https://polygon-bor-rpc.publicnode.com"},
+		vaa.ChainIDPolygon: {Finalized: true, Safe: false, EvmChainID: 137, PublicRPC: "https://polygon-bor-rpc.publicnode.com", ContractAddr: "0x7A4B5a56256163F07b2C80A7cA55aBE66c4ec4d7"},
 
-		vaa.ChainIDAvalanche: {InstantFinality: true, Finalized: true, Safe: true, EvmChainID: 43114, PublicRPC: "https://avalanche-c-chain-rpc.publicnode.com"},
-		vaa.ChainIDOasis:     {InstantFinality: true, Finalized: false, Safe: false, EvmChainID: 42262, PublicRPC: "https://emerald.oasis.dev/"},
+		vaa.ChainIDAvalanche: {InstantFinality: true, Finalized: true, Safe: true, EvmChainID: 43114, PublicRPC: "https://avalanche-c-chain-rpc.publicnode.com", ContractAddr: "0x54a8e5f9c4CbA08F9943965859F6c34eAF03E26c"},
+		vaa.ChainIDOasis:     {InstantFinality: true, Finalized: false, Safe: false, EvmChainID: 42262, PublicRPC: "https://emerald.oasis.dev/", ContractAddr: "0xfe8cd454b4a1ca468b57d79c0cc77ef5b6f64585"},
 		// vaa.ChainIDAurora:    Not supported in the guardian.
-		vaa.ChainIDFantom:   {InstantFinality: true, Finalized: false, Safe: false, EvmChainID: 250, PublicRPC: "https://fantom-rpc.publicnode.com"},
-		vaa.ChainIDKarura:   {Finalized: true, Safe: true, EvmChainID: 686, PublicRPC: "https://eth-rpc-karura.aca-api.network/"},
-		vaa.ChainIDAcala:    {Finalized: true, Safe: true, EvmChainID: 787, PublicRPC: "https://eth-rpc-acala.aca-api.network/"},
-		vaa.ChainIDKlaytn:   {InstantFinality: true, Finalized: false, Safe: false, EvmChainID: 8217, PublicRPC: "https://public-en.node.kaia.io"},
-		vaa.ChainIDCelo:     {Finalized: true, Safe: false, EvmChainID: 42220, PublicRPC: "https://celo-rpc.publicnode.com"},
-		vaa.ChainIDMoonbeam: {Finalized: true, Safe: true, EvmChainID: 1284, PublicRPC: "https://moonbeam-rpc.publicnode.com"},
-		vaa.ChainIDArbitrum: {Finalized: true, Safe: true, EvmChainID: 42161, PublicRPC: "https://arbitrum-one-rpc.publicnode.com"},
-		vaa.ChainIDOptimism: {Finalized: true, Safe: true, EvmChainID: 10, PublicRPC: "https://optimism-rpc.publicnode.com"},
+		vaa.ChainIDFantom:   {InstantFinality: true, Finalized: false, Safe: false, EvmChainID: 250, PublicRPC: "https://fantom-rpc.publicnode.com", ContractAddr: "0x126783A6Cb203a3E35344528B26ca3a0489a1485"},
+		vaa.ChainIDKarura:   {Finalized: true, Safe: true, EvmChainID: 686, PublicRPC: "https://eth-rpc-karura.aca-api.network/", ContractAddr: "0xa321448d90d4e5b0A732867c18eA198e75CAC48E"},
+		vaa.ChainIDAcala:    {Finalized: true, Safe: true, EvmChainID: 787, PublicRPC: "https://eth-rpc-acala.aca-api.network/", ContractAddr: "0xa321448d90d4e5b0A732867c18eA198e75CAC48E"},
+		vaa.ChainIDKlaytn:   {InstantFinality: true, Finalized: false, Safe: false, EvmChainID: 8217, PublicRPC: "https://public-en.node.kaia.io", ContractAddr: "0x0C21603c4f3a6387e241c0091A7EA39E43E90bb7"},
+		vaa.ChainIDCelo:     {Finalized: true, Safe: false, EvmChainID: 42220, PublicRPC: "https://celo-rpc.publicnode.com", ContractAddr: "0xa321448d90d4e5b0A732867c18eA198e75CAC48E"},
+		vaa.ChainIDMoonbeam: {Finalized: true, Safe: true, EvmChainID: 1284, PublicRPC: "https://moonbeam-rpc.publicnode.com", ContractAddr: "0xC8e2b0cD52Cf01b0Ce87d389Daa3d414d4cE29f3"},
+		vaa.ChainIDArbitrum: {Finalized: true, Safe: true, EvmChainID: 42161, PublicRPC: "https://arbitrum-one-rpc.publicnode.com", ContractAddr: "0xa5f208e072434bC67592E4C49C1B991BA79BCA46"},
+		vaa.ChainIDOptimism: {Finalized: true, Safe: true, EvmChainID: 10, PublicRPC: "https://optimism-rpc.publicnode.com", ContractAddr: "0xEe91C335eab126dF5fDB3797EA9d6aD93aeC9722"},
 		// vaa.ChainIDGnosis:     Not supported in the guardian.
 		// vaa.ChainIDBtc:        Not supported in the guardian.
-		vaa.ChainIDBase: {Finalized: true, Safe: true, EvmChainID: 8453, PublicRPC: "https://base-rpc.publicnode.com"},
+		vaa.ChainIDBase: {Finalized: true, Safe: true, EvmChainID: 8453, PublicRPC: "https://base-rpc.publicnode.com", ContractAddr: "0xbebdb6C8ddC678FfA9f8748f85C815C556Dd8ac6"},
 		// vaa.ChainIDFileCoin:   Not supported in the guardian.
 		// vaa.ChainIDRootstock:  Not supported in the guardian.
 
 		// As of 11/10/2023 Scroll supports polling for finalized but not safe.
-		vaa.ChainIDScroll: {Finalized: true, Safe: false, EvmChainID: 534352, PublicRPC: "https://scroll-rpc.publicnode.com"},
+		vaa.ChainIDScroll: {Finalized: true, Safe: false, EvmChainID: 534352, PublicRPC: "https://scroll-rpc.publicnode.com", ContractAddr: "0xbebdb6C8ddC678FfA9f8748f85C815C556Dd8ac6"},
 
-		vaa.ChainIDMantle: {Finalized: true, Safe: true, EvmChainID: 5000, PublicRPC: "https://mantle-rpc.publicnode.com"},
-		vaa.ChainIDBlast:  {Finalized: true, Safe: true, EvmChainID: 81457, PublicRPC: "https://blast-rpc.publicnode.com"},
-		vaa.ChainIDXLayer: {Finalized: true, Safe: true, EvmChainID: 196, PublicRPC: "https://xlayerrpc.okx.com"},
-
-		// As of 9/06/2024 Linea supports polling for finalized but not safe.
-		vaa.ChainIDLinea: {Finalized: true, Safe: false, EvmChainID: 59144, PublicRPC: "https://rpc.linea.build"},
-
-		vaa.ChainIDBerachain: {Finalized: true, Safe: true, EvmChainID: 80094, PublicRPC: "https://berachain-rpc.publicnode.com"},
-		vaa.ChainIDSeiEVM:    {Finalized: true, Safe: true, EvmChainID: 1329, PublicRPC: "https://evm-rpc.sei-apis.com"},
+		vaa.ChainIDMantle: {Finalized: true, Safe: true, EvmChainID: 5000, PublicRPC: "https://mantle-rpc.publicnode.com", ContractAddr: "0xbebdb6C8ddC678FfA9f8748f85C815C556Dd8ac6"},
+		vaa.ChainIDBlast:  {Finalized: true, Safe: true, EvmChainID: 81457, PublicRPC: "https://blast-rpc.publicnode.com", ContractAddr: "0xbebdb6C8ddC678FfA9f8748f85C815C556Dd8ac6"},
+		vaa.ChainIDXLayer: {Finalized: true, Safe: true, EvmChainID: 196, PublicRPC: "https://xlayerrpc.okx.com", ContractAddr: "0x194B123c5E96B9b2E49763619985790Dc241CAC0"},
+		// vaa.ChainIDLinea:   Not in Mainnet yet.
+		vaa.ChainIDBerachain: {Finalized: true, Safe: true, EvmChainID: 80094, PublicRPC: "https://berachain-rpc.publicnode.com", ContractAddr: "0xCa1D5a146B03f6303baF59e5AD5615ae0b9d146D"},
+		vaa.ChainIDSeiEVM:    {Finalized: true, Safe: true, EvmChainID: 1329, PublicRPC: "https://evm-rpc.sei-apis.com", ContractAddr: "0xCa1D5a146B03f6303baF59e5AD5615ae0b9d146D"},
 		// vaa.ChainIDEclipse:    Not supported in the guardian.
 		// vaa.ChainIDBOB:        Not supported in the guardian.
-		vaa.ChainIDSnaxchain:  {Finalized: true, Safe: true, EvmChainID: 2192, PublicRPC: "https://mainnet.snaxchain.io"},
-		vaa.ChainIDUnichain:   {Finalized: true, Safe: true, EvmChainID: 130, PublicRPC: "https://unichain-rpc.publicnode.com"},
-		vaa.ChainIDWorldchain: {Finalized: true, Safe: true, EvmChainID: 480, PublicRPC: "https://worldchain-mainnet.g.alchemy.com/public"},
-		vaa.ChainIDInk:        {Finalized: true, Safe: true, EvmChainID: 57073, PublicRPC: "https://rpc-qnd.inkonchain.com"},
+		vaa.ChainIDSnaxchain:  {Finalized: true, Safe: true, EvmChainID: 2192, PublicRPC: "https://mainnet.snaxchain.io", ContractAddr: "0xc1BA3CC4bFE724A08FbbFbF64F8db196738665f4"},
+		vaa.ChainIDUnichain:   {Finalized: true, Safe: true, EvmChainID: 130, PublicRPC: "https://unichain-rpc.publicnode.com", ContractAddr: "0xCa1D5a146B03f6303baF59e5AD5615ae0b9d146D"},
+		vaa.ChainIDWorldchain: {Finalized: true, Safe: true, EvmChainID: 480, PublicRPC: "https://worldchain-mainnet.g.alchemy.com/public", ContractAddr: "0xcbcEe4e081464A15d8Ad5f58BB493954421eB506"},
+		vaa.ChainIDInk:        {Finalized: true, Safe: true, EvmChainID: 57073, PublicRPC: "https://rpc-qnd.inkonchain.com", ContractAddr: "0xCa1D5a146B03f6303baF59e5AD5615ae0b9d146D"},
 		// vaa.ChainIDHyperEVM:   Not in Mainnet yet.
 		// vaa.ChainIDMonad:      Not in Mainnet yet.
 		// vaa.ChainIDMezo:       Not in Mainnet yet.
@@ -107,56 +107,56 @@ var (
 	// NOTE: If you change this data, be sure and run the tests described at the top of this file!
 	testnetChainConfig = EnvMap{
 		// For Ethereum testnet we actually use Holeksy since Goerli is deprecated.
-		vaa.ChainIDEthereum: {Finalized: true, Safe: true, EvmChainID: 17000, PublicRPC: "https://1rpc.io/holesky"},
-		vaa.ChainIDBSC:      {Finalized: true, Safe: true, EvmChainID: 97, PublicRPC: "https://bsc-testnet-rpc.publicnode.com"},
+		vaa.ChainIDEthereum: {Finalized: true, Safe: true, EvmChainID: 17000, PublicRPC: "https://1rpc.io/holesky", ContractAddr: "0xa10f2eF61dE1f19f586ab8B6F2EbA89bACE63F7a"},
+		vaa.ChainIDBSC:      {Finalized: true, Safe: true, EvmChainID: 97, PublicRPC: "https://bsc-testnet-rpc.publicnode.com", ContractAddr: "0x68605AD7b15c732a30b1BbC62BE8F2A509D74b4D"},
 
 		// Polygon supports polling for finalized but not safe: https://forum.polygon.technology/t/optimizing-decentralized-apps-ux-with-milestones-a-significantly-accelerated-finality-solution/13154
-		vaa.ChainIDPolygon: {Finalized: true, Safe: false, EvmChainID: 80001}, // Polygon Mumbai is deprecated.
+		vaa.ChainIDPolygon: {Finalized: true, Safe: false, EvmChainID: 80001, ContractAddr: "0x0CBE91CF822c73C2315FB05100C2F714765d5c20"}, // Polygon Mumbai is deprecated.
 
-		vaa.ChainIDAvalanche: {InstantFinality: true, Finalized: true, Safe: true, EvmChainID: 43113, PublicRPC: "https://avalanche-fuji-c-chain-rpc.publicnode.com"},
-		vaa.ChainIDOasis:     {InstantFinality: true, Finalized: false, Safe: false, EvmChainID: 42261, PublicRPC: "https://testnet.emerald.oasis.dev"},
+		vaa.ChainIDAvalanche: {InstantFinality: true, Finalized: true, Safe: true, EvmChainID: 43113, PublicRPC: "https://avalanche-fuji-c-chain-rpc.publicnode.com", ContractAddr: "0x7bbcE28e64B3F8b84d876Ab298393c38ad7aac4C"},
+		vaa.ChainIDOasis:     {InstantFinality: true, Finalized: false, Safe: false, EvmChainID: 42261, PublicRPC: "https://testnet.emerald.oasis.dev", ContractAddr: "0xc1C338397ffA53a2Eb12A7038b4eeb34791F8aCb"},
 		// vaa.ChainIDAurora:    Not supported in the guardian.
-		vaa.ChainIDFantom:   {InstantFinality: true, Finalized: false, Safe: false, EvmChainID: 4002, PublicRPC: "https://fantom-testnet-rpc.publicnode.com"},
-		vaa.ChainIDKarura:   {Finalized: true, Safe: true, EvmChainID: 596, PublicRPC: "https://eth-rpc-karura-testnet.aca-staging.network"},
-		vaa.ChainIDAcala:    {Finalized: true, Safe: true, EvmChainID: 597, PublicRPC: "https://eth-rpc-acala-testnet.aca-staging.network"},
-		vaa.ChainIDKlaytn:   {InstantFinality: true, Finalized: false, Safe: false, EvmChainID: 1001, PublicRPC: "https://public-en-kairos.node.kaia.io"},
-		vaa.ChainIDCelo:     {Finalized: true, Safe: true, EvmChainID: 44787, PublicRPC: "https://alfajores-forno.celo-testnet.org"},
-		vaa.ChainIDMoonbeam: {Finalized: true, Safe: true, EvmChainID: 1287, PublicRPC: "https://rpc.api.moonbase.moonbeam.network"},
-		vaa.ChainIDArbitrum: {Finalized: true, Safe: true, EvmChainID: 421613}, // Arbitrum Goerli is deprecated.
-		vaa.ChainIDOptimism: {Finalized: true, Safe: true, EvmChainID: 420},    // Optimism Goerli is deprecated.
+		vaa.ChainIDFantom:   {InstantFinality: true, Finalized: false, Safe: false, EvmChainID: 4002, PublicRPC: "https://fantom-testnet-rpc.publicnode.com", ContractAddr: "0x1BB3B4119b7BA9dfad76B0545fb3F531383c3bB7"},
+		vaa.ChainIDKarura:   {Finalized: true, Safe: true, EvmChainID: 596, PublicRPC: "https://eth-rpc-karura-testnet.aca-staging.network", ContractAddr: "0x64fb09E405D2043ed7785a29E296C766D56F2056"},
+		vaa.ChainIDAcala:    {Finalized: true, Safe: true, EvmChainID: 597, PublicRPC: "https://eth-rpc-acala-testnet.aca-staging.network", ContractAddr: "0x64fb09E405D2043ed7785a29E296C766D56F2056"},
+		vaa.ChainIDKlaytn:   {InstantFinality: true, Finalized: false, Safe: false, EvmChainID: 1001, PublicRPC: "https://public-en-kairos.node.kaia.io", ContractAddr: "0x1830CC6eE66c84D2F177B94D544967c774E624cA"},
+		vaa.ChainIDCelo:     {Finalized: true, Safe: true, EvmChainID: 44787, PublicRPC: "https://alfajores-forno.celo-testnet.org", ContractAddr: "0x88505117CA88e7dd2eC6EA1E13f0948db2D50D56"},
+		vaa.ChainIDMoonbeam: {Finalized: true, Safe: true, EvmChainID: 1287, PublicRPC: "https://rpc.api.moonbase.moonbeam.network", ContractAddr: "0xa5B7D85a8f27dd7907dc8FdC21FA5657D5E2F901"},
+		vaa.ChainIDArbitrum: {Finalized: true, Safe: true, EvmChainID: 421613, ContractAddr: "0xC7A204bDBFe983FCD8d8E61D02b475D4073fF97e"}, // Arbitrum Goerli is deprecated.
+		vaa.ChainIDOptimism: {Finalized: true, Safe: true, EvmChainID: 420, ContractAddr: "0x6b9C8671cdDC8dEab9c719bB87cBd3e782bA6a35"},    // Optimism Goerli is deprecated.
 		// vaa.ChainIDGnosis:      Not supported in the guardian.
 		// vaa.ChainIDBtc:         Not supported in the guardian.
-		vaa.ChainIDBase: {Finalized: true, Safe: true, EvmChainID: 84531}, // Base Goerli is deprecated.
+		vaa.ChainIDBase: {Finalized: true, Safe: true, EvmChainID: 84531, ContractAddr: "0x23908A62110e21C04F3A4e011d24F901F911744A"}, // Base Goerli is deprecated.
 		// vaa.ChainIDFileCoin:    Not supported in the guardian.
 		// vaa.ChainIDRootstock:   Not supported in the guardian.
 
 		// As of 11/10/2023 Scroll supports polling for finalized but not safe.
-		vaa.ChainIDScroll: {Finalized: true, Safe: false, EvmChainID: 534351, PublicRPC: "https://scroll-sepolia-rpc.publicnode.com"},
+		vaa.ChainIDScroll: {Finalized: true, Safe: false, EvmChainID: 534351, PublicRPC: "https://scroll-sepolia-rpc.publicnode.com", ContractAddr: "0x055F47F1250012C6B20c436570a76e52c17Af2D5"},
 
-		vaa.ChainIDMantle: {Finalized: true, Safe: true, EvmChainID: 5003, PublicRPC: "https://rpc.sepolia.mantle.xyz"},
-		vaa.ChainIDBlast:  {Finalized: true, Safe: true, EvmChainID: 168587773, PublicRPC: "https://sepolia.blast.io"},
-		vaa.ChainIDXLayer: {Finalized: true, Safe: true, EvmChainID: 195, PublicRPC: "https://xlayertestrpc.okx.com"},
+		vaa.ChainIDMantle: {Finalized: true, Safe: true, EvmChainID: 5003, PublicRPC: "https://rpc.sepolia.mantle.xyz", ContractAddr: "0x376428e7f26D5867e69201b275553C45B09EE090"},
+		vaa.ChainIDBlast:  {Finalized: true, Safe: true, EvmChainID: 168587773, PublicRPC: "https://sepolia.blast.io", ContractAddr: "0x473e002D7add6fB67a4964F13bFd61280Ca46886"},
+		vaa.ChainIDXLayer: {Finalized: true, Safe: true, EvmChainID: 195, PublicRPC: "https://xlayertestrpc.okx.com", ContractAddr: "0xA31aa3FDb7aF7Db93d18DDA4e19F811342EDF780"},
 
 		// As of 9/06/2024 Linea supports polling for finalized but not safe.
-		vaa.ChainIDLinea: {Finalized: true, Safe: false, EvmChainID: 59141, PublicRPC: "https://rpc.sepolia.linea.build"},
+		vaa.ChainIDLinea: {Finalized: true, Safe: false, EvmChainID: 59141, PublicRPC: "https://rpc.sepolia.linea.build", ContractAddr: "0x79A1027a6A159502049F10906D333EC57E95F083"},
 
-		vaa.ChainIDBerachain: {Finalized: true, Safe: true, EvmChainID: 80069, PublicRPC: "https://bepolia.rpc.berachain.com/"},
-		vaa.ChainIDSeiEVM:    {Finalized: true, Safe: true, EvmChainID: 1328, PublicRPC: "https://evm-rpc-testnet.sei-apis.com/"},
+		vaa.ChainIDBerachain: {Finalized: true, Safe: true, EvmChainID: 80069, PublicRPC: "https://bepolia.rpc.berachain.com/", ContractAddr: "0xBB73cB66C26740F31d1FabDC6b7A46a038A300dd"},
+		vaa.ChainIDSeiEVM:    {Finalized: true, Safe: true, EvmChainID: 1328, PublicRPC: "https://evm-rpc-testnet.sei-apis.com/", ContractAddr: "0xBB73cB66C26740F31d1FabDC6b7A46a038A300dd"},
 		// vaa.ChainIDEclipse:     Not supported in the guardian.
 		// vaa.ChainIDBOB:         Not supported in the guardian.
-		vaa.ChainIDSnaxchain:       {Finalized: true, Safe: true, EvmChainID: 13001, PublicRPC: "https://testnet.snaxchain.io"},
-		vaa.ChainIDUnichain:        {Finalized: true, Safe: true, EvmChainID: 1301, PublicRPC: "https://unichain-sepolia-rpc.publicnode.com"},
-		vaa.ChainIDWorldchain:      {Finalized: true, Safe: true, EvmChainID: 4801, PublicRPC: "https://worldchain-sepolia.g.alchemy.com/public"},
-		vaa.ChainIDInk:             {Finalized: true, Safe: true, EvmChainID: 763373, PublicRPC: "https://rpc-qnd-sepolia.inkonchain.com"},
-		vaa.ChainIDHyperEVM:        {Finalized: true, Safe: true, EvmChainID: 998, PublicRPC: "https://rpc.hyperliquid-testnet.xyz/evm"},
-		vaa.ChainIDMonad:           {Finalized: true, Safe: true, EvmChainID: 10143, PublicRPC: "https://testnet-rpc.monad.xyz"},
-		vaa.ChainIDMezo:            {Finalized: true, Safe: true, EvmChainID: 31611, PublicRPC: "https://rpc.test.mezo.org"},
-		vaa.ChainIDSepolia:         {Finalized: true, Safe: true, EvmChainID: 11155111, PublicRPC: "https://ethereum-sepolia-rpc.publicnode.com"},
-		vaa.ChainIDArbitrumSepolia: {Finalized: true, Safe: true, EvmChainID: 421614, PublicRPC: "https://arbitrum-sepolia-rpc.publicnode.com"},
-		vaa.ChainIDBaseSepolia:     {Finalized: true, Safe: true, EvmChainID: 84532, PublicRPC: "https://base-sepolia-rpc.publicnode.com"},
-		vaa.ChainIDOptimismSepolia: {Finalized: true, Safe: true, EvmChainID: 11155420, PublicRPC: "https://optimism-sepolia-rpc.publicnode.com"},
-		vaa.ChainIDHolesky:         {Finalized: true, Safe: true, EvmChainID: 17000, PublicRPC: "https://1rpc.io/holesky"},
-		vaa.ChainIDPolygonSepolia:  {Finalized: true, Safe: false, EvmChainID: 80002, PublicRPC: "https://polygon-amoy-bor-rpc.publicnode.com"},
+		vaa.ChainIDSnaxchain:       {Finalized: true, Safe: true, EvmChainID: 13001, PublicRPC: "https://testnet.snaxchain.io", ContractAddr: "0xBB73cB66C26740F31d1FabDC6b7A46a038A300dd"},
+		vaa.ChainIDUnichain:        {Finalized: true, Safe: true, EvmChainID: 1301, PublicRPC: "https://unichain-sepolia-rpc.publicnode.com", ContractAddr: "0xBB73cB66C26740F31d1FabDC6b7A46a038A300dd"},
+		vaa.ChainIDWorldchain:      {Finalized: true, Safe: true, EvmChainID: 4801, PublicRPC: "https://worldchain-sepolia.g.alchemy.com/public", ContractAddr: "0xe5E02cD12B6FcA153b0d7fF4bF55730AE7B3C93A"},
+		vaa.ChainIDInk:             {Finalized: true, Safe: true, EvmChainID: 763373, PublicRPC: "https://rpc-qnd-sepolia.inkonchain.com", ContractAddr: "0xBB73cB66C26740F31d1FabDC6b7A46a038A300dd"},
+		vaa.ChainIDHyperEVM:        {Finalized: true, Safe: true, EvmChainID: 998, PublicRPC: "https://rpc.hyperliquid-testnet.xyz/evm", ContractAddr: "0xBB73cB66C26740F31d1FabDC6b7A46a038A300dd"},
+		vaa.ChainIDMonad:           {Finalized: true, Safe: true, EvmChainID: 10143, PublicRPC: "https://testnet-rpc.monad.xyz", ContractAddr: "0xBB73cB66C26740F31d1FabDC6b7A46a038A300dd"},
+		vaa.ChainIDMezo:            {Finalized: true, Safe: true, EvmChainID: 31611, PublicRPC: "https://rpc.test.mezo.org", ContractAddr: "0x268557122Ffd64c85750d630b716471118F323c8"},
+		vaa.ChainIDSepolia:         {Finalized: true, Safe: true, EvmChainID: 11155111, PublicRPC: "https://ethereum-sepolia-rpc.publicnode.com", ContractAddr: "0x4a8bc80Ed5a4067f1CCf107057b8270E0cC11A78"},
+		vaa.ChainIDArbitrumSepolia: {Finalized: true, Safe: true, EvmChainID: 421614, PublicRPC: "https://arbitrum-sepolia-rpc.publicnode.com", ContractAddr: "0x6b9C8671cdDC8dEab9c719bB87cBd3e782bA6a35"},
+		vaa.ChainIDBaseSepolia:     {Finalized: true, Safe: true, EvmChainID: 84532, PublicRPC: "https://base-sepolia-rpc.publicnode.com", ContractAddr: "0x79A1027a6A159502049F10906D333EC57E95F083"},
+		vaa.ChainIDOptimismSepolia: {Finalized: true, Safe: true, EvmChainID: 11155420, PublicRPC: "https://optimism-sepolia-rpc.publicnode.com", ContractAddr: "0x31377888146f3253211EFEf5c676D41ECe7D58Fe"},
+		vaa.ChainIDHolesky:         {Finalized: true, Safe: true, EvmChainID: 17000, PublicRPC: "https://1rpc.io/holesky", ContractAddr: "0xa10f2eF61dE1f19f586ab8B6F2EbA89bACE63F7a"},
+		vaa.ChainIDPolygonSepolia:  {Finalized: true, Safe: false, EvmChainID: 80002, PublicRPC: "https://polygon-amoy-bor-rpc.publicnode.com", ContractAddr: "0x6b9C8671cdDC8dEab9c719bB87cBd3e782bA6a35"},
 	}
 )
 
@@ -281,4 +281,29 @@ func (w *Watcher) verifyEvmChainID(ctx context.Context, logger *zap.Logger, url 
 	}
 
 	return nil
+}
+
+// GetContractAddr returns the configured contract address for the specified environment / chain.
+func GetContractAddrString(env common.Environment, chainID vaa.ChainID) (string, error) {
+	m, err := GetChainConfigMap(env)
+	if err != nil {
+		return "", err
+	}
+
+	entry, exists := m[chainID]
+	if !exists {
+		return "", ErrNotFound
+	}
+
+	return entry.ContractAddr, nil
+}
+
+// GetContractAddr returns the configured contract address for the specified environment / chain.
+func GetContractAddr(env common.Environment, chainID vaa.ChainID) (ethCommon.Address, error) {
+	str, err := GetContractAddrString(env, chainID)
+	if err != nil {
+		return ethCommon.Address{}, err
+	}
+
+	return ethCommon.HexToAddress(str), nil
 }

--- a/node/pkg/watchers/evm/chain_config_test.go
+++ b/node/pkg/watchers/evm/chain_config_test.go
@@ -1,12 +1,16 @@
 package evm
 
 import (
+	"encoding/hex"
+	"strings"
 	"testing"
 
 	"github.com/certusone/wormhole/node/pkg/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wormhole-foundation/wormhole/sdk/vaa"
+
+	ethCommon "github.com/ethereum/go-ethereum/common"
 )
 
 func TestSupportedInMainnet(t *testing.T) {
@@ -78,6 +82,70 @@ func TestGetFinality(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, tc.finalized, finalized)
 				assert.Equal(t, tc.safe, safe)
+			}
+		})
+	}
+}
+
+func TestMainnetContractAddresses(t *testing.T) {
+	verifyContractAddresses(t, mainnetChainConfig)
+	verifyContractAddresses(t, testnetChainConfig)
+}
+
+func verifyContractAddresses(t *testing.T, m EnvMap) {
+	t.Helper()
+	zeroAddr := ethCommon.HexToAddress("0x0")
+	for chainId, entry := range m {
+		t.Run(chainId.String(), func(t *testing.T) {
+			// It must be set.
+			require.NotEqual(t, "", entry.ContractAddr)
+
+			// Since `ethCommon.HexToAddress` never fails, make sure a regular hex conversion works.
+			_, err := hex.DecodeString(strings.TrimPrefix(entry.ContractAddr, "0x"))
+			require.NoError(t, err)
+
+			// Don't allow it to be empty / the zero address.
+			require.NotEqual(t, zeroAddr, ethCommon.HexToAddress(entry.ContractAddr))
+		})
+	}
+}
+
+func TestGetContractAddr(t *testing.T) {
+	type test struct {
+		env    common.Environment
+		input  vaa.ChainID
+		output string
+		err    error
+	}
+
+	// Note: Don't intend to list every chain here, just enough to verify `GetContractAddrString`.
+	tests := []test{
+		{env: common.MainNet, input: vaa.ChainIDUnset, err: ErrNotFound},
+		{env: common.MainNet, input: vaa.ChainIDSepolia, err: ErrNotFound},
+		{env: common.MainNet, input: vaa.ChainIDEthereum, output: "0x98f3c9e6E3fAce36bAAd05FE09d375Ef1464288B"},
+		{env: common.MainNet, input: vaa.ChainIDBSC, output: "0x98f3c9e6E3fAce36bAAd05FE09d375Ef1464288B"},
+		{env: common.TestNet, input: vaa.ChainIDUnset, err: ErrNotFound},
+		{env: common.TestNet, input: vaa.ChainIDSepolia, output: "0x4a8bc80Ed5a4067f1CCf107057b8270E0cC11A78"},
+		{env: common.TestNet, input: vaa.ChainIDEthereum, output: "0xa10f2eF61dE1f19f586ab8B6F2EbA89bACE63F7a"},
+		{env: common.GoTest, input: vaa.ChainIDEthereum, err: ErrInvalidEnv},
+	}
+
+	for _, tc := range tests {
+		t.Run(string(tc.env)+"-"+tc.input.String(), func(t *testing.T) {
+			str, err := GetContractAddrString(tc.env, tc.input)
+			if tc.err != nil {
+				require.ErrorIs(t, tc.err, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.output, str)
+			}
+
+			addr, err := GetContractAddr(tc.env, tc.input)
+			if tc.err != nil {
+				assert.ErrorIs(t, tc.err, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, ethCommon.HexToAddress(tc.output), addr)
 			}
 		})
 	}


### PR DESCRIPTION
This PR enhances the EVM chain config to include the core contract address. This provides easy access to the contract addresses and also allows the `verify_chain_config` to confirm that the contract exists at the expected location. This PR also enhances the tool to make it easier to see what it is doing.

Note that, although it would be possible to use these contract addresses as defaults for the guardian, we are not doing that at this time since it could make it easier for an attacker to compromise the watchers.

Note, while working on this PR, I realized that Linea was currently allowed in mainnet when it should not be, so I fixed that.

Note to reviewers: If you trust the verify tool, you don't need to worry about validating the contract addresses. . .