### PR TITLE
meta: Add AR codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,14 +15,14 @@
 /solana/ @kcsongor 
 /sui/ @kcsongor @gator-boi
 /terra/ @kcsongor
-/wormchain/ @nik-suri @johnsaigle @mdulin2 @joelsmith-2019
+/wormchain/ @nik-suri @johnsaigle @mdulin2
 
 # Utilities
 
 /clients/ @kcsongor @kev1n-peters @evan-gray
 /lp_ui/ @evan-gray @kev1n-peters
 /relayer/generic_relayer @nonergodic @gator-boi
-/scripts/ @evan-gray @kcsongor
+/scripts/ @evan-gray @kcsongor @djb15
 /sdk/ @evan-gray @kev1n-peters @panoel @SEJeff
 /sdk/js-proto-node/ @evan-gray @kev1n-peters
 /sdk/js-proto-web/ @evan-gray @kev1n-peters
@@ -35,6 +35,7 @@
 /testing/ @evan-gray
 /wormchain/contracts/tools/ @evan-gray @kev1n-peters @panoel
 /wormchain/devnet/ @evan-gray
+/wormchain/devnet/txverifier @djb15 @johnsaigle @mdulin2 @pleasew8t
 /wormchain/ts-sdk/ @evan-gray @kev1n-peters @panoel
 /deployments @evan-gray @kev1n-peters @panoel
 
@@ -52,10 +53,14 @@
 
 /node/cmd/ @panoel @evan-gray
 
+## Common
+/node/pkg/common/ @panoel @evan-gray
+/node/pkg/common/pendingmessage* @djb15 @johnsaigle @mdulin2 @pleasew8t
 
 ## DB
 
 /node/pkg/db/ @evan-gray @panoel
+/node/pkg/db/notary* @djb15 @johnsaigle @mdulin2 @pleasew8t
 
 ## Accountant
 
@@ -93,6 +98,7 @@
 ## Watchers
 
 /node/pkg/watchers @evan-gray @panoel
+/node/pkg/watchers/evm/msg_verifier.go @djb15 @johnsaigle @mdulin2 @pleasew8t
 
 ## Guardian Dependency Upgrades (go.mod) 
 /node/go.mod @bemic @djb15 @johnsaigle @mdulin2 @pleasew8t


### PR DESCRIPTION
Rationale:
- Dirk is a root codeowner already and so can cover scripts/
- The Transfer Verifier and Notary code is maintained by AR
- The msg_verifier code in the watcher relates to Transfer Verifier
- The pendingmessage code is related to the Notary
- Joel no longer has write access according to GitHub