### PR TITLE
sui: testnet updates

### DIFF
--- a/sui/testing/scripts/upgrade-token-bridge.ts
+++ b/sui/testing/scripts/upgrade-token-bridge.ts
@@ -17,9 +17,9 @@ const GOVERNANCE_EMITTER =
   "0000000000000000000000000000000000000000000000000000000000000004";
 
 const TOKEN_BRIDGE_STATE_ID =
-  "0x32422cb2f929b6a4e3f81b4791ea11ac2af896b310f3d9442aa1fe924ce0bab4";
+  "0x6fb10cdb7aa299e9a4308752dadecb049ff55a892de92992a1edbd7912b3d6da";
 const WORMHOLE_STATE_ID =
-  "0x69ae41bdef4770895eb4e7aaefee5e4673acc08f6917b4856cf55549c4573ca8";
+  "0x31358d198147da50db32eda2562951d53973a0c0ad5ed738e9b17d88b213d790";
 
 async function main() {
   const guardianPrivateKey = process.env.TESTNET_GUARDIAN_PRIVATE_KEY;
@@ -69,22 +69,22 @@ async function main() {
   const signedVaa = guardians.addSignatures(published, [0]);
   console.log("Upgrade VAA:", signedVaa.toString("hex"));
 
-  // // And execute upgrade with governance VAA.
-  // const upgradeResults = await upgradeTokenBridge(
-  //   wallet,
-  //   TOKEN_BRIDGE_STATE_ID,
-  //   WORMHOLE_STATE_ID,
-  //   modules,
-  //   dependencies,
-  //   signedVaa
-  // );
+  // And execute upgrade with governance VAA.
+  const upgradeResults = await upgradeTokenBridge(
+    wallet,
+    TOKEN_BRIDGE_STATE_ID,
+    WORMHOLE_STATE_ID,
+    modules,
+    dependencies,
+    signedVaa
+  );
 
-  // console.log("tx digest", upgradeResults.digest);
-  // console.log("tx effects", JSON.stringify(upgradeResults.effects!));
-  // console.log("tx events", JSON.stringify(upgradeResults.events!));
+  console.log("tx digest", upgradeResults.digest);
+  console.log("tx effects", JSON.stringify(upgradeResults.effects!));
+  console.log("tx events", JSON.stringify(upgradeResults.events!));
 
-  // TODO: grab new package ID from the events above. Do not rely on the RPC
-  // call because it may give you a stale package ID after the upgrade.
+  // sleep 5 seconds
+  await new Promise((resolve) => setTimeout(resolve, 5000));
 
   const migrateResults = await migrateTokenBridge(
     wallet,

--- a/sui/testing/scripts/upgrade-wormhole.ts
+++ b/sui/testing/scripts/upgrade-wormhole.ts
@@ -17,7 +17,7 @@ const GOVERNANCE_EMITTER =
   "0000000000000000000000000000000000000000000000000000000000000004";
 
 const WORMHOLE_STATE_ID =
-  "0x69ae41bdef4770895eb4e7aaefee5e4673acc08f6917b4856cf55549c4573ca8";
+  "0x31358d198147da50db32eda2562951d53973a0c0ad5ed738e9b17d88b213d790";
 
 async function main() {
   const guardianPrivateKey = process.env.TESTNET_GUARDIAN_PRIVATE_KEY;
@@ -42,11 +42,11 @@ async function main() {
   const dstWormholePath = resolve(`${__dirname}/wormhole`);
 
   // Stage build(s).
-  setUpWormholeDirectory(srcWormholePath, dstWormholePath);
+  // setUpWormholeDirectory(srcWormholePath, dstWormholePath);
 
   // Build for digest.
   const { modules, dependencies, digest } =
-    buildForBytecodeAndDigest(dstWormholePath);
+    buildForBytecodeAndDigest(srcWormholePath);
 
   // We will use the signed VAA when we execute the upgrade.
   const guardians = new mock.MockGuardians(0, [guardianPrivateKey]);
@@ -76,17 +76,17 @@ async function main() {
   console.log("tx effects", JSON.stringify(upgradeResults.effects!));
   console.log("tx events", JSON.stringify(upgradeResults.events!));
 
-  // TODO: grab new package ID from the events above. Do not rely on the RPC
-  // call because it may give you a stale package ID after the upgrade.
+  // sleep for 5 seconds to ensure the upgrade is processed
+  await new Promise((resolve) => setTimeout(resolve, 5000));
 
-  // const migrateResults = await migrateWormhole(
-  //   wallet,
-  //   WORMHOLE_STATE_ID,
-  //   signedVaa
-  // );
-  // console.log("tx digest", migrateResults.digest);
-  // console.log("tx effects", JSON.stringify(migrateResults.effects!));
-  // console.log("tx events", JSON.stringify(migrateResults.events!));
+  const migrateResults = await migrateWormhole(
+    wallet,
+    WORMHOLE_STATE_ID,
+    signedVaa
+  );
+  console.log("tx digest", migrateResults.digest);
+  console.log("tx effects", JSON.stringify(migrateResults.effects!));
+  console.log("tx events", JSON.stringify(migrateResults.events!));
 
   // Clean up.
   cleanUpPackageDirectory(dstWormholePath);

--- a/sui/token_bridge/Move.testnet.toml
+++ b/sui/token_bridge/Move.testnet.toml
@@ -1,7 +1,7 @@
 [package]
 name = "TokenBridge"
 version = "0.2.0"
-published-at = "0x562760fc51d90d4ae1835bac3e91e0e6987d3497b06f066941d3e51f6e8d76d0"
+published-at = "0x71a0a23c9496d90f294fd3d3e383dd21df8819667cc6e94107ac39c8bb98ccd9"
 
 [dependencies.Sui]
 git = "https://github.com/MystenLabs/sui.git"

--- a/sui/wormhole/Move.testnet.toml
+++ b/sui/wormhole/Move.testnet.toml
@@ -1,7 +1,7 @@
 [package]
 name = "Wormhole"
 version = "0.2.0"
-published-at = "0xf47329f4344f3bf0f8e436e2f7b485466cff300f12a166563995d3888c296a94"
+published-at = "0x21473617f3565d704aa67be73ea41243e9e34a42d434c31f8182c67ba01ccf49"
 
 [dependencies.Sui]
 git = "https://github.com/MystenLabs/sui.git"


### PR DESCRIPTION
This PR updates updates the sui testnet upgrade scripts for both the wormhole and token_bridge contracts to perform the upgrade and migration against the actual deployments.
Also, update the `published-at` addresses of these contracts to the most recently deployed versions.