### PR TITLE
ci: update golangci-lint to 2.1.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -297,7 +297,7 @@ jobs:
       - name: Formatting checks
         run: ./scripts/lint.sh -l -g format
       - name: Install linters
-        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.1.2
+        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.1.5
       - name: Run linters
         run: make generate && golangci-lint --version && ./scripts/lint.sh -g lint
       - name: Ensure generated proto matches


### PR DESCRIPTION
CI is having transient failures around golangci-lint. Trying to bump the version to see if this makes the lints more stable.


Example: https://github.com/wormhole-foundation/wormhole/actions/runs/14778216211/job/41491112350?pr=4363
(I'm unable to reproduce this locally on `main`)