### PR TITLE
lint: add linters with no violations

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,14 +15,15 @@ linters:
     - typecheck
     - unused
 
-  # additional linters
-    - gosec
+    # additional linters
     - forcetypeassert
+    - gosec
+    - loggercheck
     # - contextcheck # disabled in CI for now because fixes to findings need additional work
     - noctx
     # - unconvert # disable because extra conversion typically don't hurt but can make code more clear
-    - unparam
     - prealloc
+    - unparam
 issues:
   exclude-rules:
     - path: pkg/supervisor/supervisor_testhelpers.go

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -57,4 +57,3 @@ linters-settings:
       # performance lints
       - indexAlloc
       # style lints
-      - importShadow

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,7 @@ linters:
   enable:
   # default linters
     - errcheck
+    - gocritic
     - gosimple
     - govet
     - ineffassign
@@ -32,3 +33,14 @@ issues:
     - path: pkg/txverifier/sui_test.go
 
       text: "G101: Potential hardcoded credentials"
+linters-settings:
+  gocritic:
+    # https://go-critic.com/overview
+      disable-all: true 
+      enabled-checks:
+      - argOrder
+      - badCall
+      - badCond
+      - badLock
+      - badSorting
+      - dupArg

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,9 +38,22 @@ linters-settings:
     # https://go-critic.com/overview
       disable-all: true 
       enabled-checks:
+      # diagnostic lints
       - argOrder
       - badCall
       - badCond
       - badLock
       - badSorting
+      - caseOrder
       - dupArg
+      - dupBranchBody
+      - dupCase
+      - dupSubExpr
+      - mapKey
+      - truncateCmp
+      - uncheckedInlineErr
+      - weakCond
+      # performance lints
+      - indexAlloc
+      # style lints
+      - importShadow


### PR DESCRIPTION
This PR adds new linters to golangci-lint, specifically ones that the current code does not violate. The idea here is to get these new linters "for free" and prevent any future code from violating these rules.

Related:
This PR has different scope from these other open PRs, as they aim to resolve violations:
- https://github.com/wormhole-foundation/wormhole/pull/4284 which adds new linters and fixes their violations
- #4224 which updates the golanci-lint version and fixes violations that arose from the rules being updated