### PR TITLE
ethereum: remove deleted "--no-commit" flag from forge commands

### DIFF
--- a/ethereum/Makefile
+++ b/ethereum/Makefile
@@ -35,10 +35,12 @@ node_modules: package-lock.json
 forge_dependencies: lib/forge-std lib/openzeppelin-contracts
 
 lib/forge-std:
-	forge install foundry-rs/forge-std@v1.5.5 --no-git --no-commit
+	forge --version
+	forge install foundry-rs/forge-std@v1.5.5 --no-git
 
 lib/openzeppelin-contracts:
-	forge install openzeppelin/openzeppelin-contracts@0457042d93d9dfd760dbaa06a4d2f1216fdbe297 --no-git --no-commit
+	forge --version
+	forge install openzeppelin/openzeppelin-contracts@0457042d93d9dfd760dbaa06a4d2f1216fdbe297 --no-git
 
 dependencies: node_modules forge_dependencies
 

--- a/ethereum/Makefile
+++ b/ethereum/Makefile
@@ -30,7 +30,7 @@ node_modules: package-lock.json
 # Instead, we just specify the dependencies here. make will then take care of
 # installing them if they are not yet present.
 # When adding a new dependency, make sure to specify the exact commit hash, and
-# the --no-git and --no-commit flags (see lib/forge-std below)
+# the --no-git flag (see lib/forge-std below)
 .PHONY: forge_dependencies
 forge_dependencies: lib/forge-std lib/openzeppelin-contracts
 

--- a/relayer/ethereum/Makefile
+++ b/relayer/ethereum/Makefile
@@ -15,15 +15,15 @@ node_modules: package-lock.json
 # Instead, we just specify the dependencies here. make will then take care of
 # installing them if they are not yet present.
 # When adding a new dependency, make sure to specify the exact commit hash, and
-# the --no-git and --no-commit flags (see lib/forge-std below)
+# the --no-git flag (see lib/forge-std below)
 .PHONY: forge_dependencies
 forge_dependencies: lib/forge-std lib/openzeppelin-contracts
 
 lib/forge-std:
-	forge install foundry-rs/forge-std@v1.5.5 --no-git --no-commit
+	forge install foundry-rs/forge-std@v1.5.5 --no-git
 
 lib/openzeppelin-contracts:
-	forge install openzeppelin/openzeppelin-contracts@0457042d93d9dfd760dbaa06a4d2f1216fdbe297 --no-git --no-commit
+	forge install openzeppelin/openzeppelin-contracts@0457042d93d9dfd760dbaa06a4d2f1216fdbe297 --no-git
 
 dependencies: node_modules forge_dependencies
 


### PR DESCRIPTION
The `--no-commit` flag has been removed: https://github.com/foundry-rs/foundry/pull/9884

CI is now failing as a result when pulling the `stable` foundry release via https://github.com/foundry-rs/foundry-toolchain/releases/tag/v1


### Example failure
https://github.com/wormhole-foundation/wormhole/actions/runs/14776517039/job/41485875483?pr=4357
```sh
Run cd ethereum && make test-push0 && make test
touch -m node_modules
npm ci
npm WARN reify Removing non-directory /home/runner/work/wormhole/wormhole/ethereum/node_modules

added 117 packages, and audited 118 packages in 2s

39 packages are looking for funding
  run `npm fund` for details

5 vulnerabilities ([4](https://github.com/wormhole-foundation/wormhole/actions/runs/14776517039/job/41485875483?pr=4357#step:5:5) high, 1 critical)

To address all issues, run:
  npm audit fix

Run `npm audit` for details.
forge install foundry-rs/forge-std@v1.[5](https://github.com/wormhole-foundation/wormhole/actions/runs/14776517039/job/41485875483?pr=4357#step:5:6).5 --no-git --no-commit
error: unexpected argument '--no-commit' found

  tip: a similar argument exists: '--commit'

Usage: forge install [OPTIONS] [DEPENDENCIES]...
    forge install [OPTIONS] <github username>/<github project>@<tag>...
    forge install [OPTIONS] <alias>=<github username>/<github project>@<tag>...
    forge install [OPTIONS] <https://<github token>@git url>...)]
    forge install [OPTIONS] <https:// git url>...

For more information, try '--help'.
make: *** [Makefile:3[8](https://github.com/wormhole-foundation/wormhole/actions/runs/14776517039/job/41485875483?pr=4357#step:5:9): lib/forge-std] Error 2
```

### To reproduce

#### On `origin/main`

* Get stable foundry locally: `foundryup --version stable`
* Check forge version 

```sh
$ forge --version

forge Version: 1.1.0-stable
Commit SHA: d484a00089d789a19e2e43e63bbb3f1500eb2cbf
Build Timestamp: 2025-04-30T13:50:49.971365000Z (1746021049)
Build Profile: maxperf
```

* Run `cd ethereum; make forge_dependencies`

```
make forge_dependencies
forge install openzeppelin/openzeppelin-contracts@0457042d93d9dfd760dbaa06a4d2f1216fdbe297 --no-git --no-commit
error: unexpected argument '--no-commit' found

  tip: a similar argument exists: '--commit'

Usage: forge install [OPTIONS] [DEPENDENCIES]...
    forge install [OPTIONS] <github username>/<github project>@<tag>...
    forge install [OPTIONS] <alias>=<github username>/<github project>@<tag>...
    forge install [OPTIONS] <https://<github token>@git url>...)]
    forge install [OPTIONS] <https:// git url>...

For more information, try '--help'.
make: *** [lib/openzeppelin-contracts] Error 2
```

If you checkout this PR, the error goes away.