### PR TITLE
docs: Update supervisor upstream repository path

### DIFF
--- a/node/pkg/supervisor/UPSTREAM.md
+++ b/node/pkg/supervisor/UPSTREAM.md
@@ -1,7 +1,7 @@
 # supervisor
 
 This is a vendored copy of
-https://github.com/monogon-dev/monogon/tree/main/metropolis/pkg/supervisor.
+https://github.com/monogon-dev/monogon/tree/main/osbase/supervisor.
 
 Please send bug reports and fixes to the upstream project and 
 then update our copy.


### PR DESCRIPTION
# Update supervisor upstream repository path

This PR updates the upstream repository path in UPSTREAM.md from `metropolis/pkg/supervisor` to `osbase/supervisor` to reflect the current location of the source code in the monogon repository.