### PR TITLE
ci: pin github actions for wormchain to commits instead of releases

### DIFF
--- a/.github/workflows/wormchain-icts.yml
+++ b/.github/workflows/wormchain-icts.yml
@@ -37,10 +37,10 @@ jobs:
           cache-dependency-path: wormchain/interchaintest/go.sum
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
 
       - name: Build and export
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
           context: .
           file: wormchain/Dockerfile.ict


### PR DESCRIPTION
setup-buildx-action
https://github.com/docker/setup-buildx-action/commit/b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2

The build-push-action matches the commit used elsewhere in the repo, e.g. https://github.com/wormhole-foundation/wormhole/blob/a31e5ba792bd66436cca5496867fc0823d3e99f3/.github/workflows/generic-relayer-docker.yml#L39
