### PR TITLE
Add CODEOWNERS for Guardian Dependency Upgrades

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -96,6 +96,10 @@
 
 /node/pkg/watchers @evan-gray @panoel
 
+## Guardian Dependency Upgrades (go.mod) 
+/node/go.mod @bemic @djb15 @johnsaigle @mdulin2 @pleasew8t
+/sdk/go.mod @bemic @djb15 @johnsaigle @mdulin2 @pleasew8t
+
 ## Hacks / Tools
 
 /node/hack/ @panoel @evan-gray


### PR DESCRIPTION
Allows the security team to review dependencies for major components before being upgraded. This was discussed in the security meeting this week.

Review the added `go.mod` files to ensure these are the correct ones to add. I intentionally left out Wormchain's `go.mod` , but I would consider adding it and others if others were passionate about it.