### PR TITLE
deps: Replace godo/fswatch with fsnotify/fsnotify

### DIFF
--- a/node/cmd/ccq/permissions.go
+++ b/node/cmd/ccq/permissions.go
@@ -145,7 +145,7 @@ func (perms *Permissions) StartWatcher(ctx context.Context, logger *zap.Logger, 
 				// a Write event, where Vim actually deletes the file and recreates it on save.
 				//
 				// NOTE: A `touch` command issues only a `Chmod` event,
-				// so it will trigger this branch.
+				// so it will not trigger this branch.
 				if event.Name == perms.fileName && (event.Has(fsnotify.Write) || event.Has(fsnotify.Create)) {
 					logger.Info("the permissions file has been updated", zap.String("fileName", event.Name), zap.String("event", event.String()))
 					perms.Reload(logger)

--- a/node/cmd/ccq/permissions.go
+++ b/node/cmd/ccq/permissions.go
@@ -129,7 +129,7 @@ func (perms *Permissions) StartWatcher(ctx context.Context, logger *zap.Logger, 
 		return addErr
 	}
 	perms.watcher = permWatcher
-	logger.Warn("Starting permissions watcher", zap.String("dir", watchDir))
+	logger.Info("Starting permissions watcher", zap.String("dir", watchDir))
 
 	common.RunWithScissors(ctx, errC, "perm_file_watcher", func(ctx context.Context) error {
 		for {

--- a/node/cmd/ccq/query_server.go
+++ b/node/cmd/ccq/query_server.go
@@ -281,7 +281,12 @@ func runQueryServer(cmd *cobra.Command, args []string) {
 
 	// Start watching for permissions file updates.
 	errC := make(chan error)
-	permissions.StartWatcher(ctx, logger, errC)
+	permWatcherErr := permissions.StartWatcher(ctx, logger, errC)
+	if permWatcherErr != nil {
+		// Cleanup p2p connection.
+		cancel()
+		logger.Fatal("Could not start permissions file watcher", zap.Error(err))
+	}
 
 	// Star logging cleanup process.
 	loggingMap.Start(ctx, logger, errC)

--- a/node/go.mod
+++ b/node/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/blendle/zapdriver v1.3.1
 	github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce
 	github.com/cosmos/cosmos-sdk v0.45.11
+	github.com/fsnotify/fsnotify v1.6.0
 	github.com/go-kit/kit v0.12.0
 	github.com/golang/snappy v0.0.4
 	github.com/google/uuid v1.6.0
@@ -61,7 +62,6 @@ require (
 	github.com/wormhole-foundation/wormchain v0.0.0-00010101000000-000000000000
 	github.com/wormhole-foundation/wormhole/sdk v0.0.0-20220926172624-4b38dc650bb0
 	google.golang.org/genproto/googleapis/api v0.0.0-20230726155614-23370e0ffb3e
-	gopkg.in/godo.v2 v2.0.9
 	nhooyr.io/websocket v1.8.7
 )
 
@@ -134,7 +134,6 @@ require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/flynn/noise v1.1.0 // indirect
 	github.com/francoispqt/gojay v1.2.13 // indirect
-	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/gagliardetto/binary v0.7.7 // indirect
 	github.com/gagliardetto/treeout v0.1.4 // indirect
 	github.com/go-kit/log v0.2.1 // indirect
@@ -232,7 +231,6 @@ require (
 	github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
-	github.com/mgutz/str v1.2.0 // indirect
 	github.com/miekg/dns v1.1.62 // indirect
 	github.com/mikioh/tcpinfo v0.0.0-20190314235526-30a79bb1804b // indirect
 	github.com/mikioh/tcpopt v0.0.0-20190314235656-172688c1accc // indirect

--- a/node/go.sum
+++ b/node/go.sum
@@ -2186,8 +2186,6 @@ github.com/mbilski/exhaustivestruct v1.2.0/go.mod h1:OeTBVxQWoEmB2J2JCHmXWPJ0aks
 github.com/mgechev/dots v0.0.0-20210922191527-e955255bf517/go.mod h1:KQ7+USdGKfpPjXk4Ga+5XxQM4Lm4e3gAogrreFAYpOg=
 github.com/mgechev/revive v1.2.1/go.mod h1:+Ro3wqY4vakcYNtkBWdZC7dBg1xSB6sp054wWwmeFm0=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
-github.com/mgutz/str v1.2.0 h1:4IzWSdIz9qPQWLfKZ0rJcV0jcUDpxvP4JVZ4GXQyvSw=
-github.com/mgutz/str v1.2.0/go.mod h1:w1v0ofgLaJdoD0HpQ3fycxKD1WtxpjSo151pK/31q6w=
 github.com/microcosm-cc/bluemonday v1.0.1/go.mod h1:hsXNsILzKxV+sX77C5b8FSuKF00vh2OMYv+xgHpAMF4=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
@@ -4297,8 +4295,6 @@ gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMy
 gopkg.in/gcfg.v1 v1.2.0/go.mod h1:yesOnuUOFQAhST5vPY4nbZsb/huCgGGXlipJsBn0b3o=
 gopkg.in/gcfg.v1 v1.2.3/go.mod h1:yesOnuUOFQAhST5vPY4nbZsb/huCgGGXlipJsBn0b3o=
 gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2/go.mod h1:Xk6kEKp8OKb+X14hQBKWaSkCsqBpgog8nAV2xsGOxlo=
-gopkg.in/godo.v2 v2.0.9 h1:jnbznTzXVk0JDKOxN3/LJLDPYJzIl0734y+Z0cEJb4A=
-gopkg.in/godo.v2 v2.0.9/go.mod h1:wgvPPKLsWN0hPIJ4JyxvFGGbIW3fJMSrXhdvSuZ1z/8=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/ini.v1 v1.51.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=


### PR DESCRIPTION
- The fswatch repository seems to be abandoned, whereas fsnotify is actively supported and appears to be popular.

https://github.com/go-godo/godo/tree/v2.0.9/watcher/fswatch (last released 10 years ago)
https://github.com/fsnotify/fsnotify

## Testing

I had a hard time getting the Query Server to work, both inside of Tilt and when directly running `guardiand`. 
I encountered blocking failures for the p2p section of `query_server.go` that I couldn't resolve, so I moved the permissions block above the p2p block.

After this was done, I tested by running a combination of:
* `touch node/cmd/ccq/devnet.permissions.json`
* `nano node/cmd/ccq/devnet.permissions.json`
* `nvim node/cmd/ccq/devnet.permissions.json`

I confirmed that making modifications via nano and neovim trigged the file reload. As noted in the code comments, `touch` doesn't work with this method.

To test, use Tilt or `guardiand` to launch the query server. Ensure the log level is set to at least `Info`, then modify the file. If you get query server errors, try moving the code block as described above.