### PR TITLE
sdk: Return false for empty arguments to VerifySignatures

### DIFF
--- a/sdk/vaa/structs.go
+++ b/sdk/vaa/structs.go
@@ -879,7 +879,16 @@ func verifySignature(vaa_digest []byte, signature *Signature, address common.Add
 
 // Digest should be the output of SigningMsg(data).Bytes()
 // Should not be public as other message types should be verified using a message prefix.
+// Returns false when the signatures or addresses are empty.
 func verifySignatures(vaa_digest []byte, signatures []*Signature, addresses []common.Address) bool {
+
+	// An empty set is neither valid nor invalid, it's just specified incorrectly.
+	// To help with backward-compatibility, return false instead of changing the function
+	// signature to return an error.
+	if len(signatures) == 0 || len(addresses) == 0 {
+		return false
+	}
+
 	if len(addresses) < len(signatures) {
 		return false
 	}
@@ -937,6 +946,10 @@ func VerifyMessageSignature(prefix []byte, messageBody []byte, signatures *Signa
 
 // VerifySignatures verifies the signature of the VAA given the signer addresses.
 // Returns true if the signatures were verified successfully.
+// Returns false when the signatures or addresses are empty.
+//
+// WARNING: This function is not sufficient for validating a VAA as it does not consider
+// signature quorum. [VAA.Verify] should be used instead.
 func (v *VAA) VerifySignatures(addresses []common.Address) bool {
 	return verifySignatures(v.SigningDigest().Bytes(), v.Signatures, addresses)
 }

--- a/sdk/vaa/structs_test.go
+++ b/sdk/vaa/structs_test.go
@@ -552,12 +552,12 @@ func TestVerifySignatures(t *testing.T) {
 			keyOrder:   []*ecdsa.PrivateKey{},
 			addrs:      addrs,
 			indexOrder: []uint8{0},
-			result:     true},
+			result:     false},
 		{label: "NoSignerOne",
 			keyOrder:   []*ecdsa.PrivateKey{},
 			addrs:      addrs,
 			indexOrder: []uint8{1},
-			result:     true},
+			result:     false},
 		{label: "SingleZero",
 			keyOrder:   []*ecdsa.PrivateKey{privKey1},
 			addrs:      addrs,
@@ -684,9 +684,8 @@ func TestVerifySignaturesFuzz(t *testing.T) {
 		indexPair []uint8
 	}
 
-	// Known good cases where we should have a verified result for
+	// Known good cases where we should have a verified result.
 	allows := []allow{
-		{keyPair: []*ecdsa.PrivateKey{}, indexPair: []uint8{}},
 		{keyPair: []*ecdsa.PrivateKey{privKey1}, indexPair: []uint8{0}},
 		{keyPair: []*ecdsa.PrivateKey{privKey2}, indexPair: []uint8{1}},
 		{keyPair: []*ecdsa.PrivateKey{privKey3}, indexPair: []uint8{2}},
@@ -776,10 +775,10 @@ func TestVerifySignaturesFuzz(t *testing.T) {
 				vaa.AddSignature(key, tc.indexOrder[i])
 			}
 
-			/* Fuzz Debugging
-			 * Tell us what keys and indexes were used (for debug when/if we have a failure case)
-			 */
-			if vaa.VerifySignatures(tc.addrs) != tc.result {
+			// Fuzz Debugging
+			// Tell us what keys and indexes were used (for debug when/if we have a failure case).
+			actual := vaa.VerifySignatures(tc.addrs)
+			if actual != tc.result {
 				if len(tc.keyOrder) == 0 {
 					t.Logf("Key Order %v\n", tc.keyOrder)
 				} else {
@@ -797,7 +796,7 @@ func TestVerifySignaturesFuzz(t *testing.T) {
 
 			}
 
-			assert.Equal(t, tc.result, vaa.VerifySignatures(tc.addrs))
+			assert.Equal(t, tc.result, actual)
 		})
 	}
 }


### PR DESCRIPTION
- Updates SDK function and unit tests to return false for the empty case. This is to prevent the function returning true trivially for empty arguments. Either true or false may be 'correct', but returning false is less likely to lead to failing open if empty arguments are passed by mistake.
- Adds a comment warning that VerifySignatures is the wrong function to use when actually validating a VAA. (This is a bug that has occurred before but was caught in internal review.)