### PR TITLE
node(transfer verifier): Update TransferIsValid method to return results per Message rather than per Receipt

### DIFF
--- a/node/cmd/txverifier/evm.go
+++ b/node/cmd/txverifier/evm.go
@@ -159,7 +159,7 @@ func runTransferVerifierEvm(cmd *cobra.Command, args []string) {
 		// be tested using the integration tests in Tilt.
 		for i, check := range sanityChecks {
 			logger.Info(fmt.Sprintf("Running sanity check %d for txHash %s", i, check.txHash))
-			valid, err := transferVerifier.TransferIsValid(ctx, check.txHash, nil)
+			valid, err := transferVerifier.TransferIsValid(ctx, "", check.txHash, nil)
 			logger.Debug("done processing", zap.Bool("result", valid), zap.String("txHash", check.txHash.String()))
 
 			if err != nil {
@@ -194,7 +194,7 @@ func runTransferVerifierEvm(cmd *cobra.Command, args []string) {
 	// Single-shot mode: process a single transaction hash, then quit.
 	if len(*hash) > 0 {
 		receiptHash := common.HexToHash(*hash)
-		result, err := transferVerifier.TransferIsValid(ctx, receiptHash, nil)
+		result, err := transferVerifier.TransferIsValid(ctx, "", receiptHash, nil)
 		if err != nil {
 			logger.Error("could not verify transfer", zap.Error(err))
 			os.Exit(1)
@@ -223,7 +223,7 @@ func runTransferVerifierEvm(cmd *cobra.Command, args []string) {
 
 		// Process observed LogMessagePublished events
 		case vLog := <-sub.Events():
-			valid, err := transferVerifier.TransferIsValid(ctx, vLog.Raw.TxHash, nil)
+			valid, err := transferVerifier.TransferIsValid(ctx, "", vLog.Raw.TxHash, nil)
 			if err != nil {
 				logger.Debug("could not validate",
 					zap.Error(err),

--- a/node/cmd/txverifier/evm.go
+++ b/node/cmd/txverifier/evm.go
@@ -45,9 +45,9 @@ var ErrInvariant = errors.New("invariant violation")
 // sanityCheck represents a test case for the transfer verifier that can be replayed
 // against mainnet to ensure that the tool has not regressed.
 type sanityCheck struct {
-	txHash common.Hash
-	valid  bool
-	err    error
+	txHash   common.Hash
+	msgValid bool
+	err      error
 }
 
 // Function to initialize the configuration for the TransferVerifierCmdEvm flags.
@@ -183,7 +183,7 @@ func runTransferVerifierEvm(cmd *cobra.Command, args []string) {
 			}
 
 			// Ensure that the right error type was returned
-			if valid != check.valid {
+			if valid != check.msgValid {
 				logger.Fatal(fmt.Sprintf("Sanity check %d failed (wrong result) for txHash %s", i, check.txHash))
 			}
 		}

--- a/node/pkg/txverifier/evm.go
+++ b/node/pkg/txverifier/evm.go
@@ -174,7 +174,7 @@ func (tv *TransferVerifier[ethClient, Connector]) TransferIsValid(
 		return false, nil
 	}
 
-	cacheEvaluation := NewReceiptEvaluation(receipt.BlockNumber.Uint64())
+	cacheEvaluation := NewReceiptEvaluation(summary.isSafe, receipt.BlockNumber.Uint64())
 	for msgID, isValid := range summary.msgPubResult {
 		cacheEvaluation.MsgResults[msgID] = isValid
 	}

--- a/node/pkg/txverifier/evm.go
+++ b/node/pkg/txverifier/evm.go
@@ -105,7 +105,7 @@ func (tv *TransferVerifier[ethClient, Connector]) TransferIsValid(
 			return true, nil
 		}
 
-		//  Return true if the message is safe. (This function also checks that the receipt is safe.)
+		//  Return true if the message is safe.
 		return receiptEvaluation.ReceiptSummary.msgSafe(msgID), nil
 	}
 

--- a/node/pkg/txverifier/evm.go
+++ b/node/pkg/txverifier/evm.go
@@ -86,10 +86,10 @@ func (tv *TransferVerifier[ethClient, Connector]) TransferIsValid(
 	}
 
 	// Check to see if the receipt is cached.
-	if receiptEvaluation, exists := tv.evaluations[txHash]; exists {
+	if evaluation, exists := tv.evaluations[txHash]; exists {
 
 		// Check if the message has already been verified, and if so, return the cached result.
-		if !checkWholeReceipt && !receiptEvaluation.msgInCache(msgID) {
+		if !checkWholeReceipt && !evaluation.msgInCache(msgID) {
 			// Should never happen, probably indicates a bug in the code.
 			tv.logger.Warn(
 				ErrCachedReceiptHasNoDataForMessage.Error(),
@@ -99,12 +99,12 @@ func (tv *TransferVerifier[ethClient, Connector]) TransferIsValid(
 		}
 
 		// Return true if the entire receipt is safe.
-		if receiptEvaluation.ReceiptSummary.isSafe() {
+		if evaluation.ReceiptSummary.isSafe() {
 			return true, nil
 		}
 
 		//  Return true if the message is safe.
-		return receiptEvaluation.ReceiptSummary.isMsgSafe(msgID), nil
+		return evaluation.ReceiptSummary.isMsgSafe(msgID), nil
 	}
 
 	// Get the full transaction receipt for this txHash if it was not provided as an argument.

--- a/node/pkg/txverifier/evm_test.go
+++ b/node/pkg/txverifier/evm_test.go
@@ -7,6 +7,7 @@ package txverifier
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -682,7 +683,15 @@ func TestValidateReceipt(t *testing.T) {
 
 			summary, err := mocks.transferVerifier.validateReceipt(test.transferReceipt)
 
-			assert.Equal(t, test.expected, summary.logsProcessed, "number of processed receipts did not match")
+			assert.Equal(
+				t,
+				test.expected,
+				len(summary.msgPubResult),
+				fmt.Sprintf(
+					"number of processed receipts did not match. got %v",
+					summary.msgPubResult,
+				),
+			)
 
 			if err != nil {
 				assert.True(t, test.shouldError, "test should have returned an error")

--- a/node/pkg/txverifier/evm_test.go
+++ b/node/pkg/txverifier/evm_test.go
@@ -465,8 +465,8 @@ func TestValidateReceipt(t *testing.T) {
 
 	tests := map[string]struct {
 		transferReceipt *TransferReceipt
-		expected    ReceiptSummary
-		shouldError bool
+		expected        ReceiptSummary
+		shouldError     bool
 	}{
 		"safe receipt: amounts match, deposit": {
 			transferReceipt: &TransferReceipt{
@@ -601,8 +601,7 @@ func TestValidateReceipt(t *testing.T) {
 						Amount:       big.NewInt(99),
 					},
 				},
-				Transfers: &[]*ERC20Transfer{
-				},
+				Transfers: &[]*ERC20Transfer{},
 				MessagePublications: &[]*LogMessagePublished{
 					// Transfer out WETH
 					{
@@ -809,7 +808,7 @@ func TestValidateReceipt(t *testing.T) {
 		},
 		"unsafe receipt: duplicate msgID for LogMessagePublished events": {
 			transferReceipt: &TransferReceipt{
-				Deposits: &[]*NativeDeposit{},
+				Deposits:  &[]*NativeDeposit{},
 				Transfers: &[]*ERC20Transfer{},
 				// Sequence numbers are not unique, so the receipt is invalid
 				MessagePublications: &[]*LogMessagePublished{

--- a/node/pkg/txverifier/evm_test.go
+++ b/node/pkg/txverifier/evm_test.go
@@ -6,7 +6,6 @@ package txverifier
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math/big"
 	"testing"
@@ -493,8 +492,18 @@ func TestValidateReceipt(t *testing.T) {
 					},
 				},
 			},
-			expected:    ReceiptSummary{isSafe: true},
-			shouldError: false,
+			expected: ReceiptSummary{
+				in: map[string]*big.Int{
+					fmt.Sprintf("%s-%s", nativeAddrVAA, "2"): big.NewInt(123),
+				},
+				out: map[msgID]transferOut{
+					{Sequence: 1, EmitterChain: vaa.ChainIDEthereum, EmitterAddress: VAAAddrFrom(tokenBridgeAddr)}: {fmt.Sprintf("%s-%s", nativeAddrVAA, "2"), big.NewInt(123)},
+				},
+				msgPubResult: map[msgID]bool{
+					{Sequence: 1, EmitterChain: vaa.ChainIDEthereum, EmitterAddress: VAAAddrFrom(tokenBridgeAddr)}: true,
+				},
+				problems: &Problems{},
+			},
 		},
 		"safe receipt: amounts match, transfer": {
 			transferReceipt: &TransferReceipt{
@@ -511,6 +520,7 @@ func TestValidateReceipt(t *testing.T) {
 				},
 				MessagePublications: &[]*LogMessagePublished{
 					{
+						Sequence:     1,
 						EventEmitter: coreBridgeAddr,
 						MsgSender:    tokenBridgeAddr,
 						TransferDetails: &TransferDetails{
@@ -523,8 +533,18 @@ func TestValidateReceipt(t *testing.T) {
 					},
 				},
 			},
-			expected:    ReceiptSummary{isSafe: true},
-			shouldError: false,
+			expected: ReceiptSummary{
+				in: map[string]*big.Int{
+					fmt.Sprintf("%s-%s", usdcAddrVAA, "2"): big.NewInt(456),
+				},
+				out: map[msgID]transferOut{
+					{Sequence: 1, EmitterChain: vaa.ChainIDEthereum, EmitterAddress: VAAAddrFrom(tokenBridgeAddr)}: {fmt.Sprintf("%s-%s", usdcAddrVAA, "2"), big.NewInt(456)},
+				},
+				msgPubResult: map[msgID]bool{
+					{Sequence: 1, EmitterChain: vaa.ChainIDEthereum, EmitterAddress: VAAAddrFrom(tokenBridgeAddr)}: true,
+				},
+				problems: &Problems{},
+			},
 		},
 		"safe receipt: amount in is greater than amount out, deposit": {
 			transferReceipt: &TransferReceipt{
@@ -539,6 +559,7 @@ func TestValidateReceipt(t *testing.T) {
 				Transfers: &[]*ERC20Transfer{},
 				MessagePublications: &[]*LogMessagePublished{
 					{
+						Sequence:     1,
 						EventEmitter: coreBridgeAddr,
 						MsgSender:    tokenBridgeAddr,
 						TransferDetails: &TransferDetails{
@@ -551,8 +572,18 @@ func TestValidateReceipt(t *testing.T) {
 					},
 				},
 			},
-			expected:    ReceiptSummary{isSafe: true},
-			shouldError: false,
+			expected: ReceiptSummary{
+				in: map[string]*big.Int{
+					fmt.Sprintf("%s-%s", nativeAddrVAA, "2"): big.NewInt(999),
+				},
+				out: map[msgID]transferOut{
+					{Sequence: 1, EmitterChain: vaa.ChainIDEthereum, EmitterAddress: VAAAddrFrom(tokenBridgeAddr)}: {fmt.Sprintf("%s-%s", nativeAddrVAA, "2"), big.NewInt(321)},
+				},
+				msgPubResult: map[msgID]bool{
+					{Sequence: 1, EmitterChain: vaa.ChainIDEthereum, EmitterAddress: VAAAddrFrom(tokenBridgeAddr)}: true,
+				},
+				problems: &Problems{},
+			},
 		},
 		"safe receipt: amount in is greater than amount out, transfer": {
 			transferReceipt: &TransferReceipt{
@@ -581,8 +612,18 @@ func TestValidateReceipt(t *testing.T) {
 					},
 				},
 			},
-			expected:    ReceiptSummary{isSafe: true},
-			shouldError: false,
+			expected: ReceiptSummary{
+				in: map[string]*big.Int{
+					fmt.Sprintf("%s-%s", nativeAddrVAA, "2"): big.NewInt(999),
+				},
+				out: map[msgID]transferOut{
+					{Sequence: 1, EmitterChain: vaa.ChainIDEthereum, EmitterAddress: VAAAddrFrom(tokenBridgeAddr)}: {fmt.Sprintf("%s-%s", nativeAddrVAA, "2"), big.NewInt(321)},
+				},
+				msgPubResult: map[msgID]bool{
+					{Sequence: 1, EmitterChain: vaa.ChainIDEthereum, EmitterAddress: VAAAddrFrom(tokenBridgeAddr)}: true,
+				},
+				problems: &Problems{},
+			},
 		},
 		"safe receipt: two deposits": {
 			transferReceipt: &TransferReceipt{
@@ -618,8 +659,19 @@ func TestValidateReceipt(t *testing.T) {
 					},
 				},
 			},
-			expected:    ReceiptSummary{isSafe: true},
-			shouldError: false,
+			expected: ReceiptSummary{
+				in: map[string]*big.Int{
+					fmt.Sprintf("%s-%s", nativeAddrVAA, "2"): big.NewInt(100),
+					fmt.Sprintf("%s-%s", nativeAddrVAA, "2"): big.NewInt(99),
+				},
+				out: map[msgID]transferOut{
+					{Sequence: 1, EmitterChain: vaa.ChainIDEthereum, EmitterAddress: VAAAddrFrom(tokenBridgeAddr)}: {fmt.Sprintf("%s-%s", nativeAddrVAA, "2"), big.NewInt(199)},
+				},
+				msgPubResult: map[msgID]bool{
+					{Sequence: 1, EmitterChain: vaa.ChainIDEthereum, EmitterAddress: VAAAddrFrom(tokenBridgeAddr)}: true,
+				},
+				problems: &Problems{},
+			},
 		},
 		"safe receipt: two transfers": {
 			transferReceipt: &TransferReceipt{
@@ -660,8 +712,19 @@ func TestValidateReceipt(t *testing.T) {
 					},
 				},
 			},
-			expected:    ReceiptSummary{isSafe: true},
-			shouldError: false,
+			expected: ReceiptSummary{
+				in: map[string]*big.Int{
+					fmt.Sprintf("%s-%s", usdcAddrVAA, "2"): big.NewInt(999),
+					fmt.Sprintf("%s-%s", usdcAddrVAA, "2"): big.NewInt(1),
+				},
+				out: map[msgID]transferOut{
+					{Sequence: 1, EmitterChain: vaa.ChainIDEthereum, EmitterAddress: VAAAddrFrom(tokenBridgeAddr)}: {fmt.Sprintf("%s-%s", usdcAddrVAA, "2"), big.NewInt(1000)},
+				},
+				msgPubResult: map[msgID]bool{
+					{Sequence: 1, EmitterChain: vaa.ChainIDEthereum, EmitterAddress: VAAAddrFrom(tokenBridgeAddr)}: true,
+				},
+				problems: &Problems{},
+			},
 		},
 		"safe receipt: two separate assets, one deposit and one transfer": {
 			transferReceipt: &TransferReceipt{
@@ -713,8 +776,21 @@ func TestValidateReceipt(t *testing.T) {
 					},
 				},
 			},
-			expected:    ReceiptSummary{isSafe: true},
-			shouldError: false,
+			expected: ReceiptSummary{
+				in: map[string]*big.Int{
+					fmt.Sprintf("%s-%s", nativeAddrVAA, "2"): big.NewInt(999),
+					fmt.Sprintf("%s-%s", usdcAddrVAA, "2"):   big.NewInt(999),
+				},
+				out: map[msgID]transferOut{
+					{Sequence: 1, EmitterChain: vaa.ChainIDEthereum, EmitterAddress: VAAAddrFrom(tokenBridgeAddr)}: {fmt.Sprintf("%s-%s", nativeAddrVAA, "2"), big.NewInt(321)},
+					{Sequence: 2, EmitterChain: vaa.ChainIDEthereum, EmitterAddress: VAAAddrFrom(tokenBridgeAddr)}: {fmt.Sprintf("%s-%s", usdcAddrVAA, "2"), big.NewInt(456)},
+				},
+				msgPubResult: map[msgID]bool{
+					{Sequence: 1, EmitterChain: vaa.ChainIDEthereum, EmitterAddress: VAAAddrFrom(tokenBridgeAddr)}: true,
+					{Sequence: 2, EmitterChain: vaa.ChainIDEthereum, EmitterAddress: VAAAddrFrom(tokenBridgeAddr)}: true,
+				},
+				problems: &Problems{},
+			},
 		},
 		"unsafe receipt: amount in too low, deposit": {
 			transferReceipt: &TransferReceipt{
@@ -729,6 +805,7 @@ func TestValidateReceipt(t *testing.T) {
 				Transfers: &[]*ERC20Transfer{},
 				MessagePublications: &[]*LogMessagePublished{
 					{
+						Sequence:     1,
 						EventEmitter: coreBridgeAddr,
 						MsgSender:    tokenBridgeAddr,
 						TransferDetails: &TransferDetails{
@@ -741,8 +818,23 @@ func TestValidateReceipt(t *testing.T) {
 					},
 				},
 			},
-			expected:    ReceiptSummary{isSafe: false},
-			shouldError: true,
+			expected: ReceiptSummary{
+				in: map[string]*big.Int{
+					fmt.Sprintf("%s-%s", nativeAddrVAA, "2"): big.NewInt(10),
+				},
+				out: map[msgID]transferOut{
+					{Sequence: 1, EmitterChain: vaa.ChainIDEthereum, EmitterAddress: VAAAddrFrom(tokenBridgeAddr)}: {fmt.Sprintf("%s-%s", nativeAddrVAA, "2"), big.NewInt(11)},
+				},
+				msgPubResult: map[msgID]bool{
+					{Sequence: 1, EmitterChain: vaa.ChainIDEthereum, EmitterAddress: VAAAddrFrom(tokenBridgeAddr)}: false,
+				},
+				problems: &Problems{
+					&ReceiptProblem{
+						violationKind: ReceiptInvariant,
+						err:           *ErrInvariantReceiptInsolvent,
+					},
+				},
+			},
 		},
 		"unsafe receipt: amount in too low, transfer": {
 			transferReceipt: &TransferReceipt{
@@ -759,6 +851,7 @@ func TestValidateReceipt(t *testing.T) {
 				},
 				MessagePublications: &[]*LogMessagePublished{
 					{
+						Sequence:     1,
 						EventEmitter: coreBridgeAddr,
 						MsgSender:    tokenBridgeAddr,
 						TransferDetails: &TransferDetails{
@@ -771,8 +864,23 @@ func TestValidateReceipt(t *testing.T) {
 					},
 				},
 			},
-			expected:    ReceiptSummary{isSafe: false},
-			shouldError: true,
+			expected: ReceiptSummary{
+				in: map[string]*big.Int{
+					fmt.Sprintf("%s-%s", usdcAddrVAA, "2"): big.NewInt(2),
+				},
+				out: map[msgID]transferOut{
+					{Sequence: 1, EmitterChain: vaa.ChainIDEthereum, EmitterAddress: VAAAddrFrom(tokenBridgeAddr)}: {fmt.Sprintf("%s-%s", usdcAddrVAA, "2"), big.NewInt(2)},
+				},
+				msgPubResult: map[msgID]bool{
+					{Sequence: 1, EmitterChain: vaa.ChainIDEthereum, EmitterAddress: VAAAddrFrom(tokenBridgeAddr)}: false,
+				},
+				problems: &Problems{
+					&ReceiptProblem{
+						violationKind: ReceiptInvariant,
+						err:           *ErrInvariantReceiptInsolvent,
+					},
+				},
+			},
 		},
 		"unsafe receipt: transfer out after transferring a different token": {
 			transferReceipt: &TransferReceipt{
@@ -803,8 +911,24 @@ func TestValidateReceipt(t *testing.T) {
 					},
 				},
 			},
-			expected:    ReceiptSummary{isSafe: false},
-			shouldError: true,
+			expected: ReceiptSummary{
+				in: map[string]*big.Int{
+					fmt.Sprintf("%s-%s", usdcAddrVAA, "2"): big.NewInt(2),
+				},
+				out: map[msgID]transferOut{
+					{Sequence: 1, EmitterChain: vaa.ChainIDEthereum, EmitterAddress: VAAAddrFrom(tokenBridgeAddr)}: {fmt.Sprintf("%s-%s", nativeAddrVAA, "2"), big.NewInt(2)},
+				},
+				msgPubResult: map[msgID]bool{
+					{Sequence: 1, EmitterChain: vaa.ChainIDEthereum, EmitterAddress: VAAAddrFrom(tokenBridgeAddr)}: false,
+				},
+				problems: &Problems{
+					&ReceiptProblem{
+						violationKind: ReceiptInvariant,
+						// A receipt error is expected here. Message invariants are checked only when there are multiple message publications.
+						err: *ErrInvariantReceiptInsolvent,
+					},
+				},
+			},
 		},
 		"unsafe receipt: duplicate msgID for LogMessagePublished events": {
 			transferReceipt: &TransferReceipt{
@@ -838,7 +962,8 @@ func TestValidateReceipt(t *testing.T) {
 					},
 				},
 			},
-			shouldError: true,
+			// Parsing error, so the summary should be nil.
+			// expected: ReceiptSummary{},
 		},
 		"unsafe receipt: total amount in is too small even though messages are valid when considered individually": {
 			transferReceipt: &TransferReceipt{
@@ -850,7 +975,7 @@ func TestValidateReceipt(t *testing.T) {
 						From:         eoaAddrGeth,
 						To:           tokenBridgeAddr,
 						Amount:       big.NewInt(1),
-						OriginAddr:   usdcAddrVAA,
+						OriginAddr:   nativeAddrVAA,
 					},
 				},
 				MessagePublications: &[]*LogMessagePublished{
@@ -881,19 +1006,34 @@ func TestValidateReceipt(t *testing.T) {
 				},
 			},
 			expected: ReceiptSummary{
-				isSafe: false,
 				in: map[string]*big.Int{
-					fmt.Sprintf("%s-%s", nativeAddrVAA, "2"): big.NewInt(2),
+					fmt.Sprintf("%s-%s", nativeAddrVAA, "2"): big.NewInt(1),
 				},
-				out:          map[msgID]transferOut{},
-				msgPubResult: map[msgID]bool{},
+				out: map[msgID]transferOut{
+					{Sequence: 1, EmitterChain: vaa.ChainIDEthereum, EmitterAddress: VAAAddrFrom(tokenBridgeAddr)}: {fmt.Sprintf("%s-%s", nativeAddrVAA, "2"), big.NewInt(1)},
+					{Sequence: 2, EmitterChain: vaa.ChainIDEthereum, EmitterAddress: VAAAddrFrom(tokenBridgeAddr)}: {fmt.Sprintf("%s-%s", nativeAddrVAA, "2"), big.NewInt(1)},
+				},
+				msgPubResult: map[msgID]bool{
+					{Sequence: 1, EmitterChain: vaa.ChainIDEthereum, EmitterAddress: VAAAddrFrom(tokenBridgeAddr)}: true,
+					{Sequence: 2, EmitterChain: vaa.ChainIDEthereum, EmitterAddress: VAAAddrFrom(tokenBridgeAddr)}: true,
+				},
+				problems: &Problems{
+					// This manifests as two problems because each individual message out is ruled insolvent relative to the whole receipt.
+					&ReceiptProblem{
+						violationKind: ReceiptInvariant,
+						err:           *ErrInvariantReceiptInsolvent,
+					},
+					&ReceiptProblem{
+						violationKind: ReceiptInvariant,
+						err:           *ErrInvariantReceiptInsolvent,
+					},
+				},
 			},
-			shouldError: true,
 		},
 		"unsafe receipt: one valid message, one invalid message": {
 			transferReceipt: &TransferReceipt{
 				Deposits: &[]*NativeDeposit{},
-				// Transfer in WETH but not USDC
+				// Transfer in USDC but not WETH
 				Transfers: &[]*ERC20Transfer{
 					{
 						TokenAddress: usdcAddrGeth,
@@ -933,9 +1073,28 @@ func TestValidateReceipt(t *testing.T) {
 				},
 			},
 			expected: ReceiptSummary{
-				isSafe: false,
+				in: map[string]*big.Int{
+					fmt.Sprintf("%s-%s", usdcAddrVAA, "2"): big.NewInt(2),
+				},
+				out: map[msgID]transferOut{
+					{Sequence: 1, EmitterChain: vaa.ChainIDEthereum, EmitterAddress: VAAAddrFrom(tokenBridgeAddr)}: {fmt.Sprintf("%s-%s", nativeAddrVAA, "2"), big.NewInt(2)},
+					{Sequence: 2, EmitterChain: vaa.ChainIDEthereum, EmitterAddress: VAAAddrFrom(tokenBridgeAddr)}: {fmt.Sprintf("%s-%s", usdcAddrVAA, "2"), big.NewInt(1)},
+				},
+				msgPubResult: map[msgID]bool{
+					{Sequence: 1, EmitterChain: vaa.ChainIDEthereum, EmitterAddress: VAAAddrFrom(tokenBridgeAddr)}: false,
+					{Sequence: 2, EmitterChain: vaa.ChainIDEthereum, EmitterAddress: VAAAddrFrom(tokenBridgeAddr)}: true,
+				},
+				problems: &Problems{
+					&ReceiptProblem{
+						violationKind: MsgInvariant,
+						err:           *ErrInvariantMissingCollateral,
+					},
+					&ReceiptProblem{
+						violationKind: ReceiptInvariant,
+						err:           *ErrInvariantReceiptInsolvent,
+					},
+				},
 			},
-			shouldError: true,
 		},
 	}
 
@@ -944,23 +1103,72 @@ func TestValidateReceipt(t *testing.T) {
 
 			summary, err := mocks.transferVerifier.validateReceipt(test.transferReceipt)
 
+			// Only occurs if the receipt could not be parsed.
 			if err != nil {
-				assert.True(t, test.shouldError, "test returned an error but should not have: %v", err)
+				assert.Nil(t, summary, "summary must be nil when a non-invariant error is returned")
+				return
+			}
 
-				var invErr *InvariantError
-				isInvariantErr := errors.As(err, &invErr)
+			require.NotNil(t, summary, "summary must not be nil if error is nil")
+			require.NotEmpty(t, summary.msgPubResult, "msgPubResult must not be empty")
+			require.Equal(t, len(test.expected.in), len(summary.in), "in map should have the same number of entries as expected")
+			require.Equal(t, len(test.expected.out), len(summary.out), "out map should have the same number of entries as expected")
+			require.Equal(t, len(test.expected.msgPubResult), len(summary.msgPubResult), "msgPubResult map should have the same number of entries as expected")
 
-				if !isInvariantErr {
-					// Check non-invariant errors
-					assert.Nil(t, summary, "summary must be nil when a non-invariant error is returned")
-				} else {
-					// Check summary when invariant error is returned
-					assert.NotNil(t, summary, "summary must not be nil when an invariant error is returned")
-					assert.False(t, summary.isSafe, "receipt should not be marked as safe when it returns an error")
+			if summary.isSafe() {
+				// If the receipt is safe, allMsgsSafe should be true.
+				// (Note: the inverse is not true, because a receipt can be unsafe but all messages are safe.)
+				assert.True(t, summary.allMsgsSafe(), "allMsgsSafe should be true if and only if isSafe is true")
+				require.Empty(t, summary.problems, "problems should be empty if isSafe is true")
+			} else {
+				// Assert an invariant error exists.
+				assert.Equal(t, len(*test.expected.problems), len(*summary.problems),
+					fmt.Sprintf(
+						"summary should have the same number of problems as expected, got: %s",
+						summary.InvariantErrors(),
+					),
+				)
+				require.NotEmpty(t, summary.problems, "problems must not be empty if isSafe is false")
+				require.NotEmpty(t, test.expected.problems, "bad test: expected problems must not be empty for unsafe receipts")
+
+				if summary.allMsgsSafe() {
+					var receiptInvariantFound bool
+					for _, problem := range *summary.problems {
+						if problem.violationKind == ReceiptInvariant {
+							receiptInvariantFound = true
+							break
+						}
+					}
+					assert.True(t, receiptInvariantFound, "problems must contain a receipt invariant if isSafe is false and allMsgsSafe is true")
 				}
 
-			} else {
-				assert.False(t, test.shouldError, "test should not have returned an error but got: `%w`", err)
+				// Bad receipts with a single message publication should only give a receipt invariant.
+				if len(summary.msgPubResult) == 1 {
+					// Check for a single problem.
+					require.Equal(t, len(*summary.problems), 1, "single message receipts should only give a single receipt invariant")
+
+					// Ensure that the problem is a receipt invariant.
+					var receiptInvariantFound bool
+					for _, problem := range *summary.problems {
+						if problem.violationKind == ReceiptInvariant {
+							receiptInvariantFound = true
+							break
+						}
+					}
+					assert.True(t, receiptInvariantFound, "single message receipts should only give a single receipt invariant")
+				}
+
+				// Multicall invariants are only checked when there are multiple message publications.
+				if len(summary.msgPubResult) > 2 {
+					var msgInvariantFound bool
+					for _, problem := range *summary.problems {
+						if problem.violationKind == ReceiptInvariant {
+							msgInvariantFound = true
+							break
+						}
+					}
+					assert.True(t, msgInvariantFound, "problems must contain a message invariant if isSafe is false the receipt contains more than one message")
+				}
 			}
 		})
 	}

--- a/node/pkg/txverifier/evm_test.go
+++ b/node/pkg/txverifier/evm_test.go
@@ -502,7 +502,6 @@ func TestValidateReceipt(t *testing.T) {
 				msgPubResult: map[msgID]bool{
 					{Sequence: 1, EmitterChain: vaa.ChainIDEthereum, EmitterAddress: VAAAddrFrom(tokenBridgeAddr)}: true,
 				},
-				problems: &Problems{},
 			},
 		},
 		"safe receipt: amounts match, transfer": {
@@ -543,7 +542,6 @@ func TestValidateReceipt(t *testing.T) {
 				msgPubResult: map[msgID]bool{
 					{Sequence: 1, EmitterChain: vaa.ChainIDEthereum, EmitterAddress: VAAAddrFrom(tokenBridgeAddr)}: true,
 				},
-				problems: &Problems{},
 			},
 		},
 		"safe receipt: amount in is greater than amount out, deposit": {
@@ -582,7 +580,6 @@ func TestValidateReceipt(t *testing.T) {
 				msgPubResult: map[msgID]bool{
 					{Sequence: 1, EmitterChain: vaa.ChainIDEthereum, EmitterAddress: VAAAddrFrom(tokenBridgeAddr)}: true,
 				},
-				problems: &Problems{},
 			},
 		},
 		"safe receipt: amount in is greater than amount out, transfer": {
@@ -622,7 +619,6 @@ func TestValidateReceipt(t *testing.T) {
 				msgPubResult: map[msgID]bool{
 					{Sequence: 1, EmitterChain: vaa.ChainIDEthereum, EmitterAddress: VAAAddrFrom(tokenBridgeAddr)}: true,
 				},
-				problems: &Problems{},
 			},
 		},
 		"safe receipt: two deposits": {
@@ -670,7 +666,6 @@ func TestValidateReceipt(t *testing.T) {
 				msgPubResult: map[msgID]bool{
 					{Sequence: 1, EmitterChain: vaa.ChainIDEthereum, EmitterAddress: VAAAddrFrom(tokenBridgeAddr)}: true,
 				},
-				problems: &Problems{},
 			},
 		},
 		"safe receipt: two transfers": {
@@ -723,7 +718,6 @@ func TestValidateReceipt(t *testing.T) {
 				msgPubResult: map[msgID]bool{
 					{Sequence: 1, EmitterChain: vaa.ChainIDEthereum, EmitterAddress: VAAAddrFrom(tokenBridgeAddr)}: true,
 				},
-				problems: &Problems{},
 			},
 		},
 		"safe receipt: two separate assets, one deposit and one transfer": {
@@ -789,7 +783,6 @@ func TestValidateReceipt(t *testing.T) {
 					{Sequence: 1, EmitterChain: vaa.ChainIDEthereum, EmitterAddress: VAAAddrFrom(tokenBridgeAddr)}: true,
 					{Sequence: 2, EmitterChain: vaa.ChainIDEthereum, EmitterAddress: VAAAddrFrom(tokenBridgeAddr)}: true,
 				},
-				problems: &Problems{},
 			},
 		},
 		"unsafe receipt: amount in too low, deposit": {
@@ -827,12 +820,6 @@ func TestValidateReceipt(t *testing.T) {
 				},
 				msgPubResult: map[msgID]bool{
 					{Sequence: 1, EmitterChain: vaa.ChainIDEthereum, EmitterAddress: VAAAddrFrom(tokenBridgeAddr)}: false,
-				},
-				problems: &Problems{
-					&ReceiptProblem{
-						violationKind: ReceiptInvariant,
-						err:           *ErrInvariantReceiptInsolvent,
-					},
 				},
 			},
 		},
@@ -874,12 +861,6 @@ func TestValidateReceipt(t *testing.T) {
 				msgPubResult: map[msgID]bool{
 					{Sequence: 1, EmitterChain: vaa.ChainIDEthereum, EmitterAddress: VAAAddrFrom(tokenBridgeAddr)}: false,
 				},
-				problems: &Problems{
-					&ReceiptProblem{
-						violationKind: ReceiptInvariant,
-						err:           *ErrInvariantReceiptInsolvent,
-					},
-				},
 			},
 		},
 		"unsafe receipt: transfer out after transferring a different token": {
@@ -920,13 +901,6 @@ func TestValidateReceipt(t *testing.T) {
 				},
 				msgPubResult: map[msgID]bool{
 					{Sequence: 1, EmitterChain: vaa.ChainIDEthereum, EmitterAddress: VAAAddrFrom(tokenBridgeAddr)}: false,
-				},
-				problems: &Problems{
-					&ReceiptProblem{
-						violationKind: ReceiptInvariant,
-						// A receipt error is expected here. Message invariants are checked only when there are multiple message publications.
-						err: *ErrInvariantReceiptInsolvent,
-					},
 				},
 			},
 		},
@@ -1019,14 +993,6 @@ func TestValidateReceipt(t *testing.T) {
 					{Sequence: 1, EmitterChain: vaa.ChainIDEthereum, EmitterAddress: VAAAddrFrom(tokenBridgeAddr)}: false,
 					{Sequence: 2, EmitterChain: vaa.ChainIDEthereum, EmitterAddress: VAAAddrFrom(tokenBridgeAddr)}: false,
 				},
-				problems: &Problems{
-					// The receipt is insolvent because more was transferred out than was requested in.
-					&ReceiptProblem{
-						violationKind: ReceiptInvariant,
-						err:           *ErrInvariantReceiptInsolvent,
-					},
-					// No message invariants are checked because individually they seem to be valid.
-				},
 			},
 		},
 		"unsafe receipt: two invalid messages mixed in with one valid message": {
@@ -1105,14 +1071,6 @@ func TestValidateReceipt(t *testing.T) {
 					{Sequence: 2, EmitterChain: vaa.ChainIDEthereum, EmitterAddress: VAAAddrFrom(tokenBridgeAddr)}: false,
 					{Sequence: 3, EmitterChain: vaa.ChainIDEthereum, EmitterAddress: VAAAddrFrom(tokenBridgeAddr)}: true,
 				},
-				problems: &Problems{
-					// The receipt is insolvent because more was transferred out than was requested in.
-					&ReceiptProblem{
-						violationKind: ReceiptInvariant,
-						err:           *ErrInvariantReceiptInsolvent,
-					},
-					// No message invariants are checked because individually they seem to be valid.
-				},
 			},
 		},
 		"unsafe receipt: one valid message, one invalid message": {
@@ -1170,18 +1128,6 @@ func TestValidateReceipt(t *testing.T) {
 					{Sequence: 1, EmitterChain: vaa.ChainIDEthereum, EmitterAddress: VAAAddrFrom(tokenBridgeAddr)}: false,
 					{Sequence: 2, EmitterChain: vaa.ChainIDEthereum, EmitterAddress: VAAAddrFrom(tokenBridgeAddr)}: true,
 				},
-				problems: &Problems{
-					// WETH (native) is missing collateral
-					&ReceiptProblem{
-						violationKind: MsgInvariant,
-						err:           *ErrInvariantMissingCollateral,
-					},
-					// The receipt is insolvent because more was transferred out than was requested in for WETH.
-					&ReceiptProblem{
-						violationKind: ReceiptInvariant,
-						err:           *ErrInvariantReceiptInsolvent,
-					},
-				},
 			},
 		},
 	}
@@ -1193,7 +1139,7 @@ func TestValidateReceipt(t *testing.T) {
 
 			// Only occurs if the receipt could not be parsed.
 			if err != nil {
-				assert.Nil(t, summary, "summary must be nil when a non-invariant error is returned")
+				assert.Nil(t, summary, "summary must be nil when an error is returned")
 				return
 			}
 
@@ -1203,63 +1149,31 @@ func TestValidateReceipt(t *testing.T) {
 			require.Equal(t, len(test.expected.out), len(summary.out), "out map should have the same number of entries as expected")
 			require.Equal(t, len(test.expected.msgPubResult), len(summary.msgPubResult), "msgPubResult map should have the same number of entries as expected")
 
+			// Compare the number of valid and invalid messages.
+			var (
+				expectedValidCount   = 0
+				expectedInvalidCount = 0
+				invalidCount         = summary.invalidMessageCount()
+				validCount           = len(summary.msgPubResult) - invalidCount
+			)
+			for _, valid := range test.expected.msgPubResult {
+				if valid {
+					expectedValidCount++
+				} else {
+					expectedInvalidCount++
+				}
+			}
+			require.Equal(t, expectedValidCount, validCount, "valid message count should match expected")
+			require.Equal(t, expectedInvalidCount, invalidCount, "invalid message count should match expected")
+
 			if summary.isSafe() {
 				// If the receipt is safe, allMsgsSafe should be true.
 				// (Note: the inverse is not true, because a receipt can be unsafe but all messages are safe.)
 				assert.True(t, summary.allMsgsSafe(), "allMsgsSafe should be true if and only if isSafe is true")
-				require.Empty(t, summary.problems, "problems should be empty if isSafe is true")
 			} else {
-				// Assert an invariant error exists.
-				assert.Equal(t, len(*test.expected.problems), len(*summary.problems),
-					fmt.Sprintf(
-						"summary should have the same number of problems as expected, got: %s summary: %v",
-						summary.InvariantErrors(),
-						summary,
-					),
-				)
-				require.NotEmpty(t, summary.problems, "problems must not be empty if isSafe is false")
-				require.NotEmpty(t, test.expected.problems, "bad test: expected problems must not be empty for unsafe receipts")
-
-				if summary.allMsgsSafe() {
-					var receiptInvariantFound bool
-					for _, problem := range *summary.problems {
-						if problem.violationKind == ReceiptInvariant {
-							receiptInvariantFound = true
-							break
-						}
-					}
-					assert.True(t, receiptInvariantFound, "problems must contain a receipt invariant if isSafe is false and allMsgsSafe is true")
-				}
-
-				// Bad receipts with a single message publication should only give a receipt invariant.
-				if len(summary.msgPubResult) == 1 {
-					// Check for a single problem.
-					require.Equal(t, len(*summary.problems), 1, "single message receipts should only give a single receipt invariant")
-
-					// Ensure that the problem is a receipt invariant.
-					var receiptInvariantFound bool
-					for _, problem := range *summary.problems {
-						if problem.violationKind == ReceiptInvariant {
-							receiptInvariantFound = true
-							break
-						}
-					}
-					assert.True(t, receiptInvariantFound, "single message receipts should only give a single receipt invariant")
-				}
-
-				// Message invariants are only checked when there are multiple message publications.
-				if len(summary.msgPubResult) > 2 {
-					var receiptInvariantFound bool
-					for _, problem := range *summary.problems {
-						if problem.violationKind == ReceiptInvariant {
-							receiptInvariantFound = true
-							break
-						}
-					}
-					assert.True(t, receiptInvariantFound, "problems must contain a message invariant if isSafe is false the receipt contains more than one message")
-					require.NotEmpty(t, summary.insolventAssets(), "insolventAssets must not be empty if there is a receipt invariant violation")
-					require.False(t, summary.allMsgsSafe(), "allMsgsSafe should be false if there is a receipt invariant violation (the code should manually invalidate messages with insolvent assets)")
-				}
+				assert.False(t, summary.allMsgsSafe(), "allMsgsSafe should be true if and only if isSafe is true")
+				require.NotEmpty(t, summary.insolventAssets(), "insolventAssets must not be empty if there is a receipt invariant violation")
+				require.False(t, summary.allMsgsSafe(), "allMsgsSafe should be false if there is a receipt invariant violation (the code should manually invalidate messages with insolvent assets)")
 			}
 		})
 	}

--- a/node/pkg/txverifier/evmtypes.go
+++ b/node/pkg/txverifier/evmtypes.go
@@ -733,10 +733,9 @@ func (s *ReceiptSummary) isSafe() bool {
 	return len(*s.problems) == 0 && len(s.msgPubResult) > 0
 }
 
-// msgSafe returns true if the message with the given ID is safe and the receipt is safe.
-// It's important to check both as the individual message may be valid even if the receipt is not.
+// msgSafe returns true if the message with the given ID is safe.
 func (s *ReceiptSummary) msgSafe(msgID msgID) bool {
-	return s.msgPubResult[msgID] && s.isSafe()
+	return s.msgPubResult[msgID]
 }
 
 type Problems []*ReceiptProblem

--- a/node/pkg/txverifier/evmtypes.go
+++ b/node/pkg/txverifier/evmtypes.go
@@ -773,7 +773,7 @@ const (
 	// Occurs if the receipt is not solvent.
 	ReceiptInvariant InvariantViolationKind = 1
 	// MsgInvariant is the type of invariant violation that occurs when an individual message is deemed unsafe.
-	MsgInvariant InvariantViolationKind= 2
+	MsgInvariant InvariantViolationKind = 2
 )
 
 // Custom error type used to signal that a core invariant of the token bridge has been violated.

--- a/node/pkg/txverifier/evmtypes.go
+++ b/node/pkg/txverifier/evmtypes.go
@@ -137,14 +137,14 @@ type receiptEvaluation struct {
 	// valid, but the receipt itself to be invalid.
 	Valid bool
 	// Whether individual messages in the receipt are valid or not.
-	MsgResults     map[msgID]bool
+	MsgResults  map[msgID]bool
 	blockNumber uint64
 }
 
 func NewReceiptEvaluation(blockNumber uint64) receiptEvaluation {
 	return receiptEvaluation{
-		Valid: false,
-		MsgResults:     make(map[msgID]bool),
+		Valid:       false,
+		MsgResults:  make(map[msgID]bool),
 		blockNumber: blockNumber,
 	}
 }

--- a/node/pkg/txverifier/evmtypes.go
+++ b/node/pkg/txverifier/evmtypes.go
@@ -717,14 +717,15 @@ func (s *ReceiptSummary) InvariantErrors() string {
 	if len(*s.problems) == 0 {
 		return ""
 	}
-	var errs = make([]string, 2)
+	// Preallocate a single value
+	var errs = make([]string, 1)
 	for _, p := range *s.problems {
 		errs = append(errs, p.String())
 	}
 	return strings.Join(errs, "\n")
 }
 
-// isSafe is true if and only if there are no problems in the summary, and the receipt contains at least one message.
+// isSafe is true if and only if there are no Problems in the ReceiptSummary, and the receipt contains at least one message.
 // Note: It is possible for all of the messages in a receipt to be safe, but the receipt itself to be unsafe.
 func (s *ReceiptSummary) isSafe() bool {
 	// If there are no problems, then the receipt is safe. Also check that there are messages in the receipt
@@ -822,7 +823,7 @@ func (s *ReceiptSummary) String() (outStr string) {
 	}
 
 	outStr = fmt.Sprintf(
-		"receipt summary: logsProcessed=%d requestedIn={%s} requestedOut={%v} msgResults={%s}",
+		"receipt summary: logsProcessed=%d collateralIn={%s} requestedOut={%v} msgResults={%s}",
 		len(s.out),
 		ins,
 		outs,

--- a/node/pkg/txverifier/evmtypes.go
+++ b/node/pkg/txverifier/evmtypes.go
@@ -135,15 +135,15 @@ func (tv *TransferVerifier[ethClient, Connector]) MsgID(log *LogMessagePublished
 type receiptEvaluation struct {
 	// Whether the entire receipt itself is valid or not. It is possible for all of the messages in a receipt to be
 	// valid, but the receipt itself to be invalid.
-	Valid bool
+	IsSafe bool
 	// Whether individual messages in the receipt are valid or not.
 	MsgResults  map[msgID]bool
 	blockNumber uint64
 }
 
-func NewReceiptEvaluation(blockNumber uint64) receiptEvaluation {
+func NewReceiptEvaluation(isSafe bool, blockNumber uint64) receiptEvaluation {
 	return receiptEvaluation{
-		Valid:       false,
+		IsSafe:      isSafe,
 		MsgResults:  make(map[msgID]bool),
 		blockNumber: blockNumber,
 	}

--- a/node/pkg/txverifier/evmtypes_test.go
+++ b/node/pkg/txverifier/evmtypes_test.go
@@ -294,9 +294,6 @@ func TestValidateDeposit(t *testing.T) {
 			require.NoError(t, err)
 
 			// Test the interface
-			// The Sender() field for a Deposit must always be
-			// 'zero'. It only exists to satisfy the TransferLog interface.
-			assert.Equal(t, ZERO_ADDRESS_VAA.Bytes(), test.deposit.Sender().Bytes())
 			assert.Equal(t, test.deposit.TokenAddress, test.deposit.Emitter())
 			assert.NotEqual(t, ZERO_ADDRESS, test.deposit.OriginAddress())
 		})
@@ -529,6 +526,19 @@ func TestValidateLogMessagePublished(t *testing.T) {
 					OriginAddress: usdcAddrVAA,
 					TargetAddress: eoaAddrVAA,
 					Amount:        big.NewInt(-1),
+				},
+			},
+		},
+		"invalid: msg.sender cannot be equal to emitter": {
+			logMessagePublished: LogMessagePublished{
+				EventEmitter: coreBridgeAddr,
+				MsgSender:    coreBridgeAddr,
+				TransferDetails: &TransferDetails{
+					PayloadType:   TransferTokens,
+					TokenChain:    NATIVE_CHAIN_ID,
+					OriginAddress: usdcAddrVAA,
+					TargetAddress: eoaAddrVAA,
+					Amount:        big.NewInt(1),
 				},
 			},
 		},

--- a/node/pkg/txverifier/utils.go
+++ b/node/pkg/txverifier/utils.go
@@ -66,7 +66,7 @@ func NewMsgID(in string) (msgID, error) {
 
 	supported := IsSupported(chainID)
 	if !supported {
-		return msgID{}, err
+		return msgID{}, fmt.Errorf("chainID %d (%s) is does not have a Transfer Verifier implementation or is not supported", chainID, chainID.String())
 	}
 
 	emitterAddress, err := vaa.StringToAddress(parts[1])

--- a/node/pkg/txverifier/utils.go
+++ b/node/pkg/txverifier/utils.go
@@ -45,8 +45,15 @@ func (m *msgID) String() string {
 	return fmt.Sprintf("%d/%s/%d", m.EmitterChain, m.EmitterAddress, m.Sequence)
 }
 
+func (m *msgID) Empty() bool {
+	return m.EmitterChain == 0 && m.EmitterAddress == ZERO_ADDRESS_VAA && m.Sequence == 0
+}
+
 // NewMsgID creates a new msgID from a string in the format "chainID/emitterAddress/sequence".
 func NewMsgID(in string) (msgID, error) {
+	if len(in) == 0 {
+		return msgID{}, errors.New("msgIDStr is empty")
+	}
 	parts := strings.Split(in, "/")
 	if len(parts) != 3 {
 		return msgID{}, errors.New("invalid msgID: must be in the format chainID/emitterAddress/sequence")
@@ -71,6 +78,11 @@ func NewMsgID(in string) (msgID, error) {
 	if err != nil {
 		return msgID{}, err
 	}
+
+	if chainID == vaa.ChainIDUnset || emitterAddress == ZERO_ADDRESS_VAA {
+		return msgID{}, errors.New("invalid msgID: chainID or emitterAddress is unset or zero")
+	}
+
 	return msgID{
 		EmitterChain:   chainID,
 		EmitterAddress: emitterAddress,

--- a/node/pkg/watchers/evm/msg_verifier.go
+++ b/node/pkg/watchers/evm/msg_verifier.go
@@ -46,7 +46,7 @@ func verify(
 	if evm_verifier.Cmp(localMsg.EmitterAddress, verifier.Addrs().TokenBridgeAddr) != 0 {
 		newState = common.NotApplicable
 	} else {
-		newState = state(ctx, txHash, receipt, verifier)
+		newState = state(ctx, localMsg, txHash, receipt, verifier)
 	}
 
 	// Update the state of the message.
@@ -60,10 +60,10 @@ func verify(
 }
 
 // state returns a verification state based on the results of querying the Transfer Verifier.
-func state(ctx context.Context, txHash eth_common.Hash, receipt *types.Receipt, tv evm_verifier.TransferVerifierInterface) common.VerificationState {
-	// Verify the transfer by analyzing the transaction receipt. This is a defense-in-depth mechanism
-	// to protect against fraudulent message emissions.
-	valid, err := tv.TransferIsValid(ctx, txHash, receipt)
+func state(ctx context.Context, msg *common.MessagePublication, txHash eth_common.Hash, receipt *types.Receipt, tv evm_verifier.TransferVerifierInterface) common.VerificationState {
+	// Verify the transfer represented by the message by analyzing the transaction receipt.
+	// This is a defense-in-depth mechanism to protect against fraudulent message emissions.
+	valid, err := tv.TransferIsValid(ctx, msg.MessageIDString(), txHash, receipt)
 
 	// The receipt couldn't be processed properly for some reason.
 	if err != nil {

--- a/node/pkg/watchers/evm/watcher_test.go
+++ b/node/pkg/watchers/evm/watcher_test.go
@@ -202,7 +202,7 @@ type MockTransferVerifier[E ethclient.Client, C connectors.Connector] struct {
 // TransferIsValid simulates the evaluation made by the Transfer Verifier.
 // Always returns nil. The error should be non-nil only when a parsing or RPC error occurs.
 // For now, these are not included in the unit tests.
-func (m *MockTransferVerifier[E, C]) TransferIsValid(_ context.Context, _ eth_common.Hash, _ *types.Receipt) (bool, error) {
+func (m *MockTransferVerifier[E, C]) TransferIsValid(_ context.Context, _ string, _ eth_common.Hash, _ *types.Receipt) (bool, error) {
 	return m.success, nil
 }
 func (m *MockTransferVerifier[E, C]) Addrs() *txverifier.TVAddresses {


### PR DESCRIPTION
- Update TransferIsValid method to support per-message validation

- Add `msgID` parameter (equivalent to VAA ID) to `TransferIsValid` method
  signature to enable validation of specific messages within transaction
  receipts. Update caching mechanism to store per-message validation
  results instead of per-transaction results. Modify receipt processing
  to track message-specific evaluations and validate transfer amounts on
  a per-message basis.

Key changes:
- Add msgID parameter to TransferIsValid method for targeted message validation
- Replace single Result field in evaluation struct with Results map keyed by message ID
- Update receipt summary to track transfers per message ID rather than aggregated amounts
- Modify invariant checking to validate each message's transfers individually
- Add MsgID method to generate unique message identifiers from LogMessagePublished events
- Add sequence field to LogMessagePublished struct for message identification