### PR TITLE
fix(sui): Correct doc comments in external_address.move

### DIFF
--- a/sui/wormhole/sources/datatypes/external_address.move
+++ b/sui/wormhole/sources/datatypes/external_address.move
@@ -20,7 +20,7 @@ module wormhole::external_address {
         ExternalAddress { value }
     }
 
-    /// Create `ExternalAddress` of all zeros.`
+    /// Create `ExternalAddress` of all zeros.
     public fun default(): ExternalAddress {
         new(bytes32::default())
     }
@@ -36,7 +36,7 @@ module wormhole::external_address {
         bytes32::to_bytes(to_bytes32(ext))
     }
 
-    /// Destroy 'ExternalAddress` for underlying data.
+    /// Destroy `ExternalAddress` for underlying data.
     public fun to_bytes32(ext: ExternalAddress): Bytes32 {
         let ExternalAddress { value } = ext;
         value


### PR DESCRIPTION
## Description and context
Closes #4468.

This PR corrects two minor typos in the documentation comments within the `wormhole::external_address` module. These typos were causing the `sui move build --doc` command to panic, blocking documentation generation for any project using this as a dependency.

This change serves as a workaround for an upstream issue in the Sui toolchain, tracked in [MystenLabs/sui#23125](https://github.com/MystenLabs/sui/issues/23125).

**Tasks:**
- [x] Remove stray backtick in a doc comment.
- [x] Correct a mismatched single quote to a backtick for markdown consistency.

## Definition of done
- The code changes are reviewed and approved.
- The pull request is merged, and issue #4468 is closed.
- The Sui documentation build completes successfully.