### PR TITLE
deps: Remove benbjohnson/clock as a direct dependency

### DIFF
--- a/node/go.mod
+++ b/node/go.mod
@@ -47,7 +47,6 @@ require (
 	github.com/aws/aws-sdk-go v1.55.5
 	github.com/aws/aws-sdk-go-v2/config v1.28.1
 	github.com/aws/aws-sdk-go-v2/service/kms v1.37.3
-	github.com/benbjohnson/clock v1.3.5
 	github.com/blendle/zapdriver v1.3.1
 	github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce
 	github.com/cosmos/cosmos-sdk v0.45.11
@@ -95,6 +94,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.28.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.32.3 // indirect
 	github.com/aws/smithy-go v1.22.0 // indirect
+	github.com/benbjohnson/clock v1.3.5 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bgentry/speakeasy v0.1.0 // indirect
 	github.com/btcsuite/btcd v0.22.1 // indirect

--- a/node/pkg/node/options.go
+++ b/node/pkg/node/options.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/benbjohnson/clock"
 	"github.com/certusone/wormhole/node/pkg/accountant"
 	"github.com/certusone/wormhole/node/pkg/altpub"
 	"github.com/certusone/wormhole/node/pkg/common"
@@ -502,7 +501,8 @@ func GuardianOptionWatchers(watcherConfigs []watchers.WatcherConfig, ibcWatcherC
 				}
 			}
 
-			go handleReobservationRequests(ctx, clock.New(), logger, g.obsvReqC.readC, chainObsvReqC)
+			clock := &CacheClock{}
+			go handleReobservationRequests(ctx, clock, logger, g.obsvReqC.readC, chainObsvReqC)
 
 			return nil
 		}}

--- a/node/pkg/node/reobserve.go
+++ b/node/pkg/node/reobserve.go
@@ -6,16 +6,36 @@ import (
 	"math"
 	"time"
 
-	"github.com/benbjohnson/clock"
 	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
 	"github.com/wormhole-foundation/wormhole/sdk/vaa"
 	"go.uber.org/zap"
 )
 
+const (
+	CachePurgeInterval = 7 * time.Minute
+	CacheFor           = 11 * time.Minute
+)
+
+type Clock interface {
+	Now() time.Time
+	NewTicker(d time.Duration) *time.Ticker
+}
+
+// CacheClock is a wrapper for some of the standard library's time functions.
+// It exists to allow for dependency injection while testing [handleReobservationRequests].
+type CacheClock struct{}
+
+func (c *CacheClock) Now() time.Time {
+	return time.Now()
+}
+func (c *CacheClock) NewTicker(d time.Duration) *time.Ticker {
+	return time.NewTicker(d)
+}
+
 // Multiplex observation requests to the appropriate chain
 func handleReobservationRequests(
 	ctx context.Context,
-	clock clock.Clock,
+	clock Clock,
 	logger *zap.Logger,
 	obsvReqC <-chan *gossipv1.ObservationRequest,
 	chainObsvReqC map[vaa.ChainID]chan *gossipv1.ObservationRequest,
@@ -30,7 +50,7 @@ func handleReobservationRequests(
 	}
 
 	cache := make(map[cachedRequest]time.Time)
-	ticker := clock.Ticker(7 * time.Minute)
+	ticker := clock.NewTicker(CachePurgeInterval)
 	for {
 		select {
 		case <-ctx.Done():
@@ -38,7 +58,7 @@ func handleReobservationRequests(
 		case <-ticker.C:
 			now := clock.Now()
 			for r, t := range cache {
-				if now.Sub(t) > 11*time.Minute {
+				if now.Sub(t) > CacheFor {
 					delete(cache, r)
 				}
 			}


### PR DESCRIPTION
- Replaces the [archived dependency](https://github.com/benbjohnson/clock)'s mock clock capabilities with an interface defined in the files that use it. The implementation is similar to how the library does it.
- Update go.mod via `go mod tidy`
- Minor refactoring of reobserve.go to change in-line durations to named constants.