### PR TITLE
cleanup: Remove use of tendermint/random for non-Cosmos code

### DIFF
--- a/node/cmd/guardiand/admintemplate.go
+++ b/node/cmd/guardiand/admintemplate.go
@@ -14,7 +14,6 @@ import (
 	"github.com/holiman/uint256"
 	"github.com/mr-tron/base58"
 	"github.com/spf13/pflag"
-	"github.com/tendermint/tendermint/libs/rand"
 	"github.com/wormhole-foundation/wormhole/sdk/vaa"
 
 	"github.com/ethereum/go-ethereum/crypto"
@@ -23,6 +22,7 @@ import (
 
 	"github.com/certusone/wormhole/node/pkg/devnet"
 	nodev1 "github.com/certusone/wormhole/node/pkg/proto/node/v1"
+	"github.com/certusone/wormhole/node/pkg/random"
 )
 
 var setUpdateNumGuardians *int
@@ -365,13 +365,14 @@ func runGuardianSetTemplate(cmd *cobra.Command, args []string) {
 			Name:   fmt.Sprintf("Example validator %d", i),
 		}
 	}
+	seq, nonce := randSeqNonce()
 
 	m := &nodev1.InjectGovernanceVAARequest{
 		CurrentSetIndex: uint32(*templateGuardianIndex), // #nosec G115 -- Number of guardians will never overflow here
 		Messages: []*nodev1.GovernanceMessage{
 			{
-				Sequence: rand.Uint64(),
-				Nonce:    rand.Uint32(),
+				Sequence: seq,
+				Nonce:    nonce,
 				Payload: &nodev1.GovernanceMessage_GuardianSet{
 					GuardianSet: &nodev1.GuardianSetUpdate{Guardians: guardians},
 				},
@@ -396,12 +397,14 @@ func runContractUpgradeTemplate(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 
+	seq, nonce := randSeqNonce()
+
 	m := &nodev1.InjectGovernanceVAARequest{
 		CurrentSetIndex: uint32(*templateGuardianIndex), // #nosec G115 -- This will never overflow
 		Messages: []*nodev1.GovernanceMessage{
 			{
-				Sequence: rand.Uint64(),
-				Nonce:    rand.Uint32(),
+				Sequence: seq,
+				Nonce:    nonce,
 				Payload: &nodev1.GovernanceMessage_ContractUpgrade{
 					ContractUpgrade: &nodev1.ContractUpgrade{
 						ChainId:     uint32(chainID),
@@ -428,12 +431,13 @@ func runTokenBridgeRegisterChainTemplate(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 
+	seq, nonce := randSeqNonce()
 	m := &nodev1.InjectGovernanceVAARequest{
 		CurrentSetIndex: uint32(*templateGuardianIndex), // #nosec G115 -- This will never overflow
 		Messages: []*nodev1.GovernanceMessage{
 			{
-				Sequence: rand.Uint64(),
-				Nonce:    rand.Uint32(),
+				Sequence: seq,
+				Nonce:    nonce,
 				Payload: &nodev1.GovernanceMessage_BridgeRegisterChain{
 					BridgeRegisterChain: &nodev1.BridgeRegisterChain{
 						Module:         *module,
@@ -462,12 +466,13 @@ func runTokenBridgeUpgradeContractTemplate(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 
+	seq, nonce := randSeqNonce()
 	m := &nodev1.InjectGovernanceVAARequest{
 		CurrentSetIndex: uint32(*templateGuardianIndex), // #nosec G115 -- This will never overflow
 		Messages: []*nodev1.GovernanceMessage{
 			{
-				Sequence: rand.Uint64(),
-				Nonce:    rand.Uint32(),
+				Sequence: seq,
+				Nonce:    nonce,
 				Payload: &nodev1.GovernanceMessage_BridgeContractUpgrade{
 					BridgeContractUpgrade: &nodev1.BridgeUpgradeContract{
 						Module:        *module,
@@ -504,12 +509,13 @@ func runRecoverChainIdTemplate(cmd *cobra.Command, args []string) {
 		log.Fatal("failed to parse chain id:", err)
 	}
 
+	seq, nonce := randSeqNonce()
 	m := &nodev1.InjectGovernanceVAARequest{
 		CurrentSetIndex: uint32(*templateGuardianIndex), // #nosec G115 -- This will never overflow
 		Messages: []*nodev1.GovernanceMessage{
 			{
-				Sequence: rand.Uint64(),
-				Nonce:    rand.Uint32(),
+				Sequence: seq,
+				Nonce:    nonce,
 				Payload: &nodev1.GovernanceMessage_RecoverChainId{
 					RecoverChainId: &nodev1.RecoverChainId{
 						Module:     *module,
@@ -595,12 +601,13 @@ func runAccountantModifyBalanceTemplate(cmd *cobra.Command, args []string) {
 	if len(*accountantModifyBalanceReason) > vaa.AccountantModifyBalanceReasonLength {
 		log.Fatalf("reason is too long, can be at most %d bytes", vaa.AccountantModifyBalanceReasonLength)
 	}
+	seq, nonce := randSeqNonce()
 	m := &nodev1.InjectGovernanceVAARequest{
 		CurrentSetIndex: uint32(*templateGuardianIndex), // #nosec G115 -- This will never overflow
 		Messages: []*nodev1.GovernanceMessage{
 			{
-				Sequence: rand.Uint64(),
-				Nonce:    rand.Uint32(),
+				Sequence: seq,
+				Nonce:    nonce,
 				Payload: &nodev1.GovernanceMessage_AccountantModifyBalance{
 					AccountantModifyBalance: &nodev1.AccountantModifyBalance{
 						Module:        *accountantModifyBalanceModule,
@@ -641,12 +648,13 @@ func runCircleIntegrationUpdateWormholeFinalityTemplate(cmd *cobra.Command, args
 		log.Fatal("failed to parse finality as uint8: ", err)
 	}
 
+	seq, nonce := randSeqNonce()
 	m := &nodev1.InjectGovernanceVAARequest{
 		CurrentSetIndex: uint32(*templateGuardianIndex), // #nosec G115 -- This will never overflow
 		Messages: []*nodev1.GovernanceMessage{
 			{
-				Sequence: rand.Uint64(),
-				Nonce:    rand.Uint32(),
+				Sequence: seq,
+				Nonce:    nonce,
 				Payload: &nodev1.GovernanceMessage_CircleIntegrationUpdateWormholeFinality{
 					CircleIntegrationUpdateWormholeFinality: &nodev1.CircleIntegrationUpdateWormholeFinality{
 						TargetChainId: uint32(chainID),
@@ -694,12 +702,13 @@ func runCircleIntegrationRegisterEmitterAndDomainTemplate(cmd *cobra.Command, ar
 		log.Fatal("failed to parse circle domain as uint32:", err)
 	}
 
+	seq, nonce := randSeqNonce()
 	m := &nodev1.InjectGovernanceVAARequest{
 		CurrentSetIndex: uint32(*templateGuardianIndex), // #nosec G115 -- This will never overflow
 		Messages: []*nodev1.GovernanceMessage{
 			{
-				Sequence: rand.Uint64(),
-				Nonce:    rand.Uint32(),
+				Sequence: seq,
+				Nonce:    nonce,
 				Payload: &nodev1.GovernanceMessage_CircleIntegrationRegisterEmitterAndDomain{
 					CircleIntegrationRegisterEmitterAndDomain: &nodev1.CircleIntegrationRegisterEmitterAndDomain{
 						TargetChainId:         uint32(chainID),
@@ -735,12 +744,13 @@ func runCircleIntegrationUpgradeContractImplementationTemplate(cmd *cobra.Comman
 		log.Fatal("failed to parse new implementation address: ", err)
 	}
 
+	seq, nonce := randSeqNonce()
 	m := &nodev1.InjectGovernanceVAARequest{
 		CurrentSetIndex: uint32(*templateGuardianIndex), // #nosec G115 -- This will never overflow
 		Messages: []*nodev1.GovernanceMessage{
 			{
-				Sequence: rand.Uint64(),
-				Nonce:    rand.Uint32(),
+				Sequence: seq,
+				Nonce:    nonce,
 				Payload: &nodev1.GovernanceMessage_CircleIntegrationUpgradeContractImplementation{
 					CircleIntegrationUpgradeContractImplementation: &nodev1.CircleIntegrationUpgradeContractImplementation{
 						TargetChainId:            uint32(chainID),
@@ -774,12 +784,13 @@ func runWormchainStoreCodeTemplate(cmd *cobra.Command, args []string) {
 		log.Fatalf("wasm-hash (expected 32 bytes but received %d bytes)", len(buf))
 	}
 
+	seq, nonce := randSeqNonce()
 	m := &nodev1.InjectGovernanceVAARequest{
 		CurrentSetIndex: uint32(*templateGuardianIndex), // #nosec G115 -- This will never overflow
 		Messages: []*nodev1.GovernanceMessage{
 			{
-				Sequence: rand.Uint64(),
-				Nonce:    rand.Uint32(),
+				Sequence: seq,
+				Nonce:    nonce,
 				Payload: &nodev1.GovernanceMessage_WormchainStoreCode{
 					WormchainStoreCode: &nodev1.WormchainStoreCode{
 						WasmHash: string(*wormchainStoreCodeWasmHash),
@@ -811,12 +822,13 @@ func runWormchainInstantiateContractTemplate(cmd *cobra.Command, args []string) 
 		log.Fatal("--instantiation-msg must be specified.")
 	}
 
+	seq, nonce := randSeqNonce()
 	m := &nodev1.InjectGovernanceVAARequest{
 		CurrentSetIndex: uint32(*templateGuardianIndex), // #nosec G115 -- This will never overflow
 		Messages: []*nodev1.GovernanceMessage{
 			{
-				Sequence: rand.Uint64(),
-				Nonce:    rand.Uint32(),
+				Sequence: seq,
+				Nonce:    nonce,
 				Payload: &nodev1.GovernanceMessage_WormchainInstantiateContract{
 					WormchainInstantiateContract: &nodev1.WormchainInstantiateContract{
 						CodeId:           codeId,
@@ -850,12 +862,13 @@ func runWormchainMigrateContractTemplate(cmd *cobra.Command, args []string) {
 		log.Fatal("--instantiation-msg must be specified.")
 	}
 
+	seq, nonce := randSeqNonce()
 	m := &nodev1.InjectGovernanceVAARequest{
 		CurrentSetIndex: uint32(*templateGuardianIndex), // #nosec G115 -- This will never overflow
 		Messages: []*nodev1.GovernanceMessage{
 			{
-				Sequence: rand.Uint64(),
-				Nonce:    rand.Uint32(),
+				Sequence: seq,
+				Nonce:    nonce,
 				Payload: &nodev1.GovernanceMessage_WormchainMigrateContract{
 					WormchainMigrateContract: &nodev1.WormchainMigrateContract{
 						CodeId:           codeId,
@@ -894,12 +907,13 @@ func runWormchainWasmInstantiateAllowlistTemplate(action nodev1.WormchainWasmIns
 		log.Fatal("--contract-address must be specified")
 	}
 
+	seq, nonce := randSeqNonce()
 	m := &nodev1.InjectGovernanceVAARequest{
 		CurrentSetIndex: uint32(*templateGuardianIndex), // #nosec G115 -- This will never overflow
 		Messages: []*nodev1.GovernanceMessage{
 			{
-				Sequence: rand.Uint64(),
-				Nonce:    rand.Uint32(),
+				Sequence: seq,
+				Nonce:    nonce,
 				Payload: &nodev1.GovernanceMessage_WormchainWasmInstantiateAllowlist{
 					WormchainWasmInstantiateAllowlist: &nodev1.WormchainWasmInstantiateAllowlist{
 						CodeId:   codeId,
@@ -932,12 +946,13 @@ func runGatewayScheduleUpgradeTemplate(cmd *cobra.Command, args []string) {
 		log.Fatal("failed to parse height as uint64: ", err)
 	}
 
+	seq, nonce := randSeqNonce()
 	m := &nodev1.InjectGovernanceVAARequest{
 		CurrentSetIndex: uint32(*templateGuardianIndex), // #nosec G115 -- This will never overflow
 		Messages: []*nodev1.GovernanceMessage{
 			{
-				Sequence: rand.Uint64(),
-				Nonce:    rand.Uint32(),
+				Sequence: seq,
+				Nonce:    nonce,
 				Payload: &nodev1.GovernanceMessage_GatewayScheduleUpgrade{
 					GatewayScheduleUpgrade: &nodev1.GatewayScheduleUpgrade{
 						Name:   *gatewayScheduleUpgradeName,
@@ -956,12 +971,13 @@ func runGatewayScheduleUpgradeTemplate(cmd *cobra.Command, args []string) {
 }
 
 func runGatewayCancelUpgradeTemplate(cmd *cobra.Command, args []string) {
+	seq, nonce := randSeqNonce()
 	m := &nodev1.InjectGovernanceVAARequest{
 		CurrentSetIndex: uint32(*templateGuardianIndex), // #nosec G115 -- This will never overflow
 		Messages: []*nodev1.GovernanceMessage{
 			{
-				Sequence: rand.Uint64(),
-				Nonce:    rand.Uint32(),
+				Sequence: seq,
+				Nonce:    nonce,
 				Payload:  &nodev1.GovernanceMessage_GatewayCancelUpgrade{},
 			},
 		},
@@ -979,12 +995,13 @@ func runGatewayIbcComposabilityMwSetContractTemplate(cmd *cobra.Command, args []
 		log.Fatal("--contract-address must be specified")
 	}
 
+	seq, nonce := randSeqNonce()
 	m := &nodev1.InjectGovernanceVAARequest{
 		CurrentSetIndex: uint32(*templateGuardianIndex), // #nosec G115 -- This will never overflow
 		Messages: []*nodev1.GovernanceMessage{
 			{
-				Sequence: rand.Uint64(),
-				Nonce:    rand.Uint32(),
+				Sequence: seq,
+				Nonce:    nonce,
 				Payload: &nodev1.GovernanceMessage_GatewayIbcComposabilityMwSetContract{
 					GatewayIbcComposabilityMwSetContract: &nodev1.GatewayIbcComposabilityMwSetContract{
 						Contract: *gatewayIbcComposabilityMwContractAddress,
@@ -1033,12 +1050,13 @@ func runIbcUpdateChannelChainTemplate(module nodev1.IbcUpdateChannelChainModule)
 		log.Fatal("failed to parse chain id: ", err)
 	}
 
+	seq, nonce := randSeqNonce()
 	m := &nodev1.InjectGovernanceVAARequest{
 		CurrentSetIndex: uint32(*templateGuardianIndex), // #nosec G115 -- This will never overflow
 		Messages: []*nodev1.GovernanceMessage{
 			{
-				Sequence: rand.Uint64(),
-				Nonce:    rand.Uint32(),
+				Sequence: seq,
+				Nonce:    nonce,
 				Payload: &nodev1.GovernanceMessage_IbcUpdateChannelChain{
 					IbcUpdateChannelChain: &nodev1.IbcUpdateChannelChain{
 						TargetChainId: uint32(targetChainId),
@@ -1069,12 +1087,13 @@ func runWormholeRelayerSetDefaultDeliveryProviderTemplate(cmd *cobra.Command, ar
 		log.Fatal(err)
 	}
 
+	seq, nonce := randSeqNonce()
 	m := &nodev1.InjectGovernanceVAARequest{
 		CurrentSetIndex: uint32(*templateGuardianIndex), // #nosec G115 -- This will never overflow
 		Messages: []*nodev1.GovernanceMessage{
 			{
-				Sequence: rand.Uint64(),
-				Nonce:    rand.Uint32(),
+				Sequence: seq,
+				Nonce:    nonce,
 				Payload: &nodev1.GovernanceMessage_WormholeRelayerSetDefaultDeliveryProvider{
 					WormholeRelayerSetDefaultDeliveryProvider: &nodev1.WormholeRelayerSetDefaultDeliveryProvider{
 						ChainId:                           uint32(chainID),
@@ -1118,12 +1137,13 @@ func runGeneralPurposeGovernanceEvmCallTemplate(cmd *cobra.Command, args []strin
 		log.Fatal("failed to parse chain id: ", err)
 	}
 
+	seq, nonce := randSeqNonce()
 	m := &nodev1.InjectGovernanceVAARequest{
 		CurrentSetIndex: uint32(*templateGuardianIndex), // #nosec G115 -- This will never overflow
 		Messages: []*nodev1.GovernanceMessage{
 			{
-				Sequence: rand.Uint64(),
-				Nonce:    rand.Uint32(),
+				Sequence: seq,
+				Nonce:    nonce,
 				Payload: &nodev1.GovernanceMessage_EvmCall{
 					EvmCall: &nodev1.EvmCall{
 						ChainId:            uint32(chainID),
@@ -1162,12 +1182,13 @@ func runGeneralPurposeGovernanceSolanaCallTemplate(cmd *cobra.Command, args []st
 		log.Fatal("failed to parse chain id: ", err)
 	}
 
+	seq, nonce := randSeqNonce()
 	m := &nodev1.InjectGovernanceVAARequest{
 		CurrentSetIndex: uint32(*templateGuardianIndex), // #nosec G115 -- This will never overflow
 		Messages: []*nodev1.GovernanceMessage{
 			{
-				Sequence: rand.Uint64(),
-				Nonce:    rand.Uint32(),
+				Sequence: seq,
+				Nonce:    nonce,
 				Payload: &nodev1.GovernanceMessage_SolanaCall{
 					SolanaCall: &nodev1.SolanaCall{
 						ChainId:            uint32(chainID),
@@ -1251,4 +1272,17 @@ func isValidUint256(s string) (bool, error) {
 	}
 
 	return true, nil
+}
+
+// randSeqNonce returns a new random sequence and nonce. It exits if the random numbers can't be generated.
+func randSeqNonce() (uint64, uint32) {
+	seq, err := random.Uint64()
+	if err != nil {
+		log.Fatal("random number: ", err)
+	}
+	nonce, err := random.Uint32()
+	if err != nil {
+		log.Fatal("random number: ", err)
+	}
+	return seq, nonce
 }

--- a/node/hack/query/ccqlistener/ccqlistener.go
+++ b/node/hack/query/ccqlistener/ccqlistener.go
@@ -57,12 +57,12 @@ import (
 	"github.com/certusone/wormhole/node/pkg/p2p"
 	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
 	"github.com/certusone/wormhole/node/pkg/query"
+	"github.com/certusone/wormhole/node/pkg/random"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	ethCrypto "github.com/ethereum/go-ethereum/crypto"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/crypto"
-	"github.com/tendermint/tendermint/libs/rand"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 )
@@ -276,8 +276,12 @@ const (
 )
 
 func createQueryRequest(callRequest *query.EthCallQueryRequest) *query.QueryRequest {
+	nonce, err := random.Uint32()
+	if err != nil {
+		panic(err)
+	}
 	queryRequest := &query.QueryRequest{
-		Nonce: rand.Uint32(),
+		Nonce: nonce,
 		PerChainQueries: []*query.PerChainQueryRequest{
 			{
 				ChainId: 2,

--- a/node/hack/query/send_req.go
+++ b/node/hack/query/send_req.go
@@ -18,13 +18,13 @@ import (
 	"github.com/certusone/wormhole/node/pkg/p2p"
 	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
 	"github.com/certusone/wormhole/node/pkg/query"
+	"github.com/certusone/wormhole/node/pkg/random"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	ethCommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	ethCrypto "github.com/ethereum/go-ethereum/crypto"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/crypto"
-	"github.com/tendermint/tendermint/libs/rand"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 
@@ -143,8 +143,12 @@ func main() {
 			Accounts:        [][query.SolanaPublicKeyLength]byte{account1, account2},
 		}
 
+		nonce, err := random.Uint32()
+		if err != nil {
+			panic(err)
+		}
 		queryRequest := &query.QueryRequest{
-			Nonce: rand.Uint32(),
+			Nonce: nonce,
 			PerChainQueries: []*query.PerChainQueryRequest{
 				{
 					ChainId: 1,
@@ -174,8 +178,12 @@ func main() {
 			},
 		}
 
+		nonce, err := random.Uint32()
+		if err != nil {
+			panic(err)
+		}
 		queryRequest := &query.QueryRequest{
-			Nonce: rand.Uint32(),
+			Nonce: nonce,
 			PerChainQueries: []*query.PerChainQueryRequest{
 				{
 					ChainId: 1,
@@ -287,8 +295,12 @@ const (
 )
 
 func createQueryRequest(callRequest *query.EthCallQueryRequest) *query.QueryRequest {
+	nonce, err := random.Uint32()
+	if err != nil {
+		panic(err)
+	}
 	queryRequest := &query.QueryRequest{
-		Nonce: rand.Uint32(),
+		Nonce: nonce,
 		PerChainQueries: []*query.PerChainQueryRequest{
 			{
 				ChainId: 2,
@@ -308,8 +320,12 @@ func createQueryRequestWithMultipleRequests(callRequests []*query.EthCallQueryRe
 		})
 	}
 
+	nonce, err := random.Uint32()
+	if err != nil {
+		panic(err)
+	}
 	queryRequest := &query.QueryRequest{
-		Nonce:           rand.Uint32(),
+		Nonce:           nonce,
 		PerChainQueries: perChainQueries,
 	}
 	return queryRequest

--- a/node/pkg/random/random.go
+++ b/node/pkg/random/random.go
@@ -1,0 +1,42 @@
+package random
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+	"fmt"
+)
+
+// ErrFailedToGenerate is returned when random number generation fails
+type ErrFailedToGenerate struct {
+	Op  string // Operation that failed
+	Err error  // Underlying error
+}
+
+// Error implements the error interface
+func (e *ErrFailedToGenerate) Error() string {
+	return fmt.Sprintf("failed to generate random %s: %v", e.Op, e.Err)
+}
+
+func Uint32() (uint32, error) {
+	var n uint32
+	err := binary.Read(rand.Reader, binary.BigEndian, &n)
+	if err != nil {
+		return 0, &ErrFailedToGenerate{
+			Op:  "uint32",
+			Err: err,
+		}
+	}
+	return n, nil
+}
+
+func Uint64() (uint64, error) {
+	var n uint64
+	err := binary.Read(rand.Reader, binary.BigEndian, &n)
+	if err != nil {
+		return 0, &ErrFailedToGenerate{
+			Op:  "uint64",
+			Err: err,
+		}
+	}
+	return n, nil
+}


### PR DESCRIPTION
- Removes references to tendermint/random. 
This package was being used to generate random Uint32 and Uint64 values for sequence and nonce values. This dependency was added to the admintemplate many years ago and there isn't a justification in the commit for adding it instead of using std library functions. The original motivation may have been that the Tendermint library claims that it is thread-safe; however Go's standard cryptography libraries have changed a lot and there's no reason to think they are not thread safe.

- Adds new random functionality in the form of Uint32 and Uint64 functions.

These changes make it so that the only parts of the node that reference Tendermint are the ones directly related to Cosmos code. 

Note that both Tendermint and the CometBFT fork have either deleted or deprecated this functionality anyway.
- https://github.com/tendermint/tendermint/issues/2956 
- https://github.com/cometbft/cometbft/blob/main/libs/rand/random.go