### PR TITLE
node: Drop MessagePublications with Rejected status

### DIFF
--- a/node/pkg/processor/observation.go
+++ b/node/pkg/processor/observation.go
@@ -1,4 +1,3 @@
-//nolint:unparam // this will be refactored in https://github.com/wormhole-foundation/wormhole/pull/1953
 package processor
 
 import (

--- a/node/pkg/processor/processor.go
+++ b/node/pkg/processor/processor.go
@@ -275,6 +275,18 @@ func (p *Processor) Run(ctx context.Context) error {
 			)
 			p.gst.Set(p.gs)
 		case k := <-p.msgC:
+
+			switch k.VerificationState() {
+			case common.Rejected:
+				// Drop messages marked as Rejected.
+				p.logger.Error(
+					"dropping message",
+					zap.String("msgID", k.MessageIDString()),
+					zap.String("verificationState", k.VerificationState().String()),
+				)
+				continue
+			}
+
 			if p.governor != nil {
 				if !p.governor.ProcessMsg(k) {
 					continue


### PR DESCRIPTION
This PR adds a changes that causes the processor to drop messages marked as Rejected and logs that it has done so.

Messages can only be marked as Rejected if:
- Transfer Verification is enabled via a CLI flag
- The originating chain is Ethereum (or an Ethereum testnet)
- The message fails transfer verification

Follow-up work to: #4233