### PR TITLE
fix(transfer verifier): Use Uint64() instead of parseUint for EVM chain ID conversion

### DIFF
--- a/node/pkg/txverifier/evmtypes.go
+++ b/node/pkg/txverifier/evmtypes.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strconv"
 
 	"math/big"
 	"time"
@@ -197,11 +196,8 @@ func NewTransferVerifier(ctx context.Context, connector connectors.Connector, tv
 		return nil, fmt.Errorf("failed to get chain ID: %w", err)
 	}
 
-	// Fetch EVM chain ID from the connector and attempt to convert it to a Wormhole chain ID.
-	evmChainId, parseErr := strconv.ParseUint(chainIdFromClient.String(), 10, 16)
-	if parseErr != nil {
-		return nil, fmt.Errorf("failed to parse chainId from string returned by connector client: %w", parseErr)
-	}
+	// Convert chainId to uint64
+	evmChainId := chainIdFromClient.Uint64()
 
 	wormholeChainId, unregisteredErr := TryWormholeChainIdFromNative(evmChainId)
 	if unregisteredErr != nil {


### PR DESCRIPTION
We identified an issue with the EVM transfer verifier in testnet, where it was reading the EVM chain id from the connector and attempting to parse it into a `uint64`, with 16-bit resolution. This failed for Sepolia, which has the EVM chain id 11155111. 

This change replaces the conversion with the `big.Int` `Uint64()` method, instead.