### PR TITLE
node: add targets for linting to Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,10 @@ generate: dirs
 	rm -rf node/pkg/proto
 	tools/bin/buf generate
 
+.PHONY: lint
+lint:
+	bash scripts/lint.sh lint
+
 .PHONY: node
 ## Build guardiand binary
 node: $(BIN)/guardiand

--- a/node/Makefile
+++ b/node/Makefile
@@ -1,3 +1,7 @@
+.PHONY: lint
+lint: 
+	golangci-lint run -c ../.golangci.yml ./...
+
 .PHONY: test
 test: 
 	go test -v ./...


### PR DESCRIPTION
Adds convenience `make lint` commands for the root directory and `node/`.