### PR TITLE
ci: Add durationcheck linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,7 @@ linters:
     - depguard
     # Duplicate word usage, such as 'and and' in a comment.
     - dupword
+    - durationcheck
     - errcheck
     # Type assertion and comparison validation on errors. https://github.com/polyfloyd/go-errorlint
     - errorlint


### PR DESCRIPTION
https://github.com/charithe/durationcheck

> A Go linter to detect cases where two time.Duration values are being multiplied in possibly erroneous ways.
> Consider the following (highly contrived) code:
```go
func waitForSeconds(someDuration time.Duration) {
	timeToWait := someDuration * time.Second
	fmt.Printf("Waiting for %s\n", timeToWait)
}

func main() {
	waitForSeconds(5) // waits for 5 seconds
	waitForSeconds(5 * time.Second) // waits for 1388888h 53m 20s
}
```