### PR TITLE
Node: Add Solana shim feature flag

### DIFF
--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -1726,7 +1726,7 @@ func runNode(cmd *cobra.Command, args []string) {
 		watcherConfigs = append(watcherConfigs, wc)
 
 		if *solanaShimContract != "" {
-			featureFlags = append(featureFlags, "solshim")
+			featureFlags = append(featureFlags, fmt.Sprintf("solshim:%s", *solanaShimContract))
 		}
 	}
 

--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -289,6 +289,9 @@ var (
 	// Global variable used to store enabled Chain IDs for Transfer Verification. Contents are parsed from
 	// transferVerifierEnabledChainIDs.
 	txVerifierChains []vaa.ChainID
+
+	// featureFlags are additional static flags that should be published in P2P heartbeats.
+	featureFlags []string
 )
 
 func init() {
@@ -1721,6 +1724,10 @@ func runNode(cmd *cobra.Command, args []string) {
 			Commitment:    rpc.CommitmentFinalized,
 		}
 		watcherConfigs = append(watcherConfigs, wc)
+
+		if *solanaShimContract != "" {
+			featureFlags = append(featureFlags, "solshim")
+		}
 	}
 
 	if shouldStart(pythnetRPC) {
@@ -1853,7 +1860,8 @@ func runNode(cmd *cobra.Command, args []string) {
 		node.GuardianOptionGatewayRelayer(*gatewayRelayerContract, gatewayRelayerWormchainConn),
 		node.GuardianOptionQueryHandler(*ccqEnabled, *ccqAllowedRequesters),
 		node.GuardianOptionAdminService(*adminSocketPath, ethRPC, ethContract, rpcMap),
-		node.GuardianOptionP2P(p2pKey, *p2pNetworkID, *p2pBootstrap, *nodeName, *subscribeToVAAs, *disableHeartbeatVerify, *p2pPort, *ccqP2pBootstrap, *ccqP2pPort, *ccqAllowedPeers, *gossipAdvertiseAddress, ibc.GetFeatures, protectedPeers, ccqProtectedPeers),
+		node.GuardianOptionP2P(p2pKey, *p2pNetworkID, *p2pBootstrap, *nodeName, *subscribeToVAAs, *disableHeartbeatVerify, *p2pPort, *ccqP2pBootstrap, *ccqP2pPort, *ccqAllowedPeers,
+			*gossipAdvertiseAddress, ibc.GetFeatures, protectedPeers, ccqProtectedPeers, featureFlags),
 		node.GuardianOptionStatusServer(*statusAddr),
 		node.GuardianOptionProcessor(*p2pNetworkID),
 	}

--- a/node/pkg/node/node_test.go
+++ b/node/pkg/node/node_test.go
@@ -190,7 +190,7 @@ func mockGuardianRunnable(t testing.TB, gs []*mockGuardian, mockGuardianIndex ui
 			GuardianOptionNoAccountant(), // disable accountant
 			GuardianOptionGovernor(true, false, ""),
 			GuardianOptionGatewayRelayer("", nil), // disable gateway relayer
-			GuardianOptionP2P(gs[mockGuardianIndex].p2pKey, networkID, bootstrapPeers, nodeName, false, false, cfg.p2pPort, "", 0, "", "", func() string { return "" }, []string{}, []string{}),
+			GuardianOptionP2P(gs[mockGuardianIndex].p2pKey, networkID, bootstrapPeers, nodeName, false, false, cfg.p2pPort, "", 0, "", "", func() string { return "" }, []string{}, []string{}, []string{}),
 			GuardianOptionPublicRpcSocket(cfg.publicSocket, publicRpcLogDetail),
 			GuardianOptionPublicrpcTcpService(cfg.publicRpc, publicRpcLogDetail),
 			GuardianOptionPublicWeb(cfg.publicWeb, cfg.publicSocket, "", false, ""),

--- a/node/pkg/node/options.go
+++ b/node/pkg/node/options.go
@@ -54,6 +54,7 @@ func GuardianOptionP2P(
 	ibcFeaturesFunc func() string,
 	protectedPeers []string,
 	ccqProtectedPeers []string,
+	featureFlags []string,
 ) *GuardianOption {
 	return &GuardianOption{
 		name:         "p2p",
@@ -106,6 +107,7 @@ func GuardianOptionP2P(
 					ccqAllowedPeers,
 					protectedPeers,
 					ccqProtectedPeers,
+					featureFlags,
 				),
 				p2p.WithProcessorFeaturesFunc(processor.GetFeatures),
 			)

--- a/node/pkg/p2p/p2p.go
+++ b/node/pkg/p2p/p2p.go
@@ -559,6 +559,9 @@ func Run(params *RunParams) func(ctx context.Context) error {
 							if params.ccqEnabled {
 								features = append(features, "ccq")
 							}
+							if len(params.featureFlags) != 0 {
+								features = append(features, params.featureFlags...)
+							}
 
 							heartbeat := &gossipv1.Heartbeat{
 								NodeName:      params.nodeName,

--- a/node/pkg/p2p/run_params.go
+++ b/node/pkg/p2p/run_params.go
@@ -62,6 +62,7 @@ type (
 		ccqAllowedPeers        string
 		protectedPeers         []string
 		ccqProtectedPeers      []string
+		featureFlags           []string
 	}
 
 	// RunOpt is used to specify optional parameters.
@@ -205,6 +206,7 @@ func WithGuardianOptions(
 	ccqAllowedPeers string,
 	protectedPeers []string,
 	ccqProtectedPeers []string,
+	featureFlags []string,
 ) RunOpt {
 	return func(p *RunParams) error {
 		p.nodeName = nodeName
@@ -230,6 +232,7 @@ func WithGuardianOptions(
 		p.ccqAllowedPeers = ccqAllowedPeers
 		p.protectedPeers = protectedPeers
 		p.ccqProtectedPeers = ccqProtectedPeers
+		p.featureFlags = featureFlags
 		return nil
 	}
 }

--- a/node/pkg/p2p/run_params_test.go
+++ b/node/pkg/p2p/run_params_test.go
@@ -243,6 +243,7 @@ func TestRunParamsWithGuardianOptions(t *testing.T) {
 			ccqAllowedPeers,
 			protectedPeers,
 			ccqProtectedPeers,
+			[]string{}, // featureFlags
 		),
 	)
 

--- a/node/pkg/p2p/watermark_test.go
+++ b/node/pkg/p2p/watermark_test.go
@@ -200,6 +200,7 @@ func startGuardian(t *testing.T, ctx context.Context, g *G) {
 			"",         // query allowed peers),
 			[]string{}, // protected peers
 			[]string{}, // ccq protected peers
+			[]string{}, // featureFlags
 		))
 	require.NoError(t, err)
 


### PR DESCRIPTION
This PR adds a the Solana shim to the feature flags published in heartbeat messages (as "solshim") so that we can see in the dashboard if a guardian has it enabled. This feature can be used for other features, such as the Fogo shim.