### PR TITLE
node: Add Fogo to the Governor

### DIFF
--- a/node/pkg/governor/mainnet_chains.go
+++ b/node/pkg/governor/mainnet_chains.go
@@ -40,5 +40,6 @@ func ChainList() []ChainConfigEntry {
 		{EmitterChainID: vaa.ChainIDMezo, DailyLimit: 500_000, BigTransactionSize: 50_000},
 		{EmitterChainID: vaa.ChainIDXRPLEVM, DailyLimit: 500_000, BigTransactionSize: 50_000},
 		{EmitterChainID: vaa.ChainIDLinea, DailyLimit: 500_000, BigTransactionSize: 50_000},
+		{EmitterChainID: vaa.ChainIDFogo, DailyLimit: 500_000, BigTransactionSize: 50_000},
 	}
 }


### PR DESCRIPTION
A few notes:

- We need to add manual tokens to the list for Fogo in order for unit tests to pass. However, there is no CoinGecko data yet. We may need to temporarily add an exception in the unit test such that Fogo has an outbound limit contrained by the Governor for foreign assets. (i.e. SOL minted on Solana should be rate-limited when leaving Fogo, even if Fogo has no native assets being governed)

- For CI to pass, the Token Bridge on Fogo must be registered to KnownTokenBridgeEmitters in the SDK. 