### PR TITLE
docs: Add transfer verifier instructions for guardians

### DIFF
--- a/docs/transfer-verifier.md
+++ b/docs/transfer-verifier.md
@@ -1,0 +1,15 @@
+# Transfer Verifier
+
+Below are admin controls surfaced to the Guardians for the Governor plugin. For
+a background on the feature and its objectives, see [the whitepaper](whitepapers/0014_transfer_verifier.md)
+
+## How To Enable Transfer Verifier
+The Transfer Verifier feature is disabled by default. Guardians can enable it by passing the following flag to the `guardiand` command when starting it up:
+
+```bash
+# Enable Transfer Verifier for chain with ID 2 (Ethereum)
+--transferVerifierEnabledChainIDs=2
+```
+
+This parameter is a comma-separated list of Wormhole Chain IDs for which transfer verification will be enabled.
+Only some chains support the Transfer Verifier.


### PR DESCRIPTION
This document serves as configuration instructions for the Guardians for enabling the Transfer Verifier feature.

## Related

- #4242 (The actual whitepaper is here)
- #4233