### PR TITLE
Node: Converge VAAs not getting published

### DIFF
--- a/sdk/vaa/structs.go
+++ b/sdk/vaa/structs.go
@@ -544,6 +544,7 @@ func GetAllNetworkIDs() []ChainID {
 		ChainIDMezo,
 		ChainIDFogo,
 		ChainIDSonic,
+		ChainIDConverge,
 		ChainIDWormchain,
 		ChainIDCosmoshub,
 		ChainIDEvmos,


### PR DESCRIPTION
#4394 added support for Converge in testnet. Unfortunately it did not update `GetAllNetworkIDs` which means that observations published by the watcher never make it into the processor, so they do not get published.