### PR TITLE
Node/Solana: Minor watcher cleanup

### DIFF
--- a/node/pkg/watchers/solana/client.go
+++ b/node/pkg/watchers/solana/client.go
@@ -819,7 +819,7 @@ func (s *SolanaWatcher) processInstruction(ctx context.Context, rpcClient *rpc.C
 				zap.String("watcher commitment", string(s.commitment)),
 			)
 		}
-		return true, nil
+		return false, nil
 	}
 
 	// The second account in a well-formed Wormhole instruction is the VAA program account.

--- a/node/pkg/watchers/solana/client.go
+++ b/node/pkg/watchers/solana/client.go
@@ -1172,6 +1172,8 @@ func isPossibleWormholeMessage(whLogPrefix string, logMessages []string) bool {
 					return true
 				}
 			}
+			// There are no sequence logs anywhere below this, so we can quit looking.
+			return false
 		}
 	}
 	return false

--- a/node/pkg/watchers/solana/client_test.go
+++ b/node/pkg/watchers/solana/client_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/rpc"
@@ -55,4 +56,54 @@ func TestCheckCommitment(t *testing.T) {
 			assert.Equal(t, tc.result, s.checkCommitment(commitment, tc.isReobservation))
 		})
 	}
+}
+
+const whLogPrefix = "Program worm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMTth"
+
+func TestIsPossibleWormholeMessageSuccess(t *testing.T) {
+	logs := []string{
+		"Program ComputeBudget111111111111111111111111111111 invoke [1]",
+		"Program ComputeBudget111111111111111111111111111111 success",
+		"Program ComputeBudget111111111111111111111111111111 invoke [1]",
+		"Program ComputeBudget111111111111111111111111111111 success",
+		"Program BLZRi6frs4X4DNLw56V4EXai1b6QVESN1BhHBTYM9VcY invoke [1]",
+		"Program log: Instruction: PostUnlock",
+		"Program 11111111111111111111111111111111 invoke [2]",
+		"Program 11111111111111111111111111111111 success",
+		"Program worm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMTth invoke [2]",
+		"Program log: Sequence: 149587",
+		"Program 11111111111111111111111111111111 invoke [3]",
+		"Program 11111111111111111111111111111111 success",
+		"Program 11111111111111111111111111111111 invoke [3]",
+		"Program 11111111111111111111111111111111 success",
+		"Program 11111111111111111111111111111111 invoke [3]",
+		"Program 11111111111111111111111111111111 success",
+		"Program worm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMTth consumed 27143 of 33713 compute units",
+		"Program worm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMTth success",
+		"Program log: unlock message seq: 149587",
+		"Program BLZRi6frs4X4DNLw56V4EXai1b6QVESN1BhHBTYM9VcY consumed 88681 of 94020 compute units",
+		"Program BLZRi6frs4X4DNLw56V4EXai1b6QVESN1BhHBTYM9VcY success",
+	}
+
+	require.True(t, isPossibleWormholeMessage(whLogPrefix, logs))
+}
+
+func TestIsPossibleWormholeMessageFail(t *testing.T) {
+	logs := []string{
+		"Program ComputeBudget111111111111111111111111111111 invoke [1]",
+		"Program ComputeBudget111111111111111111111111111111 success",
+		"Program ComputeBudget111111111111111111111111111111 invoke [1]",
+		"Program ComputeBudget111111111111111111111111111111 success",
+		"Program worm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMTth invoke [1]",
+		"Program 11111111111111111111111111111111 invoke [2]",
+		"Program 11111111111111111111111111111111 success",
+		"Program 11111111111111111111111111111111 invoke [2]",
+		"Program 11111111111111111111111111111111 success",
+		"Program 11111111111111111111111111111111 invoke [2]",
+		"Program 11111111111111111111111111111111 success",
+		"Program worm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMTth consumed 92816 of 154700 compute units",
+		"Program worm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMTth success",
+	}
+
+	require.False(t, isPossibleWormholeMessage(whLogPrefix, logs))
 }

--- a/node/pkg/watchers/solana/config.go
+++ b/node/pkg/watchers/solana/config.go
@@ -65,7 +65,7 @@ func (wc *WatcherConfig) Create(
 		obsvReqC = nil
 	}
 
-	watcher := NewSolanaWatcher(wc.Rpc, &wc.Websocket, solAddress, wc.Contract, msgC, obsvReqC, wc.Commitment, wc.ChainID, queryReqC, queryResponseC, wc.ShimContract, shimContractAddr)
+	watcher := NewSolanaWatcher(wc.Rpc, wc.Websocket, solAddress, wc.Contract, msgC, obsvReqC, wc.Commitment, wc.ChainID, queryReqC, queryResponseC, wc.ShimContract, shimContractAddr)
 
 	var reobserver interfaces.Reobserver
 	if wc.Commitment == solana_rpc.CommitmentFinalized {


### PR DESCRIPTION
This PR does some minor clean up of the Solana watcher. Notably:

- Optimizes the check to see if a transaction might include a wormhole `PostMessage`
- Can't save the `ctx` across a restart since it may have previously been canceled
- Removes logging of the commitment level since it is in the logger name
- Cleans up various other log messages
- A few other minor things
- Don't count the wrong commitment level as an observation