### PR TITLE
node: Log version on watcher start

### DIFF
--- a/node/pkg/watchers/near/nearapi/mock/mock_server.go
+++ b/node/pkg/watchers/near/nearapi/mock/mock_server.go
@@ -125,6 +125,12 @@ func (s *ForwardingCachingServer) ServeHTTP(w http.ResponseWriter, req *http.Req
 		return
 	}
 
+	// Mock the status request to return a version
+	if bytes.Contains(origReqBody, []byte("\"method\": \"status\"")) {
+		_, _ = w.Write([]byte(`{"id": "dontcare", "jsonrpc": "2.0", "result": {"version": "1.0.0"}}`))
+		return
+	}
+
 	reqBody := s.RewriteReq(origReqBody)
 	req.Body = io.NopCloser(bytes.NewReader(reqBody))
 

--- a/node/pkg/watchers/near/nearapi/nearapi.go
+++ b/node/pkg/watchers/near/nearapi/nearapi.go
@@ -42,6 +42,7 @@ type (
 		GetFinalBlock(ctx context.Context) (Block, error)
 		GetChunk(ctx context.Context, chunkHeader ChunkHeader) (Chunk, error)
 		GetTxStatus(ctx context.Context, txHash string, senderAccountId string) ([]byte, error)
+		GetVersion(ctx context.Context) (string, error)
 	}
 	NearApiImpl struct {
 		nearRPC NearRpc
@@ -174,6 +175,21 @@ func (n NearApiImpl) GetChunk(ctx context.Context, chunkHeader ChunkHeader) (Chu
 func (n NearApiImpl) GetTxStatus(ctx context.Context, txHash string, senderAccountId string) ([]byte, error) {
 	s := fmt.Sprintf(`{"id": "dontcare", "jsonrpc": "2.0", "method": "tx", "params": ["%s", "%s"]}`, txHash, senderAccountId)
 	return n.nearRPC.Query(ctx, s)
+}
+
+func (n NearApiImpl) GetVersion(ctx context.Context) (string, error) {
+	s := `{"id": "dontcare", "jsonrpc": "2.0", "method": "status"}`
+	versionBytes, err := n.nearRPC.Query(ctx, s)
+	if err != nil {
+		return "", err
+	}
+
+	version, err := VersionFromBytes(versionBytes)
+	if err != nil {
+		return "", err
+	}
+
+	return version, nil
 }
 
 func IsWellFormedHash(hash string) error {

--- a/node/pkg/watchers/near/nearapi/types.go
+++ b/node/pkg/watchers/near/nearapi/types.go
@@ -82,6 +82,22 @@ func NewBlockFromBytes(bytes []byte) (Block, error) {
 	}, nil
 }
 
+func VersionFromBytes(bytes []byte) (string, error) {
+	if !gjson.ValidBytes(bytes) {
+		return "", errors.New("invalid json")
+	}
+
+	json := gjson.ParseBytes(bytes)
+
+	version := jsonGetString(json, "result.version")
+
+	if version == "" {
+		return "", errors.New("invalid json")
+	}
+
+	return version, nil
+}
+
 func (b Block) Timestamp() uint64 {
 	ts_nanosec := jsonGetUint(b.json, "result.header.timestamp")
 	return ts_nanosec / 1000000000

--- a/node/pkg/watchers/near/watcher.go
+++ b/node/pkg/watchers/near/watcher.go
@@ -292,6 +292,9 @@ func (e *Watcher) Run(ctx context.Context) error {
 		ContractAddress: e.wormholeAccount,
 	})
 
+	// Get the node version for troubleshooting
+	e.logVersion(ctx, logger)
+
 	logger.Info("Near watcher connecting to RPC node ", zap.String("url", e.nearRPC))
 
 	// start metrics reporter
@@ -349,4 +352,23 @@ func (e *Watcher) schedule(ctx context.Context, job *transactionProcessingJob, d
 			return nil
 		})
 	return nil
+}
+
+// logVersion retrieves the NEAR node version and logs it
+func (e *Watcher) logVersion(ctx context.Context, logger *zap.Logger) {
+	// From: https://www.quicknode.com/docs/near/status
+	networkName := "near"
+	version, err := e.nearAPI.GetVersion(ctx)
+	if err != nil {
+		logger.Error("problem retrieving node version",
+			zap.Error(err),
+			zap.String("network", networkName),
+		)
+		return
+	}
+
+	logger.Info("node version",
+		zap.String("version", version),
+		zap.String("network", networkName),
+	)
 }

--- a/node/pkg/watchers/solana/client.go
+++ b/node/pkg/watchers/solana/client.go
@@ -402,6 +402,9 @@ func (s *SolanaWatcher) Run(ctx context.Context) error {
 		}
 	}
 
+	// Get the node version for troubleshooting
+	s.logVersion(ctx, logger)
+
 	common.RunWithScissors(ctx, s.errC, "SolanaWatcher", func(ctx context.Context) error {
 		timer := time.NewTicker(pollInterval)
 		defer timer.Stop()
@@ -1168,6 +1171,24 @@ func (s *SolanaWatcher) checkCommitment(commitment rpc.CommitmentType, isReobser
 		}
 	}
 	return true
+}
+
+// logVersion runs the getVersion rpc and logs the node version.
+func (s *SolanaWatcher) logVersion(ctx context.Context, logger *zap.Logger) {
+	// From: https://docs.solana.com/api/http#getversion
+	v, err := s.rpcClient.GetVersion(ctx)
+	if err != nil {
+		logger.Error("problem retrieving node version",
+			zap.Error(err),
+			zap.String("network", s.networkName),
+		)
+		return
+	}
+	logger.Info("node version",
+		zap.String("network", s.networkName),
+		zap.Int64("feature_set", v.FeatureSet),
+		zap.String("version", v.SolanaCore),
+	)
 }
 
 // isPossibleWormholeMessage searches the logs on a transaction to see if it contains a Wormhole core PostMessage.


### PR DESCRIPTION
Thanks to @SEJeff for https://github.com/wormhole-foundation/wormhole/pull/2520 from which this is based.

This has been tested manually for every watcher in Tilt devnet to confirm we get the expected output.

I have also deliberately induced a panic in a `logVersion` method and confirmed that CI fails. For watchers without tests, the watcher will boot loop in Tilt and eventually timeout. The new changes are designed in such a way that if the version can't be fetched successfully an error is logged and the watcher continues as normal.