### PR TITLE
Node: Alternate publishers

### DIFF
--- a/node/cmd/guardiand/adminclient.go
+++ b/node/cmd/guardiand/adminclient.go
@@ -23,8 +23,8 @@ import (
 	"github.com/spf13/pflag"
 	"golang.org/x/crypto/sha3"
 
+	"github.com/certusone/wormhole/node/pkg/common"
 	"github.com/certusone/wormhole/node/pkg/guardiansigner"
-	"github.com/certusone/wormhole/node/pkg/node"
 	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
 	publicrpcv1 "github.com/certusone/wormhole/node/pkg/proto/publicrpc/v1"
 	"github.com/wormhole-foundation/wormhole/sdk"
@@ -450,7 +450,7 @@ func runReobserveWithEndpoint(cmd *cobra.Command, args []string) {
 	}
 
 	url := args[2]
-	if valid := node.ValidateURL(url, []string{"http", "https"}); !valid {
+	if valid := common.ValidateURL(url, []string{"http", "https"}); !valid {
 		log.Fatalf(`invalid url, must be "http" or "https"`)
 	}
 

--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -323,76 +323,76 @@ func init() {
 	fogoContract = NodeCmd.Flags().String("fogoContract", "", "Address of the Fogo program (required if fogoRpc is specified)")
 	fogoShimContract = NodeCmd.Flags().String("fogoShimContract", "", "Address of the Fogo shim program")
 
-	ethRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "ethRPC", "Ethereum RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	ethRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "ethRPC", "Ethereum RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	ethContract = NodeCmd.Flags().String("ethContract", "", "Ethereum contract address")
 
-	bscRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "bscRPC", "Binance Smart Chain RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	bscRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "bscRPC", "Binance Smart Chain RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	bscContract = NodeCmd.Flags().String("bscContract", "", "Binance Smart Chain contract address")
 
-	polygonRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "polygonRPC", "Polygon RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	polygonRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "polygonRPC", "Polygon RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	polygonContract = NodeCmd.Flags().String("polygonContract", "", "Polygon contract address")
 
-	avalancheRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "avalancheRPC", "Avalanche RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	avalancheRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "avalancheRPC", "Avalanche RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	avalancheContract = NodeCmd.Flags().String("avalancheContract", "", "Avalanche contract address")
 
-	oasisRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "oasisRPC", "Oasis RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	oasisRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "oasisRPC", "Oasis RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	oasisContract = NodeCmd.Flags().String("oasisContract", "", "Oasis contract address")
 
-	fantomRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "fantomRPC", "Fantom Websocket RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	fantomRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "fantomRPC", "Fantom Websocket RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	fantomContract = NodeCmd.Flags().String("fantomContract", "", "Fantom contract address")
 
-	karuraRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "karuraRPC", "Karura RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	karuraRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "karuraRPC", "Karura RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	karuraContract = NodeCmd.Flags().String("karuraContract", "", "Karura contract address")
 
-	acalaRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "acalaRPC", "Acala RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	acalaRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "acalaRPC", "Acala RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	acalaContract = NodeCmd.Flags().String("acalaContract", "", "Acala contract address")
 
-	klaytnRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "klaytnRPC", "Klaytn RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	klaytnRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "klaytnRPC", "Klaytn RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	klaytnContract = NodeCmd.Flags().String("klaytnContract", "", "Klaytn contract address")
 
-	celoRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "celoRPC", "Celo RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	celoRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "celoRPC", "Celo RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	celoContract = NodeCmd.Flags().String("celoContract", "", "Celo contract address")
 
-	moonbeamRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "moonbeamRPC", "Moonbeam RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	moonbeamRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "moonbeamRPC", "Moonbeam RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	moonbeamContract = NodeCmd.Flags().String("moonbeamContract", "", "Moonbeam contract address")
 
-	terraWS = common.RegisterFlagWithValidationOrFail(NodeCmd, "terraWS", "Path to terrad root for websocket connection", "ws://terra-terrad:26657/websocket", []string{"ws", "wss"})
-	terraLCD = common.RegisterFlagWithValidationOrFail(NodeCmd, "terraLCD", "Path to LCD service root for http calls", "http://terra-terrad:1317", []string{"http", "https"})
+	terraWS = node.RegisterFlagWithValidationOrFail(NodeCmd, "terraWS", "Path to terrad root for websocket connection", "ws://terra-terrad:26657/websocket", []string{"ws", "wss"})
+	terraLCD = node.RegisterFlagWithValidationOrFail(NodeCmd, "terraLCD", "Path to LCD service root for http calls", "http://terra-terrad:1317", []string{"http", "https"})
 	terraContract = NodeCmd.Flags().String("terraContract", "", "Wormhole contract address on Terra blockchain")
 
-	terra2WS = common.RegisterFlagWithValidationOrFail(NodeCmd, "terra2WS", "Path to terrad root for websocket connection", "ws://terra2-terrad:26657/websocket", []string{"ws", "wss"})
-	terra2LCD = common.RegisterFlagWithValidationOrFail(NodeCmd, "terra2LCD", "Path to LCD service root for http calls", "http://terra2-terrad:1317", []string{"http", "https"})
+	terra2WS = node.RegisterFlagWithValidationOrFail(NodeCmd, "terra2WS", "Path to terrad root for websocket connection", "ws://terra2-terrad:26657/websocket", []string{"ws", "wss"})
+	terra2LCD = node.RegisterFlagWithValidationOrFail(NodeCmd, "terra2LCD", "Path to LCD service root for http calls", "http://terra2-terrad:1317", []string{"http", "https"})
 	terra2Contract = NodeCmd.Flags().String("terra2Contract", "", "Wormhole contract address on Terra 2 blockchain")
 
-	injectiveWS = common.RegisterFlagWithValidationOrFail(NodeCmd, "injectiveWS", "Path to root for Injective websocket connection", "ws://injective:26657/websocket", []string{"ws", "wss"})
-	injectiveLCD = common.RegisterFlagWithValidationOrFail(NodeCmd, "injectiveLCD", "Path to LCD service root for Injective http calls", "http://injective:1317", []string{"http", "https"})
+	injectiveWS = node.RegisterFlagWithValidationOrFail(NodeCmd, "injectiveWS", "Path to root for Injective websocket connection", "ws://injective:26657/websocket", []string{"ws", "wss"})
+	injectiveLCD = node.RegisterFlagWithValidationOrFail(NodeCmd, "injectiveLCD", "Path to LCD service root for Injective http calls", "http://injective:1317", []string{"http", "https"})
 	injectiveContract = NodeCmd.Flags().String("injectiveContract", "", "Wormhole contract address on Injective blockchain")
 
-	xplaWS = common.RegisterFlagWithValidationOrFail(NodeCmd, "xplaWS", "Path to root for XPLA websocket connection", "ws://xpla:26657/websocket", []string{"ws", "wss"})
-	xplaLCD = common.RegisterFlagWithValidationOrFail(NodeCmd, "xplaLCD", "Path to LCD service root for XPLA http calls", "http://xpla:1317", []string{"http", "https"})
+	xplaWS = node.RegisterFlagWithValidationOrFail(NodeCmd, "xplaWS", "Path to root for XPLA websocket connection", "ws://xpla:26657/websocket", []string{"ws", "wss"})
+	xplaLCD = node.RegisterFlagWithValidationOrFail(NodeCmd, "xplaLCD", "Path to LCD service root for XPLA http calls", "http://xpla:1317", []string{"http", "https"})
 	xplaContract = NodeCmd.Flags().String("xplaContract", "", "Wormhole contract address on XPLA blockchain")
 
-	gatewayWS = common.RegisterFlagWithValidationOrFail(NodeCmd, "gatewayWS", "Path to root for Gateway watcher websocket connection", "ws://wormchain:26657/websocket", []string{"ws", "wss"})
-	gatewayLCD = common.RegisterFlagWithValidationOrFail(NodeCmd, "gatewayLCD", "Path to LCD service root for Gateway watcher http calls", "http://wormchain:1317", []string{"http", "https"})
+	gatewayWS = node.RegisterFlagWithValidationOrFail(NodeCmd, "gatewayWS", "Path to root for Gateway watcher websocket connection", "ws://wormchain:26657/websocket", []string{"ws", "wss"})
+	gatewayLCD = node.RegisterFlagWithValidationOrFail(NodeCmd, "gatewayLCD", "Path to LCD service root for Gateway watcher http calls", "http://wormchain:1317", []string{"http", "https"})
 	gatewayContract = NodeCmd.Flags().String("gatewayContract", "", "Wormhole contract address on Gateway blockchain")
 
-	algorandIndexerRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "algorandIndexerRPC", "Algorand Indexer RPC URL", "http://algorand:8980", []string{"http", "https"})
+	algorandIndexerRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "algorandIndexerRPC", "Algorand Indexer RPC URL", "http://algorand:8980", []string{"http", "https"})
 	algorandIndexerToken = NodeCmd.Flags().String("algorandIndexerToken", "", "Algorand Indexer access token")
-	algorandAlgodRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "algorandAlgodRPC", "Algorand Algod RPC URL", "http://algorand:4001", []string{"http", "https"})
+	algorandAlgodRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "algorandAlgodRPC", "Algorand Algod RPC URL", "http://algorand:4001", []string{"http", "https"})
 	algorandAlgodToken = NodeCmd.Flags().String("algorandAlgodToken", "", "Algorand Algod access token")
 	algorandAppID = NodeCmd.Flags().Uint64("algorandAppID", 0, "Algorand app id")
 
-	nearRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "nearRPC", "Near RPC URL", "http://near:3030", []string{"http", "https"})
+	nearRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "nearRPC", "Near RPC URL", "http://near:3030", []string{"http", "https"})
 	nearContract = NodeCmd.Flags().String("nearContract", "", "Near contract")
 
-	wormchainURL = common.RegisterFlagWithValidationOrFail(NodeCmd, "wormchainURL", "Wormhole-chain gRPC URL", "wormchain:9090", []string{""})
+	wormchainURL = node.RegisterFlagWithValidationOrFail(NodeCmd, "wormchainURL", "Wormhole-chain gRPC URL", "wormchain:9090", []string{""})
 
-	ibcWS = common.RegisterFlagWithValidationOrFail(NodeCmd, "ibcWS", "Websocket used to listen to the IBC receiver smart contract on wormchain", "ws://wormchain:26657/websocket", []string{"ws", "wss"})
-	ibcLCD = common.RegisterFlagWithValidationOrFail(NodeCmd, "ibcLCD", "Path to LCD service root for http calls", "http://wormchain:1317", []string{"http", "https"})
-	ibcBlockHeightURL = common.RegisterFlagWithValidationOrFail(NodeCmd, "ibcBlockHeightURL", "Optional URL to query for the block height (generated from ibcWS if not specified)", "http://wormchain:1317", []string{"http", "https"})
+	ibcWS = node.RegisterFlagWithValidationOrFail(NodeCmd, "ibcWS", "Websocket used to listen to the IBC receiver smart contract on wormchain", "ws://wormchain:26657/websocket", []string{"ws", "wss"})
+	ibcLCD = node.RegisterFlagWithValidationOrFail(NodeCmd, "ibcLCD", "Path to LCD service root for http calls", "http://wormchain:1317", []string{"http", "https"})
+	ibcBlockHeightURL = node.RegisterFlagWithValidationOrFail(NodeCmd, "ibcBlockHeightURL", "Optional URL to query for the block height (generated from ibcWS if not specified)", "http://wormchain:1317", []string{"http", "https"})
 	ibcContract = NodeCmd.Flags().String("ibcContract", "", "Address of the IBC smart contract on wormchain")
 
-	accountantWS = common.RegisterFlagWithValidationOrFail(NodeCmd, "accountantWS", "Websocket used to listen to the accountant smart contract on wormchain", "http://wormchain:26657", []string{"http", "https"})
+	accountantWS = node.RegisterFlagWithValidationOrFail(NodeCmd, "accountantWS", "Websocket used to listen to the accountant smart contract on wormchain", "http://wormchain:26657", []string{"http", "https"})
 	accountantContract = NodeCmd.Flags().String("accountantContract", "", "Address of the accountant smart contract on wormchain")
 	accountantKeyPath = NodeCmd.Flags().String("accountantKeyPath", "", "path to accountant private key for signing transactions")
 	accountantKeyPassPhrase = NodeCmd.Flags().String("accountantKeyPassPhrase", "", "pass phrase used to unarmor the accountant key file")
@@ -402,91 +402,91 @@ func init() {
 	accountantNttKeyPath = NodeCmd.Flags().String("accountantNttKeyPath", "", "path to NTT accountant private key for signing transactions")
 	accountantNttKeyPassPhrase = NodeCmd.Flags().String("accountantNttKeyPassPhrase", "", "pass phrase used to unarmor the NTT accountant key file")
 
-	aptosRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "aptosRPC", "Aptos RPC URL", "http://aptos:8080", []string{"http", "https"})
+	aptosRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "aptosRPC", "Aptos RPC URL", "http://aptos:8080", []string{"http", "https"})
 	aptosAccount = NodeCmd.Flags().String("aptosAccount", "", "aptos account")
 	aptosHandle = NodeCmd.Flags().String("aptosHandle", "", "aptos handle")
 
-	movementRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "movementRPC", "Movement RPC URL", "", []string{"http", "https"})
+	movementRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "movementRPC", "Movement RPC URL", "", []string{"http", "https"})
 	movementAccount = NodeCmd.Flags().String("movementAccount", "", "movement account")
 	movementHandle = NodeCmd.Flags().String("movementHandle", "", "movement handle")
 
-	suiRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "suiRPC", "Sui RPC URL", "http://sui:9000", []string{"http", "https"})
+	suiRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "suiRPC", "Sui RPC URL", "http://sui:9000", []string{"http", "https"})
 	suiMoveEventType = NodeCmd.Flags().String("suiMoveEventType", "", "Sui move event type for publish_message")
 
-	solanaRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "solanaRPC", "Solana RPC URL (required)", "http://solana-devnet:8899", []string{"http", "https"})
-	fogoRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "fogoRPC", "Fogo RPC URL (required)", "http://solana-devnet:8899", []string{"http", "https"})
+	solanaRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "solanaRPC", "Solana RPC URL (required)", "http://solana-devnet:8899", []string{"http", "https"})
+	fogoRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "fogoRPC", "Fogo RPC URL (required)", "http://solana-devnet:8899", []string{"http", "https"})
 
 	pythnetContract = NodeCmd.Flags().String("pythnetContract", "", "Address of the PythNet program (required)")
-	pythnetRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "pythnetRPC", "PythNet RPC URL (required)", "http://pythnet.rpcpool.com", []string{"http", "https"})
-	pythnetWS = common.RegisterFlagWithValidationOrFail(NodeCmd, "pythnetWS", "PythNet WS URL", "wss://pythnet.rpcpool.com", []string{"ws", "wss"})
+	pythnetRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "pythnetRPC", "PythNet RPC URL (required)", "http://pythnet.rpcpool.com", []string{"http", "https"})
+	pythnetWS = node.RegisterFlagWithValidationOrFail(NodeCmd, "pythnetWS", "PythNet WS URL", "wss://pythnet.rpcpool.com", []string{"ws", "wss"})
 
-	arbitrumRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "arbitrumRPC", "Arbitrum RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	arbitrumRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "arbitrumRPC", "Arbitrum RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	arbitrumContract = NodeCmd.Flags().String("arbitrumContract", "", "Arbitrum contract address")
 
-	sepoliaRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "sepoliaRPC", "Sepolia RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	sepoliaRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "sepoliaRPC", "Sepolia RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	sepoliaContract = NodeCmd.Flags().String("sepoliaContract", "", "Sepolia contract address")
 
-	holeskyRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "holeskyRPC", "Holesky RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	holeskyRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "holeskyRPC", "Holesky RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	holeskyContract = NodeCmd.Flags().String("holeskyContract", "", "Holesky contract address")
 
-	optimismRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "optimismRPC", "Optimism RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	optimismRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "optimismRPC", "Optimism RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	optimismContract = NodeCmd.Flags().String("optimismContract", "", "Optimism contract address")
 
-	scrollRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "scrollRPC", "Scroll RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	scrollRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "scrollRPC", "Scroll RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	scrollContract = NodeCmd.Flags().String("scrollContract", "", "Scroll contract address")
 
-	mantleRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "mantleRPC", "Mantle RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	mantleRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "mantleRPC", "Mantle RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	mantleContract = NodeCmd.Flags().String("mantleContract", "", "Mantle contract address")
 
-	blastRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "blastRPC", "Blast RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	blastRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "blastRPC", "Blast RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	blastContract = NodeCmd.Flags().String("blastContract", "", "Blast contract address")
 
-	xlayerRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "xlayerRPC", "XLayer RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	xlayerRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "xlayerRPC", "XLayer RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	xlayerContract = NodeCmd.Flags().String("xlayerContract", "", "XLayer contract address")
 
-	lineaRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "lineaRPC", "Linea RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	lineaRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "lineaRPC", "Linea RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	lineaContract = NodeCmd.Flags().String("lineaContract", "", "Linea contract address")
 
-	berachainRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "berachainRPC", "Berachain RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	berachainRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "berachainRPC", "Berachain RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	berachainContract = NodeCmd.Flags().String("berachainContract", "", "Berachain contract address")
 
-	snaxchainRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "snaxchainRPC", "Snaxchain RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	snaxchainRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "snaxchainRPC", "Snaxchain RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	snaxchainContract = NodeCmd.Flags().String("snaxchainContract", "", "Snaxchain contract address")
 
-	unichainRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "unichainRPC", "Unichain RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	unichainRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "unichainRPC", "Unichain RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	unichainContract = NodeCmd.Flags().String("unichainContract", "", "Unichain contract address")
 
-	worldchainRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "worldchainRPC", "Worldchain RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	worldchainRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "worldchainRPC", "Worldchain RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	worldchainContract = NodeCmd.Flags().String("worldchainContract", "", "Worldchain contract address")
 
-	baseRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "baseRPC", "Base RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	baseRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "baseRPC", "Base RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	baseContract = NodeCmd.Flags().String("baseContract", "", "Base contract address")
 
-	inkRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "inkRPC", "Ink RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	inkRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "inkRPC", "Ink RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	inkContract = NodeCmd.Flags().String("inkContract", "", "Ink contract address")
 
-	hyperEvmRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "hyperEvmRPC", "HyperEVM RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	hyperEvmRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "hyperEvmRPC", "HyperEVM RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	hyperEvmContract = NodeCmd.Flags().String("hyperEvmContract", "", "HyperEVM contract address")
 
-	monadRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "monadRPC", "Monad RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	monadRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "monadRPC", "Monad RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	monadContract = NodeCmd.Flags().String("monadContract", "", "Monad contract address")
 
-	seiEvmRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "seiEvmRPC", "SeiEVM RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	seiEvmRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "seiEvmRPC", "SeiEVM RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	seiEvmContract = NodeCmd.Flags().String("seiEvmContract", "", "SeiEVM contract address")
 
-	mezoRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "mezoRPC", "Mezo RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	mezoRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "mezoRPC", "Mezo RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	mezoContract = NodeCmd.Flags().String("mezoContract", "", "Mezo contract address")
 
-	arbitrumSepoliaRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "arbitrumSepoliaRPC", "Arbitrum on Sepolia RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	arbitrumSepoliaRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "arbitrumSepoliaRPC", "Arbitrum on Sepolia RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	arbitrumSepoliaContract = NodeCmd.Flags().String("arbitrumSepoliaContract", "", "Arbitrum on Sepolia contract address")
 
-	baseSepoliaRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "baseSepoliaRPC", "Base on Sepolia RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	baseSepoliaRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "baseSepoliaRPC", "Base on Sepolia RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	baseSepoliaContract = NodeCmd.Flags().String("baseSepoliaContract", "", "Base on Sepolia contract address")
 
-	optimismSepoliaRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "optimismSepoliaRPC", "Optimism on Sepolia RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	optimismSepoliaRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "optimismSepoliaRPC", "Optimism on Sepolia RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	optimismSepoliaContract = NodeCmd.Flags().String("optimismSepoliaContract", "", "Optimism on Sepolia contract address")
 
-	polygonSepoliaRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "polygonSepoliaRPC", "Polygon on Sepolia RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	polygonSepoliaRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "polygonSepoliaRPC", "Polygon on Sepolia RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	polygonSepoliaContract = NodeCmd.Flags().String("polygonSepoliaContract", "", "Polygon on Sepolia contract address")
 
 	logLevel = NodeCmd.Flags().String("logLevel", "info", "Logging level (debug, info, warn, error, dpanic, panic, fatal)")

--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -17,6 +17,7 @@ import (
 	"github.com/certusone/wormhole/node/pkg/guardiansigner"
 	"github.com/certusone/wormhole/node/pkg/watchers"
 	"github.com/certusone/wormhole/node/pkg/watchers/ibc"
+	"github.com/ethereum/go-ethereum/crypto"
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 
 	"github.com/certusone/wormhole/node/pkg/watchers/cosmwasm"
@@ -52,10 +53,11 @@ import (
 )
 
 var (
-	p2pNetworkID   *string
-	p2pPort        *uint
-	p2pBootstrap   *string
-	protectedPeers []string
+	p2pNetworkID         *string
+	p2pPort              *uint
+	p2pBootstrap         *string
+	protectedPeers       []string
+	additionalPublishers *[]string
 
 	nodeKeyPath *string
 
@@ -303,6 +305,7 @@ func init() {
 	p2pPort = NodeCmd.Flags().Uint("port", p2p.DefaultPort, "P2P UDP listener port")
 	p2pBootstrap = NodeCmd.Flags().String("bootstrap", "", "P2P bootstrap peers (optional for mainnet or testnet, overrides default, required for unsafeDevMode)")
 	NodeCmd.Flags().StringSliceVarP(&protectedPeers, "protectedPeers", "", []string{}, "")
+	additionalPublishers = NodeCmd.Flags().StringArray("additionalPublishEndpoint", []string{}, "defines an alternate publisher as label:url:delay:chains where delay and chains are optional")
 
 	statusAddr = NodeCmd.Flags().String("statusAddr", "[::]:6060", "Listen address for status server (disabled if blank)")
 
@@ -320,76 +323,76 @@ func init() {
 	fogoContract = NodeCmd.Flags().String("fogoContract", "", "Address of the Fogo program (required if fogoRpc is specified)")
 	fogoShimContract = NodeCmd.Flags().String("fogoShimContract", "", "Address of the Fogo shim program")
 
-	ethRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "ethRPC", "Ethereum RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	ethRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "ethRPC", "Ethereum RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	ethContract = NodeCmd.Flags().String("ethContract", "", "Ethereum contract address")
 
-	bscRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "bscRPC", "Binance Smart Chain RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	bscRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "bscRPC", "Binance Smart Chain RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	bscContract = NodeCmd.Flags().String("bscContract", "", "Binance Smart Chain contract address")
 
-	polygonRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "polygonRPC", "Polygon RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	polygonRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "polygonRPC", "Polygon RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	polygonContract = NodeCmd.Flags().String("polygonContract", "", "Polygon contract address")
 
-	avalancheRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "avalancheRPC", "Avalanche RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	avalancheRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "avalancheRPC", "Avalanche RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	avalancheContract = NodeCmd.Flags().String("avalancheContract", "", "Avalanche contract address")
 
-	oasisRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "oasisRPC", "Oasis RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	oasisRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "oasisRPC", "Oasis RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	oasisContract = NodeCmd.Flags().String("oasisContract", "", "Oasis contract address")
 
-	fantomRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "fantomRPC", "Fantom Websocket RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	fantomRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "fantomRPC", "Fantom Websocket RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	fantomContract = NodeCmd.Flags().String("fantomContract", "", "Fantom contract address")
 
-	karuraRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "karuraRPC", "Karura RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	karuraRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "karuraRPC", "Karura RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	karuraContract = NodeCmd.Flags().String("karuraContract", "", "Karura contract address")
 
-	acalaRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "acalaRPC", "Acala RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	acalaRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "acalaRPC", "Acala RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	acalaContract = NodeCmd.Flags().String("acalaContract", "", "Acala contract address")
 
-	klaytnRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "klaytnRPC", "Klaytn RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	klaytnRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "klaytnRPC", "Klaytn RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	klaytnContract = NodeCmd.Flags().String("klaytnContract", "", "Klaytn contract address")
 
-	celoRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "celoRPC", "Celo RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	celoRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "celoRPC", "Celo RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	celoContract = NodeCmd.Flags().String("celoContract", "", "Celo contract address")
 
-	moonbeamRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "moonbeamRPC", "Moonbeam RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	moonbeamRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "moonbeamRPC", "Moonbeam RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	moonbeamContract = NodeCmd.Flags().String("moonbeamContract", "", "Moonbeam contract address")
 
-	terraWS = node.RegisterFlagWithValidationOrFail(NodeCmd, "terraWS", "Path to terrad root for websocket connection", "ws://terra-terrad:26657/websocket", []string{"ws", "wss"})
-	terraLCD = node.RegisterFlagWithValidationOrFail(NodeCmd, "terraLCD", "Path to LCD service root for http calls", "http://terra-terrad:1317", []string{"http", "https"})
+	terraWS = common.RegisterFlagWithValidationOrFail(NodeCmd, "terraWS", "Path to terrad root for websocket connection", "ws://terra-terrad:26657/websocket", []string{"ws", "wss"})
+	terraLCD = common.RegisterFlagWithValidationOrFail(NodeCmd, "terraLCD", "Path to LCD service root for http calls", "http://terra-terrad:1317", []string{"http", "https"})
 	terraContract = NodeCmd.Flags().String("terraContract", "", "Wormhole contract address on Terra blockchain")
 
-	terra2WS = node.RegisterFlagWithValidationOrFail(NodeCmd, "terra2WS", "Path to terrad root for websocket connection", "ws://terra2-terrad:26657/websocket", []string{"ws", "wss"})
-	terra2LCD = node.RegisterFlagWithValidationOrFail(NodeCmd, "terra2LCD", "Path to LCD service root for http calls", "http://terra2-terrad:1317", []string{"http", "https"})
+	terra2WS = common.RegisterFlagWithValidationOrFail(NodeCmd, "terra2WS", "Path to terrad root for websocket connection", "ws://terra2-terrad:26657/websocket", []string{"ws", "wss"})
+	terra2LCD = common.RegisterFlagWithValidationOrFail(NodeCmd, "terra2LCD", "Path to LCD service root for http calls", "http://terra2-terrad:1317", []string{"http", "https"})
 	terra2Contract = NodeCmd.Flags().String("terra2Contract", "", "Wormhole contract address on Terra 2 blockchain")
 
-	injectiveWS = node.RegisterFlagWithValidationOrFail(NodeCmd, "injectiveWS", "Path to root for Injective websocket connection", "ws://injective:26657/websocket", []string{"ws", "wss"})
-	injectiveLCD = node.RegisterFlagWithValidationOrFail(NodeCmd, "injectiveLCD", "Path to LCD service root for Injective http calls", "http://injective:1317", []string{"http", "https"})
+	injectiveWS = common.RegisterFlagWithValidationOrFail(NodeCmd, "injectiveWS", "Path to root for Injective websocket connection", "ws://injective:26657/websocket", []string{"ws", "wss"})
+	injectiveLCD = common.RegisterFlagWithValidationOrFail(NodeCmd, "injectiveLCD", "Path to LCD service root for Injective http calls", "http://injective:1317", []string{"http", "https"})
 	injectiveContract = NodeCmd.Flags().String("injectiveContract", "", "Wormhole contract address on Injective blockchain")
 
-	xplaWS = node.RegisterFlagWithValidationOrFail(NodeCmd, "xplaWS", "Path to root for XPLA websocket connection", "ws://xpla:26657/websocket", []string{"ws", "wss"})
-	xplaLCD = node.RegisterFlagWithValidationOrFail(NodeCmd, "xplaLCD", "Path to LCD service root for XPLA http calls", "http://xpla:1317", []string{"http", "https"})
+	xplaWS = common.RegisterFlagWithValidationOrFail(NodeCmd, "xplaWS", "Path to root for XPLA websocket connection", "ws://xpla:26657/websocket", []string{"ws", "wss"})
+	xplaLCD = common.RegisterFlagWithValidationOrFail(NodeCmd, "xplaLCD", "Path to LCD service root for XPLA http calls", "http://xpla:1317", []string{"http", "https"})
 	xplaContract = NodeCmd.Flags().String("xplaContract", "", "Wormhole contract address on XPLA blockchain")
 
-	gatewayWS = node.RegisterFlagWithValidationOrFail(NodeCmd, "gatewayWS", "Path to root for Gateway watcher websocket connection", "ws://wormchain:26657/websocket", []string{"ws", "wss"})
-	gatewayLCD = node.RegisterFlagWithValidationOrFail(NodeCmd, "gatewayLCD", "Path to LCD service root for Gateway watcher http calls", "http://wormchain:1317", []string{"http", "https"})
+	gatewayWS = common.RegisterFlagWithValidationOrFail(NodeCmd, "gatewayWS", "Path to root for Gateway watcher websocket connection", "ws://wormchain:26657/websocket", []string{"ws", "wss"})
+	gatewayLCD = common.RegisterFlagWithValidationOrFail(NodeCmd, "gatewayLCD", "Path to LCD service root for Gateway watcher http calls", "http://wormchain:1317", []string{"http", "https"})
 	gatewayContract = NodeCmd.Flags().String("gatewayContract", "", "Wormhole contract address on Gateway blockchain")
 
-	algorandIndexerRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "algorandIndexerRPC", "Algorand Indexer RPC URL", "http://algorand:8980", []string{"http", "https"})
+	algorandIndexerRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "algorandIndexerRPC", "Algorand Indexer RPC URL", "http://algorand:8980", []string{"http", "https"})
 	algorandIndexerToken = NodeCmd.Flags().String("algorandIndexerToken", "", "Algorand Indexer access token")
-	algorandAlgodRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "algorandAlgodRPC", "Algorand Algod RPC URL", "http://algorand:4001", []string{"http", "https"})
+	algorandAlgodRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "algorandAlgodRPC", "Algorand Algod RPC URL", "http://algorand:4001", []string{"http", "https"})
 	algorandAlgodToken = NodeCmd.Flags().String("algorandAlgodToken", "", "Algorand Algod access token")
 	algorandAppID = NodeCmd.Flags().Uint64("algorandAppID", 0, "Algorand app id")
 
-	nearRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "nearRPC", "Near RPC URL", "http://near:3030", []string{"http", "https"})
+	nearRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "nearRPC", "Near RPC URL", "http://near:3030", []string{"http", "https"})
 	nearContract = NodeCmd.Flags().String("nearContract", "", "Near contract")
 
-	wormchainURL = node.RegisterFlagWithValidationOrFail(NodeCmd, "wormchainURL", "Wormhole-chain gRPC URL", "wormchain:9090", []string{""})
+	wormchainURL = common.RegisterFlagWithValidationOrFail(NodeCmd, "wormchainURL", "Wormhole-chain gRPC URL", "wormchain:9090", []string{""})
 
-	ibcWS = node.RegisterFlagWithValidationOrFail(NodeCmd, "ibcWS", "Websocket used to listen to the IBC receiver smart contract on wormchain", "ws://wormchain:26657/websocket", []string{"ws", "wss"})
-	ibcLCD = node.RegisterFlagWithValidationOrFail(NodeCmd, "ibcLCD", "Path to LCD service root for http calls", "http://wormchain:1317", []string{"http", "https"})
-	ibcBlockHeightURL = node.RegisterFlagWithValidationOrFail(NodeCmd, "ibcBlockHeightURL", "Optional URL to query for the block height (generated from ibcWS if not specified)", "http://wormchain:1317", []string{"http", "https"})
+	ibcWS = common.RegisterFlagWithValidationOrFail(NodeCmd, "ibcWS", "Websocket used to listen to the IBC receiver smart contract on wormchain", "ws://wormchain:26657/websocket", []string{"ws", "wss"})
+	ibcLCD = common.RegisterFlagWithValidationOrFail(NodeCmd, "ibcLCD", "Path to LCD service root for http calls", "http://wormchain:1317", []string{"http", "https"})
+	ibcBlockHeightURL = common.RegisterFlagWithValidationOrFail(NodeCmd, "ibcBlockHeightURL", "Optional URL to query for the block height (generated from ibcWS if not specified)", "http://wormchain:1317", []string{"http", "https"})
 	ibcContract = NodeCmd.Flags().String("ibcContract", "", "Address of the IBC smart contract on wormchain")
 
-	accountantWS = node.RegisterFlagWithValidationOrFail(NodeCmd, "accountantWS", "Websocket used to listen to the accountant smart contract on wormchain", "http://wormchain:26657", []string{"http", "https"})
+	accountantWS = common.RegisterFlagWithValidationOrFail(NodeCmd, "accountantWS", "Websocket used to listen to the accountant smart contract on wormchain", "http://wormchain:26657", []string{"http", "https"})
 	accountantContract = NodeCmd.Flags().String("accountantContract", "", "Address of the accountant smart contract on wormchain")
 	accountantKeyPath = NodeCmd.Flags().String("accountantKeyPath", "", "path to accountant private key for signing transactions")
 	accountantKeyPassPhrase = NodeCmd.Flags().String("accountantKeyPassPhrase", "", "pass phrase used to unarmor the accountant key file")
@@ -399,91 +402,91 @@ func init() {
 	accountantNttKeyPath = NodeCmd.Flags().String("accountantNttKeyPath", "", "path to NTT accountant private key for signing transactions")
 	accountantNttKeyPassPhrase = NodeCmd.Flags().String("accountantNttKeyPassPhrase", "", "pass phrase used to unarmor the NTT accountant key file")
 
-	aptosRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "aptosRPC", "Aptos RPC URL", "http://aptos:8080", []string{"http", "https"})
+	aptosRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "aptosRPC", "Aptos RPC URL", "http://aptos:8080", []string{"http", "https"})
 	aptosAccount = NodeCmd.Flags().String("aptosAccount", "", "aptos account")
 	aptosHandle = NodeCmd.Flags().String("aptosHandle", "", "aptos handle")
 
-	movementRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "movementRPC", "Movement RPC URL", "", []string{"http", "https"})
+	movementRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "movementRPC", "Movement RPC URL", "", []string{"http", "https"})
 	movementAccount = NodeCmd.Flags().String("movementAccount", "", "movement account")
 	movementHandle = NodeCmd.Flags().String("movementHandle", "", "movement handle")
 
-	suiRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "suiRPC", "Sui RPC URL", "http://sui:9000", []string{"http", "https"})
+	suiRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "suiRPC", "Sui RPC URL", "http://sui:9000", []string{"http", "https"})
 	suiMoveEventType = NodeCmd.Flags().String("suiMoveEventType", "", "Sui move event type for publish_message")
 
-	solanaRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "solanaRPC", "Solana RPC URL (required)", "http://solana-devnet:8899", []string{"http", "https"})
-	fogoRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "fogoRPC", "Fogo RPC URL (required)", "http://solana-devnet:8899", []string{"http", "https"})
+	solanaRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "solanaRPC", "Solana RPC URL (required)", "http://solana-devnet:8899", []string{"http", "https"})
+	fogoRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "fogoRPC", "Fogo RPC URL (required)", "http://solana-devnet:8899", []string{"http", "https"})
 
 	pythnetContract = NodeCmd.Flags().String("pythnetContract", "", "Address of the PythNet program (required)")
-	pythnetRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "pythnetRPC", "PythNet RPC URL (required)", "http://pythnet.rpcpool.com", []string{"http", "https"})
-	pythnetWS = node.RegisterFlagWithValidationOrFail(NodeCmd, "pythnetWS", "PythNet WS URL", "wss://pythnet.rpcpool.com", []string{"ws", "wss"})
+	pythnetRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "pythnetRPC", "PythNet RPC URL (required)", "http://pythnet.rpcpool.com", []string{"http", "https"})
+	pythnetWS = common.RegisterFlagWithValidationOrFail(NodeCmd, "pythnetWS", "PythNet WS URL", "wss://pythnet.rpcpool.com", []string{"ws", "wss"})
 
-	arbitrumRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "arbitrumRPC", "Arbitrum RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	arbitrumRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "arbitrumRPC", "Arbitrum RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	arbitrumContract = NodeCmd.Flags().String("arbitrumContract", "", "Arbitrum contract address")
 
-	sepoliaRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "sepoliaRPC", "Sepolia RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	sepoliaRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "sepoliaRPC", "Sepolia RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	sepoliaContract = NodeCmd.Flags().String("sepoliaContract", "", "Sepolia contract address")
 
-	holeskyRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "holeskyRPC", "Holesky RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	holeskyRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "holeskyRPC", "Holesky RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	holeskyContract = NodeCmd.Flags().String("holeskyContract", "", "Holesky contract address")
 
-	optimismRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "optimismRPC", "Optimism RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	optimismRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "optimismRPC", "Optimism RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	optimismContract = NodeCmd.Flags().String("optimismContract", "", "Optimism contract address")
 
-	scrollRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "scrollRPC", "Scroll RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	scrollRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "scrollRPC", "Scroll RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	scrollContract = NodeCmd.Flags().String("scrollContract", "", "Scroll contract address")
 
-	mantleRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "mantleRPC", "Mantle RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	mantleRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "mantleRPC", "Mantle RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	mantleContract = NodeCmd.Flags().String("mantleContract", "", "Mantle contract address")
 
-	blastRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "blastRPC", "Blast RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	blastRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "blastRPC", "Blast RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	blastContract = NodeCmd.Flags().String("blastContract", "", "Blast contract address")
 
-	xlayerRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "xlayerRPC", "XLayer RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	xlayerRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "xlayerRPC", "XLayer RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	xlayerContract = NodeCmd.Flags().String("xlayerContract", "", "XLayer contract address")
 
-	lineaRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "lineaRPC", "Linea RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	lineaRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "lineaRPC", "Linea RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	lineaContract = NodeCmd.Flags().String("lineaContract", "", "Linea contract address")
 
-	berachainRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "berachainRPC", "Berachain RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	berachainRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "berachainRPC", "Berachain RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	berachainContract = NodeCmd.Flags().String("berachainContract", "", "Berachain contract address")
 
-	snaxchainRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "snaxchainRPC", "Snaxchain RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	snaxchainRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "snaxchainRPC", "Snaxchain RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	snaxchainContract = NodeCmd.Flags().String("snaxchainContract", "", "Snaxchain contract address")
 
-	unichainRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "unichainRPC", "Unichain RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	unichainRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "unichainRPC", "Unichain RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	unichainContract = NodeCmd.Flags().String("unichainContract", "", "Unichain contract address")
 
-	worldchainRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "worldchainRPC", "Worldchain RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	worldchainRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "worldchainRPC", "Worldchain RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	worldchainContract = NodeCmd.Flags().String("worldchainContract", "", "Worldchain contract address")
 
-	baseRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "baseRPC", "Base RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	baseRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "baseRPC", "Base RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	baseContract = NodeCmd.Flags().String("baseContract", "", "Base contract address")
 
-	inkRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "inkRPC", "Ink RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	inkRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "inkRPC", "Ink RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	inkContract = NodeCmd.Flags().String("inkContract", "", "Ink contract address")
 
-	hyperEvmRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "hyperEvmRPC", "HyperEVM RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	hyperEvmRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "hyperEvmRPC", "HyperEVM RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	hyperEvmContract = NodeCmd.Flags().String("hyperEvmContract", "", "HyperEVM contract address")
 
-	monadRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "monadRPC", "Monad RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	monadRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "monadRPC", "Monad RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	monadContract = NodeCmd.Flags().String("monadContract", "", "Monad contract address")
 
-	seiEvmRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "seiEvmRPC", "SeiEVM RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	seiEvmRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "seiEvmRPC", "SeiEVM RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	seiEvmContract = NodeCmd.Flags().String("seiEvmContract", "", "SeiEVM contract address")
 
-	mezoRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "mezoRPC", "Mezo RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	mezoRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "mezoRPC", "Mezo RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	mezoContract = NodeCmd.Flags().String("mezoContract", "", "Mezo contract address")
 
-	arbitrumSepoliaRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "arbitrumSepoliaRPC", "Arbitrum on Sepolia RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	arbitrumSepoliaRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "arbitrumSepoliaRPC", "Arbitrum on Sepolia RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	arbitrumSepoliaContract = NodeCmd.Flags().String("arbitrumSepoliaContract", "", "Arbitrum on Sepolia contract address")
 
-	baseSepoliaRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "baseSepoliaRPC", "Base on Sepolia RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	baseSepoliaRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "baseSepoliaRPC", "Base on Sepolia RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	baseSepoliaContract = NodeCmd.Flags().String("baseSepoliaContract", "", "Base on Sepolia contract address")
 
-	optimismSepoliaRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "optimismSepoliaRPC", "Optimism on Sepolia RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	optimismSepoliaRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "optimismSepoliaRPC", "Optimism on Sepolia RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	optimismSepoliaContract = NodeCmd.Flags().String("optimismSepoliaContract", "", "Optimism on Sepolia contract address")
 
-	polygonSepoliaRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "polygonSepoliaRPC", "Polygon on Sepolia RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	polygonSepoliaRPC = common.RegisterFlagWithValidationOrFail(NodeCmd, "polygonSepoliaRPC", "Polygon on Sepolia RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	polygonSepoliaContract = NodeCmd.Flags().String("polygonSepoliaContract", "", "Polygon on Sepolia contract address")
 
 	logLevel = NodeCmd.Flags().String("logLevel", "info", "Logging level (debug, info, warn, error, dpanic, panic, fatal)")
@@ -1901,6 +1904,11 @@ func runNode(cmd *cobra.Command, args []string) {
 		guardianSigner,
 	)
 
+	var guardianAddrAsBytes []byte
+	if len(*additionalPublishers) > 0 {
+		guardianAddrAsBytes = crypto.PubkeyToAddress(guardianSigner.PublicKey(rootCtx)).Bytes()
+	}
+
 	guardianOptions := []*node.GuardianOption{
 		node.GuardianOptionDatabase(db),
 		node.GuardianOptionWatchers(watcherConfigs, ibcWatcherConfig),
@@ -1912,6 +1920,7 @@ func runNode(cmd *cobra.Command, args []string) {
 		node.GuardianOptionP2P(p2pKey, *p2pNetworkID, *p2pBootstrap, *nodeName, *subscribeToVAAs, *disableHeartbeatVerify, *p2pPort, *ccqP2pBootstrap, *ccqP2pPort, *ccqAllowedPeers,
 			*gossipAdvertiseAddress, ibc.GetFeatures, protectedPeers, ccqProtectedPeers, featureFlags),
 		node.GuardianOptionStatusServer(*statusAddr),
+		node.GuardianOptionAlternatePublisher(guardianAddrAsBytes, *additionalPublishers),
 		node.GuardianOptionProcessor(*p2pNetworkID),
 	}
 

--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -17,7 +17,6 @@ import (
 	"github.com/certusone/wormhole/node/pkg/guardiansigner"
 	"github.com/certusone/wormhole/node/pkg/watchers"
 	"github.com/certusone/wormhole/node/pkg/watchers/ibc"
-	"github.com/ethereum/go-ethereum/crypto"
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 
 	"github.com/certusone/wormhole/node/pkg/watchers/cosmwasm"
@@ -305,7 +304,7 @@ func init() {
 	p2pPort = NodeCmd.Flags().Uint("port", p2p.DefaultPort, "P2P UDP listener port")
 	p2pBootstrap = NodeCmd.Flags().String("bootstrap", "", "P2P bootstrap peers (optional for mainnet or testnet, overrides default, required for unsafeDevMode)")
 	NodeCmd.Flags().StringSliceVarP(&protectedPeers, "protectedPeers", "", []string{}, "")
-	additionalPublishers = NodeCmd.Flags().StringArray("additionalPublishEndpoint", []string{}, "defines an alternate publisher as label:url:delay:chains where delay and chains are optional")
+	additionalPublishers = NodeCmd.Flags().StringArray("additionalPublishEndpoint", []string{}, "defines an alternate publisher as label;url;delay;chains where delay and chains are optional")
 
 	statusAddr = NodeCmd.Flags().String("statusAddr", "[::]:6060", "Listen address for status server (disabled if blank)")
 
@@ -1906,7 +1905,7 @@ func runNode(cmd *cobra.Command, args []string) {
 
 	var guardianAddrAsBytes []byte
 	if len(*additionalPublishers) > 0 {
-		guardianAddrAsBytes = crypto.PubkeyToAddress(guardianSigner.PublicKey(rootCtx)).Bytes()
+		guardianAddrAsBytes = ethcrypto.PubkeyToAddress(guardianSigner.PublicKey(rootCtx)).Bytes()
 	}
 
 	guardianOptions := []*node.GuardianOption{

--- a/node/pkg/altpub/README.md
+++ b/node/pkg/altpub/README.md
@@ -35,7 +35,10 @@ The fields are defined as follows:
 - **delay**, if specified (or non-zero) is the time the guardian should delay in order to batch observations. Zero / not set means publish immediately.
 - **chains**, if specified, is a comma-separated list of emitter chain IDs or names for which observations should be forwarded. If not set, all chains will be published.
 
-The **label** and **url** fields are required, but the **delay** and **chains** are optional. If **chains** is specified, **delay** is required and you may use a value of "0" to publish immediately.
+The **label** and **url** fields are required, but the **delay** and **chains** are optional.
+
+If **chains** is specified, **delay** is required but you may leave it blank or specify "0" to publish immediately. It is valid to specify the **delay** without the **chains**,
+meaning there are only three fields (without a final semicolon).
 
 The **delay** is specified as a `time.Duration`. Please see [here](https://pkg.go.dev/time#ParseDuration) for a description of how to specify it.
 

--- a/node/pkg/altpub/README.md
+++ b/node/pkg/altpub/README.md
@@ -34,6 +34,7 @@ The fields are defined as follows:
 - **url** is the http server endpoint to which the guardian should connect and publish.
 - **delay**, if specified (or non-zero) is the time the guardian should delay in order to batch observations. Zero / not set means publish immediately.
 - **chains**, if specified, is a comma-separated list of emitter chain IDs or names for which observations should be forwarded. If not set, all chains will be published.
+  For supported values, please see the definition of `ChainID` [here](../../../sdk/vaa/structs.go).
 
 The **label** and **url** fields are required, but the **delay** and **chains** are optional.
 

--- a/node/pkg/altpub/README.md
+++ b/node/pkg/altpub/README.md
@@ -1,0 +1,110 @@
+# Alternate Publisher
+
+## Introduction
+
+The Alternate Publisher provides a mechanism to publish observations (and potentially signed VAAs) to one or more HTTP endpoints
+as a backup to the P2P gossip network. The guardian can be configured to publish to one or more endpoints, or none (disabling the feature).
+Note that this is in addition to publishing to gossip. This feature does not impact gossip traffic.
+
+For each endpoint, a list of chains may be specified, meaning only events for those chains are published to that endpoint (default is all chains).
+
+Additionally, for each endpoint, a publish delay may be specified. If a delay is specified (the default is immediate), then observations
+will be batched for that long before publishing. This should allow for reduced HTTP traffic.
+
+A couple of possible use cases for this feature might be Pyth and Wormholescan.
+
+- Pyth would probably want to only receive observations from PythNet and without any delay.
+- Wormholescan would probably want to receive observations for all chains and wouldn't mind some delay to allow for batching.
+
+## Configuration
+
+The Alternate Publisher can be enabled by specifying one or more `--additionalPublishEndpoint` parameters in the guardiand config. Each instance of the parameter represents a single publishing endpoint and is defined as follows:
+
+<!-- cspell:disable -->
+
+```bash
+--additionalPublishEndpoint label;url;delay;chains
+```
+
+<!-- cspell:enable -->
+
+The fields are defined as follows:
+
+- **label** is a string that is used to tag this endpoint in log messages and Prometheus metrics.
+- **url** is the http server endpoint to which the guardian should connect and publish.
+- **delay**, if specified (or non-zero) is the time the guardian should delay in order to batch observations. Zero / not set means publish immediately.
+- **chains**, if specified, is a comma-separated list of emitter chain IDs or names for which observations should be forwarded. If not set, all chains will be published.
+
+The **label** and **url** fields are required, but the **delay** and **chains** are optional. If **chains** is specified, **delay** is required and you may use a value of "0" to publish immediately.
+
+The **delay** is specified as a `time.Duration`. Please see [here](https://pkg.go.dev/time#ParseDuration) for a description of how to specify it.
+
+Note that if the **chains** parameter begins with a dash (minus sign), then it means "publish everything **except** these chains.
+
+### Configuration Example
+
+For the Pyth and Wormholescan examples, the configuration might look like this.
+
+<!-- cspell:disable -->
+
+```bash
+--additionalPublishEndpoint "pyth;http:pyth_endpoint_url;0;pythnet"
+--additionalPublishEndpoint "wormholescan;http:wormholescan_endpoint;1s"
+```
+
+<!-- cspell:enable -->
+
+This means we will immediately publish events for ChainIDPythNet to the Pyth endpoint, and we will publish all events to the Wormholescan
+endpoint with a one second delay to allow for batching.
+
+## Implementation
+
+The Alternate Publisher uses an `http.Client` and HTTP POST to publish requests. It creates a pool of workers to allow for multiple parallel requests.
+This means that observations may be received at an endpoint in a different order than they are published by a guardian. This should be acceptable.
+
+If an endpoint is configured with a delay, it creates a worker routine to manage the batching before publishing requests to the worker pool.
+
+For immediate publishing, it formats the request and writes it to the worker pool channel immediately.
+
+### Object Layout
+
+If alternate publishing is enabled, there will be a single `AlternatePublisher` object. It contains a list of `Endpoint` objects where each one represents a configured / enabled endpoint. A pointer to the `AlternatePublisher` (or nil) is passed into the processor, which will call into it to publish observations.
+
+The `AlternatePublisher` object has a single `http.Client` and a pool of `httpWorker` routines fed by a single `httpWorkerChan` channel. The payload of that channel is an HTTP request. The workers pick requests off of the channel and post them in a blocking manner. They update metrics based on the result.
+
+The `AlternatePublisher.PublishObservation` function loops through the endpoints. For each endpoint, it calls `shouldPublish` to see if the observation should be published based on the emitter chain ID. If the observation should be published, and the endpoint is not configured for batching, the HTTP request is formatted and posted to the `httpWorkerChan` for immediate publishing. Otherwise, the observation is posted to the `obsvBatchChan` channel on the endpoint for batching.
+
+The `Endpoint` object contains the URL of the endpoint, the delay value, and a map of enabled chains. If the map is empty, then observations for all chains are published. Otherwise, the emitter chain ID must be in the map for the observation to be published. If the delay is zero, then observations are published immediately.
+
+If the endpoint delay is non-zero, the `Endpoint` object has a `batchWorker` with a `obsvBatchChan` channel used to post to it. The `batchWorker` delays publishing to the `httpWorkerChan` to allow for batching. It uses the existing `common.ReadFromChannelWithTimeout` function to perform batching.
+
+## Endpoint Interface
+
+Messages are published using HTTP POST operations where the body is a protobuf encoded message. The posts have the `"Content-Type", "application/octet-stream"` header.
+
+Currently the only messages being published on this interface are signed observations. They are published to `/SignedObservationBatch` where the body is a `gossipv1.SignedObservationBatch` message. This message can contain _up to_ `MaxObservationBatchSize` (4000) observations, although will most likely be much less than that.
+
+## Testing
+
+### Unit Tests
+
+There are a variety of unit tests in `alternate_pub_test.go` which test individual functions.
+
+### End to End Test
+
+In addition to the unit tests, the test in `end2end_test.go` does a full end-to-end test of the pyth and wormholescan scenarios. It instantiates an `AlternatePublisher`
+with two endpoints simulated by local HTTP server objects. It then publishes a bunch of observations and verifies that the endpoints received the correct results.
+
+## Possible Future Enhancement
+
+It may be desirable to also publish signed VAAs. To do that, we would add an `AlternatePublisher.PostSignedVAA` function and publish to `/SignedVAAWithQuorum`.
+The payload could be a protobuf encoded `gossipv1.SignedVAAWithQuorum`.
+
+We would need to decide if it makes sense to batch signed VAAs. If not, we could just format the HTTP request and post it to the `httpWorkerChan` like the immediate
+observation case. If we do want to allow batching of signed VAAs, we could add a parallel channel and batch worker for it.
+
+If we add support for signed VAAs, we may want to update the config parameter to allow publishing only some event types (observations vs. VAAs vs. both).
+
+## TODO
+
+Please see the prologue of [alternate_pub.go](alternate_pub.go) for the current list of outstanding issues.

--- a/node/pkg/altpub/alternate_pub.go
+++ b/node/pkg/altpub/alternate_pub.go
@@ -1,0 +1,534 @@
+package altpub
+
+// Please see `node/pkg/altpub/README.md` for an overview of this feature.
+
+// TODO: Think about transport tuning parameters.
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+	"net/http"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/certusone/wormhole/node/pkg/common"
+	"github.com/certusone/wormhole/node/pkg/p2p"
+	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
+	ethCommon "github.com/ethereum/go-ethereum/common"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/wormhole-foundation/wormhole/sdk/vaa"
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/proto"
+)
+
+const (
+	// PubChanSize is the size of the channel used to communicate with the pool of HTTP workers.
+	PubChanSize = 1000
+
+	// ObservationChanSize is the size of the channel used to post observations to the batching worker for a given endpoint.
+	ObservationChanSize = 1000
+
+	// NumWorkersPerEndpoint is how many HTTP workers will be created per endpoint (so we create NumWorkersPerEndpoint * len(endpoints)).
+	NumWorkersPerEndpoint = 10
+
+	// These are used to create the http.Transport used by the http.Client. See https://www.loginradius.com/blog/engineering/tune-the-go-http-client-for-high-performance/ for tuning details.
+	// TODO: What values make sense here? Maybe use NumWorkersPerEndpoint for last two and NumWorkersPerEndpoint * len(endpoints) for first one?
+	MaxIdleConns        = 100
+	MaxConnsPerHost     = 100
+	MaxIdleConnsPerHost = 100
+
+	// HttpClientTimeout is the timeout used on the HTTP client connection.
+	HttpClientTimeout = 10 * time.Second
+)
+
+type (
+	// AlternatePublisher is used to manage alternate publishing. There is a single instance for a guardian if alternate publishing is enabled.
+	AlternatePublisher struct {
+		// logger uses the "altpub" component to identify our log messages.
+		logger *zap.Logger
+
+		// guardianAddr is used in gossipv1.SignedObservationBatch.
+		guardianAddr []byte
+
+		// endpoints is the list of enabled endpoints. Must not be empty.
+		endpoints Endpoints
+
+		// httpWorkerChan is the channel used to post requests to the HTTP worker pool.
+		httpWorkerChan chan *HttpRequest
+	}
+
+	// Endpoint defines a single endpoint to which we should publish.
+	Endpoint struct {
+		// label is used to identify the endpoint in the logs and Prometheus metrics.
+		label string
+
+		// baseUrl is the URL string before adding the topic.
+		baseUrl string
+
+		// delay is how long to delay for batching, zero for publish immediately.
+		delay Delay
+
+		// enabledChains is the set of chains for which we should publish events on this endpoint, empty means all.
+		enabledChains EnabledChains
+
+		// obsvBatchChan is used to post individual observations to the batch worker.
+		obsvBatchChan chan *gossipv1.Observation
+
+		// signedObservationUrl is an optimization so we don't have to format the URL on each post.
+		signedObservationUrl string
+	}
+
+	// Endpoints defines the list of enabled endpoints.
+	Endpoints []*Endpoint
+
+	// Delay extends time.Duration to allow us to override `String`.
+	Delay time.Duration
+
+	// EnabledChains tracks the chains for which publishing is enabled.
+	// - If the map is empty, all chains are enabled.
+	// - If `exceptFor` is false, then the chains in the map are enabled.
+	// - If `exceptFor is true, then all but the chains in the map are enabled.
+	EnabledChains struct {
+		exceptFor bool
+		chains    map[vaa.ChainID]struct{}
+	}
+
+	// HttpRequest is the object sent to the worker for publishing.
+	HttpRequest struct {
+		// start is used for computing wormhole_alt_pub_channel_delay_in_us.
+		start time.Time
+
+		// ep is the endpoint this request is for (used for logging and metrics)
+		ep *Endpoint
+
+		// url is the URL used in the POST request.
+		url string
+
+		// Data is the body of the POST request.
+		data []byte
+	}
+
+	// HttpWorker is the data passed to an individual HTTP worker on startup.
+	HttpWorker struct {
+		// ap provides access to the application publisher in the worker.
+		ap *AlternatePublisher
+
+		// client is the global HTTP client used by the application publisher.
+		client *http.Client
+
+		// workerId is used for logging.
+		workerId int
+	}
+
+	// BatchWorker is the data passed to the batch worker for an endpoint that is doing batching (delay not zero).
+	BatchWorker struct {
+		// ap provides access to the application publisher in the worker.
+		ap *AlternatePublisher
+
+		// ep provides access to the endpoint in the worker.
+		ep *Endpoint
+	}
+)
+
+// All of the Prometheus metrics are indexed by the endpoint label.
+var (
+	obsvDropped = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "wormhole_alt_pub_requests_dropped",
+			Help: "Total number of alternate publication requests dropped due to channel overflow",
+		}, []string{"endpoint"})
+
+	requestSuccess = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "wormhole_alt_pub_requests_success",
+			Help: "Total number of alternate publication requests that succeeded",
+		}, []string{"endpoint"})
+
+	requestFailed = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "wormhole_alt_pub_requests_failed",
+			Help: "Total number of alternate publication requests that failed by failure reason",
+		}, []string{"endpoint", "reason"})
+
+	channelDelay = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "wormhole_alt_pub_channel_delay_in_us",
+			Help:    "Latency histogram for the time it took the request to reach the publisher in microseconds",
+			Buckets: []float64{10.0, 100.0, 500.0, 1000.0, 2000.0, 5000.0, 10000.0, 100000.0},
+		}, []string{"endpoint"})
+
+	postTime = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "wormhole_alt_pub_post_time_in_ms",
+			Help:    "Latency histogram for the time it took to post a request in milliseconds",
+			Buckets: []float64{10.0, 100.0, 500.0, 1000.0, 2000.0, 5000.0, 10000.0, 100000.0},
+		}, []string{"endpoint"})
+)
+
+// String implementation of our duration.
+func (d Delay) String() string {
+	if d == 0 {
+		return "immediate"
+	}
+
+	return time.Duration(d).String()
+}
+
+// String implementation of our enabled chains map. It prints the enabled chains in chainID order.
+func (e EnabledChains) String() string {
+	if len(e.chains) == 0 {
+		return "all-chains"
+	}
+
+	str := ""
+	chainIds := slices.Sorted(maps.Keys(e.chains))
+	for _, chainId := range chainIds {
+		if str != "" {
+			str += ","
+		}
+		str += chainId.String()
+	}
+	if e.exceptFor {
+		return "all-except:" + str
+	}
+	return str
+}
+
+// shouldPublish checks to see if the chain passed in is in is enabled.
+func (e EnabledChains) shouldPublish(chainId vaa.ChainID) bool {
+	if len(e.chains) == 0 {
+		return true
+	}
+
+	_, exists := e.chains[chainId]
+	if e.exceptFor {
+		return !exists
+	}
+	return exists
+}
+
+// NewAlternatePublisher creates an alternate publisher object, validating the endpoint parameters. Returns nil,nil if the feature is not enabled.
+func NewAlternatePublisher(logger *zap.Logger, guardianAddr []byte, configs []string) (*AlternatePublisher, error) {
+	if len(configs) == 0 {
+		return nil, nil
+	}
+
+	if len(guardianAddr) != ethCommon.AddressLength {
+		return nil, fmt.Errorf("unexpected guardian key length, should be %d, is %d", ethCommon.AddressLength, len(guardianAddr))
+	}
+
+	// Validate the endpoint parameters and create endpoint objects.
+	endpoints := make([]*Endpoint, len(configs))
+	labels := map[string]struct{}{}
+	for idx, config := range configs {
+		ep, err := parseEndpoint(config)
+		if err != nil {
+			return nil, err
+		}
+
+		if _, exists := labels[ep.label]; exists {
+			return nil, fmt.Errorf("duplicate label in --additionalPublishEndpoint '%s'", config)
+		}
+
+		labels[ep.label] = struct{}{}
+		endpoints[idx] = ep
+	}
+
+	if len(endpoints) == 0 {
+		// Not sure this can happen, but let's be safe!
+		return nil, errors.New("there are no enabled endpoints")
+	}
+
+	return &AlternatePublisher{
+		logger:         logger.With(zap.String("component", "altpub")),
+		guardianAddr:   guardianAddr,
+		endpoints:      endpoints,
+		httpWorkerChan: make(chan *HttpRequest, PubChanSize),
+	}, nil
+}
+
+// parseEndpoint parses an `--additionalPublishEndpoint` parameter into an Endpoint object. It returns an error if the string is invalid.
+func parseEndpoint(config string) (*Endpoint, error) {
+	fields := strings.Split(config, ";")
+	if len(fields) < 2 {
+		return nil, fmt.Errorf("not enough fields in --additionalPublishEndpoint '%s': should be at least 2, there are %d", config, len(fields))
+	}
+
+	if len(fields) > 4 {
+		return nil, fmt.Errorf("too many fields in --additionalPublishEndpoint '%s': may not be more than 4, there are %d", config, len(fields))
+	}
+
+	label := fields[0]
+	if len(label) == 0 {
+		return nil, fmt.Errorf("invalid label in --additionalPublishEndpoint '%s': may not be zero length", config)
+	}
+
+	baseUrl := fields[1]
+	if valid := common.ValidateURL(baseUrl, []string{"http", "https"}); !valid {
+		return nil, fmt.Errorf("invalid url in --additionalPublishEndpoint '%s': must be `http` or `https`", config)
+	}
+
+	delay := time.Duration(0)
+	if len(fields) > 2 {
+		var err error
+		delay, err = time.ParseDuration(fields[2])
+		if err != nil {
+			return nil, fmt.Errorf("invalid delay duration in --additionalPublishEndpoint '%s', delay %s: %w", config, fields[2], err)
+		}
+	}
+
+	enabledChainsMap := make(map[vaa.ChainID]struct{})
+	exceptFor := false
+	if len(fields) > 3 {
+		str := fields[3]
+		if strings.HasPrefix(str, "-") {
+			exceptFor = true
+			str = str[1:]
+		}
+		chainIds := strings.Split(str, ",")
+		for _, str := range chainIds {
+			chainId, err := vaa.StringToKnownChainID(str)
+			if err != nil {
+				return nil, fmt.Errorf("invalid chain ID --additionalPublishEndpoint '%s' ('%s'): %w", config, str, err)
+			}
+
+			enabledChainsMap[chainId] = struct{}{}
+		}
+	}
+
+	enabledChains := EnabledChains{exceptFor, enabledChainsMap}
+
+	// Only create an observation batch channel if batching is enabled.
+	var obsvBatchChan chan *gossipv1.Observation
+	if delay != 0 {
+		obsvBatchChan = make(chan *gossipv1.Observation, ObservationChanSize)
+	}
+
+	ep := &Endpoint{
+		label:         label,
+		baseUrl:       baseUrl,
+		delay:         Delay(delay),
+		enabledChains: enabledChains,
+		obsvBatchChan: obsvBatchChan,
+	}
+
+	// Format our topic URLs and add the endpoint to the list.
+	ep.createUrls()
+	return ep, nil
+}
+
+// Run is the runnable for the alternate publisher. It creates the various workers and then waits for shutdown.
+func (ap *AlternatePublisher) Run(ctx context.Context) error {
+	errC := make(chan error)
+
+	ap.logger.Info("Starting alternate publisher", zap.Int("numEndpoints", len(ap.endpoints)))
+
+	client, err := ap.createClient()
+	if err != nil {
+		return fmt.Errorf("failed to create http client: %w", err)
+	}
+
+	ap.startHttpWorkers(ctx, client, errC, NumWorkersPerEndpoint*len(ap.endpoints))
+
+	for _, ep := range ap.endpoints {
+		ap.logger.Info("Enabling endpoint", zap.String("endpoint", ep.label), zap.String("url", ep.baseUrl), zap.Stringer("delay", ep.delay), zap.Stringer("enabledChains", ep.enabledChains))
+		if ep.delay != 0 {
+			worker := &BatchWorker{ap, ep}
+			common.RunWithScissors(ctx, errC, fmt.Sprintf("alt_pub_batcher_%s", ep.label), worker.batchWorker)
+		}
+	}
+
+	// Wait until shutdown or an error occurs.
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case err := <-errC:
+		return err
+	}
+}
+
+// PublishObservation publishes a signed observation to all the endpoints that care about it. It handles both immediate and delayed publishers.
+func (ap *AlternatePublisher) PublishObservation(emitterChain vaa.ChainID, obs *gossipv1.Observation) {
+	var data []byte
+	for _, ep := range ap.endpoints {
+		if ep.shouldPublish(emitterChain) {
+			if ep.delay == 0 {
+				// We are publishing immediately, build the HTTP request and post it directly to the HTTP worker pool.
+				if data == nil {
+					batch := gossipv1.SignedObservationBatch{
+						Addr:         ap.guardianAddr,
+						Observations: []*gossipv1.Observation{obs},
+					}
+
+					var err error
+					data, err = proto.Marshal((&batch))
+					if err != nil {
+						panic("failed to marshal batch")
+					}
+				}
+
+				req := &HttpRequest{start: time.Now(), ep: ep, url: ep.signedObservationUrl, data: data}
+				select {
+				case ap.httpWorkerChan <- req:
+				default:
+					obsvDropped.WithLabelValues(ep.label).Inc()
+				}
+			} else {
+				// We are batching, post it to the endpoint batching worker.
+				select {
+				case ep.obsvBatchChan <- obs:
+				default:
+					obsvDropped.WithLabelValues(ep.label).Inc()
+				}
+			}
+		}
+	}
+}
+
+// createClient creates the HTTP client using a custom configured transport.
+func (ap *AlternatePublisher) createClient() (*http.Client, error) {
+	defTrans, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return nil, errors.New("failed to cast default transport for alternate publisher")
+	}
+
+	t := defTrans.Clone()
+	t.MaxIdleConns = MaxIdleConns
+	t.MaxConnsPerHost = MaxConnsPerHost
+	t.MaxIdleConnsPerHost = MaxIdleConnsPerHost
+
+	return &http.Client{
+		Timeout:   HttpClientTimeout,
+		Transport: t,
+	}, nil
+}
+
+// startHttpWorkers starts all of the workers in the HTTP worker pool.
+func (ap *AlternatePublisher) startHttpWorkers(ctx context.Context, client *http.Client, errC chan error, numWorkers int) {
+	for count := range numWorkers {
+		worker := &HttpWorker{ap, client, count}
+		common.RunWithScissors(ctx, errC, "alt_pub_worker", worker.httpWorker)
+	}
+}
+
+// httpWorker is the entrypoint for an HTTP worker. Each httpWorker is responsible for posting an HTTP request and waiting for the response.
+func (w *HttpWorker) httpWorker(ctx context.Context) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case req := <-w.ap.httpWorkerChan:
+			w.ap.httpPost(ctx, w.client, req)
+		}
+	}
+}
+
+// httpPost actually posts an HTTP request and waits for the response. It pegs metrics based on the results.
+func (ap *AlternatePublisher) httpPost(ctx context.Context, client *http.Client, req *HttpRequest) {
+	channelDelay.WithLabelValues(req.ep.label).Observe(float64(time.Since(req.start).Microseconds()))
+
+	// Create the HTTP POST request using our context so it can be interrupted.
+	// Note that we are not using a timeout context because the HTTP client already has a timeout.
+	// Note that we make a copy of the payload because `bytes.NewBuffer` takes ownership of the data, and the same data might be in multiple requests.
+	r, err := http.NewRequestWithContext(ctx, "POST", req.url, bytes.NewBuffer(bytes.Clone(req.data)))
+	if err != nil {
+		ap.logger.Error("Failed to create post request", zap.Error(err))
+		requestFailed.WithLabelValues(req.ep.label, "create_failed").Inc()
+		return
+	}
+	r.Header.Add("Content-Type", "application/octet-stream")
+
+	start := time.Now()
+	resp, err := client.Do(r)
+	if err != nil {
+		ap.logger.Error("Failed to post request", zap.Error(err))
+		if strings.Contains(err.Error(), "connection refused") {
+			requestFailed.WithLabelValues(req.ep.label, "connection_refused").Inc()
+		} else {
+			requestFailed.WithLabelValues(req.ep.label, "post_failed").Inc()
+		}
+		return
+	}
+	stop := time.Now()
+	resp.Body.Close()
+
+	// Peg the appropriate metric, based on the request result.
+	if resp.StatusCode < 300 {
+		requestSuccess.WithLabelValues(req.ep.label).Inc()
+		postTime.WithLabelValues(req.ep.label).Observe(float64(stop.Sub(start).Milliseconds()))
+	} else {
+		reason := http.StatusText(resp.StatusCode)
+		if reason == "" {
+			reason = fmt.Sprintf("status_code_%d", resp.StatusCode)
+		}
+		requestFailed.WithLabelValues(req.ep.label, reason).Inc()
+		ap.logger.Error("Failed to post request", zap.String("endpoint", req.ep.label), zap.Int("statusCode", resp.StatusCode), zap.String("statusText", reason))
+	}
+}
+
+// createUrls is a helper for the endpoint that formats the URLs for each request type.
+// NOTE: Initially there is only one request type, but that may change later.
+func (ep *Endpoint) createUrls() {
+	ep.signedObservationUrl = ep.baseUrl + "/SignedObservationBatch"
+}
+
+// shouldPublish is a helper for the endpoint that checks to see if the chain passed in is in the set of chains enabled for the endpoint.
+func (ep *Endpoint) shouldPublish(chainId vaa.ChainID) bool {
+	return ep.enabledChains.shouldPublish(chainId)
+}
+
+// batchWorker is the entrypoint for a per-endpoint worker that batches observations based on the batching interval.
+// This is only created if batching is enabled for the endpoint.
+func (w *BatchWorker) batchWorker(ctx context.Context) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+			if err := w.handleBatch(ctx); err != nil {
+				if errors.Is(err, context.Canceled) {
+					return nil
+				}
+
+				return fmt.Errorf("handleBatch failed: %w", err)
+			}
+		}
+	}
+}
+
+// handleBatch waits up to the delay interval to batch requests. It then formats a request and posts it to the httpWorkerChan.
+func (w *BatchWorker) handleBatch(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, time.Duration(w.ep.delay))
+	defer cancel()
+
+	observations, err := common.ReadFromChannelWithTimeout(ctx, w.ep.obsvBatchChan, p2p.MaxObservationBatchSize)
+	if err != nil && !errors.Is(err, context.DeadlineExceeded) {
+		return fmt.Errorf("failed to read observations from the internal observation batch channel: %w", err)
+	}
+
+	if len(observations) != 0 {
+		batch := gossipv1.SignedObservationBatch{
+			Addr:         w.ap.guardianAddr,
+			Observations: observations,
+		}
+
+		data, err := proto.Marshal((&batch))
+		if err != nil {
+			panic("failed to marshal batch")
+		}
+
+		req := &HttpRequest{start: time.Now(), ep: w.ep, url: w.ep.signedObservationUrl, data: data}
+		select {
+		case w.ap.httpWorkerChan <- req:
+		default:
+			obsvDropped.WithLabelValues(w.ep.label).Add(float64(len(observations)))
+		}
+	}
+
+	return nil
+}

--- a/node/pkg/altpub/alternate_pub_test.go
+++ b/node/pkg/altpub/alternate_pub_test.go
@@ -81,7 +81,8 @@ func TestParseEndpoint(t *testing.T) {
 		{label: "With_delay_and_one_chain_name", input: "test;http://localhost:3333;200us;solana", delayUs: 200, chains: []vaa.ChainID{vaa.ChainIDSolana}},
 		{label: "With_delay_and_two_chain_numbers", input: "test;http://localhost:3333;500ms;1,2", delayUs: 500000, chains: []vaa.ChainID{vaa.ChainIDSolana, vaa.ChainIDEthereum}},
 		{label: "With_delay_and_chain_number_and_name", input: "test;http://localhost:3333;500ms;1,ethereum", delayUs: 500000, chains: []vaa.ChainID{vaa.ChainIDSolana, vaa.ChainIDEthereum}},
-		{label: "With_no_delay_and_one_chain", input: "test;http://localhost:3333;0;1", chains: []vaa.ChainID{vaa.ChainIDSolana}},
+		{label: "With_zero_delay_and_one_chain", input: "test;http://localhost:3333;0;1", chains: []vaa.ChainID{vaa.ChainIDSolana}},
+		{label: "With_no_delay_and_one_chain", input: "test;http://localhost:3333;;1", chains: []vaa.ChainID{vaa.ChainIDSolana}},
 		{label: "With_no_delay_and_except_one_chain", input: "test;http://localhost:3333;0;-pythnet", chains: []vaa.ChainID{vaa.ChainIDPythNet}, exceptFor: true},
 		{label: "With_no_delay_and_except_two_chains", input: "test;http://localhost:3333;0;-pythnet,1", chains: []vaa.ChainID{vaa.ChainIDSolana, vaa.ChainIDPythNet}, exceptFor: true},
 

--- a/node/pkg/altpub/alternate_pub_test.go
+++ b/node/pkg/altpub/alternate_pub_test.go
@@ -1,0 +1,279 @@
+package altpub
+
+import (
+	"encoding/hex"
+	"fmt"
+	"maps"
+	"slices"
+	"testing"
+	"time"
+
+	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
+	ethCommon "github.com/ethereum/go-ethereum/common"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wormhole-foundation/wormhole/sdk/vaa"
+	"go.uber.org/zap"
+)
+
+func TestDelayString(t *testing.T) {
+	type test struct {
+		inputUs int64
+		output  string
+	}
+	tests := []test{
+		{inputUs: 0, output: "immediate"},
+		{inputUs: 250, output: "250µs"},
+		{inputUs: 42000, output: "42ms"},
+		{inputUs: 7000000, output: "7s"},
+	}
+
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("%d", tc.inputUs), func(t *testing.T) {
+			delay := time.Microsecond * time.Duration(tc.inputUs)
+			require.Equal(t, tc.output, Delay(delay).String())
+		})
+	}
+}
+
+func TestEnabledChainsString(t *testing.T) {
+	// NOTE: The output will be sorted in chainID order.
+	type test struct {
+		input     []vaa.ChainID
+		exceptFor bool
+		output    string
+	}
+	tests := []test{
+		{input: []vaa.ChainID{}, output: "all-chains"},
+		{input: []vaa.ChainID{vaa.ChainIDPythNet}, output: "pythnet"},
+		{input: []vaa.ChainID{vaa.ChainIDEthereum, vaa.ChainIDSolana}, output: "solana,ethereum"},
+		{input: []vaa.ChainID{vaa.ChainIDPythNet}, exceptFor: true, output: "all-except:pythnet"},
+		{input: []vaa.ChainID{vaa.ChainIDEthereum, vaa.ChainIDSolana}, exceptFor: true, output: "all-except:solana,ethereum"},
+	}
+
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("%d", tc.input), func(t *testing.T) {
+			enabledChainsMap := make(map[vaa.ChainID]struct{})
+			for _, chainID := range tc.input {
+				enabledChainsMap[chainID] = struct{}{}
+			}
+			require.Equal(t, tc.output, EnabledChains{tc.exceptFor, enabledChainsMap}.String())
+		})
+	}
+}
+
+func TestParseEndpoint(t *testing.T) {
+	type test struct {
+		input     string
+		errText   string
+		delayUs   int64
+		chains    []vaa.ChainID
+		exceptFor bool
+		label     string
+	}
+	tests := []test{
+		// Success cases
+		{label: "Minimum_config", input: "test;http://localhost:3333"},
+		{label: "With_delay_no_chains", input: "test;http://localhost:3333;1s", delayUs: 1000000},
+		{label: "With_delay_and_one_chain_number", input: "test;http://localhost:3333;200us;1", delayUs: 200, chains: []vaa.ChainID{vaa.ChainIDSolana}},
+		{label: "With_delay_and_one_chain_name", input: "test;http://localhost:3333;200us;solana", delayUs: 200, chains: []vaa.ChainID{vaa.ChainIDSolana}},
+		{label: "With_delay_and_two_chain_numbers", input: "test;http://localhost:3333;500ms;1,2", delayUs: 500000, chains: []vaa.ChainID{vaa.ChainIDSolana, vaa.ChainIDEthereum}},
+		{label: "With_delay_and_chain_number_and_name", input: "test;http://localhost:3333;500ms;1,ethereum", delayUs: 500000, chains: []vaa.ChainID{vaa.ChainIDSolana, vaa.ChainIDEthereum}},
+		{label: "With_no_delay_and_one_chain", input: "test;http://localhost:3333;0;1", chains: []vaa.ChainID{vaa.ChainIDSolana}},
+		{label: "With_no_delay_and_except_one_chain", input: "test;http://localhost:3333;0;-pythnet", chains: []vaa.ChainID{vaa.ChainIDPythNet}, exceptFor: true},
+		{label: "With_no_delay_and_except_two_chains", input: "test;http://localhost:3333;0;-pythnet,1", chains: []vaa.ChainID{vaa.ChainIDSolana, vaa.ChainIDPythNet}, exceptFor: true},
+
+		// Error cases
+		{label: "Empty", input: "", errText: "not enough fields"},
+		{label: "Only_label", input: "test", errText: "not enough fields"},
+		{label: "Too_many_fields", input: "1;2;3;4;5", errText: "too many fields"},
+		{label: "Empty_label", input: ";http://localhost:3333", errText: "invalid label"},
+		{label: "Bad_url", input: "test;ws://localhost:3333", errText: "invalid url"},
+		{label: "Bad_delay", input: "test;https://localhost:3333;Hi_Mom", errText: "invalid delay duration"},
+		{label: "Empty_chains", input: "test;https://localhost:3333;1h;", errText: "invalid chain ID"},
+		{label: "Empty_except_chains", input: "test;https://localhost:3333;1h;-", errText: "invalid chain ID"},
+		{label: "Invalid_chains", input: "test;https://localhost:3333;1h;Hi_Mom", errText: "invalid chain ID"},
+		{label: "Invalid_chain_in_list", input: "test;https://localhost:3333;1h;1,Hi_Mom,3", errText: "invalid chain ID"},
+		{label: "Too_big_chain_ID_in_list", input: "test;https://localhost:3333;1h;1,1000000,3", errText: "invalid chain ID"},
+		{label: "Invalid_chain_ID_in_list", input: "test;https://localhost:3333;1h;1,65535,3", errText: "invalid chain ID"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.label, func(t *testing.T) {
+			ep, err := parseEndpoint(tc.input)
+			if tc.errText == "" {
+				require.NoError(t, err)
+
+				// Verify the delay.
+				if tc.delayUs == 0 {
+					require.Equal(t, Delay(0), ep.delay)
+					require.Nil(t, ep.obsvBatchChan)
+				} else {
+					require.NoError(t, err)
+					require.Equal(t, tc.delayUs, time.Duration(ep.delay).Microseconds())
+					require.NotNil(t, ep.obsvBatchChan)
+					assert.Equal(t, ObservationChanSize, cap(ep.obsvBatchChan))
+				}
+
+				require.True(t, slices.Equal(tc.chains, slices.Sorted(maps.Keys(ep.enabledChains.chains))))
+				require.Equal(t, tc.exceptFor, ep.enabledChains.exceptFor)
+				require.Equal(t, ep.baseUrl+"/SignedObservationBatch", ep.signedObservationUrl)
+			} else {
+				require.ErrorContains(t, err, tc.errText)
+			}
+		})
+	}
+}
+
+func TestNewAlternatePublisher(t *testing.T) {
+	logger := zap.NewNop()
+	guardianAddr, err := hex.DecodeString("13947Bd48b18E53fdAeEe77F3473391aC727C638")
+	require.NoError(t, err)
+	require.Equal(t, ethCommon.AddressLength, len(guardianAddr))
+
+	// Empty config (feature disabled) should return nil, nil
+	ap, err := NewAlternatePublisher(logger, []byte{}, []string{})
+	require.NoError(t, err)
+	require.Nil(t, ap)
+
+	// Wrong length guardian key should return an error.
+	ap, err = NewAlternatePublisher(logger, guardianAddr[:ethCommon.AddressLength-1], []string{"test;http://localhost:3333"})
+	require.ErrorContains(t, err, "unexpected guardian key length")
+	require.Nil(t, ap)
+
+	// Bad config entry should return an error.
+	ap, err = NewAlternatePublisher(logger, guardianAddr, []string{"test;http://localhost:3333", "test"})
+	require.ErrorContains(t, err, "not enough fields")
+	require.Nil(t, ap)
+
+	// Duplicate label should return an error.
+	ap, err = NewAlternatePublisher(logger, guardianAddr, []string{"test;http://localhost:3333", "test;http://localhost:3334"})
+	require.ErrorContains(t, err, "duplicate label")
+	require.Nil(t, ap)
+
+	// Success case.
+	ap, err = NewAlternatePublisher(logger, guardianAddr, []string{"test1;http://localhost:3333", "test2;http://localhost:3333;500ms;1,2"})
+	require.NoError(t, err)
+	require.NotNil(t, ap)
+	assert.NotNil(t, ap.logger)
+	assert.True(t, slices.Equal(guardianAddr, ap.guardianAddr))
+	assert.Equal(t, 2, len(ap.endpoints))
+	// TestParseEndpoint actually verifies that the endpoints are created properly.
+	require.NotNil(t, ap.httpWorkerChan)
+	assert.Equal(t, PubChanSize, cap(ap.httpWorkerChan))
+}
+
+func TestShouldPublish(t *testing.T) {
+	ep := &Endpoint{
+		label:   "test",
+		baseUrl: "some_url",
+		delay:   Delay(0),
+		enabledChains: EnabledChains{chains: map[vaa.ChainID]struct{}{
+			vaa.ChainIDSolana: {},
+		}},
+	}
+
+	require.True(t, ep.shouldPublish(vaa.ChainIDSolana))
+	require.False(t, ep.shouldPublish(vaa.ChainIDEthereum))
+
+	ep = &Endpoint{
+		label:   "test",
+		baseUrl: "some_url",
+		delay:   Delay(0),
+		enabledChains: EnabledChains{chains: map[vaa.ChainID]struct{}{
+			vaa.ChainIDSolana:   {},
+			vaa.ChainIDEthereum: {},
+		}},
+	}
+
+	require.True(t, ep.shouldPublish(vaa.ChainIDSolana))
+	require.True(t, ep.shouldPublish(vaa.ChainIDEthereum))
+	require.False(t, ep.shouldPublish(vaa.ChainIDPythNet))
+
+	ep = &Endpoint{
+		label:         "test",
+		baseUrl:       "some_url",
+		delay:         Delay(0),
+		enabledChains: EnabledChains{chains: map[vaa.ChainID]struct{}{}},
+	}
+
+	require.True(t, ep.shouldPublish(vaa.ChainIDSolana))
+	require.True(t, ep.shouldPublish(vaa.ChainIDEthereum))
+	require.True(t, ep.shouldPublish(vaa.ChainIDPythNet))
+}
+
+func TestShouldPublishExceptFor(t *testing.T) {
+	ep := &Endpoint{
+		label:   "test",
+		baseUrl: "some_url",
+		delay:   Delay(0),
+		enabledChains: EnabledChains{true, map[vaa.ChainID]struct{}{
+			vaa.ChainIDSolana: {},
+		}},
+	}
+
+	require.False(t, ep.shouldPublish(vaa.ChainIDSolana))
+	require.True(t, ep.shouldPublish(vaa.ChainIDEthereum))
+
+	ep = &Endpoint{
+		label:   "test",
+		baseUrl: "some_url",
+		delay:   Delay(0),
+		enabledChains: EnabledChains{true, map[vaa.ChainID]struct{}{
+			vaa.ChainIDSolana:   {},
+			vaa.ChainIDEthereum: {},
+		}},
+	}
+
+	require.False(t, ep.shouldPublish(vaa.ChainIDSolana))
+	require.False(t, ep.shouldPublish(vaa.ChainIDEthereum))
+	require.True(t, ep.shouldPublish(vaa.ChainIDPythNet))
+}
+
+func TestPublishObservation(t *testing.T) {
+	logger := zap.NewNop()
+	guardianAddr, err := hex.DecodeString("13947Bd48b18E53fdAeEe77F3473391aC727C638")
+	require.NoError(t, err)
+	require.Equal(t, ethCommon.AddressLength, len(guardianAddr))
+
+	ap, err := NewAlternatePublisher(logger, guardianAddr, []string{"pyth;http://localhost:3333;0;26", "wormholescan;http://localhost:3333;500ms"})
+	require.NoError(t, err)
+	require.NotNil(t, ap)
+
+	// When we post something to PythNet, it should go directly to the httpWorkerChan (tagged with the first endpoint).
+	// When we post something to any chain, it should go to the obsvBatchChan on the second endpoint.
+
+	ep2 := ap.endpoints[1]
+
+	assert.Equal(t, 0.0, getCounterValue(obsvDropped, "pyth"))
+	assert.Equal(t, 0.0, getCounterValue(obsvDropped, "wormholescan"))
+
+	// A Solana observation should go to the second endpoint but not the first.
+	ap.PublishObservation(vaa.ChainIDSolana, &gossipv1.Observation{})
+	require.Equal(t, 0, len(ap.httpWorkerChan))
+	require.Equal(t, 1, len(ep2.obsvBatchChan))
+
+	// A PythNet observation should go to both.
+	ap.PublishObservation(vaa.ChainIDPythNet, &gossipv1.Observation{})
+	require.Equal(t, 1, len(ap.httpWorkerChan))
+	require.Equal(t, 2, len(ep2.obsvBatchChan))
+
+	// Fill up both channels and make sure we don't block. (If this test doesn't complete, then we blocked!)
+	for range PubChanSize + 10 {
+		ap.PublishObservation(vaa.ChainIDPythNet, &gossipv1.Observation{})
+	}
+
+	// Make sure we pegged the drop metric.
+	assert.Equal(t, 11.0, getCounterValue(obsvDropped, "pyth"))         // One initial plus ten extra.
+	assert.Equal(t, 12.0, getCounterValue(obsvDropped, "wormholescan")) // Two initial plus ten extra.
+}
+
+func getCounterValue(metric *prometheus.CounterVec, runnableName string) float64 {
+	var m = &dto.Metric{}
+	if err := metric.WithLabelValues(runnableName).Write(m); err != nil {
+		return 0
+	}
+	return m.Counter.GetValue()
+}

--- a/node/pkg/altpub/alternate_pub_test.go
+++ b/node/pkg/altpub/alternate_pub_test.go
@@ -166,6 +166,31 @@ func TestNewAlternatePublisher(t *testing.T) {
 	assert.Equal(t, PubChanSize, cap(ap.httpWorkerChan))
 }
 
+func TestGetFeatures(t *testing.T) {
+	logger := zap.NewNop()
+	guardianAddr, err := hex.DecodeString("13947Bd48b18E53fdAeEe77F3473391aC727C638")
+	require.NoError(t, err)
+	require.Equal(t, ethCommon.AddressLength, len(guardianAddr))
+
+	// One endpoint.
+	ap, err := NewAlternatePublisher(logger, guardianAddr, []string{"pyth;http://localhost:3333"})
+	require.NoError(t, err)
+	require.NotNil(t, ap)
+	assert.Equal(t, "altpub:pyth", ap.GetFeatures())
+
+	// Two endpoints.
+	ap, err = NewAlternatePublisher(logger, guardianAddr, []string{"pyth;http://localhost:3333", "wormholescan;http://localhost:3334"})
+	require.NoError(t, err)
+	require.NotNil(t, ap)
+	assert.Equal(t, "altpub:pyth|wormholescan", ap.GetFeatures())
+
+	// Three endpoints.
+	ap, err = NewAlternatePublisher(logger, guardianAddr, []string{"pyth;http://localhost:3333", "wormholescan;http://localhost:3334", "joe_integrator;http://localhost:3335"})
+	require.NoError(t, err)
+	require.NotNil(t, ap)
+	assert.Equal(t, "altpub:pyth|wormholescan|joe_integrator", ap.GetFeatures())
+}
+
 func TestShouldPublish(t *testing.T) {
 	ep := &Endpoint{
 		label:   "test",

--- a/node/pkg/altpub/end2end_test.go
+++ b/node/pkg/altpub/end2end_test.go
@@ -1,0 +1,252 @@
+package altpub
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
+	ethCommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wormhole-foundation/wormhole/sdk/vaa"
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/proto"
+)
+
+const (
+	NumObservations = 100
+
+	PythPort         = 3333
+	WormholescanPort = 3334
+
+	// These are just meaningless values used to generate observation message IDs.
+	pythEmitterAddr   = "00000000000000000000000022427d90B7dA3fA4642F7025A854c7254E4e45BF"
+	solanaEmitterAddr = "3b26409f8aaded3f5ddca184695aa6a0fa829b0c85caf84856324896d214ca98"
+)
+
+// TestEndToEnd creates an ApplicationPublisher with two endpoints. Each endpoint is handled by a localhost HTTP server running on a unique port.
+// - The first simulates what Pyth might use, an immediate publisher for the PythNet chain only.
+// - The second simulates what Wormholescan might use, a delayed publisher for all chains.
+// The test then blasts a bunch of observations, interleaving PythNet and Solana.
+// It then verifies that the results received on the two endpoint servers match what was sent.
+func TestEndToEnd(t *testing.T) {
+	logger := zap.NewNop()
+	guardianAddr, err := hex.DecodeString("13947Bd48b18E53fdAeEe77F3473391aC727C638")
+	require.NoError(t, err)
+	require.Equal(t, ethCommon.AddressLength, len(guardianAddr))
+
+	logger.Info("Starting two endpoint servers")
+	pythEP := newServer(logger, guardianAddr, PythPort)
+	go pythEP.run()
+
+	wormscanEP := newServer(logger, guardianAddr, WormholescanPort)
+	go wormscanEP.run()
+
+	// Give the endpoints some time to start.
+	time.Sleep(10 * time.Millisecond)
+
+	// Create an alternate publisher with two endpoints. Note that the labels start with "e2e_" so our metrics don't clash with other tests.
+	ap, err := NewAlternatePublisher(logger, guardianAddr, []string{"e2e_pyth;" + pythEP.url + ";0;pythnet", "e2e_wormholescan;" + wormscanEP.url + ";10ms"})
+	require.NoError(t, err)
+	require.NotNil(t, ap)
+	require.Equal(t, 2, len(ap.endpoints))
+
+	logger.Info("Starting the alternate publisher")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		err := ap.Run(ctx)
+		if err != nil && !errors.Is(err, context.Canceled) {
+			require.NoError(t, err)
+		}
+	}()
+
+	// Give the alternate publisher some time to start.
+	time.Sleep(10 * time.Millisecond)
+
+	logger.Info("Publishing some observations across pythnet and solana")
+	pythSeqNum := 0
+	solanaSeqNum := 0
+	expectedPythObsv := []*gossipv1.Observation{}
+	expectedWormscanObsv := []*gossipv1.Observation{}
+	for count := range NumObservations {
+		pythObs := createObservation(vaa.ChainIDPythNet, pythEmitterAddr, pythSeqNum)
+		ap.PublishObservation(vaa.ChainIDPythNet, pythObs)
+		expectedPythObsv = append(expectedPythObsv, pythObs)
+		expectedWormscanObsv = append(expectedWormscanObsv, pythObs)
+		pythSeqNum++
+
+		if count%5 == 0 {
+			solanaObs := createObservation(vaa.ChainIDSolana, solanaEmitterAddr, solanaSeqNum)
+			ap.PublishObservation(vaa.ChainIDSolana, solanaObs)
+			expectedWormscanObsv = append(expectedWormscanObsv, solanaObs)
+			solanaSeqNum++
+		}
+
+		// Put in some delay so batching can do something.
+		time.Sleep(time.Millisecond)
+	}
+
+	logger.Info("Sleeping to give time for things to calm down")
+	time.Sleep(10 * time.Millisecond)
+	logger.Info("Canceling context")
+	cancel()
+	time.Sleep(10 * time.Millisecond)
+
+	// Make sure we didn't drop anything.
+	require.Equal(t, 0.0, getCounterValue(obsvDropped, "e2e_pyth"))
+	require.Equal(t, 0.0, getCounterValue(obsvDropped, "e2e_wormholescan"))
+
+	// Get the results from the endpoint servers.
+	pythStats := pythEP.getStatus()
+	wormscanStats := wormscanEP.getStatus()
+
+	// Since the workers may publish the observations out of order, we need to sort the observations.
+	sortObservations(expectedPythObsv)
+	sortObservations(expectedWormscanObsv)
+	sortObservations(pythStats.observations)
+	sortObservations(wormscanStats.observations)
+
+	// Since the pyth endpoint is immediate, the number of batches should equal the number of pythnet observations
+	assert.Equal(t, len(expectedPythObsv), pythStats.numBatches)
+	compareObservations(t, expectedPythObsv, pythStats.observations, "pyth")
+
+	// The wormholescan endpoint is listening to everything, so it should see the total of both pythnet and solana observations.
+	// Since it is using batching, it should see fewer batches than the number of observations. I don't think we can predict the exact number.
+	assert.Greater(t, len(expectedWormscanObsv), wormscanStats.numBatches)
+	compareObservations(t, expectedWormscanObsv, wormscanStats.observations, "wormholescan")
+
+	logger.Info("Exiting")
+}
+
+// createObservation creates a completely bogus unique observation so we can compare sent to received.
+func createObservation(emitterChain vaa.ChainID, emitterAddress string, seqNum int) *gossipv1.Observation {
+	messageId := fmt.Sprintf("%d/%s/%d", emitterChain, emitterAddress, seqNum)
+	txHash := crypto.Keccak256Hash([]byte(messageId)).Bytes()
+	digest := crypto.Keccak256Hash(txHash).Bytes()
+	sig := append(txHash, digest...)
+	return &gossipv1.Observation{
+		Hash:      digest,
+		Signature: sig,
+		TxHash:    txHash,
+		MessageId: messageId,
+	}
+}
+
+// sortObservations sorts a slice of observations into ascending order.
+func sortObservations(observations []*gossipv1.Observation) {
+	slices.SortFunc(observations, func(a, b *gossipv1.Observation) int {
+		if a.MessageId < b.MessageId {
+			return -1
+		}
+		if a.MessageId > b.MessageId {
+			return 1
+		}
+		return 0
+	})
+}
+
+// compareObservations compares two slices of observations to make sure they are equal.
+func compareObservations(t *testing.T, expected []*gossipv1.Observation, actual []*gossipv1.Observation, tag string) {
+	t.Helper()
+	require.Equal(t, len(expected), len(actual))
+	for idx := range expected {
+		t.Run(fmt.Sprintf("%s-%d", tag, idx), func(t *testing.T) {
+			require.True(t, bytes.Equal(expected[idx].Hash, actual[idx].Hash))
+			require.True(t, bytes.Equal(expected[idx].Signature, actual[idx].Signature))
+			require.True(t, bytes.Equal(expected[idx].TxHash, actual[idx].TxHash))
+			require.Equal(t, expected[idx].MessageId, actual[idx].MessageId)
+		})
+	}
+}
+
+/////// Below here is the implementation of our test HTTP server. It just counts and stores observations and batches.
+
+type (
+	// Server represents a single endpoint.
+	Server struct {
+		logger       *zap.Logger
+		guardianAddr []byte
+		port         int
+		url          string
+		statsLock    sync.Mutex
+		stats        ServerStats
+	}
+
+	// ServerStats is the data protected by the lock.
+	ServerStats struct {
+		numBatches   int
+		observations []*gossipv1.Observation
+	}
+)
+
+// newServer creates a new localhost HTTP server listening on the specified port.
+func newServer(logger *zap.Logger, guardianAddr []byte, port int) *Server {
+	return &Server{
+		logger:       logger.With(zap.String("component", "server")),
+		guardianAddr: guardianAddr,
+		port:         port,
+		url:          fmt.Sprintf("http://localhost:%d", port),
+		stats:        newServerStats(),
+	}
+}
+
+// newServerStats initializes the server stats object.
+func newServerStats() ServerStats {
+	return ServerStats{observations: make([]*gossipv1.Observation, 0, 1000)}
+}
+
+// run starts the server. It should be called in a go routine.
+func (s *Server) run() {
+	serverMux := http.NewServeMux()
+	serverMux.HandleFunc("/SignedObservationBatch", s.handleSignedObservationBatch)
+
+	s.logger.Info(fmt.Sprintf("server listening on port %d", s.port))
+	err := http.ListenAndServe(fmt.Sprintf(":%d", s.port), serverMux) // #nosec G114 TODO: Think about this
+	if errors.Is(err, http.ErrServerClosed) {
+		s.logger.Info("server closed")
+	} else if err != nil {
+		s.logger.Fatal("error starting server", zap.Error(err))
+	}
+}
+
+// handleSignedObservationBatch is the handler for a signed observation.
+func (s *Server) handleSignedObservationBatch(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	r.Body.Close()
+	if err != nil {
+		s.logger.Fatal("error extracting body", zap.Error(err))
+	}
+
+	var batch gossipv1.SignedObservationBatch
+	err = proto.Unmarshal(body, &batch)
+	if err != nil {
+		s.logger.Fatal("failed to unmarshal batch", zap.Error(err))
+	}
+
+	if !slices.Equal(s.guardianAddr, batch.Addr) {
+		s.logger.Fatal("invalid guardian address", zap.String("expected", hex.EncodeToString(s.guardianAddr)), zap.String("actual", hex.EncodeToString(batch.Addr)))
+	}
+
+	s.statsLock.Lock()
+	defer s.statsLock.Unlock()
+	s.stats.numBatches++
+	s.stats.observations = append(s.stats.observations, batch.Observations...)
+}
+
+// getStatus returns the stats for a server.
+func (s *Server) getStatus() ServerStats {
+	s.statsLock.Lock()
+	defer s.statsLock.Unlock()
+	return s.stats
+}

--- a/node/pkg/common/url_verification.go
+++ b/node/pkg/common/url_verification.go
@@ -1,4 +1,4 @@
-package node
+package common
 
 import (
 	"fmt"

--- a/node/pkg/common/url_verification.go
+++ b/node/pkg/common/url_verification.go
@@ -1,13 +1,9 @@
 package common
 
 import (
-	"fmt"
-	"log"
 	"net"
 	"net/url"
 	"strings"
-
-	"github.com/spf13/cobra"
 )
 
 func hasKnownSchemePrefix(urlStr string) bool {
@@ -39,40 +35,4 @@ func ValidateURL(urlStr string, validSchemes []string) bool {
 		}
 	}
 	return false
-}
-
-func generateFormatString(schemes []string) string {
-	var formatBuilder strings.Builder
-
-	for i, scheme := range schemes {
-		if scheme == "" {
-			formatBuilder.WriteString("<host>:<port>")
-		} else {
-			formatBuilder.WriteString(strings.ToUpper(scheme))
-		}
-
-		if i < len(schemes)-1 {
-			formatBuilder.WriteString(" or ")
-		}
-	}
-
-	return formatBuilder.String()
-}
-
-func RegisterFlagWithValidationOrFail(cmd *cobra.Command, name string, description string, example string, expectedSchemes []string) *string {
-	formatExample := generateFormatString(expectedSchemes)
-	flagValue := cmd.Flags().String(name, "", fmt.Sprintf("%s.\nFormat: %s. Example: '%s'", description, formatExample, example))
-
-	// Perform validation after flags are parsed
-	cobra.OnInitialize(func() {
-		if *flagValue == "" || *flagValue == "none" {
-			return
-		}
-
-		if valid := ValidateURL(*flagValue, expectedSchemes); !valid {
-			log.Fatalf("Invalid format for flag --%s. Expected format: %s. Example: '%s'", name, formatExample, example)
-		}
-	})
-
-	return flagValue
 }

--- a/node/pkg/common/url_verification_test.go
+++ b/node/pkg/common/url_verification_test.go
@@ -1,4 +1,4 @@
-package node
+package common
 
 import (
 	"testing"

--- a/node/pkg/node/node.go
+++ b/node/pkg/node/node.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/certusone/wormhole/node/pkg/accountant"
+	"github.com/certusone/wormhole/node/pkg/altpub"
 	"github.com/certusone/wormhole/node/pkg/common"
 	"github.com/certusone/wormhole/node/pkg/db"
 	"github.com/certusone/wormhole/node/pkg/governor"
@@ -64,13 +65,14 @@ type G struct {
 	guardianSigner guardiansigner.GuardianSigner
 
 	// components
-	db              *db.Database
-	gst             *common.GuardianSetState
-	acct            *accountant.Accountant
-	gov             *governor.ChainGovernor
-	gatewayRelayer  *gwrelayer.GatewayRelayer
-	queryHandler    *query.QueryHandler
-	publicrpcServer *grpc.Server
+	db                 *db.Database
+	gst                *common.GuardianSetState
+	acct               *accountant.Accountant
+	gov                *governor.ChainGovernor
+	gatewayRelayer     *gwrelayer.GatewayRelayer
+	queryHandler       *query.QueryHandler
+	publicrpcServer    *grpc.Server
+	alternatePublisher *altpub.AlternatePublisher
 
 	// runnables
 	runnablesWithScissors map[string]supervisor.Runnable

--- a/node/pkg/node/node_test.go
+++ b/node/pkg/node/node_test.go
@@ -196,6 +196,7 @@ func mockGuardianRunnable(t testing.TB, gs []*mockGuardian, mockGuardianIndex ui
 			GuardianOptionPublicWeb(cfg.publicWeb, cfg.publicSocket, "", false, ""),
 			GuardianOptionAdminService(cfg.adminSocket, nil, nil, rpcMap),
 			GuardianOptionStatusServer(fmt.Sprintf("[::]:%d", cfg.statusPort)),
+			GuardianOptionAlternatePublisher([]byte{}, []string{}),
 			GuardianOptionProcessor(networkID),
 		}
 

--- a/node/pkg/node/options.go
+++ b/node/pkg/node/options.go
@@ -78,6 +78,11 @@ func GuardianOptionP2P(
 			// Add the gossip advertisement address
 			components.GossipAdvertiseAddress = gossipAdvertiseAddress
 
+			var alternatePublisherFeaturesFunc func() string
+			if g.alternatePublisher != nil {
+				alternatePublisherFeaturesFunc = g.alternatePublisher.GetFeatures
+			}
+
 			params, err := p2p.NewRunParams(
 				bootstrapPeers,
 				networkId,
@@ -111,6 +116,7 @@ func GuardianOptionP2P(
 					featureFlags,
 				),
 				p2p.WithProcessorFeaturesFunc(processor.GetFeatures),
+				p2p.WithAlternatePublisherFeaturesFunc(alternatePublisherFeaturesFunc),
 			)
 			if err != nil {
 				return err

--- a/node/pkg/node/url_verification.go
+++ b/node/pkg/node/url_verification.go
@@ -1,0 +1,46 @@
+package node
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/certusone/wormhole/node/pkg/common"
+	"github.com/spf13/cobra"
+)
+
+func generateFormatString(schemes []string) string {
+	var formatBuilder strings.Builder
+
+	for i, scheme := range schemes {
+		if scheme == "" {
+			formatBuilder.WriteString("<host>:<port>")
+		} else {
+			formatBuilder.WriteString(strings.ToUpper(scheme))
+		}
+
+		if i < len(schemes)-1 {
+			formatBuilder.WriteString(" or ")
+		}
+	}
+
+	return formatBuilder.String()
+}
+
+func RegisterFlagWithValidationOrFail(cmd *cobra.Command, name string, description string, example string, expectedSchemes []string) *string {
+	formatExample := generateFormatString(expectedSchemes)
+	flagValue := cmd.Flags().String(name, "", fmt.Sprintf("%s.\nFormat: %s. Example: '%s'", description, formatExample, example))
+
+	// Perform validation after flags are parsed
+	cobra.OnInitialize(func() {
+		if *flagValue == "" || *flagValue == "none" {
+			return
+		}
+
+		if valid := common.ValidateURL(*flagValue, expectedSchemes); !valid {
+			log.Fatalf("Invalid format for flag --%s. Expected format: %s. Example: '%s'", name, formatExample, example)
+		}
+	})
+
+	return flagValue
+}

--- a/node/pkg/p2p/p2p.go
+++ b/node/pkg/p2p/p2p.go
@@ -537,6 +537,12 @@ func Run(params *RunParams) func(ctx context.Context) error {
 									features = append(features, flag)
 								}
 							}
+							if params.alternatePublisherFeaturesFunc != nil {
+								flag := params.alternatePublisherFeaturesFunc()
+								if flag != "" {
+									features = append(features, flag)
+								}
+							}
 							if params.gov != nil {
 								if params.gov.IsFlowCancelEnabled() {
 									features = append(features, "governor:fc")

--- a/node/pkg/p2p/run_params.go
+++ b/node/pkg/p2p/run_params.go
@@ -42,27 +42,28 @@ type (
 		disableHeartbeatVerify bool
 
 		// The following options are guardian specific. Set with `WithGuardianOptions`.
-		nodeName               string
-		guardianSigner         guardiansigner.GuardianSigner
-		gossipControlSendC     chan []byte
-		gossipAttestationSendC chan []byte
-		gossipVaaSendC         chan []byte
-		obsvReqSendC           <-chan *gossipv1.ObservationRequest
-		acct                   *accountant.Accountant
-		gov                    *governor.ChainGovernor
-		components             *Components
-		ibcFeaturesFunc        func() string
-		processorFeaturesFunc  func() string
-		gatewayRelayerEnabled  bool
-		ccqEnabled             bool
-		signedQueryReqC        chan<- *gossipv1.SignedQueryRequest
-		queryResponseReadC     <-chan *query.QueryResponsePublication
-		ccqBootstrapPeers      string
-		ccqPort                uint
-		ccqAllowedPeers        string
-		protectedPeers         []string
-		ccqProtectedPeers      []string
-		featureFlags           []string
+		nodeName                       string
+		guardianSigner                 guardiansigner.GuardianSigner
+		gossipControlSendC             chan []byte
+		gossipAttestationSendC         chan []byte
+		gossipVaaSendC                 chan []byte
+		obsvReqSendC                   <-chan *gossipv1.ObservationRequest
+		acct                           *accountant.Accountant
+		gov                            *governor.ChainGovernor
+		components                     *Components
+		ibcFeaturesFunc                func() string
+		processorFeaturesFunc          func() string
+		alternatePublisherFeaturesFunc func() string
+		gatewayRelayerEnabled          bool
+		ccqEnabled                     bool
+		signedQueryReqC                chan<- *gossipv1.SignedQueryRequest
+		queryResponseReadC             <-chan *query.QueryResponsePublication
+		ccqBootstrapPeers              string
+		ccqPort                        uint
+		ccqAllowedPeers                string
+		protectedPeers                 []string
+		ccqProtectedPeers              []string
+		featureFlags                   []string
 	}
 
 	// RunOpt is used to specify optional parameters.
@@ -113,6 +114,14 @@ func WithComponents(components *Components) RunOpt {
 func WithProcessorFeaturesFunc(processorFeaturesFunc func() string) RunOpt {
 	return func(p *RunParams) error {
 		p.processorFeaturesFunc = processorFeaturesFunc
+		return nil
+	}
+}
+
+// WithAlternatePublisherFeaturesFunc is used to set the alternate publisher features function.
+func WithAlternatePublisherFeaturesFunc(alternatePublisherFeaturesFunc func() string) RunOpt {
+	return func(p *RunParams) error {
+		p.alternatePublisherFeaturesFunc = alternatePublisherFeaturesFunc
 		return nil
 	}
 }

--- a/node/pkg/processor/broadcast.go
+++ b/node/pkg/processor/broadcast.go
@@ -7,6 +7,7 @@ import (
 	ethCommon "github.com/ethereum/go-ethereum/common"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/certusone/wormhole/node/pkg/common"
 	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
 	"github.com/wormhole-foundation/wormhole/sdk/vaa"
 )
@@ -34,17 +35,16 @@ var (
 // broadcastSignature broadcasts the observation for something we observed locally.
 func (p *Processor) broadcastSignature(
 	messageID string,
-	txhash []byte,
+	k *common.MessagePublication,
 	digest ethCommon.Hash,
 	signature []byte,
 	shouldPublishImmediately bool,
-	emitterChain vaa.ChainID,
 ) (ourObs *gossipv1.Observation, msg []byte) {
 	// Create the observation to either be submitted to the batch processor or published immediately.
 	ourObs = &gossipv1.Observation{
 		Hash:      digest.Bytes(),
 		Signature: signature,
-		TxHash:    txhash,
+		TxHash:    k.TxID,
 		MessageId: messageID,
 	}
 
@@ -57,7 +57,7 @@ func (p *Processor) broadcastSignature(
 	}
 
 	if p.alternatePublisher != nil {
-		p.alternatePublisher.PublishObservation(emitterChain, ourObs)
+		p.alternatePublisher.PublishObservation(k.EmitterChain, ourObs)
 	}
 
 	return ourObs, msg

--- a/node/pkg/processor/broadcast.go
+++ b/node/pkg/processor/broadcast.go
@@ -38,6 +38,7 @@ func (p *Processor) broadcastSignature(
 	digest ethCommon.Hash,
 	signature []byte,
 	shouldPublishImmediately bool,
+	emitterChain vaa.ChainID,
 ) (ourObs *gossipv1.Observation, msg []byte) {
 	// Create the observation to either be submitted to the batch processor or published immediately.
 	ourObs = &gossipv1.Observation{
@@ -53,6 +54,10 @@ func (p *Processor) broadcastSignature(
 	} else {
 		p.postObservationToBatch(ourObs)
 		batchObservationsBroadcast.Inc()
+	}
+
+	if p.alternatePublisher != nil {
+		p.alternatePublisher.PublishObservation(emitterChain, ourObs)
 	}
 
 	return ourObs, msg

--- a/node/pkg/processor/message.go
+++ b/node/pkg/processor/message.go
@@ -93,7 +93,7 @@ func (p *Processor) handleMessage(ctx context.Context, k *common.MessagePublicat
 	}
 
 	// Broadcast the signature.
-	ourObs, msg := p.broadcastSignature(v.MessageID(), k.TxID, digest, signature, shouldPublishImmediately)
+	ourObs, msg := p.broadcastSignature(v.MessageID(), k.TxID, digest, signature, shouldPublishImmediately, k.EmitterChain)
 
 	// Indicate that we observed this one.
 	observationsReceivedTotal.Inc()

--- a/node/pkg/processor/message.go
+++ b/node/pkg/processor/message.go
@@ -93,7 +93,7 @@ func (p *Processor) handleMessage(ctx context.Context, k *common.MessagePublicat
 	}
 
 	// Broadcast the signature.
-	ourObs, msg := p.broadcastSignature(v.MessageID(), k.TxID, digest, signature, shouldPublishImmediately, k.EmitterChain)
+	ourObs, msg := p.broadcastSignature(v.MessageID(), k, digest, signature, shouldPublishImmediately)
 
 	// Indicate that we observed this one.
 	observationsReceivedTotal.Inc()

--- a/node/pkg/processor/processor.go
+++ b/node/pkg/processor/processor.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/certusone/wormhole/node/pkg/altpub"
 	"github.com/certusone/wormhole/node/pkg/db"
 	"github.com/certusone/wormhole/node/pkg/governor"
 	"github.com/certusone/wormhole/node/pkg/guardiansigner"
@@ -130,6 +131,8 @@ type Processor struct {
 
 	db *db.Database
 
+	alternatePublisher *altpub.AlternatePublisher
+
 	// Runtime state
 
 	// gs is the currently valid guardian set
@@ -218,6 +221,7 @@ func NewProcessor(
 	acctReadC <-chan *common.MessagePublication,
 	gatewayRelayer *gwrelayer.GatewayRelayer,
 	networkID string,
+	alternatePublisher *altpub.AlternatePublisher,
 ) *Processor {
 
 	return &Processor{
@@ -231,6 +235,7 @@ func NewProcessor(
 		guardianSigner:         guardianSigner,
 		gst:                    gst,
 		db:                     db,
+		alternatePublisher:     alternatePublisher,
 
 		logger:         supervisor.Logger(ctx),
 		state:          &aggregationState{observationMap{}},


### PR DESCRIPTION
Please see the file README.md for an overview of this feature.

Note that this PR includes moving `url_verification.go` from `node/pkg/node` to `node/pkg/common` and updating all references to it. This was necessary so the `altpub` package could use `ValidateURL` without causing a circular reference.