### PR TITLE
node: Add emitters for mUSD deployment to NTT Accountant

### DIFF
--- a/node/pkg/accountant/ntt_config.go
+++ b/node/pkg/accountant/ntt_config.go
@@ -31,6 +31,9 @@ func nttGetEmitters(env common.Environment) (validEmitters, validEmitters, error
 			// Lido wstETH + NTT deployment emitters
 			{chainId: vaa.ChainIDEthereum, addr: "000000000000000000000000A1ACC1e6edaB281Febd91E3515093F1DE81F25c0"},
 			{chainId: vaa.ChainIDBSC, addr: "000000000000000000000000be3F7e06872E0dF6CD7FF35B7aa4Bb1446DC9986"},
+			// mUSD NTT deployment emitters
+			{chainId: vaa.ChainIDEthereum, addr: "00000000000000000000000056E27f1A8425515FFD4BD76A254Ac1a5c0B66D71"},
+			{chainId: vaa.ChainIDBSC, addr: "00000000000000000000000076ddB3f1dDe02391Ef0A28664499B74C29d18d3E"},
 		}
 	} else if env == common.TestNet {
 		directEmitterConfig = emitterConfig{

--- a/node/pkg/accountant/ntt_config.go
+++ b/node/pkg/accountant/ntt_config.go
@@ -32,8 +32,8 @@ func nttGetEmitters(env common.Environment) (validEmitters, validEmitters, error
 			{chainId: vaa.ChainIDEthereum, addr: "000000000000000000000000A1ACC1e6edaB281Febd91E3515093F1DE81F25c0"},
 			{chainId: vaa.ChainIDBSC, addr: "000000000000000000000000be3F7e06872E0dF6CD7FF35B7aa4Bb1446DC9986"},
 			// mUSD NTT deployment emitters
-			{chainId: vaa.ChainIDEthereum, addr: "00000000000000000000000056E27f1A8425515FFD4BD76A254Ac1a5c0B66D71"},
-			{chainId: vaa.ChainIDBSC, addr: "00000000000000000000000076ddB3f1dDe02391Ef0A28664499B74C29d18d3E"},
+			{chainId: vaa.ChainIDMezo, addr: "00000000000000000000000056E27f1A8425515FFD4BD76A254Ac1a5c0B66D71"},
+			{chainId: vaa.ChainIDEthereum, addr: "00000000000000000000000076ddB3f1dDe02391Ef0A28664499B74C29d18d3E"},
 		}
 	} else if env == common.TestNet {
 		directEmitterConfig = emitterConfig{

--- a/node/pkg/accountant/ntt_test.go
+++ b/node/pkg/accountant/ntt_test.go
@@ -275,7 +275,7 @@ func TestNttParseArMsgUnknownArEmitter(t *testing.T) {
 func TestNttVerifyMainnetEmitters(t *testing.T) {
 	directEmitters, arEmitters, err := nttGetEmitters(common.MainNet)
 	require.NoError(t, err)
-	assert.Equal(t, 7, len(directEmitters)) // TODO: Change this when we add a mainnet emitter!
+	assert.Equal(t, 9, len(directEmitters)) // TODO: Change this when we add a mainnet emitter!
 	assert.NotEqual(t, 0, len(arEmitters))
 }
 


### PR DESCRIPTION
Mezo Transceiver: https://explorer.mezo.org/address/0x56E27f1A8425515FFD4BD76A254Ac1a5c0B66D71

Ethereum Transceiver: https://etherscan.io/address/0x76ddb3f1dde02391ef0a28664499b74c29d18d3e

