### PR TITLE
deps: Remove Go-Spew and add new debugging function for VAAs

### DIFF
--- a/node/cmd/debug/vaa.go
+++ b/node/cmd/debug/vaa.go
@@ -2,10 +2,10 @@ package debug
 
 import (
 	"encoding/hex"
+	"fmt"
 	"log"
 	"strings"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/spf13/cobra"
 	"github.com/wormhole-foundation/wormhole/sdk/vaa"
 )
@@ -26,7 +26,12 @@ var decodeVaaCmd = &cobra.Command{
 				log.Fatal(err)
 			}
 
-			spew.Dump(v)
+			debugStr, err := v.DebugString()
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			fmt.Printf("%s", debugStr)
 		}
 	},
 }

--- a/node/cmd/guardiand/adminclient.go
+++ b/node/cmd/guardiand/adminclient.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/cosmos/cosmos-sdk/types"
-	"github.com/davecgh/go-spew/spew"
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/mr-tron/base58"
@@ -393,7 +392,11 @@ func runDumpVAAByMessageID(cmd *cobra.Command, args []string) {
 		log.Fatalf("failed to decode VAA: %v", err)
 	}
 
-	log.Printf("VAA with digest %s: %+v\n", v.HexDigest(), spew.Sdump(v))
+	debugStr, err := v.DebugString()
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+	log.Printf("VAA with digest %s: %+v\n", v.HexDigest(), debugStr)
 	fmt.Printf("Bytes:\n%s\n", hex.EncodeToString(resp.VaaBytes))
 }
 

--- a/node/cmd/guardiand/adminverify.go
+++ b/node/cmd/guardiand/adminverify.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/encoding/prototext"
 
@@ -54,6 +53,10 @@ func runGovernanceVAAVerify(cmd *cobra.Command, args []string) {
 
 		log.Printf("Serialized: %v", hex.EncodeToString(b))
 
-		log.Printf("VAA with digest %x: %+v", digest, spew.Sdump(v))
+		debugStr, err := v.DebugString()
+		if err != nil {
+			log.Fatal(err.Error())
+		}
+		log.Printf("VAA with digest %s: %+v\n", digest, debugStr)
 	}
 }

--- a/node/go.mod
+++ b/node/go.mod
@@ -5,7 +5,7 @@ go 1.23.3
 require (
 	github.com/cenkalti/backoff/v4 v4.2.0
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf
-	github.com/davecgh/go-spew v1.1.1
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgraph-io/badger/v3 v3.2103.1
 	github.com/ethereum/go-ethereum v1.10.21
 	github.com/gagliardetto/solana-go v1.8.4

--- a/sdk/vaa/structs.go
+++ b/sdk/vaa/structs.go
@@ -1214,66 +1214,6 @@ func BytesToHash(b []byte) (common.Hash, error) {
 	return hash, nil
 }
 
-// vaaJSON is a helper struct for JSON marshaling that provides proper field names
-// and handles special formatting requirements
-type vaaJSON struct {
-	Version          uint8        `json:"version"`
-	GuardianSetIndex uint32       `json:"guardian_set_index"`
-	Signatures       []*Signature `json:"signatures"`
-	Timestamp        string       `json:"timestamp"`
-	Nonce            uint32       `json:"nonce"`
-	Sequence         uint64       `json:"sequence"`
-	ConsistencyLevel uint8        `json:"consistency_level"`
-	EmitterChain     ChainID      `json:"emitter_chain"`
-	EmitterAddress   string       `json:"emitter_address"`
-	Payload          []byte       `json:"payload"`
-}
-
-// MarshalJSON implements the json.Marshaler interface for VAA.
-// NOTE: This is currently used only for debugging output. There is no UnmarshalJSON implementation.
-func (v *VAA) MarshalJSON() ([]byte, error) {
-	if v == nil {
-		return nil, errors.New("MarshalJSON called on nil VAA")
-	}
-
-	// Create the helper struct with properly formatted fields
-	vj := vaaJSON{
-		Version:          v.Version,
-		GuardianSetIndex: v.GuardianSetIndex,
-		Signatures:       v.Signatures, // Uses Signature's MarshalJSON
-		Timestamp:        v.Timestamp.Format(time.RFC3339Nano),
-		Nonce:            v.Nonce,
-		Sequence:         v.Sequence,
-		ConsistencyLevel: v.ConsistencyLevel,
-		EmitterChain:     v.EmitterChain,
-		EmitterAddress:   v.EmitterAddress.String(),
-		Payload:          v.Payload,
-	}
-
-	return json.Marshal(vj)
-}
-
-// signatureJSON is a helper struct for JSON marshaling of Signature
-type signatureJSON struct {
-	Index     uint8  `json:"index"`
-	Signature string `json:"signature"`
-}
-
-// MarshalJSON implements the json.Marshaler interface for Signature.
-// This ensures signatures are properly formatted in the VAA JSON output.
-func (s *Signature) MarshalJSON() ([]byte, error) {
-	if s == nil {
-		return nil, errors.New("MarshalJSON called on nil Signature")
-	}
-
-	sj := signatureJSON{
-		Index:     s.Index,
-		Signature: s.Signature.String(),
-	}
-
-	return json.Marshal(sj)
-}
-
 // DebugString returns a pretty-formatted JSON string representation of the VAA.
 func (v *VAA) DebugString() (string, error) {
 	jsonBytes, err := json.MarshalIndent(v, "", "  ")

--- a/sdk/vaa/structs.go
+++ b/sdk/vaa/structs.go
@@ -6,6 +6,7 @@ import (
 	"encoding"
 	"encoding/binary"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -1211,4 +1212,74 @@ func BytesToHash(b []byte) (common.Hash, error) {
 
 	hash = common.BytesToHash(b)
 	return hash, nil
+}
+
+// vaaJSON is a helper struct for JSON marshaling that provides proper field names
+// and handles special formatting requirements
+type vaaJSON struct {
+	Version          uint8        `json:"version"`
+	GuardianSetIndex uint32       `json:"guardian_set_index"`
+	Signatures       []*Signature `json:"signatures"`
+	Timestamp        string       `json:"timestamp"`
+	Nonce            uint32       `json:"nonce"`
+	Sequence         uint64       `json:"sequence"`
+	ConsistencyLevel uint8        `json:"consistency_level"`
+	EmitterChain     ChainID      `json:"emitter_chain"`
+	EmitterAddress   string       `json:"emitter_address"`
+	Payload          []byte       `json:"payload"`
+}
+
+// MarshalJSON implements the json.Marshaler interface for VAA.
+// NOTE: This is currently used only for debugging output. There is no UnmarshalJSON implementation.
+func (v *VAA) MarshalJSON() ([]byte, error) {
+	if v == nil {
+		return nil, errors.New("MarshalJSON called on nil VAA")
+	}
+
+	// Create the helper struct with properly formatted fields
+	vj := vaaJSON{
+		Version:          v.Version,
+		GuardianSetIndex: v.GuardianSetIndex,
+		Signatures:       v.Signatures, // Uses Signature's MarshalJSON
+		Timestamp:        v.Timestamp.Format(time.RFC3339Nano),
+		Nonce:            v.Nonce,
+		Sequence:         v.Sequence,
+		ConsistencyLevel: v.ConsistencyLevel,
+		EmitterChain:     v.EmitterChain,
+		EmitterAddress:   v.EmitterAddress.String(),
+		Payload:          v.Payload,
+	}
+
+	return json.Marshal(vj)
+}
+
+// signatureJSON is a helper struct for JSON marshaling of Signature
+type signatureJSON struct {
+	Index     uint8  `json:"index"`
+	Signature string `json:"signature"`
+}
+
+// MarshalJSON implements the json.Marshaler interface for Signature.
+// This ensures signatures are properly formatted in the VAA JSON output.
+func (s *Signature) MarshalJSON() ([]byte, error) {
+	if s == nil {
+		return nil, errors.New("MarshalJSON called on nil Signature")
+	}
+
+	sj := signatureJSON{
+		Index:     s.Index,
+		Signature: s.Signature.String(),
+	}
+
+	return json.Marshal(sj)
+}
+
+// DebugString returns a pretty-formatted JSON string representation of the VAA.
+func (v *VAA) DebugString() (string, error) {
+	jsonBytes, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal VAA to JSON for debugging: %w", err)
+	}
+
+	return string(jsonBytes), nil
 }


### PR DESCRIPTION
# Purpose

Remove unmaintained dependency. It was only being used to print a dump of VAAs, so this PR adds a function specifically for debugging VAA info and removes the dependency.

## Details

- Removes go-spew (https://github.com/davecgh/go-spew) as it has not been updated in 7 years.
- Replaces the Go Spew functionality with a JSON-encoded string. The new function DebugString() can be used to get a spew-like output.

## Example outputs

While the new format isn't the same, it does capture most of the existing functionality.

<details>
The command to run is the following:

```sh
./build/bin/guardiand debug decode-vaa 01000000040d034b96c773dce897724ed8ed4851cfa4f5077c35b7aa397251a3941fc587328a872ce9eac4228c692b2ce2ec9c4a958658fb7e290fdc98eaee1c9c2785c489c2ca010412878b0893d2b98c06490662174c22214417a299ddf6dbd11240fb5781891ff217d023c07cb6d1522d93678269d5dca557d50c2deada2c2126ca5242f96cdcef01051b2a2d7506a6917be3a5fb65b224c77bd7e11c50960d4aed1964ff317afbe7337923f7b656fbf1a88daa2241d73ebdd6e40c6ebad3f9243f93c3c16a9100271f0006e6cbfeadbbed74c30920540c03d35cbece22842371fd87dbc013ae48cf93c4da50bcb57aec8164c2d7ed398a790530a0c76625f440e117b09bb31d9e8f45a77400096ba176d6a0576102261181317d44e28048eaee1ddd76d8a2e4733e47154e524061b1192eedc9c023ceeba3b49f852d9306dada693c211dea0d63545b95139ca9000a5a062b0b5b44ec1f74e1f0548734dae018d70a6c203dc47ca4c7083caa25a81e5420612472b374fbdde1b0401a605f16536d0593faea2d41b82fe5a2895a586d000b929cce6b8a05eb1e57ec34b3728c95c21e9b2915ec61f58e645449fa033815d4158f187ba7080248c3e207debf7492c8096d1a966be4d4de7e6ccbe520b3a983010db8df4588928b1c86ee335666c7034119e2cbea4ae93399a800dca5d7df66d170740ecdacb276ae88f8dab26914bf55eac0043a8917ac21f443508c5a2cf7f5da000e04ab7b872086bf3b333a81fa9630961a1d435d3df12b6c5c4c148c737996d22c2008c11e7f0ec483c4ecd2b55d78f55b40426979230815dce97e552d7917a780000ff8e65d7ce1851a608130cf67f19708d73e655a01e28dee8f6a6a199a27bb93a17ded9c39b018af65ac7f22fcd13de9cb8fba5b60c5fe18f515462a0abc88ec07011070c6a861910be9f680afba830393c7611d0a3ee93b2429a5912157ae9a89428c6bda3dc0d4a31a720e1e290e8d97b133e0b7a3885a658d2d5209ac94789c4f830111aac7526ff88272dadc3d52adf1cc06600a923ae75cfd1359e0922db703b78aea5c10beeec7a85668c3d5a8e4ddc4676eabae5e2a1c86f14da5e22a7d27c1c0bf011231c626e7f23a55a0b1b49296ebac76eee2e7b4e17ddab3d306717ae76ff44fc96f5ac73435e5a63d9e09c84aaabbc07b6fad85b03e7e4013c510af0585ed41e60100000000bf77d51800010000000000000000000000000000000000000000000000000000000000000004d137b2c61b8b0e9c20000000000000000047656e6572616c507572706f7365476f7665726e616e636501001736cf4c88fa548c6ad9fcdc696e1c27bb3306163fb0ffa8000886e57f86dd5264b9582b2ad87b2b910004cefc1429
```
</details>

### Old Spew output


```
(*vaa.VAA)(0x14000b34870)({
 Version: (uint8) 1,
 GuardianSetIndex: (uint32) 4,
 Signatures: ([]*vaa.Signature) (len=13 cap=13) {
  (*vaa.Signature)(0x14000900eb0)({
   Index: (uint8) 3,
   Signature: (vaa.SignatureData) (len=65 cap=65) 4b96c773dce897724ed8ed4851cfa4f5077c35b7aa397251a3941fc587328a872ce9eac4228c692b2ce2ec9c4a958658fb7e290fdc98eaee1c9c2785c489c2ca01
  }),
  (*vaa.Signature)(0x14000900f00)({
   Index: (uint8) 4,
   Signature: (vaa.SignatureData) (len=65 cap=65) 12878b0893d2b98c06490662174c22214417a299ddf6dbd11240fb5781891ff217d023c07cb6d1522d93678269d5dca557d50c2deada2c2126ca5242f96cdcef01
  }),
  (*vaa.Signature)(0x14000900f50)({
   Index: (uint8) 5,
   Signature: (vaa.SignatureData) (len=65 cap=65) 1b2a2d7506a6917be3a5fb65b224c77bd7e11c50960d4aed1964ff317afbe7337923f7b656fbf1a88daa2241d73ebdd6e40c6ebad3f9243f93c3c16a9100271f00
  }),
  (*vaa.Signature)(0x14000900fa0)({
   Index: (uint8) 6,
   Signature: (vaa.SignatureData) (len=65 cap=65) e6cbfeadbbed74c30920540c03d35cbece22842371fd87dbc013ae48cf93c4da50bcb57aec8164c2d7ed398a790530a0c76625f440e117b09bb31d9e8f45a77400
  }),
  (*vaa.Signature)(0x14000900ff0)({
   Index: (uint8) 9,
   Signature: (vaa.SignatureData) (len=65 cap=65) 6ba176d6a0576102261181317d44e28048eaee1ddd76d8a2e4733e47154e524061b1192eedc9c023ceeba3b49f852d9306dada693c211dea0d63545b95139ca900
  }),
  (*vaa.Signature)(0x14000901040)({
   Index: (uint8) 10,
   Signature: (vaa.SignatureData) (len=65 cap=65) 5a062b0b5b44ec1f74e1f0548734dae018d70a6c203dc47ca4c7083caa25a81e5420612472b374fbdde1b0401a605f16536d0593faea2d41b82fe5a2895a586d00
  }),
  (*vaa.Signature)(0x14000901090)({
   Index: (uint8) 11,
   Signature: (vaa.SignatureData) (len=65 cap=65) 929cce6b8a05eb1e57ec34b3728c95c21e9b2915ec61f58e645449fa033815d4158f187ba7080248c3e207debf7492c8096d1a966be4d4de7e6ccbe520b3a98301
  }),
  (*vaa.Signature)(0x140009010e0)({
   Index: (uint8) 13,
   Signature: (vaa.SignatureData) (len=65 cap=65) b8df4588928b1c86ee335666c7034119e2cbea4ae93399a800dca5d7df66d170740ecdacb276ae88f8dab26914bf55eac0043a8917ac21f443508c5a2cf7f5da00
  }),
  (*vaa.Signature)(0x14000901130)({
   Index: (uint8) 14,
   Signature: (vaa.SignatureData) (len=65 cap=65) 04ab7b872086bf3b333a81fa9630961a1d435d3df12b6c5c4c148c737996d22c2008c11e7f0ec483c4ecd2b55d78f55b40426979230815dce97e552d7917a78000
  }),
  (*vaa.Signature)(0x14000901180)({
   Index: (uint8) 15,
   Signature: (vaa.SignatureData) (len=65 cap=65) f8e65d7ce1851a608130cf67f19708d73e655a01e28dee8f6a6a199a27bb93a17ded9c39b018af65ac7f22fcd13de9cb8fba5b60c5fe18f515462a0abc88ec0701
  }),
  (*vaa.Signature)(0x140009011d0)({
   Index: (uint8) 16,
   Signature: (vaa.SignatureData) (len=65 cap=65) 70c6a861910be9f680afba830393c7611d0a3ee93b2429a5912157ae9a89428c6bda3dc0d4a31a720e1e290e8d97b133e0b7a3885a658d2d5209ac94789c4f8301
  }),
  (*vaa.Signature)(0x14000901220)({
   Index: (uint8) 17,
   Signature: (vaa.SignatureData) (len=65 cap=65) aac7526ff88272dadc3d52adf1cc06600a923ae75cfd1359e0922db703b78aea5c10beeec7a85668c3d5a8e4ddc4676eabae5e2a1c86f14da5e22a7d27c1c0bf01
  }),
  (*vaa.Signature)(0x14000901270)({
   Index: (uint8) 18,
   Signature: (vaa.SignatureData) (len=65 cap=65) 31c626e7f23a55a0b1b49296ebac76eee2e7b4e17ddab3d306717ae76ff44fc96f5ac73435e5a63d9e09c84aaabbc07b6fad85b03e7e4013c510af0585ed41e601
  })
 },
 Timestamp: (time.Time) 1969-12-31 19:00:00 -0500 EST,
 Nonce: (uint32) 3212301592,
 Sequence: (uint64) 15075714841581391516,
 ConsistencyLevel: (uint8) 32,
 EmitterChain: (vaa.ChainID) solana,
 EmitterAddress: (vaa.Address) (len=32 cap=32) 0000000000000000000000000000000000000000000000000000000000000004,
 Payload: ([]uint8) (len=81 cap=81) {
  00000000  00 00 00 00 00 00 00 00  47 65 6e 65 72 61 6c 50  |........GeneralP|
  00000010  75 72 70 6f 73 65 47 6f  76 65 72 6e 61 6e 63 65  |urposeGovernance|
  00000020  01 00 17 36 cf 4c 88 fa  54 8c 6a d9 fc dc 69 6e  |...6.L..T.j...in|
  00000030  1c 27 bb 33 06 16 3f b0  ff a8 00 08 86 e5 7f 86  |.'.3..?.........|
  00000040  dd 52 64 b9 58 2b 2a d8  7b 2b 91 00 04 ce fc 14  |.Rd.X+*.{+......|
  00000050  29                                                |)|
 }
})

```

### New, JSON-based output

```
{
  "version": 1,
  "guardian_set_index": 4,
  "signatures": [
    {
      "index": 3,
      "signature": "4b96c773dce897724ed8ed4851cfa4f5077c35b7aa397251a3941fc587328a872ce9eac4228c692b2ce2ec9c4a958658fb7e290fdc98eaee1c9c2785c489c2ca01"
    },
    {
      "index": 4,
      "signature": "12878b0893d2b98c06490662174c22214417a299ddf6dbd11240fb5781891ff217d023c07cb6d1522d93678269d5dca557d50c2deada2c2126ca5242f96cdcef01"
    },
    {
      "index": 5,
      "signature": "1b2a2d7506a6917be3a5fb65b224c77bd7e11c50960d4aed1964ff317afbe7337923f7b656fbf1a88daa2241d73ebdd6e40c6ebad3f9243f93c3c16a9100271f00"
    },
    {
      "index": 6,
      "signature": "e6cbfeadbbed74c30920540c03d35cbece22842371fd87dbc013ae48cf93c4da50bcb57aec8164c2d7ed398a790530a0c76625f440e117b09bb31d9e8f45a77400"
    },
    {
      "index": 9,
      "signature": "6ba176d6a0576102261181317d44e28048eaee1ddd76d8a2e4733e47154e524061b1192eedc9c023ceeba3b49f852d9306dada693c211dea0d63545b95139ca900"
    },
    {
      "index": 10,
      "signature": "5a062b0b5b44ec1f74e1f0548734dae018d70a6c203dc47ca4c7083caa25a81e5420612472b374fbdde1b0401a605f16536d0593faea2d41b82fe5a2895a586d00"
    },
    {
      "index": 11,
      "signature": "929cce6b8a05eb1e57ec34b3728c95c21e9b2915ec61f58e645449fa033815d4158f187ba7080248c3e207debf7492c8096d1a966be4d4de7e6ccbe520b3a98301"
    },
    {
      "index": 13,
      "signature": "b8df4588928b1c86ee335666c7034119e2cbea4ae93399a800dca5d7df66d170740ecdacb276ae88f8dab26914bf55eac0043a8917ac21f443508c5a2cf7f5da00"
    },
    {
      "index": 14,
      "signature": "04ab7b872086bf3b333a81fa9630961a1d435d3df12b6c5c4c148c737996d22c2008c11e7f0ec483c4ecd2b55d78f55b40426979230815dce97e552d7917a78000"
    },
    {
      "index": 15,
      "signature": "f8e65d7ce1851a608130cf67f19708d73e655a01e28dee8f6a6a199a27bb93a17ded9c39b018af65ac7f22fcd13de9cb8fba5b60c5fe18f515462a0abc88ec0701"
    },
    {
      "index": 16,
      "signature": "70c6a861910be9f680afba830393c7611d0a3ee93b2429a5912157ae9a89428c6bda3dc0d4a31a720e1e290e8d97b133e0b7a3885a658d2d5209ac94789c4f8301"
    },
    {
      "index": 17,
      "signature": "aac7526ff88272dadc3d52adf1cc06600a923ae75cfd1359e0922db703b78aea5c10beeec7a85668c3d5a8e4ddc4676eabae5e2a1c86f14da5e22a7d27c1c0bf01"
    },
    {
      "index": 18,
      "signature": "31c626e7f23a55a0b1b49296ebac76eee2e7b4e17ddab3d306717ae76ff44fc96f5ac73435e5a63d9e09c84aaabbc07b6fad85b03e7e4013c510af0585ed41e601"
    }
  ],
  "timestamp": "1969-12-31T19:00:00-05:00",
  "nonce": 3212301592,
  "sequence": 15075714841581391516,
  "consistency_level": 32,
  "emitter_chain": 1,
  "emitter_address": "0000000000000000000000000000000000000000000000000000000000000004",
  "payload": "AAAAAAAAAABHZW5lcmFsUHVycG9zZUdvdmVybmFuY2UBABc2z0yI+lSMatn83GluHCe7MwYWP7D/qAAIhuV/ht1SZLlYKyrYeyuRAATO/BQp"
}
```
