### PR TITLE
near: remove signer check

### DIFF
--- a/near/contracts/token-bridge/src/lib.rs
+++ b/near/contracts/token-bridge/src/lib.rs
@@ -1508,10 +1508,6 @@ impl TokenBridge {
             token
         ));
 
-        if env::signer_account_id() != sender_id {
-            env::panic_str("signer != sender");
-        }
-
         if ft_info.is_err() {
             env::panic_str("ft_infoError");
         }


### PR DESCRIPTION
Remove signer check to support asset bridging from contracts and keyless accounts.