### PR TITLE
ci: add cspell to lint script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -313,6 +313,7 @@ jobs:
       # Pinned version of the v6 tag, which is a lightweight and hence mutable tag
       - uses: streetsidesoftware/cspell-action@214db1e3138f326d33b7a6a51c92852e89ab0618
         with:
+          # NOTE: Keep this command in sync with `scripts/lint.sh`
           # For now, only lint markdown files
           files: "**/*.md"
           inline: warning

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -55,6 +55,15 @@ format(){
 }
 
 lint(){
+    # === Spell check
+    if ! command -v cspell >/dev/null 2>&1; then
+        printf "%s\n" "cspell is not installed. Skipping spellcheck"
+    else
+    # NOTE: Keep this command in sync with `.github/workflows/build.yml`
+        cspell -c cspell.config.yaml --dictionary cspell-custom-words.txt "**.*md"
+    fi
+    
+    # === Go linting
     # Check for dependencies
     if ! command -v golangci-lint >/dev/null 2>&1; then
         printf "%s\n" "Require golangci-lint. You can run this command in a docker container instead with '-c' and not worry about it or install it: https://golangci-lint.run/usage/install/"


### PR DESCRIPTION
Runs `cspell` (if installed) as part of local linting. This allows developers to spellcheck locally and catch errors, which helps avoid doing an entire CI run that fails just because of a typo.