### PR TITLE
node(near): Replace `npm install` with `npm ci`

### DIFF
--- a/near/Makefile
+++ b/near/Makefile
@@ -53,10 +53,7 @@ contracts/token-bridge/target/wasm32-unknown-unknown/release/near_token_bridge.w
 contracts/wormhole/target/wasm32-unknown-unknown/release/near_wormhole.wasm: contracts/wormhole/src/*.rs contracts/wormhole/Cargo.toml
 	cd contracts/wormhole; cargo build --target wasm32-unknown-unknown --release
 
-package-lock.json: package.json
-	npm install
-
-node_modules: package-lock.json
+node_modules:
 	touch -m node_modules
 	npm ci
 


### PR DESCRIPTION
- Removed the Make target for package-lock.json. There's already a lock file in-place that should be used in most cases. Otherwise, developers should be thoughtfully upgrading packages slowly when the needed arises. Exposing a make target for `npm install` is suboptimal and encourages a workflow that goes against the contributor guidelines.