### PR TITLE
evm: Custom consistency level

### DIFF
--- a/ethereum/contracts/custom_consistency_level/CustomConsistencyLevel.sol
+++ b/ethereum/contracts/custom_consistency_level/CustomConsistencyLevel.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache 2
+pragma solidity ^0.8.0;
+
+import "./interfaces/ICustomConsistencyLevel.sol";
+
+string constant customConsistencyLevelVersion = "CustomConsistencyLevel-0.0.1";
+
+/// @title CustomConsistencyLevel
+/// @author Wormhole Project Contributors.
+/// @notice The CustomConsistencyLevel contract is an immutable contract that tracks custom consistency level configurations per integrator (emitter address).
+contract CustomConsistencyLevel is ICustomConsistencyLevel {
+    string public constant VERSION = customConsistencyLevelVersion;
+
+    mapping(address => bytes32) private _configurations;
+
+    // ==================== External Interface ===============================================
+
+    /// @inheritdoc ICustomConsistencyLevel
+    function configure(
+        bytes32 config
+    ) external override {
+        _configurations[msg.sender] = config;
+        emit ConfigSet(msg.sender, config);
+    }
+
+    /// @inheritdoc ICustomConsistencyLevel
+    function getConfiguration(
+        address emitterAddress
+    ) external view override returns (bytes32) {
+        return _configurations[emitterAddress];
+    }
+}

--- a/ethereum/contracts/custom_consistency_level/TestCustomConsistencyLevel.sol
+++ b/ethereum/contracts/custom_consistency_level/TestCustomConsistencyLevel.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache 2
+pragma solidity ^0.8.0;
+
+import "../interfaces/IWormhole.sol";
+import "./interfaces/ICustomConsistencyLevel.sol";
+import "./interfaces/ITestCustomConsistencyLevel.sol";
+import "./libraries/ConfigMakers.sol";
+
+string constant testCustomConsistencyLevelVersion = "TestCustomConsistencyLevel-0.0.1";
+
+/// @title TestCustomConsistencyLevel
+/// @author Wormhole Project Contributors.
+/// @notice The TestCustomConsistencyLevel contract can be used to test the custom consistency level functionality.
+contract TestCustomConsistencyLevel is ITestCustomConsistencyLevel {
+    string public constant VERSION = testCustomConsistencyLevelVersion;
+
+    ICustomConsistencyLevel public immutable customConsistencyLevel;
+    IWormhole public immutable wormhole;
+    uint32 public nonce;
+
+    constructor(address _wormhole, address _customConsistencyLevel) {
+        wormhole = IWormhole(_wormhole);
+        customConsistencyLevel = ICustomConsistencyLevel(_customConsistencyLevel);
+    }
+
+    // ==================== External Interface ===============================================
+
+    /// @inheritdoc ITestCustomConsistencyLevel
+    function configure() external override {
+        customConsistencyLevel.configure(ConfigMakers.makeAdditionalBlocksConfig(201, 5));
+    }
+
+    /// @inheritdoc ITestCustomConsistencyLevel
+    function publishMessage(
+        bytes memory payload
+    ) external payable override returns (uint64 sequence) {
+        nonce++;
+        sequence = wormhole.publishMessage(nonce, payload, 203);
+    }
+}

--- a/ethereum/contracts/custom_consistency_level/TestCustomConsistencyLevel.sol
+++ b/ethereum/contracts/custom_consistency_level/TestCustomConsistencyLevel.sol
@@ -18,23 +18,26 @@ contract TestCustomConsistencyLevel is ITestCustomConsistencyLevel {
     IWormhole public immutable wormhole;
     uint32 public nonce;
 
-    constructor(address _wormhole, address _customConsistencyLevel) {
+    constructor(
+        address _wormhole,
+        address _customConsistencyLevel,
+        uint8 _consistencyLevel,
+        uint16 _blocks
+    ) {
         wormhole = IWormhole(_wormhole);
         customConsistencyLevel = ICustomConsistencyLevel(_customConsistencyLevel);
+        ICustomConsistencyLevel(_customConsistencyLevel).configure(
+            ConfigMakers.makeAdditionalBlocksConfig(_consistencyLevel, _blocks)
+        );
     }
 
     // ==================== External Interface ===============================================
 
     /// @inheritdoc ITestCustomConsistencyLevel
-    function configure() external override {
-        customConsistencyLevel.configure(ConfigMakers.makeAdditionalBlocksConfig(201, 5));
-    }
-
-    /// @inheritdoc ITestCustomConsistencyLevel
     function publishMessage(
-        bytes memory payload
+        string memory str
     ) external payable override returns (uint64 sequence) {
         nonce++;
-        sequence = wormhole.publishMessage(nonce, payload, 203);
+        sequence = wormhole.publishMessage(nonce, bytes(str), 203);
     }
 }

--- a/ethereum/contracts/custom_consistency_level/interfaces/ICustomConsistencyLevel.sol
+++ b/ethereum/contracts/custom_consistency_level/interfaces/ICustomConsistencyLevel.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache 2
+pragma solidity ^0.8.0;
+
+interface ICustomConsistencyLevel {
+    /// @notice The configuration for an emitter has been set.
+    /// @dev Topic0
+    ///      0xa37f0112e03d41de27266c1680238ff1548c0441ad1e73c82917c000eefdd5ea.
+    /// @param emitterAddress The emitter address for which the config has been set.
+    /// @param config The config data that was set.
+    event ConfigSet(address emitterAddress, bytes32 config);
+
+    /// @notice Sets / updates the configuration for a given emitter address (msg.sender).
+    /// @param config The config used to determine the custom consistency level handling for an emitter.
+    function configure(
+        bytes32 config
+    ) external;
+
+    /// @notice Returns the configuration for a given emitter address.
+    /// @param emitterAddress The emitter address for which the config has been set.
+    /// @return The configuration.
+    function getConfiguration(
+        address emitterAddress
+    ) external returns (bytes32);
+}

--- a/ethereum/contracts/custom_consistency_level/interfaces/ITestCustomConsistencyLevel.sol
+++ b/ethereum/contracts/custom_consistency_level/interfaces/ITestCustomConsistencyLevel.sol
@@ -2,9 +2,7 @@
 pragma solidity ^0.8.0;
 
 interface ITestCustomConsistencyLevel {
-    function configure() external;
-
     function publishMessage(
-        bytes memory payload
+        string memory str
     ) external payable returns (uint64 sequence);
 }

--- a/ethereum/contracts/custom_consistency_level/interfaces/ITestCustomConsistencyLevel.sol
+++ b/ethereum/contracts/custom_consistency_level/interfaces/ITestCustomConsistencyLevel.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache 2
+pragma solidity ^0.8.0;
+
+interface ITestCustomConsistencyLevel {
+    function configure() external;
+
+    function publishMessage(
+        bytes memory payload
+    ) external payable returns (uint64 sequence);
+}

--- a/ethereum/contracts/custom_consistency_level/libraries/ConfigMakers.sol
+++ b/ethereum/contracts/custom_consistency_level/libraries/ConfigMakers.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+import "../../libraries/external/BytesLib.sol";
+
+library ConfigMakers {
+    using BytesLib for bytes;
+
+    uint8 public constant TYPE_ADDITIONAL_BLOCKS = 1;
+
+    /// @notice Encodes an additional blocks custom consistency level configuration.
+    /// @param consistencyLevel The consistency level to wait for.
+    /// @param blocksToWait The number of additional blocks to wait after the consistency level is reached.
+    /// @return bytes The encoded config.
+    function makeAdditionalBlocksConfig(
+        uint8 consistencyLevel,
+        uint16 blocksToWait
+    ) internal pure returns (bytes32) {
+        bytes28 padding;
+        return abi.encodePacked(TYPE_ADDITIONAL_BLOCKS, consistencyLevel, blocksToWait, padding)
+            .toBytes32(0);
+    }
+}

--- a/ethereum/forge-scripts/ConfigureTestCustomConsistencyLevel.s.sol
+++ b/ethereum/forge-scripts/ConfigureTestCustomConsistencyLevel.s.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+import {ITestCustomConsistencyLevel} from
+    "../contracts/custom_consistency_level/interfaces/ITestCustomConsistencyLevel.sol";
+import "forge-std/Script.sol";
+
+contract ConfigureTestCustomConsistencyLevel is Script {
+    function test() public {} // Exclude this from coverage report.
+
+    function dryRun(
+        address _tccl
+    ) public {
+        _configure(_tccl);
+    }
+
+    function run(
+        address _tccl
+    ) public {
+        vm.startBroadcast();
+        _configure(_tccl);
+        vm.stopBroadcast();
+    }
+
+    function _configure(
+        address _tccl
+    ) internal {
+        ITestCustomConsistencyLevel tccl = ITestCustomConsistencyLevel(_tccl);
+        tccl.configure();
+    }
+}

--- a/ethereum/forge-scripts/DeployCustomConsistencyLevel.s.sol
+++ b/ethereum/forge-scripts/DeployCustomConsistencyLevel.s.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+import {
+    CustomConsistencyLevel,
+    customConsistencyLevelVersion
+} from "../contracts/custom_consistency_level/CustomConsistencyLevel.sol";
+import "forge-std/Script.sol";
+
+// DeployCustomConsistencyLevel is a forge script to deploy the CustomConsistencyLevel contract. Use ./sh/deployCustomConsistencyLevel.sh to invoke this.
+// e.g. anvil
+// EVM_CHAIN_ID=31337 MNEMONIC=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 ./sh/deployCustomConsistencyLevel.sh
+// e.g. anvil --fork-url https://ethereum-rpc.publicnode.com
+// EVM_CHAIN_ID=1 MNEMONIC=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 ./sh/deployCustomConsistencyLevel.sh
+contract DeployCustomConsistencyLevel is Script {
+    function test() public {} // Exclude this from coverage report.
+
+    function dryRun() public {
+        _deploy();
+    }
+
+    function run() public returns (address deployedAddress) {
+        vm.startBroadcast();
+        (deployedAddress) = _deploy();
+        vm.stopBroadcast();
+    }
+
+    function _deploy() internal returns (address deployedAddress) {
+        bytes32 salt = keccak256(abi.encodePacked(customConsistencyLevelVersion));
+        CustomConsistencyLevel customConsistencyLevel = new CustomConsistencyLevel{salt: salt}();
+
+        return (address(customConsistencyLevel));
+    }
+}

--- a/ethereum/forge-scripts/DeployTestCustomConsistencyLevel.s.sol
+++ b/ethereum/forge-scripts/DeployTestCustomConsistencyLevel.s.sol
@@ -15,26 +15,36 @@ import "forge-std/Script.sol";
 contract DeployTestCustomConsistencyLevel is Script {
     function test() public {} // Exclude this from coverage report.
 
-    function dryRun(address _wormhole, address _customConsistencyLevel) public {
-        _deploy(_wormhole, _customConsistencyLevel);
+    function dryRun(
+        address _wormhole,
+        address _customConsistencyLevel,
+        uint8 _consistencyLevel,
+        uint16 _blocks
+    ) public {
+        _deploy(_wormhole, _customConsistencyLevel, _consistencyLevel, _blocks);
     }
 
     function run(
         address _wormhole,
-        address _customConsistencyLevel
+        address _customConsistencyLevel,
+        uint8 _consistencyLevel,
+        uint16 _blocks
     ) public returns (address deployedAddress) {
         vm.startBroadcast();
-        (deployedAddress) = _deploy(_wormhole, _customConsistencyLevel);
+        (deployedAddress) = _deploy(_wormhole, _customConsistencyLevel, _consistencyLevel, _blocks);
         vm.stopBroadcast();
     }
 
     function _deploy(
         address _wormhole,
-        address _customConsistencyLevel
+        address _customConsistencyLevel,
+        uint8 _consistencyLevel,
+        uint16 _blocks
     ) internal returns (address deployedAddress) {
         bytes32 salt = keccak256(abi.encodePacked(testCustomConsistencyLevelVersion));
-        TestCustomConsistencyLevel customConsistencyLevel =
-            new TestCustomConsistencyLevel{salt: salt}(_wormhole, _customConsistencyLevel);
+        TestCustomConsistencyLevel customConsistencyLevel = new TestCustomConsistencyLevel{
+            salt: salt
+        }(_wormhole, _customConsistencyLevel, _consistencyLevel, _blocks);
 
         return (address(customConsistencyLevel));
     }

--- a/ethereum/forge-scripts/DeployTestCustomConsistencyLevel.s.sol
+++ b/ethereum/forge-scripts/DeployTestCustomConsistencyLevel.s.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+import {
+    TestCustomConsistencyLevel,
+    testCustomConsistencyLevelVersion
+} from "../contracts/custom_consistency_level/TestCustomConsistencyLevel.sol";
+import "forge-std/Script.sol";
+
+// DeployTestCustomConsistencyLevel is a forge script to deploy the TestCustomConsistencyLevel contract. Use ./sh/deployTestCustomConsistencyLevel.sh to invoke this.
+// e.g. anvil
+// EVM_CHAIN_ID=31337 MNEMONIC=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 WORMHOLE_ADDRESS= CUSTOM_CONSISTENCY_LEVEL= ./sh/deployTestCustomConsistencyLevel.sh
+// e.g. anvil --fork-url https://ethereum-rpc.publicnode.com
+// EVM_CHAIN_ID=1 MNEMONIC=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 WORMHOLE_ADDRESS= CUSTOM_CONSISTENCY_LEVEL= ./sh/deployTestCustomConsistencyLevel.sh
+contract DeployTestCustomConsistencyLevel is Script {
+    function test() public {} // Exclude this from coverage report.
+
+    function dryRun(address _wormhole, address _customConsistencyLevel) public {
+        _deploy(_wormhole, _customConsistencyLevel);
+    }
+
+    function run(
+        address _wormhole,
+        address _customConsistencyLevel
+    ) public returns (address deployedAddress) {
+        vm.startBroadcast();
+        (deployedAddress) = _deploy(_wormhole, _customConsistencyLevel);
+        vm.stopBroadcast();
+    }
+
+    function _deploy(
+        address _wormhole,
+        address _customConsistencyLevel
+    ) internal returns (address deployedAddress) {
+        bytes32 salt = keccak256(abi.encodePacked(testCustomConsistencyLevelVersion));
+        TestCustomConsistencyLevel customConsistencyLevel =
+            new TestCustomConsistencyLevel{salt: salt}(_wormhole, _customConsistencyLevel);
+
+        return (address(customConsistencyLevel));
+    }
+}

--- a/ethereum/forge-scripts/PostTestCustomConsistencyLevelMsg.s.sol
+++ b/ethereum/forge-scripts/PostTestCustomConsistencyLevelMsg.s.sol
@@ -5,27 +5,21 @@ import {ITestCustomConsistencyLevel} from
     "../contracts/custom_consistency_level/interfaces/ITestCustomConsistencyLevel.sol";
 import "forge-std/Script.sol";
 
-contract ConfigureTestCustomConsistencyLevel is Script {
+contract PostTestCustomConsistencyLevelMsg is Script {
     function test() public {} // Exclude this from coverage report.
 
-    function dryRun(
-        address _tccl
-    ) public {
-        _configure(_tccl);
+    function dryRun(address _tccl, string calldata _payload) public {
+        _publishMessage(_tccl, _payload);
     }
 
-    function run(
-        address _tccl
-    ) public {
+    function run(address _tccl, string calldata _payload) public {
         vm.startBroadcast();
-        _configure(_tccl);
+        _publishMessage(_tccl, _payload);
         vm.stopBroadcast();
     }
 
-    function _configure(
-        address _tccl
-    ) internal {
+    function _publishMessage(address _tccl, string calldata _payload) internal {
         ITestCustomConsistencyLevel tccl = ITestCustomConsistencyLevel(_tccl);
-        tccl.configure();
+        tccl.publishMessage(_payload);
     }
 }

--- a/ethereum/forge-test/CustomConsistencyLevel.t.sol
+++ b/ethereum/forge-test/CustomConsistencyLevel.t.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+import {Test, console} from "forge-std/Test.sol";
+import {CustomConsistencyLevel} from
+    "../contracts/custom_consistency_level/CustomConsistencyLevel.sol";
+import {ConfigMakers} from "../contracts/custom_consistency_level/libraries/ConfigMakers.sol";
+
+contract CustomConsistencyLevelTest is Test {
+    CustomConsistencyLevel public customConsistencyLevel;
+
+    address public userA = address(0x123);
+    address public userB = address(0x456);
+    address public guardian = address(0x789);
+
+    function setUp() public {
+        customConsistencyLevel = new CustomConsistencyLevel();
+    }
+
+    function test_makeAdditionalBlocksConfig() public {
+        bytes32 expected = 0x01c9002a00000000000000000000000000000000000000000000000000000000;
+        bytes32 result = ConfigMakers.makeAdditionalBlocksConfig(201, 42);
+        assertEq(expected, result);
+    }
+
+    function test_configure() public {
+        vm.startPrank(userA);
+        customConsistencyLevel.configure(ConfigMakers.makeAdditionalBlocksConfig(201, 42));
+
+        vm.startPrank(guardian);
+        assertEq(
+            0x01c9002a00000000000000000000000000000000000000000000000000000000,
+            customConsistencyLevel.getConfiguration(userA)
+        );
+        assertEq(bytes32(0), customConsistencyLevel.getConfiguration(userB));
+    }
+}

--- a/ethereum/forge-test/TestCustomConsistencyLevel.t.sol
+++ b/ethereum/forge-test/TestCustomConsistencyLevel.t.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+import {Test, console} from "forge-std/Test.sol";
+import {TestCustomConsistencyLevel} from
+    "../contracts/custom_consistency_level/TestCustomConsistencyLevel.sol";
+import {CustomConsistencyLevel} from
+    "../contracts/custom_consistency_level/CustomConsistencyLevel.sol";
+import {ConfigMakers} from "../contracts/custom_consistency_level/libraries/ConfigMakers.sol";
+
+contract TestCustomConsistencyLevelTest is Test {
+    CustomConsistencyLevel public customConsistencyLevel;
+    TestCustomConsistencyLevel public testCustomConsistencyLevel;
+
+    address public userA = address(0x123);
+    address public userB = address(0x456);
+    address public guardian = address(0x789);
+    address public wormhole = address(0x123456);
+
+    function setUp() public {
+        customConsistencyLevel = new CustomConsistencyLevel();
+        testCustomConsistencyLevel =
+            new TestCustomConsistencyLevel(wormhole, address(customConsistencyLevel), 201, 5);
+    }
+
+    function test_configure() public {
+        vm.startPrank(guardian);
+        assertEq(
+            0x01c9000500000000000000000000000000000000000000000000000000000000,
+            customConsistencyLevel.getConfiguration(address(testCustomConsistencyLevel))
+        );
+        assertEq(bytes32(0), customConsistencyLevel.getConfiguration(userB));
+    }
+}

--- a/ethereum/sh/deployCustomConsistencyLevel.sh
+++ b/ethereum/sh/deployCustomConsistencyLevel.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+#
+# This script deploys the CustomConsistencyLevel contract.
+# Usage: RPC_URL= MNEMONIC= EVM_CHAIN_ID= ./sh/deployCustomConsistencyLevel.sh
+#  tilt: ./sh/deployCustomConsistencyLevel.sh
+#  anvil: EVM_CHAIN_ID=31337 MNEMONIC=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 ./sh/deployCustomConsistencyLevel.sh
+
+if [ "${RPC_URL}X" == "X" ]; then
+  RPC_URL=http://localhost:8545
+fi
+
+if [ "${MNEMONIC}X" == "X" ]; then
+  MNEMONIC=0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d
+fi
+
+if [ "${EVM_CHAIN_ID}X" == "X" ]; then
+  EVM_CHAIN_ID=1337
+fi
+
+forge script ./forge-scripts/DeployCustomConsistencyLevel.s.sol:DeployCustomConsistencyLevel \
+	--sig "run()" \
+	--rpc-url "$RPC_URL" \
+	--private-key "$MNEMONIC" \
+	--broadcast ${FORGE_ARGS}
+
+returnInfo=$(cat ./broadcast/DeployCustomConsistencyLevel.s.sol/$EVM_CHAIN_ID/run-latest.json)
+
+DEPLOYED_ADDRESS=$(jq -r '.returns.deployedAddress.value' <<< "$returnInfo")
+echo "Deployed custom consistency level to address: $DEPLOYED_ADDRESS"

--- a/ethereum/sh/deployTestCustomConsistencyLevel.sh
+++ b/ethereum/sh/deployTestCustomConsistencyLevel.sh
@@ -2,9 +2,9 @@
 
 #
 # This script deploys the CustomConsistencyLevel contract.
-# Usage: RPC_URL= MNEMONIC= EVM_CHAIN_ID= WORMHOLE_ADDRESS= CUSTOM_CONSISTENCY_LEVEL= ./sh/deployCustomConsistencyLevel.sh
+# Usage: RPC_URL= MNEMONIC= EVM_CHAIN_ID= WORMHOLE_ADDRESS= CUSTOM_CONSISTENCY_LEVEL= CONSISTENCY_LEVEL = BLOCKS= ./sh/deployCustomConsistencyLevel.sh
 #  tilt: ./sh/deployCustomConsistencyLevel.sh
-#  anvil: EVM_CHAIN_ID=31337 MNEMONIC=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 WORMHOLE_ADDRESS= CUSTOM_CONSISTENCY_LEVEL= ./sh/deployCustomConsistencyLevel.sh
+#  anvil: EVM_CHAIN_ID=31337 MNEMONIC=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 WORMHOLE_ADDRESS= CUSTOM_CONSISTENCY_LEVEL= CONSISTENCY_LEVEL = BLOCKS= ./sh/deployCustomConsistencyLevel.sh
 
 if [ "${RPC_URL}X" == "X" ]; then
   RPC_URL=http://localhost:8545
@@ -21,8 +21,16 @@ fi
 [[ -z $WORMHOLE_ADDRESS ]] && { echo "Missing WORMHOLE_ADDRESS"; exit 1; }
 [[ -z $CUSTOM_CONSISTENCY_LEVEL ]] && { echo "Missing CUSTOM_CONSISTENCY_LEVEL"; exit 1; }
 
+if [ "${CONSISTENCY_LEVEL}X" == "X" ]; then
+  CONSISTENCY_LEVEL=201
+fi
+
+if [ "${BLOCKS}X" == "X" ]; then
+  BLOCKS=5
+fi
+
 forge script ./forge-scripts/DeployTestCustomConsistencyLevel.s.sol:DeployTestCustomConsistencyLevel \
-	--sig "run(address,address)" $WORMHOLE_ADDRESS $CUSTOM_CONSISTENCY_LEVEL \
+	--sig "run(address,address, uint8, uint16)" $WORMHOLE_ADDRESS $CUSTOM_CONSISTENCY_LEVEL $CONSISTENCY_LEVEL $BLOCKS \
 	--rpc-url "$RPC_URL" \
 	--private-key "$MNEMONIC" \
 	--broadcast ${FORGE_ARGS}
@@ -31,12 +39,3 @@ returnInfo=$(cat ./broadcast/DeployTestCustomConsistencyLevel.s.sol/$EVM_CHAIN_I
 
 DEPLOYED_ADDRESS=$(jq -r '.returns.deployedAddress.value' <<< "$returnInfo")
 echo "Deployed test custom consistency level to address: $DEPLOYED_ADDRESS using core address $WORMHOLE_ADDRESS and custom consistency level $CUSTOM_CONSISTENCY_LEVEL"
-
-echo "Configuring test custom consistency level at address $DEPLOYED_ADDRESS"
-forge script ./forge-scripts/ConfigureTestCustomConsistencyLevel.s.sol:ConfigureTestCustomConsistencyLevel \
-	--sig "run(address)" $DEPLOYED_ADDRESS \
-	--rpc-url $RPC_URL \
-	--private-key $MNEMONIC \
-	--broadcast
-
-	echo "Configured test custom consistency level at address $DEPLOYED_ADDRESS"

--- a/ethereum/sh/deployTestCustomConsistencyLevel.sh
+++ b/ethereum/sh/deployTestCustomConsistencyLevel.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+#
+# This script deploys the CustomConsistencyLevel contract.
+# Usage: RPC_URL= MNEMONIC= EVM_CHAIN_ID= WORMHOLE_ADDRESS= CUSTOM_CONSISTENCY_LEVEL= ./sh/deployCustomConsistencyLevel.sh
+#  tilt: ./sh/deployCustomConsistencyLevel.sh
+#  anvil: EVM_CHAIN_ID=31337 MNEMONIC=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 WORMHOLE_ADDRESS= CUSTOM_CONSISTENCY_LEVEL= ./sh/deployCustomConsistencyLevel.sh
+
+if [ "${RPC_URL}X" == "X" ]; then
+  RPC_URL=http://localhost:8545
+fi
+
+if [ "${MNEMONIC}X" == "X" ]; then
+  MNEMONIC=0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d
+fi
+
+if [ "${EVM_CHAIN_ID}X" == "X" ]; then
+  EVM_CHAIN_ID=1337
+fi
+
+[[ -z $WORMHOLE_ADDRESS ]] && { echo "Missing WORMHOLE_ADDRESS"; exit 1; }
+[[ -z $CUSTOM_CONSISTENCY_LEVEL ]] && { echo "Missing CUSTOM_CONSISTENCY_LEVEL"; exit 1; }
+
+forge script ./forge-scripts/DeployTestCustomConsistencyLevel.s.sol:DeployTestCustomConsistencyLevel \
+	--sig "run(address,address)" $WORMHOLE_ADDRESS $CUSTOM_CONSISTENCY_LEVEL \
+	--rpc-url "$RPC_URL" \
+	--private-key "$MNEMONIC" \
+	--broadcast ${FORGE_ARGS}
+
+returnInfo=$(cat ./broadcast/DeployTestCustomConsistencyLevel.s.sol/$EVM_CHAIN_ID/run-latest.json)
+
+DEPLOYED_ADDRESS=$(jq -r '.returns.deployedAddress.value' <<< "$returnInfo")
+echo "Deployed test custom consistency level to address: $DEPLOYED_ADDRESS using core address $WORMHOLE_ADDRESS and custom consistency level $CUSTOM_CONSISTENCY_LEVEL"
+
+echo "Configuring test custom consistency level at address $DEPLOYED_ADDRESS"
+forge script ./forge-scripts/ConfigureTestCustomConsistencyLevel.s.sol:ConfigureTestCustomConsistencyLevel \
+	--sig "run(address)" $DEPLOYED_ADDRESS \
+	--rpc-url $RPC_URL \
+	--private-key $MNEMONIC \
+	--broadcast
+
+	echo "Configured test custom consistency level at address $DEPLOYED_ADDRESS"

--- a/ethereum/sh/devnetInitialization.sh
+++ b/ethereum/sh/devnetInitialization.sh
@@ -82,3 +82,15 @@ echo "Registering chains on nft bridge"
 echo "NFT_BRIDGE_REGISTRATION_VAAS: $NFT_BRIDGE_REGISTRATION_VAAS"
 source "./sh/registerChainsNFTBridge.sh"
 echo "Done registering chains on nft bridge"
+
+echo "Deploying Custom Consistency Level"
+source ./sh/deployCustomConsistencyLevel.sh
+returnInfo=$(cat ./broadcast/DeployCustomConsistencyLevel.s.sol/$INIT_EVM_CHAIN_ID/run-latest.json)
+CUSTOM_CONSISTENCY_LEVEL=$(jq -r '.returns.deployedAddress.value' <<< "$returnInfo")
+echo "CUSTOM_CONSISTENCY_LEVEL: $CUSTOM_CONSISTENCY_LEVEL"
+
+echo "Deploying Test Custom Consistency Level"
+source ./sh/deployTestCustomConsistencyLevel.sh
+returnInfo=$(cat ./broadcast/DeployTestCustomConsistencyLevel.s.sol/$INIT_EVM_CHAIN_ID/run-latest.json)
+TEST_CUSTOM_CONSISTENCY_LEVEL=$(jq -r '.returns.deployedAddress.value' <<< "$returnInfo")
+echo "TEST_CUSTOM_CONSISTENCY_LEVEL: $TEST_CUSTOM_CONSISTENCY_LEVEL"

--- a/ethereum/sh/postTestCustomConsistencyLevelMsg.sh
+++ b/ethereum/sh/postTestCustomConsistencyLevelMsg.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+#
+# This script posts an observation via the TestCustomConsistencyLevel contract.
+# Usage: RPC_URL= MNEMONIC= EVM_CHAIN_ID= ADDR= PAYLOAD= ./sh/postTestCustomConsistencyLevelMsg.sh
+#  tilt: ./sh/postTestCustomConsistencyLevelMsg.sh
+
+if [ "${RPC_URL}X" == "X" ]; then
+  RPC_URL=http://localhost:8545
+fi
+
+if [ "${MNEMONIC}X" == "X" ]; then
+  MNEMONIC=0x4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d
+fi
+
+if [ "${EVM_CHAIN_ID}X" == "X" ]; then
+  EVM_CHAIN_ID=1337
+fi
+
+if [ "${ADDR}X" == "X" ]; then
+  ADDR=0x40d5B8a71a5e8202a26a53406eFAb755C0db6e93 
+fi
+
+if [ "${PAYLOAD}X" == "X" ]; then
+  PAYLOAD="Hello, World!"
+fi
+
+forge script ./forge-scripts/PostTestCustomConsistencyLevelMsg.s.sol:PostTestCustomConsistencyLevelMsg \
+	--sig "run(address,string calldata)" $ADDR "$PAYLOAD" \
+	--rpc-url "$RPC_URL" \
+	--private-key "$MNEMONIC" \
+	--broadcast ${FORGE_ARGS}
+
+DEPLOYED_ADDRESS=$(jq -r '.returns.deployedAddress.value' <<< "$returnInfo")
+echo "Posted a message to address: $ADDR: $returnInfo"


### PR DESCRIPTION
This PR implements the EVM contract to allow an integrator to specify a custom consistency level for their observations.

This feature is described [here](https://www.notion.so/wormholefoundation/EVM-Custom-Consistency-Level-Tech-Spec-207887494223813e9519f9719aeaf41d).