### PR TITLE
deps: Update elliptic to >= 6.6.1 (round 2)

### DIFF
--- a/solana/scripts/package-lock.json
+++ b/solana/scripts/package-lock.json
@@ -3621,22 +3621,6 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/eccrypto/node_modules/elliptic": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "bn.js": "^4.11.9",
-        "brorand": "^1.1.0",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.1",
-        "inherits": "^2.0.4",
-        "minimalistic-assert": "^1.0.1",
-        "minimalistic-crypto-utils": "^1.0.1"
-      }
-    },
     "node_modules/eccrypto/node_modules/secp256k1": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.7.1.tgz",
@@ -4375,29 +4359,6 @@
         "elliptic": "6.5.4",
         "hash.js": "1.1.7"
       }
-    },
-    "node_modules/eth-crypto/node_modules/@ethersproject/signing-key/node_modules/elliptic": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "bn.js": "^4.11.9",
-        "brorand": "^1.1.0",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.1",
-        "inherits": "^2.0.4",
-        "minimalistic-assert": "^1.0.1",
-        "minimalistic-crypto-utils": "^1.0.1"
-      }
-    },
-    "node_modules/eth-crypto/node_modules/@ethersproject/signing-key/node_modules/elliptic/node_modules/bn.js": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
-      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/eth-crypto/node_modules/@ethersproject/solidity": {
       "version": "5.7.0",

--- a/solana/scripts/package.json
+++ b/solana/scripts/package.json
@@ -3,5 +3,8 @@
     "@certusone/wormhole-sdk": "^0.10.18",
     "@coral-xyz/anchor": "^0.31.0",
     "tsx": "^4.19.3"
+  },
+  "overrides": {
+    "elliptic": "^6.6.1"
   }
 }

--- a/svm/wormhole-core-shims/anchor/package.json
+++ b/svm/wormhole-core-shims/anchor/package.json
@@ -7,7 +7,8 @@
   "dependencies": {
     "@certusone/wormhole-sdk": "^0.10.18",
     "@coral-xyz/anchor": "^0.30.1",
-    "@improbable-eng/grpc-web-node-http-transport": "0.15.0"
+    "@improbable-eng/grpc-web-node-http-transport": "0.15.0",
+    "elliptic": "^6.6.1"
   },
   "devDependencies": {
     "@types/bn.js": "^5.1.0",
@@ -19,5 +20,11 @@
     "ts-mocha": "^10.0.0",
     "tsx": "^4.19.2",
     "typescript": "^4.3.5"
+  },
+  "overrides": {
+    "elliptic": "^6.6.1"
+  },
+  "resolutions": {
+    "elliptic": "^6.6.1"
   }
 }

--- a/svm/wormhole-core-shims/anchor/yarn.lock
+++ b/svm/wormhole-core-shims/anchor/yarn.lock
@@ -2148,20 +2148,7 @@ eccrypto@1.1.6:
   optionalDependencies:
     secp256k1 "3.7.1"
 
-elliptic@6.5.4:
-  version "6.5.4"
-  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb"
-  integrity sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==
-  dependencies:
-    bn.js "^4.11.9"
-    brorand "^1.1.0"
-    hash.js "^1.0.0"
-    hmac-drbg "^1.0.1"
-    inherits "^2.0.4"
-    minimalistic-assert "^1.0.1"
-    minimalistic-crypto-utils "^1.0.1"
-
-elliptic@^6.4.0, elliptic@^6.4.1, elliptic@^6.5.2, elliptic@^6.5.4, elliptic@^6.5.7:
+elliptic@6.5.4, elliptic@^6.4.0, elliptic@^6.4.1, elliptic@^6.5.2, elliptic@^6.5.4, elliptic@^6.5.7, elliptic@^6.6.1:
   version "6.6.1"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.6.1.tgz#3b8ffb02670bf69e382c7f65bf524c97c5405c06"
   integrity sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==


### PR DESCRIPTION
This is a follow-up PR to #4272. 

The affected package was updated in that PR, but vulnerable versions were re-added in 059b64f2e311a4d26b72c50c0598a17749238d88 and #4311.

For the yarn-based file, I had to use a `resolution` in addition to an override as the vulnerable package was being imported indirectly via a dependency.