### PR TITLE
Tilt/CI: Pin foundry release

### DIFF
--- a/devnet/tx-verifier/Dockerfile.cast
+++ b/devnet/tx-verifier/Dockerfile.cast
@@ -1,7 +1,7 @@
 # These versions are pinned to match the Dockerfile in the `ethereum/`
 # directory. Otherwise, there is nothing special about them and they can be
 # updated alongside the other Dockerfile.
-FROM --platform=linux/amd64 ghcr.io/foundry-rs/foundry:nightly-55bf41564f605cae3ca4c95ac5d468b1f14447f9@sha256:8c15d322da81a6deaf827222e173f3f81c653136a3518d5eeb41250a0f2e17ea as foundry
+FROM --platform=linux/amd64 ghcr.io/foundry-rs/foundry:v1.0.0@sha256:d12a373ec950de170d5461014ef9320ba0fb6e0db6f87835999d0fcf3820370e as foundry
 # node is required to install Foundry
 FROM node:19.6.1-slim@sha256:a1ba21bf0c92931d02a8416f0a54daad66cb36a85d2b73af9d73b044f5f57cfc
 

--- a/devnet/tx-verifier/Dockerfile.tx-verifier-evm
+++ b/devnet/tx-verifier/Dockerfile.tx-verifier-evm
@@ -4,7 +4,7 @@ FROM guardiand-image AS base
 # These versions are pinned to match the Dockerfile in the `ethereum/`
 # directory. Otherwise, there is nothing special about them and they can be
 # updated alongside the other Dockerfile.
-FROM --platform=linux/amd64 ghcr.io/foundry-rs/foundry:nightly-55bf41564f605cae3ca4c95ac5d468b1f14447f9@sha256:8c15d322da81a6deaf827222e173f3f81c653136a3518d5eeb41250a0f2e17ea as foundry
+FROM --platform=linux/amd64 ghcr.io/foundry-rs/foundry:v1.0.0@sha256:d12a373ec950de170d5461014ef9320ba0fb6e0db6f87835999d0fcf3820370e as foundry
 
 # node is required to install Foundry
 FROM node:19.6.1-slim@sha256:a1ba21bf0c92931d02a8416f0a54daad66cb36a85d2b73af9d73b044f5f57cfc

--- a/ethereum/Dockerfile
+++ b/ethereum/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker.io/docker/dockerfile:1.3@sha256:42399d4635eddd7a9b8a24be879d2f9a930d0ed040a61324cfdf59ef1357b3b2
 FROM const-gen AS const-export
-FROM --platform=linux/amd64 ghcr.io/foundry-rs/foundry:nightly-55bf41564f605cae3ca4c95ac5d468b1f14447f9@sha256:8c15d322da81a6deaf827222e173f3f81c653136a3518d5eeb41250a0f2e17ea as foundry
+FROM --platform=linux/amd64 ghcr.io/foundry-rs/foundry:v1.0.0@sha256:d12a373ec950de170d5461014ef9320ba0fb6e0db6f87835999d0fcf3820370e as foundry
 FROM node:19.6.1-slim@sha256:a1ba21bf0c92931d02a8416f0a54daad66cb36a85d2b73af9d73b044f5f57cfc
 
 # npm wants to clone random Git repositories - lovely.

--- a/ethereum/foundry
+++ b/ethereum/foundry
@@ -11,7 +11,7 @@
 set -eo pipefail
 
 # This is a known-to-be-working build.
-DOCKER_IMAGE="ghcr.io/foundry-rs/foundry:nightly-6defdcebf7f59ee471086b1b51ff85392aafd445@sha256:cd9a68e7bd69d9d5f9025eaeb525efd7f162f11e4566792da8ec4891b080a415"
+DOCKER_IMAGE="ghcr.io/foundry-rs/foundry:v1.0.0@sha256:d12a373ec950de170d5461014ef9320ba0fb6e0db6f87835999d0fcf3820370e"
 
 args=$(printf '"%s" ' "$@")
 

--- a/testing/Dockerfile.sdk.test
+++ b/testing/Dockerfile.sdk.test
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 ghcr.io/foundry-rs/foundry:nightly-ea2eff95b5c17edd3ffbdfc6daab5ce5cc80afc0@sha256:2a774f86765258a0d176366fc46f92bc14f5040faae7a3c3ba59b1c24c5fa7cb as foundry
+FROM --platform=linux/amd64 ghcr.io/foundry-rs/foundry:v1.0.0@sha256:d12a373ec950de170d5461014ef9320ba0fb6e0db6f87835999d0fcf3820370e as foundry
 FROM node:19.6.1-slim@sha256:a1ba21bf0c92931d02a8416f0a54daad66cb36a85d2b73af9d73b044f5f57cfc
 
 RUN apt-get update && apt-get -y install \


### PR DESCRIPTION
It looks like some of the nightly releases of foundry are disappearing. This PR pins foundry to a specific official release.