### PR TITLE
Node: Remove obsolete L1Finalizer

### DIFF
--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -1416,13 +1416,12 @@ func runNode(cmd *cobra.Command, args []string) {
 
 	if shouldStart(arbitrumRPC) {
 		wc := &evm.WatcherConfig{
-			NetworkID:           "arbitrum",
-			ChainID:             vaa.ChainIDArbitrum,
-			Rpc:                 *arbitrumRPC,
-			Contract:            *arbitrumContract,
-			L1FinalizerRequired: "eth",
-			TxVerifierEnabled:   slices.Contains(txVerifierChains, vaa.ChainIDArbitrum),
-			CcqBackfillCache:    *ccqBackfillCache,
+			NetworkID:         "arbitrum",
+			ChainID:           vaa.ChainIDArbitrum,
+			Rpc:               *arbitrumRPC,
+			Contract:          *arbitrumContract,
+			TxVerifierEnabled: slices.Contains(txVerifierChains, vaa.ChainIDArbitrum),
+			CcqBackfillCache:  *ccqBackfillCache,
 		}
 
 		watcherConfigs = append(watcherConfigs, wc)

--- a/node/pkg/node/node_test.go
+++ b/node/pkg/node/node_test.go
@@ -872,9 +872,8 @@ func TestWatcherConfigs(t *testing.T) {
 						ChainID:   vaa.ChainIDSolana,
 					},
 					&mock.WatcherConfig{
-						NetworkID:           "mock2",
-						ChainID:             vaa.ChainIDEthereum,
-						L1FinalizerRequired: "mock1",
+						NetworkID: "mock2",
+						ChainID:   vaa.ChainIDEthereum,
 					},
 				}, nil),
 			},
@@ -895,19 +894,6 @@ func TestWatcherConfigs(t *testing.T) {
 				}, nil),
 			},
 			err: "NetworkID already configured: mock",
-		},
-		{
-			name: "watcher-noL1",
-			opts: []*GuardianOption{
-				GuardianOptionWatchers([]watchers.WatcherConfig{
-					&mock.WatcherConfig{
-						NetworkID:           "mock",
-						ChainID:             vaa.ChainIDSolana,
-						L1FinalizerRequired: "something-that-does-not-exist",
-					},
-				}, nil),
-			},
-			err: "L1finalizer does not exist. Please check the order of the watcher configurations in watcherConfigs.",
 		},
 	}
 	runGuardianConfigTests(t, tc)

--- a/node/pkg/watchers/algorand/config.go
+++ b/node/pkg/watchers/algorand/config.go
@@ -28,14 +28,6 @@ func (wc *WatcherConfig) GetChainID() vaa.ChainID {
 	return wc.ChainID
 }
 
-func (wc *WatcherConfig) RequiredL1Finalizer() watchers.NetworkID {
-	return ""
-}
-
-func (wc *WatcherConfig) SetL1Finalizer(l1finalizer interfaces.L1Finalizer) {
-	// empty
-}
-
 //nolint:unparam // error is always nil here but the return type is required to satisfy the interface.
 func (wc *WatcherConfig) Create(
 	msgC chan<- *common.MessagePublication,
@@ -44,6 +36,6 @@ func (wc *WatcherConfig) Create(
 	_ chan<- *query.PerChainQueryResponseInternal,
 	_ chan<- *common.GuardianSet,
 	_ common.Environment,
-) (interfaces.L1Finalizer, supervisor.Runnable, interfaces.Reobserver, error) {
-	return nil, NewWatcher(wc.IndexerRPC, wc.IndexerToken, wc.AlgodRPC, wc.AlgodToken, wc.AppID, msgC, obsvReqC).Run, nil, nil
+) (supervisor.Runnable, interfaces.Reobserver, error) {
+	return NewWatcher(wc.IndexerRPC, wc.IndexerToken, wc.AlgodRPC, wc.AlgodToken, wc.AppID, msgC, obsvReqC).Run, nil, nil
 }

--- a/node/pkg/watchers/aptos/config.go
+++ b/node/pkg/watchers/aptos/config.go
@@ -26,14 +26,6 @@ func (wc *WatcherConfig) GetChainID() vaa.ChainID {
 	return wc.ChainID
 }
 
-func (wc *WatcherConfig) RequiredL1Finalizer() watchers.NetworkID {
-	return ""
-}
-
-func (wc *WatcherConfig) SetL1Finalizer(l1finalizer interfaces.L1Finalizer) {
-	// empty
-}
-
 //nolint:unparam // error is always nil here but the return type is required to satisfy the interface.
 func (wc *WatcherConfig) Create(
 	msgC chan<- *common.MessagePublication,
@@ -42,6 +34,6 @@ func (wc *WatcherConfig) Create(
 	_ chan<- *query.PerChainQueryResponseInternal,
 	_ chan<- *common.GuardianSet,
 	_ common.Environment,
-) (interfaces.L1Finalizer, supervisor.Runnable, interfaces.Reobserver, error) {
-	return nil, NewWatcher(wc.ChainID, wc.NetworkID, wc.Rpc, wc.Account, wc.Handle, msgC, obsvReqC).Run, nil, nil
+) (supervisor.Runnable, interfaces.Reobserver, error) {
+	return NewWatcher(wc.ChainID, wc.NetworkID, wc.Rpc, wc.Account, wc.Handle, msgC, obsvReqC).Run, nil, nil
 }

--- a/node/pkg/watchers/cosmwasm/config.go
+++ b/node/pkg/watchers/cosmwasm/config.go
@@ -26,14 +26,6 @@ func (wc *WatcherConfig) GetChainID() vaa.ChainID {
 	return wc.ChainID
 }
 
-func (wc *WatcherConfig) RequiredL1Finalizer() watchers.NetworkID {
-	return ""
-}
-
-func (wc *WatcherConfig) SetL1Finalizer(l1finalizer interfaces.L1Finalizer) {
-	// empty
-}
-
 //nolint:unparam // error is always nil here but the return type is required to satisfy the interface.
 func (wc *WatcherConfig) Create(
 	msgC chan<- *common.MessagePublication,
@@ -42,6 +34,6 @@ func (wc *WatcherConfig) Create(
 	_ chan<- *query.PerChainQueryResponseInternal,
 	_ chan<- *common.GuardianSet,
 	env common.Environment,
-) (interfaces.L1Finalizer, supervisor.Runnable, interfaces.Reobserver, error) {
-	return nil, NewWatcher(wc.Websocket, wc.Lcd, wc.Contract, msgC, obsvReqC, wc.ChainID, env).Run, nil, nil
+) (supervisor.Runnable, interfaces.Reobserver, error) {
+	return NewWatcher(wc.Websocket, wc.Lcd, wc.Contract, msgC, obsvReqC, wc.ChainID, env).Run, nil, nil
 }

--- a/node/pkg/watchers/evm/ccq.go
+++ b/node/pkg/watchers/evm/ccq.go
@@ -572,7 +572,7 @@ func (w *Watcher) ccqHandleEthCallWithFinalityQueryRequest(ctx context.Context, 
 	if safeMode {
 		latestBlockNum = w.getLatestSafeBlockNumber()
 	} else {
-		latestBlockNum = w.GetLatestFinalizedBlockNumber()
+		latestBlockNum = w.getLatestFinalizedBlockNumber()
 	}
 
 	// Make sure the block has reached requested finality.

--- a/node/pkg/watchers/evm/config.go
+++ b/node/pkg/watchers/evm/config.go
@@ -17,8 +17,6 @@ type WatcherConfig struct {
 	Rpc                    string             // RPC URL
 	Contract               string             // hex representation of the contract address
 	GuardianSetUpdateChain bool               // if `true`, we will retrieve the GuardianSet from this chain and watch this chain for GuardianSet updates
-	L1FinalizerRequired    watchers.NetworkID // (optional)
-	l1Finalizer            interfaces.L1Finalizer
 	CcqBackfillCache       bool
 	TxVerifierEnabled      bool
 }
@@ -31,14 +29,6 @@ func (wc *WatcherConfig) GetChainID() vaa.ChainID {
 	return wc.ChainID
 }
 
-func (wc *WatcherConfig) RequiredL1Finalizer() watchers.NetworkID {
-	return wc.L1FinalizerRequired
-}
-
-func (wc *WatcherConfig) SetL1Finalizer(l1finalizer interfaces.L1Finalizer) {
-	wc.l1Finalizer = l1finalizer
-}
-
 //nolint:unparam // error is always nil here but the return type is required to satisfy the interface.
 func (wc *WatcherConfig) Create(
 	msgC chan<- *common.MessagePublication,
@@ -47,7 +37,7 @@ func (wc *WatcherConfig) Create(
 	queryResponseC chan<- *query.PerChainQueryResponseInternal,
 	setC chan<- *common.GuardianSet,
 	env common.Environment,
-) (interfaces.L1Finalizer, supervisor.Runnable, interfaces.Reobserver, error) {
+) (supervisor.Runnable, interfaces.Reobserver, error) {
 
 	// only actually use the guardian set channel if wc.GuardianSetUpdateChain == true
 	var setWriteC chan<- *common.GuardianSet = nil
@@ -69,6 +59,5 @@ func (wc *WatcherConfig) Create(
 		wc.CcqBackfillCache,
 		wc.TxVerifierEnabled,
 	)
-	watcher.SetL1Finalizer(wc.l1Finalizer)
-	return watcher, watcher.Run, watcher, nil
+	return watcher.Run, watcher, nil
 }

--- a/node/pkg/watchers/evm/watcher.go
+++ b/node/pkg/watchers/evm/watcher.go
@@ -15,7 +15,6 @@ import (
 	"github.com/certusone/wormhole/node/pkg/watchers"
 	"github.com/certusone/wormhole/node/pkg/watchers/evm/connectors"
 	"github.com/certusone/wormhole/node/pkg/watchers/evm/connectors/ethabi"
-	"github.com/certusone/wormhole/node/pkg/watchers/interfaces"
 
 	"github.com/certusone/wormhole/node/pkg/p2p"
 	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
@@ -137,7 +136,6 @@ type (
 		latestBlockNumber          uint64
 		latestSafeBlockNumber      uint64
 		latestFinalizedBlockNumber uint64
-		l1Finalizer                interfaces.L1Finalizer
 
 		ccqConfig          query.PerChainConfig
 		ccqMaxBlockNumber  *big.Int
@@ -743,18 +741,12 @@ func (w *Watcher) getFinality(ctx context.Context) (bool, bool, error) {
 	return finalized, safe, nil
 }
 
-// SetL1Finalizer is used to set the layer one finalizer.
-func (w *Watcher) SetL1Finalizer(l1Finalizer interfaces.L1Finalizer) {
-	w.l1Finalizer = l1Finalizer
-}
-
-// GetLatestFinalizedBlockNumber() implements the L1Finalizer interface and allows other watchers to
-// get the latest finalized block number from this watcher.
-func (w *Watcher) GetLatestFinalizedBlockNumber() uint64 {
+// getLatestFinalizedBlockNumber() returns the latest finalized block seen by this watcher.
+func (w *Watcher) getLatestFinalizedBlockNumber() uint64 {
 	return atomic.LoadUint64(&w.latestFinalizedBlockNumber)
 }
 
-// getLatestSafeBlockNumber() returns the latest safe block seen by this watcher..
+// getLatestSafeBlockNumber() returns the latest safe block seen by this watcher.
 func (w *Watcher) getLatestSafeBlockNumber() uint64 {
 	return atomic.LoadUint64(&w.latestSafeBlockNumber)
 }

--- a/node/pkg/watchers/interfaces/l1Finalizer.go
+++ b/node/pkg/watchers/interfaces/l1Finalizer.go
@@ -1,5 +1,0 @@
-package interfaces
-
-type L1Finalizer interface {
-	GetLatestFinalizedBlockNumber() uint64
-}

--- a/node/pkg/watchers/mock/config.go
+++ b/node/pkg/watchers/mock/config.go
@@ -15,13 +15,11 @@ type ObservationDb map[eth_common.Hash]*common.MessagePublication
 
 // The Mock Watcher is a watcher that will make a new observation
 type WatcherConfig struct {
-	NetworkID           watchers.NetworkID              // human readable name
-	ChainID             vaa.ChainID                     // ChainID
-	MockObservationC    chan *common.MessagePublication // Channel to feed this watcher mock observations that it will then make
-	ObservationDb       ObservationDb                   // If the watcher receives a re-observation request with a TxHash in this map, it will make the corresponding observation in this map.
-	MockSetC            <-chan *common.GuardianSet
-	L1FinalizerRequired watchers.NetworkID // (optional)
-	l1Finalizer         interfaces.L1Finalizer
+	NetworkID        watchers.NetworkID              // human readable name
+	ChainID          vaa.ChainID                     // ChainID
+	MockObservationC chan *common.MessagePublication // Channel to feed this watcher mock observations that it will then make
+	ObservationDb    ObservationDb                   // If the watcher receives a re-observation request with a TxHash in this map, it will make the corresponding observation in this map.
+	MockSetC         <-chan *common.GuardianSet
 }
 
 func (wc *WatcherConfig) GetNetworkID() watchers.NetworkID {
@@ -32,14 +30,6 @@ func (wc *WatcherConfig) GetChainID() vaa.ChainID {
 	return wc.ChainID
 }
 
-func (wc *WatcherConfig) RequiredL1Finalizer() watchers.NetworkID {
-	return wc.L1FinalizerRequired
-}
-
-func (wc *WatcherConfig) SetL1Finalizer(l1finalizer interfaces.L1Finalizer) {
-	wc.l1Finalizer = l1finalizer
-}
-
 //nolint:unparam // error is always nil here but the return type is required to satisfy the interface.
 func (wc *WatcherConfig) Create(
 	msgC chan<- *common.MessagePublication,
@@ -48,6 +38,6 @@ func (wc *WatcherConfig) Create(
 	_ chan<- *query.PerChainQueryResponseInternal,
 	setC chan<- *common.GuardianSet,
 	_ common.Environment,
-) (interfaces.L1Finalizer, supervisor.Runnable, interfaces.Reobserver, error) {
-	return MockL1Finalizer{}, NewWatcherRunnable(msgC, obsvReqC, setC, wc), nil, nil
+) (supervisor.Runnable, interfaces.Reobserver, error) {
+	return NewWatcherRunnable(msgC, obsvReqC, setC, wc), nil, nil
 }

--- a/node/pkg/watchers/mock/watcher.go
+++ b/node/pkg/watchers/mock/watcher.go
@@ -20,10 +20,6 @@ func NewWatcherRunnable(
 		logger := supervisor.Logger(ctx)
 		supervisor.Signal(ctx, supervisor.SignalHealthy)
 
-		if c.L1FinalizerRequired != "" && c.l1Finalizer == nil {
-			logger.Fatal("Mock watcher: L1FinalizerRequired but not set.")
-		}
-
 		logger.Info("Mock Watcher running.")
 
 		for {
@@ -48,10 +44,4 @@ func NewWatcherRunnable(
 			}
 		}
 	}
-}
-
-type MockL1Finalizer struct{}
-
-func (f MockL1Finalizer) GetLatestFinalizedBlockNumber() uint64 {
-	return 0
 }

--- a/node/pkg/watchers/near/config.go
+++ b/node/pkg/watchers/near/config.go
@@ -25,14 +25,6 @@ func (wc *WatcherConfig) GetChainID() vaa.ChainID {
 	return wc.ChainID
 }
 
-func (wc *WatcherConfig) RequiredL1Finalizer() watchers.NetworkID {
-	return ""
-}
-
-func (wc *WatcherConfig) SetL1Finalizer(l1finalizer interfaces.L1Finalizer) {
-	// empty
-}
-
 //nolint:unparam // error is always nil here but the return type is required to satisfy the interface.
 func (wc *WatcherConfig) Create(
 	msgC chan<- *common.MessagePublication,
@@ -41,7 +33,7 @@ func (wc *WatcherConfig) Create(
 	_ chan<- *query.PerChainQueryResponseInternal,
 	_ chan<- *common.GuardianSet,
 	env common.Environment,
-) (interfaces.L1Finalizer, supervisor.Runnable, interfaces.Reobserver, error) {
+) (supervisor.Runnable, interfaces.Reobserver, error) {
 	var mainnet = (env == common.MainNet)
-	return nil, NewWatcher(wc.Rpc, wc.Contract, msgC, obsvReqC, mainnet).Run, nil, nil
+	return NewWatcher(wc.Rpc, wc.Contract, msgC, obsvReqC, mainnet).Run, nil, nil
 }

--- a/node/pkg/watchers/solana/ccq.go
+++ b/node/pkg/watchers/solana/ccq.go
@@ -287,7 +287,7 @@ func (w *SolanaWatcher) ccqCheckForMinSlotContext(
 	if currentSlotFromError != 0 {
 		currentSlot = currentSlotFromError
 	} else {
-		currentSlot = w.GetLatestFinalizedBlockNumber()
+		currentSlot = w.getLatestFinalizedBlockNumber()
 	}
 
 	// Estimate how far in the future the requested slot is, using our estimated slot time.

--- a/node/pkg/watchers/solana/client.go
+++ b/node/pkg/watchers/solana/client.go
@@ -1102,8 +1102,8 @@ func (s *SolanaWatcher) updateLatestBlock(slot uint64) {
 	}
 }
 
-// GetLatestFinalizedBlockNumber() returns the latest published block.
-func (s *SolanaWatcher) GetLatestFinalizedBlockNumber() uint64 {
+// getLatestFinalizedBlockNumber() returns the latest published block.
+func (s *SolanaWatcher) getLatestFinalizedBlockNumber() uint64 {
 	s.latestBlockNumberMu.Lock()
 	defer s.latestBlockNumberMu.Unlock()
 	return s.latestBlockNumber

--- a/node/pkg/watchers/solana/config.go
+++ b/node/pkg/watchers/solana/config.go
@@ -33,14 +33,6 @@ func (wc *WatcherConfig) GetChainID() vaa.ChainID {
 	return wc.ChainID
 }
 
-func (wc *WatcherConfig) RequiredL1Finalizer() watchers.NetworkID {
-	return ""
-}
-
-func (wc *WatcherConfig) SetL1Finalizer(l1finalizer interfaces.L1Finalizer) {
-	// empty
-}
-
 func (wc *WatcherConfig) Create(
 	msgC chan<- *common.MessagePublication,
 	obsvReqC <-chan *gossipv1.ObservationRequest,
@@ -48,17 +40,17 @@ func (wc *WatcherConfig) Create(
 	queryResponseC chan<- *query.PerChainQueryResponseInternal,
 	_ chan<- *common.GuardianSet,
 	_ common.Environment,
-) (interfaces.L1Finalizer, supervisor.Runnable, interfaces.Reobserver, error) {
+) (supervisor.Runnable, interfaces.Reobserver, error) {
 	solAddress, err := solana_types.PublicKeyFromBase58(wc.Contract)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, err
 	}
 
 	var shimContractAddr solana.PublicKey
 	if wc.ShimContract != "" {
 		shimContractAddr, err = solana_types.PublicKeyFromBase58(wc.ShimContract)
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, nil, err
 		}
 	}
 
@@ -73,5 +65,5 @@ func (wc *WatcherConfig) Create(
 		reobserver = watcher
 	}
 
-	return watcher, watcher.Run, reobserver, nil
+	return watcher.Run, reobserver, nil
 }

--- a/node/pkg/watchers/sui/config.go
+++ b/node/pkg/watchers/sui/config.go
@@ -25,14 +25,6 @@ func (wc *WatcherConfig) GetChainID() vaa.ChainID {
 	return wc.ChainID
 }
 
-func (wc *WatcherConfig) RequiredL1Finalizer() watchers.NetworkID {
-	return ""
-}
-
-func (wc *WatcherConfig) SetL1Finalizer(l1finalizer interfaces.L1Finalizer) {
-	// empty
-}
-
 //nolint:unparam // error is always nil here but the return type is required to satisfy the interface.
 func (wc *WatcherConfig) Create(
 	msgC chan<- *common.MessagePublication,
@@ -41,8 +33,8 @@ func (wc *WatcherConfig) Create(
 	_ chan<- *query.PerChainQueryResponseInternal,
 	_ chan<- *common.GuardianSet,
 	env common.Environment,
-) (interfaces.L1Finalizer, supervisor.Runnable, interfaces.Reobserver, error) {
+) (supervisor.Runnable, interfaces.Reobserver, error) {
 	var devMode = (env == common.UnsafeDevNet)
 
-	return nil, NewWatcher(wc.Rpc, wc.SuiMoveEventType, devMode, msgC, obsvReqC).Run, nil, nil
+	return NewWatcher(wc.Rpc, wc.SuiMoveEventType, devMode, msgC, obsvReqC).Run, nil, nil
 }

--- a/node/pkg/watchers/watchers.go
+++ b/node/pkg/watchers/watchers.go
@@ -18,8 +18,6 @@ type NetworkID string
 type WatcherConfig interface {
 	GetNetworkID() NetworkID
 	GetChainID() vaa.ChainID
-	RequiredL1Finalizer() NetworkID // returns NetworkID of the L1 Finalizer that should be used for this Watcher.
-	SetL1Finalizer(l1finalizer interfaces.L1Finalizer)
 	Create(
 		msgC chan<- *common.MessagePublication,
 		obsvReqC <-chan *gossipv1.ObservationRequest,
@@ -27,7 +25,7 @@ type WatcherConfig interface {
 		queryResponseC chan<- *query.PerChainQueryResponseInternal,
 		setC chan<- *common.GuardianSet,
 		env common.Environment,
-	) (interfaces.L1Finalizer, supervisor.Runnable, interfaces.Reobserver, error)
+	) (supervisor.Runnable, interfaces.Reobserver, error)
 }
 
 var (


### PR DESCRIPTION
Since none of the watchers for L2 chains require access to the finalized L1 block, this PR removes the `L1Finalizer` and all references to it. This makes the code easier to understand and should help avoid confusion.