### PR TITLE
deps: Remove status-im/keycard-go

### DIFF
--- a/node/cmd/guardiand/adminclient.go
+++ b/node/cmd/guardiand/adminclient.go
@@ -31,7 +31,6 @@ import (
 	"github.com/wormhole-foundation/wormhole/sdk/vaa"
 
 	"github.com/spf13/cobra"
-	"github.com/status-im/keycard-go/hexutils"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -303,7 +302,7 @@ func runInjectGovernanceVAA(cmd *cobra.Command, args []string) {
 	}
 
 	for _, digest := range resp.Digests {
-		log.Printf("VAA successfully injected with digest %s", hexutils.BytesToHex(digest))
+		log.Printf("VAA successfully injected with digest %x", digest)
 	}
 }
 

--- a/node/cmd/guardiand/adminverify.go
+++ b/node/cmd/guardiand/adminverify.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/spf13/cobra"
-	"github.com/status-im/keycard-go/hexutils"
 	"google.golang.org/protobuf/encoding/prototext"
 
 	"github.com/certusone/wormhole/node/pkg/adminrpc"
@@ -55,6 +54,6 @@ func runGovernanceVAAVerify(cmd *cobra.Command, args []string) {
 
 		log.Printf("Serialized: %v", hex.EncodeToString(b))
 
-		log.Printf("VAA with digest %s: %+v", hexutils.BytesToHex(digest), spew.Sdump(v))
+		log.Printf("VAA with digest %x: %+v", digest, spew.Sdump(v))
 	}
 }

--- a/node/go.mod
+++ b/node/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.14.0
-	github.com/status-im/keycard-go v0.0.0-20200402102358-957c09536969
+	github.com/status-im/keycard-go v0.0.0-20200402102358-957c09536969 // indirect
 	github.com/stretchr/testify v1.9.0
 	github.com/tendermint/tendermint v0.34.24
 	github.com/tidwall/gjson v1.15.0


### PR DESCRIPTION
- This dependency was being used only to print hex-encoded bytes, but this can be done by passing `%x` to `fmt.Printf()`

`go mod tidy` has removed this as a direct dependency.