### PR TITLE
node(governor): add some type safety; rename decimals to scalingFactor

### DIFF
--- a/node/pkg/governor/governor_test.go
+++ b/node/pkg/governor/governor_test.go
@@ -43,7 +43,7 @@ func (gov *ChainGovernor) initConfigForTest(
 	decimals, _ := decimalsFloat.Int(nil)
 	key := tokenKey{chain: tokenChainID, addr: tokenAddr}
 
-	gov.tokens[key] = &tokenEntry{price: price, decimals: decimals, symbol: tokenSymbol, token: key}
+	gov.tokens[key] = &tokenEntry{price: price, scalingFactor: decimals, symbol: tokenSymbol, token: key}
 }
 
 func (gov *ChainGovernor) setDayLengthInMinutes(minimum int) {
@@ -89,17 +89,19 @@ func (gov *ChainGovernor) setTokenForTesting(
 	gov.mutex.Lock()
 	defer gov.mutex.Unlock()
 
+	const Decimals = 8
+
 	tokenAddr, err := vaa.StringToAddress(tokenAddrStr)
 	if err != nil {
 		return err
 	}
 
 	bigPrice := big.NewFloat(price)
-	decimalsFloat := big.NewFloat(math.Pow(10.0, float64(8)))
-	decimals, _ := decimalsFloat.Int(nil)
+	scalingFactorFloat := big.NewFloat(math.Pow(10.0, float64(Decimals)))
+	scalingFactor, _ := scalingFactorFloat.Int(nil)
 
 	key := tokenKey{chain: tokenChainID, addr: tokenAddr}
-	te := &tokenEntry{cfgPrice: bigPrice, price: bigPrice, decimals: decimals, symbol: symbol, coinGeckoId: symbol, token: key, flowCancels: flowCancels}
+	te := &tokenEntry{cfgPrice: bigPrice, price: bigPrice, scalingFactor: scalingFactor, symbol: symbol, coinGeckoId: symbol, token: key, flowCancels: flowCancels}
 	gov.tokens[key] = te
 	cge, cgExists := gov.tokensByCoinGeckoId[te.coinGeckoId]
 	if !cgExists {

--- a/node/pkg/governor/mainnet_tokens_test.go
+++ b/node/pkg/governor/mainnet_tokens_test.go
@@ -56,6 +56,18 @@ func TestTokensHaveGovernedChains(t *testing.T) {
 	require.Empty(t, badTokens, "Some tokens are not governed by a chain: %v", badTokens)
 }
 
+func TestTokenSensibleDecimals(t *testing.T) {
+	tokenConfigEntries := TokenList()
+	// This is the global maximum number of decimals among the tokens we have configured. (due to NEAR)
+	// A larger number may be fine but it's unusual, so it's worth flagging.
+	const maxDecimals = 24
+
+	for tokenConfigEntry := range slices.Values(tokenConfigEntries) {
+		assert.GreaterOrEqual(t, tokenConfigEntry.Decimals, uint8(0), "Token decimals must be greater than or equal to zero")
+		assert.LessOrEqual(t, tokenConfigEntry.Decimals, uint8(maxDecimals), fmt.Sprintf("Token decimals must be less than or equal to %d but got %d. details: %v", maxDecimals, tokenConfigEntry.Decimals, tokenConfigEntry))
+	}
+}
+
 // Flag a situation where a Governed chain does not have any governed assets. Often times when adding a mainnet chain,
 // a list of tokens will be added so that they can be governed. (These tokens are sourced by CoinGecko or manually
 // populated.) While this is not a hard requirement, it may represent that a developer has forgotten to take the step


### PR DESCRIPTION
- Change TokenConfigEntry.Decimals field from int64 to uint8 for more appropriate data type
- Rename tokenEntry.decimals to scalingFactor with clarifying comment explaining it represents 10^decimals
- Add comprehensive error checking in computeValue function to prevent nil pointer dereferences and division by zero
- Add test cases to validate token prices are positive and decimals are within sensible bounds (0-24)