### PR TITLE
ci: Fix docker-related errors in Algorand job

### DIFF
--- a/algorand/runPythonUnitTests.sh
+++ b/algorand/runPythonUnitTests.sh
@@ -15,6 +15,13 @@ sed -i -e 's@export ALGOD_URL=""@export ALGOD_URL="https://github.com/algorand/g
        -e 's/export INDEXER_ENABLE_ALL_PARAMETERS="false"/export INDEXER_ENABLE_ALL_PARAMETERS="true"/'  _sandbox/config.dev
 
 cd _sandbox
+
+# NOTE: This is a workaround for a bug. It's already fixed in `d8e60ed1a6203f02d3b4702e2e2eefdb7f246f92` in the sandbox
+# repository, but we're not ready to upgrade. This allows docker to work in the meantime.
+# These lines can be removed when we update the commit hash.
+sed -i -e 's/docker compose help/docker compose --help/' ./sandbox
+sed -i -e 's/-eq 16/-eq 0/' ./sandbox
+
 ./sandbox clean
 ./sandbox up -v dev
 cd ..


### PR DESCRIPTION
This fixes errors related to 'docker compose' not being installed. This should unblock CI.

The version of the sandbox we use has a bug with its `docker compose`
check. This commit includes a workaround to get CI to work.

I tried upgrading to the latest `sandbox` version but it caused other errors. Rather than attempt a full upgrade, this commit does a cheeky rewrite of the upstream `sandbox` script to fix how it detects docker.

Compare with:
https://github.com/algorand/sandbox/blob/59803a56a2d254bc49df36e964dc4e4f94435446/sandbox#L45-L55

Upstream bug fix PR:
https://github.com/algorand/sandbox/pull/206