### PR TITLE
node: Remove go-homedir dependency

### DIFF
--- a/node/cmd/root.go
+++ b/node/cmd/root.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/viper"
 
 	"github.com/certusone/wormhole/node/cmd/guardiand"
@@ -66,7 +65,7 @@ func initConfig() {
 		viper.SetConfigFile(cfgFile)
 	} else {
 		// Find home directory.
-		home, err := homedir.Dir()
+		home, err := os.UserHomeDir()
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)

--- a/node/go.mod
+++ b/node/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/libp2p/go-libp2p-kad-dht v0.25.2
 	github.com/libp2p/go-libp2p-pubsub v0.12.0
 	github.com/miguelmota/go-ethereum-hdwallet v0.1.0
-	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mr-tron/base58 v1.2.0
 	github.com/multiformats/go-multiaddr v0.13.0
 	github.com/near/borsh-go v0.3.0
@@ -243,6 +242,7 @@ require (
 	github.com/mimoo/StrobeGo v0.0.0-20210601165009-122bf33a46e0 // indirect
 	github.com/minio/highwayhash v1.0.2 // indirect
 	github.com/minio/sha256-simd v1.0.1 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect


### PR DESCRIPTION
This dependency is deprecated and seems easy to replace via a call to the standard library.

Background: https://github.com/mitchellh/go-homedir/issues/34

Note that this is still an indirect dependency for us:

```sh
$ go mod why github.com/mitchellh/go-homedir

# github.com/mitchellh/go-homedir
github.com/certusone/wormhole/node/pkg/telemetry
github.com/grafana/loki/clients/pkg/promtail/client
github.com/grafana/loki/pkg/util
github.com/grafana/dskit/kv
github.com/grafana/dskit/kv/consul
github.com/hashicorp/consul/api
github.com/hashicorp/go-rootcerts
github.com/mitchellh/go-homedir
```

There is an open PR to remove this dependency in `github.com/hashicorp/go-rootcerts` as well, at which point it shouldn't be a dependency for us. https://github.com/hashicorp/go-rootcerts/pull/28
