### PR TITLE
governor: update big transaction limits

### DIFF
--- a/node/pkg/governor/mainnet_chains.go
+++ b/node/pkg/governor/mainnet_chains.go
@@ -10,8 +10,8 @@ import (
 
 func ChainList() []ChainConfigEntry {
 	return []ChainConfigEntry{
-		{EmitterChainID: vaa.ChainIDSolana, DailyLimit: 50_000_000, BigTransactionSize: 2_500_000},
-		{EmitterChainID: vaa.ChainIDEthereum, DailyLimit: 100_000_000, BigTransactionSize: 5_000_000},
+		{EmitterChainID: vaa.ChainIDSolana, DailyLimit: 50_000_000, BigTransactionSize: 10_000_000},
+		{EmitterChainID: vaa.ChainIDEthereum, DailyLimit: 100_000_000, BigTransactionSize: 20_000_000},
 		{EmitterChainID: vaa.ChainIDTerra, DailyLimit: 150_000, BigTransactionSize: 15_000},
 		{EmitterChainID: vaa.ChainIDBSC, DailyLimit: 5_000_000, BigTransactionSize: 500_000},
 		{EmitterChainID: vaa.ChainIDPolygon, DailyLimit: 5_000_000, BigTransactionSize: 500_000},
@@ -28,12 +28,12 @@ func ChainList() []ChainConfigEntry {
 		{EmitterChainID: vaa.ChainIDMoonbeam, DailyLimit: 5_000_000, BigTransactionSize: 500_000},
 		{EmitterChainID: vaa.ChainIDTerra2, DailyLimit: 100_000, BigTransactionSize: 10_000},
 		{EmitterChainID: vaa.ChainIDInjective, DailyLimit: 150_000, BigTransactionSize: 15_000},
-		{EmitterChainID: vaa.ChainIDSui, DailyLimit: 10_000_000, BigTransactionSize: 500_000},
+		{EmitterChainID: vaa.ChainIDSui, DailyLimit: 10_000_000, BigTransactionSize: 2_000_000},
 		{EmitterChainID: vaa.ChainIDAptos, DailyLimit: 1_000_000, BigTransactionSize: 100_000},
-		{EmitterChainID: vaa.ChainIDArbitrum, DailyLimit: 5_000_000, BigTransactionSize: 500_000},
+		{EmitterChainID: vaa.ChainIDArbitrum, DailyLimit: 5_000_000, BigTransactionSize: 2_000_000},
 		{EmitterChainID: vaa.ChainIDOptimism, DailyLimit: 5_000_000, BigTransactionSize: 500_000},
 		{EmitterChainID: vaa.ChainIDXpla, DailyLimit: 50_000, BigTransactionSize: 5_000},
-		{EmitterChainID: vaa.ChainIDBase, DailyLimit: 5_000_000, BigTransactionSize: 500_000},
+		{EmitterChainID: vaa.ChainIDBase, DailyLimit: 5_000_000, BigTransactionSize: 2_000_000},
 		{EmitterChainID: vaa.ChainIDSei, DailyLimit: 150_000, BigTransactionSize: 15_000},
 		{EmitterChainID: vaa.ChainIDScroll, DailyLimit: 500_000, BigTransactionSize: 50_000},
 		{EmitterChainID: vaa.ChainIDMantle, DailyLimit: 100_000, BigTransactionSize: 10_000},

--- a/node/pkg/governor/mainnet_chains_test.go
+++ b/node/pkg/governor/mainnet_chains_test.go
@@ -1,6 +1,7 @@
 package governor
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -76,6 +77,19 @@ func TestChainListBigTransfers(t *testing.T) {
 		assert.Less(t, e.BigTransactionSize, e.DailyLimit)
 
 		// in fact, it's even better for bigTransactionSize not to exceed 1/3rd the limit (convention has it at 1/10th to start)
-		assert.Less(t, e.BigTransactionSize, e.DailyLimit/3)
+		switch e.EmitterChainID {
+		// Base and Arbitrum are intentionally configured to not follow the 1/3rd convention for now.
+		// However, this check is still useful for other chains.
+		case vaa.ChainIDBase, vaa.ChainIDArbitrum:
+			continue
+		default:
+			assert.Less(t, e.BigTransactionSize, e.DailyLimit/3,
+				fmt.Sprintf(
+					"Chain %s has a big transaction size of %d which is more than 1/3 of the daily limit of %d",
+					e.EmitterChainID,
+					e.BigTransactionSize,
+					e.DailyLimit,
+				))
+		}
 	}
 }


### PR DESCRIPTION
Updates mainnet configuration for the Governor:

```
Ethereum
 $5M => $20M

Arbitrum
$500K => $2M

Base
$500K => $2M

Sui
$500K => $2M

Solana
$2.5M => $10M
```