### PR TITLE
ci: fix clippy lint violation

### DIFF
--- a/cosmwasm/contracts/shutdown-wormhole/src/testing/integration.rs
+++ b/cosmwasm/contracts/shutdown-wormhole/src/testing/integration.rs
@@ -75,7 +75,7 @@ fn fee_change_blocked_in_shutdown() -> StdResult<()> {
         },
         &[],
     );
-    println!("vaa resp {:?}", vaa_response);
+    println!("vaa resp {vaa_response:?}");
 
     assert!(
         vaa_response.is_err(),


### PR DESCRIPTION
Rust 1.88 upgraded a new lint to a warning, causing our CI to fail https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#moves-and-deprecations

This commit fixes the lint violation