### PR TITLE
update environment variable to proper PROGRAM_ID

### DIFF
--- a/solana/scripts/derive-upgrade-authority.ts
+++ b/solana/scripts/derive-upgrade-authority.ts
@@ -1,13 +1,13 @@
 import { PublicKey } from "@solana/web3.js";
 import { Buffer } from "buffer";
 
-const tokenBridgeProgramId = process.env.TOKEN_BRIDGE_PROGRAM_ID;
+const programId = process.env.PROGRAM_ID;
 
-if (!tokenBridgeProgramId) {
-    console.error("TOKEN_BRIDGE_PROGRAM_ID environment variable not set.");
+if (!programId) {
+    console.error("PROGRAM_ID environment variable not set.");
     process.exit(1);
 }
 
 console.log(
-    PublicKey.findProgramAddressSync([Buffer.from("upgrade")], new PublicKey(tokenBridgeProgramId))[0].toString()
+    PublicKey.findProgramAddressSync([Buffer.from("upgrade")], new PublicKey(programId))[0].toString()
 );


### PR DESCRIPTION
Since this script can be used to derive PDAs for both Core *And* TB  authority transfers as stated in the playbook, a name change is proposed.