### PR TITLE
node: improve message verification code for EVM Transfer Verifier; update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -35,6 +35,7 @@
 /testing/ @a5-pickle @evan-gray
 /wormchain/contracts/tools/ @evan-gray @kev1n-peters @panoel
 /wormchain/devnet/ @evan-gray @bruce-riley
+/wormchain/devnet/txverifier/ @djb15 @johnsaigle @mdulin2 @pleasew8t
 /wormchain/ts-sdk/ @evan-gray @kev1n-peters @panoel
 /deployments @evan-gray @kev1n-peters @panoel @bruce-riley
 
@@ -95,6 +96,7 @@
 ## Watchers
 
 /node/pkg/watchers @evan-gray @bruce-riley @panoel
+/node/pkg/watchers/evm/msg_verifier.go @djb15 @johnsaigle @mdulin2 @pleasew8t
 
 ## Hacks / Tools
 

--- a/node/pkg/watchers/evm/watcher.go
+++ b/node/pkg/watchers/evm/watcher.go
@@ -884,7 +884,7 @@ func (w *Watcher) verifyAndPublish(
 	}
 
 	if w.txVerifier != nil {
-		verifiedMsg, err := verify(ctx, msg, txHash, receipt, w.txVerifier)
+		verifiedMsg, err := w.verify(ctx, msg, txHash, receipt)
 
 		if err != nil {
 			return err


### PR DESCRIPTION
Brings the EVM implementation of Transfer Verifier into closer alignment with the Sui side (https://github.com/wormhole-foundation/wormhole/pull/4324), specifically:

- Fix pointer copy that should've been a value copy
- Modify the function into a method of the watcher
- Return early if the message is not a token transfer

This PR also makes some modifications to CODEOWNERS to help with the PR review process. 