### PR TITLE
guardiand: fix set message fee serialization

### DIFF
--- a/node/cmd/guardiand/adminverify.go
+++ b/node/cmd/guardiand/adminverify.go
@@ -57,6 +57,6 @@ func runGovernanceVAAVerify(cmd *cobra.Command, args []string) {
 		if err != nil {
 			log.Fatal(err.Error())
 		}
-		log.Printf("VAA with digest %s: %+v\n", digest, debugStr)
+		log.Printf("VAA with digest %x: %+v\n", digest, debugStr)
 	}
 }

--- a/sdk/vaa/payloads.go
+++ b/sdk/vaa/payloads.go
@@ -503,7 +503,6 @@ func (r BodyWormholeRelayerSetDefaultDeliveryProvider) Serialize() ([]byte, erro
 
 func (r BodyCoreBridgeSetMessageFee) Serialize() ([]byte, error) {
 	payload := &bytes.Buffer{}
-	MustWrite(payload, binary.BigEndian, r.ChainID)
 	MustWrite(payload, binary.BigEndian, r.MessageFee)
 	return serializeBridgeGovernanceVaa(CoreModuleStr, ActionCoreSetMessageFee, r.ChainID, payload.Bytes())
 }

--- a/sdk/vaa/payloads_test.go
+++ b/sdk/vaa/payloads_test.go
@@ -457,10 +457,10 @@ func TestBodyRecoverChainIdModuleTooLong(t *testing.T) {
 }
 
 func TestBodyCoreBridgeSetMessageFeeSerialize(t *testing.T) {
-	expected := "00000000000000000000000000000000000000000000000000000000436f72650300040004000000000000007b"
+	expected := "00000000000000000000000000000000000000000000000000000000436f72650304560000000000000123"
 	bodyCoreBridgeSetMessageFee := BodyCoreBridgeSetMessageFee{
-		ChainID:    4,
-		MessageFee: uint64(123),
+		ChainID:    0x456,
+		MessageFee: uint64(0x123),
 	}
 	buf, err := bodyCoreBridgeSetMessageFee.Serialize()
 	require.NoError(t, err)


### PR DESCRIPTION
* Fixed a bug that made chain id to appear twice in the `CoreBridgeSetMessageFee` payload.
* Fixed a format issue that was printing VAA digests as binary instead of as hex