### PR TITLE
node: Increase Governor maximum delay to 30 days

### DIFF
--- a/node/cmd/guardiand/adminclient.go
+++ b/node/cmd/guardiand/adminclient.go
@@ -175,7 +175,7 @@ var ClientChainGovernorReleasePendingVAACmd = &cobra.Command{
 
 var ClientChainGovernorResetReleaseTimerCmd = &cobra.Command{
 	Use:   "governor-reset-release-timer [VAA_ID] <num_days>",
-	Short: "Resets the release timer for a chain governor pending VAA, extending it to num_days (up to a maximum of 7), defaulting to one day if num_days is omitted",
+	Short: "Resets the release timer for a chain governor pending VAA, extending it to num_days (up to a maximum of 30), defaulting to one day if num_days is omitted",
 	Run:   runChainGovernorResetReleaseTimer,
 	Args:  cobra.RangeArgs(1, 2),
 }

--- a/node/pkg/adminrpc/adminserver.go
+++ b/node/pkg/adminrpc/adminserver.go
@@ -42,7 +42,7 @@ import (
 	sdktypes "github.com/cosmos/cosmos-sdk/types"
 )
 
-const maxResetReleaseTimerDays = 7
+const maxResetReleaseTimerDays = 30
 const ecdsaSignatureLength = 65
 
 var (

--- a/node/pkg/adminrpc/adminserver_test.go
+++ b/node/pkg/adminrpc/adminserver_test.go
@@ -359,7 +359,7 @@ func TestChainGovernorResetReleaseTimer(t *testing.T) {
 
 	// governor has no VAAs enqueued, so if we receive this error we know the input validation passed
 	success := `vaa not found in the pending list`
-	boundsCheckFailure := `the specified number of days falls outside the range of 1 to 7`
+	boundsCheckFailure := `the specified number of days falls outside the range of 1 to 30`
 	vaaIdLengthFailure := `the VAA id must be specified as "chainId/emitterAddress/seqNum"`
 
 	tests := map[string]struct {

--- a/whitepapers/0007_governor.md
+++ b/whitepapers/0007_governor.md
@@ -104,7 +104,7 @@ In this design, there are three mechanisms for enqueued messages to be published
 
 ## Operational Considerations
 ### Extending the release time to have more time to investigate
-Guardian operators can use the `ChainGovernorResetReleaseTimer` admin RPC or the `governor-reset-release-timer [VAA_ID] <num_days>` admin command to reset the delay to the specified amount of days (`num_days`), up to 7 days. Omitting the argument defaults to 1 day.
+Guardian operators can use the `ChainGovernorResetReleaseTimer` admin RPC or the `governor-reset-release-timer [VAA_ID] <num_days>` admin command to reset the delay to the specified amount of days (`num_days`), up to 30 days. Omitting the argument defaults to 1 day.
 
 ### Dropping messages from the Governor
 Guardian operators can use the `ChainGovernorDropPendingVAA` admin RPC or `governor-drop-pending-vaa [VAA_ID]` admin command to remove a VAA from the Governor queue. Note that in most cases this should be done in conjunction with disconnecting a chain or block-listing certain messages because otherwise the message may just get re-observed through automatic observation requests.


### PR DESCRIPTION
This PR increases the maximum delay extension in the Governor from 7 days to 30 days. The Guardians still have the ability to choose any number in the range 1 - 30 (inclusive), but this gives more optionality and should reduce the burden on the Guardians that elect to delay for longer than 7 days (which currently would require multiple delay extensions).

The early release mechanism still exists to allow Guardians to release delayed transfers early if the delay extension ends up being longer than desired.