### PR TITLE
fix: remove redundant --contract-address parameter from worm submit command

### DIFF
--- a/aptos/scripts/upgrade
+++ b/aptos/scripts/upgrade
@@ -154,9 +154,8 @@ fi
 
 echo "Submitting VAA: $VAA"
 
-# TODO: --contract-address should not be neded after the sdk has these addresses
 CONTRACT_ADDR=$(worm info contract "$NETWORK" aptos "$MODULE")
-worm submit --network "$NETWORK" "$VAA" --contract-address "$CONTRACT_ADDR"
+worm submit --network "$NETWORK" "$VAA" --chain aptos
 worm aptos upgrade $DIR --network "$NETWORK" --contract-address "$CONTRACT_ADDR" --named-addresses "$NAMED_ADDRS"
 worm aptos migrate --network "$NETWORK" --contract-address "$CONTRACT_ADDR"
 


### PR DESCRIPTION
Resolved a TODO comment in the Aptos upgrade script by removing the redundant --contract-address parameter from the worm submit command. 

The SDK already knows the contract addresses for each chain and module, making the explicit parameter unnecessary. 

Instead, the script now uses the --chain parameter to specify Aptos as the target chain, allowing the SDK to automatically resolve the correct contract address.

Changes:
- Removed --contract-address parameter from worm submit command
- Added --chain aptos parameter for explicit chain targeting
- Removed the related TODO comment