### PR TITLE
docs: Add AGENTS.md to allow LLMs to work effectively with the codebase

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# AGENTS.md
+
+## Project Overview
+This file contains essential configuration and commands for LLM agents to work effectively with this codebase. It serves as a reference for automated agents and human developers.
+
+## Build, Lint, Test Commands
+- **Build**: `make node` (Go guardian), `npm run build` (JS/TS projects), `forge build` (Solidity)
+- **Lint**: `./scripts/lint.sh lint` (Go + spellcheck), `npm run lint` (TypeScript projects)
+- **Test**: `npm test` (JS/TS), `jest --verbose` (specific tests), `DEV=true NETWORK=DEVNET jest --verbose` (SDK tests)
+- **Single test**: `jest path/to/test.js -t "test name"` or `npm test -- --testNamePattern="pattern"`
+- **Format**: `./scripts/lint.sh format` (Go), `./scripts/lint.sh -w format` (auto-fix)
+
+## Code Style Guidelines
+- **Go**: Use `goimports`, follow `.golangci.yml` rules, camelCase for unexported, PascalCase for exported
+- **TypeScript**: Use existing project conventions, prefer `import` over `require`, explicit types over `any`
+- **Solidity**: Follow existing patterns in `ethereum/contracts/`, use Forge for builds
+- **Imports**: Organize by standard lib, external packages, internal packages (Go); relative imports last (TS)
+- **Error handling**: Always handle errors explicitly, use proper error types, no silent failures
+- **Naming**: Descriptive names, avoid abbreviations, match existing patterns in codebase
+- **Comments**: Follow [Go Doc Comments](https://go.dev/doc/comment) for Go, [TSDoc](https://tsdoc.org/) for TypeScript
+
+## Development Workflow
+- **Pre-commit**: Run `./scripts/lint.sh -d format` and `./scripts/lint.sh lint` before committing
+- **Commits**: Small atomic commits with meaningful messages, prefix with component name (e.g., "node: fix bug")
+- **PRs**: All features require GitHub issue discussion first, complex features need design docs
+- **Quality focus**: Optimize for reading over writing, meaningful commit messages, useful comments
+- **Dependencies**: Document benefits vs security/compatibility when updating dependencies
+
+## Testing by Component
+- **Guardian Node**: `cd node && make test` (tests in `./node/**/*_test.go`)
+- **Ethereum**: `cd ethereum && make test` (tests in `./ethereum/test/`)  
+- **Solana**: `cd solana && make test` (tests in `./solana/bridge/program/tests/`)
+- **Cosmwasm/Algorand**: `cd {component} && make test`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,3 +152,9 @@ Places to find out more about existing test coverage and how to run those tests:
   - Run: `cd algorand && make test`
 
 The best place to understand how we invoke these tests via GitHub Actions on every commit can be found via `./.github/workflows/*.yml` and the best place to observe the results of these builds can be found via [https://github.com/wormhole-foundation/wormhole/actions](https://github.com/wormhole-foundation/wormhole/actions).
+
+## Working with LLMs/Agents
+
+The repository contains an [AGENTS.md](./AGENTS.md) file that can be used to direct LLMs to work effectively with the repository.
+Rather than adding a custom markdown file for the wide range of LLM tools that exist, we've opted to use AGENTS.md
+as it is relatively general (https://agents.md/). Its contents can be copied into e.g. CLAUDE.md or cursor rules etc. depending on the developer's taste.


### PR DESCRIPTION
LLM agent tools are very popular for developers and auditors alike. Providing an `AGENTS.md` file should allow them to be more effective with their tools. We may as well add one here because people using these tools will be creating their own versions of it anyway.

I used the nomenclature from https://agents.md because it seems to be the most general/least vendor-specific, but I'm open to using a different style or name.

It's important to keep these files pretty concise in order to not waste context window space or otherwise 'poison' the window with irrelevant or misleading info. As a result, I tried to avoid content that's already well-covered by README, CONTRIBUTING, and DEVELOP or items that are already handled by CI.