### PR TITLE
sui: Fixes shell command built from environment values

### DIFF
--- a/algorand/audit_test/src/sdk/Deployer.ts
+++ b/algorand/audit_test/src/sdk/Deployer.ts
@@ -666,10 +666,9 @@ export class Deployer {
             // Run current program
             const pythonCommand = 'python3.10'
             const preArgs = overrideArgs ?? []
-            const args = [...preArgs, ...outputPaths]
-            const cmd = `${pythonCommand} "${pytealSourceFile}" ${args.join(' ')}`
-             console.log(`Running command ${cmd}`)
-            const logs = await util.promisify(child_process.exec)(cmd)
+            const args = [pytealSourceFile, ...preArgs, ...outputPaths]
+            console.log(`Running command: ${pythonCommand} ${args.map(a => JSON.stringify(a)).join(' ')}`)
+            const logs = await util.promisify(child_process.execFile)(pythonCommand, args)
             if (logs.stderr && logs.stderr.length > 0) {
                 throw Error(`Could not compile file: ${pytealSourceFile} with ${pythonCommand}.\nError: ${logs.stderr}`)
             }

--- a/clients/js/src/chains/sui/publish.ts
+++ b/clients/js/src/chains/sui/publish.ts
@@ -5,7 +5,7 @@ import {
   RawSigner,
   TransactionBlock,
 } from "@mysten/sui.js";
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 import fs from "fs";
 import { resolve } from "path";
 import { MoveToml } from "./MoveToml";
@@ -19,10 +19,18 @@ export const buildPackage = (packagePath: string): SuiBuildOutput => {
   }
 
   return JSON.parse(
-    execSync(
-      `sui move build --dump-bytecode-as-base64 --path ${packagePath} 2> /dev/null`,
+    execFileSync(
+      "sui",
+      [
+        "move",
+        "build",
+        "--dump-bytecode-as-base64",
+        "--path",
+        packagePath
+      ],
       {
         encoding: "utf-8",
+        stdio: ["ignore", "pipe", "ignore"], // Redirect stderr to /dev/null
       }
     )
   );

--- a/sui/testing/scripts/upgrade-token-bridge.ts
+++ b/sui/testing/scripts/upgrade-token-bridge.ts
@@ -9,7 +9,7 @@ import {
   Ed25519Keypair,
   testnetConnection,
 } from "@mysten/sui.js";
-import { execSync } from "child_process";
+import { execSync, execFileSync } from "child_process";
 import { resolve } from "path";
 import * as fs from "fs";
 
@@ -107,9 +107,10 @@ function buildForBytecodeAndDigest(packagePath: string) {
     dependencies: string[];
     digest: number[];
   } = JSON.parse(
-    execSync(
-      `sui move build --dump-bytecode-as-base64 -p ${packagePath} 2> /dev/null`,
-      { encoding: "utf-8" }
+    execFileSync(
+      "sui",
+      ["move", "build", "--dump-bytecode-as-base64", "-p", packagePath],
+      { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] }
     )
   );
   return {

--- a/sui/testing/scripts/upgrade-wormhole.ts
+++ b/sui/testing/scripts/upgrade-wormhole.ts
@@ -9,7 +9,7 @@ import {
   Ed25519Keypair,
   testnetConnection,
 } from "@mysten/sui.js";
-import { execSync } from "child_process";
+import { execSync, execFileSync } from "child_process";
 import { resolve } from "path";
 import * as fs from "fs";
 
@@ -102,9 +102,10 @@ function buildForBytecodeAndDigest(packagePath: string) {
     dependencies: string[];
     digest: number[];
   } = JSON.parse(
-    execSync(
-      `sui move build --dump-bytecode-as-base64 -p ${packagePath} 2> /dev/null`,
-      { encoding: "utf-8" }
+    execFileSync(
+      "sui",
+      ["move", "build", "--dump-bytecode-as-base64", "-p", packagePath],
+      { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] }
     )
   );
   return {


### PR DESCRIPTION
https://github.com/wormhole-foundation/wormhole/blob/7842829b4f1f8446c48f37ab67b227a974904d46/sui/testing/scripts/upgrade-token-bridge.ts#L110-L112

https://github.com/wormhole-foundation/wormhole/blob/7842829b4f1f8446c48f37ab67b227a974904d46/clients/js/src/chains/sui/publish.ts#L22-L23


https://github.com/wormhole-foundation/wormhole/blob/7842829b4f1f8446c48f37ab67b227a974904d46/algorand/audit_test/src/sdk/Deployer.ts#L669-L672

Dynamically constructing a shell command with values from the local environment, such as file paths, may inadvertently change the meaning of the shell command. Such changes can occur when an environment value contains characters that the shell interprets in a special way, for instance quotes and spaces. This can result in the shell command misbehaving, or even allowing a malicious user to execute arbitrary commands on the system.

---

Fix the problem, we should avoid constructing a shell command string with interpolated values and passing it to `execSync`, which invokes a shell. Instead, we should use `execFileSync` from the `child_process` module, which allows us to pass the command and its arguments as separate parameters, thus avoiding shell interpretation of the arguments. Specifically, we should replace the use of `execSync` with `execFileSync`, passing `"sui"` as the command and the rest of the arguments as an array. We should also capture the output as a string, as before. This change should be made in the `buildForBytecodeAndDigest` function, specifically on lines 110-113. We will need to import `execFileSync` from `child_process` if it is not already imported.

Specifically, in `clients/js/src/chains/sui/publish.ts`, replace the use of `execSync` with a string command on line 23 with `execFileSync`, passing the command as `"sui"`, the arguments as an array (including `"move"`, `"build"`, `"--dump-bytecode-as-base64"`, `"--path"`, and `packagePath`), and redirecting stderr to `/dev/null` if needed. You may need to import `execFileSync` from `child_process` if not already imported.


Specifically, in `compilePyTeal`, instead of building a string like  
```js
const cmd = `${pythonCommand} "${pytealSourceFile}" ${args.join(' ')}`
const logs = await util.promisify(child_process.exec)(cmd)
```
we should do:  
```js
const logs = await util.promisify(child_process.execFile)(pythonCommand, [pytealSourceFile, ...args])
```
This requires changing the way arguments are constructed and passed, and updating the logging to print the command and arguments array.

**Required changes:**
- Replace the construction and use of `cmd` with a call to `execFile` (promisified).
- Update the logging to print the command and arguments.
- Import and use `util.promisify(child_process.execFile)` if not already available.

### References

[Shell Escaping in TypeScript](https://mojoauth.com/escaping/shell-escaping-in-typescript/)
[Command Injection](https://www.owasp.org/index.php/Command_Injection)
[CWE-78](https://cwe.mitre.org/data/definitions/78.html)
[CWE-88](https://cwe.mitre.org/data/definitions/88.html)