### PR TITLE
meta: Update codeowners for Transfer Verifier (after Sui portion was merged)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -37,7 +37,6 @@
 /tools @evan-gray @panoel @djb15 @johnsaigle
 /wormchain/contracts/tools/ @evan-gray @kev1n-peters @panoel
 /wormchain/devnet/ @evan-gray
-/wormchain/devnet/txverifier @djb15 @johnsaigle @mdulin2 @pleasew8t
 /wormchain/ts-sdk/ @evan-gray @kev1n-peters @panoel
 
 # Protobuf for node
@@ -126,6 +125,8 @@
 
 /node/pkg/txverifier/ @djb15 @johnsaigle @mdulin2 @pleasew8t
 /node/cmd/txverifier/ @djb15 @johnsaigle @mdulin2 @pleasew8t
+/devnet/txverifier/ @djb15 @johnsaigle @mdulin2 @pleasew8t
+/devnet/tx-verifier-sui.yaml @djb15 @johnsaigle @mdulin2 @pleasew8t
 
 ## Watchers
 


### PR DESCRIPTION
Rationale:
- New Transfer Verifier related files were added for Sui in #4324
- msg_verifier is related to Transfer Verifier
- the `wormchain/devnet` path was incorrect; instead it should've been the devnet/ directory at root which contains the Transfer Verifier integration tests

See also #4549 