### PR TITLE
ci: Add additional linting via govet

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -141,6 +141,20 @@ linters:
         - sloppyLen
         - underef
         - unslice
+    govet:
+      # The following list includes all the linters that are disabled by default.
+      # Uncomment any of these to enable them:
+      enable:
+        # - atomicalign          # Check for non-64-bits-aligned arguments to sync/atomic functions
+        # - deepequalerrors      # Check for calls of reflect.DeepEqual on error values
+        # - fieldalignment       # Find structs that would use less memory if their fields were sorted
+        # - findcall             # Find calls to a particular function
+        - nilness              # Check for redundant or impossible nil comparisons
+        # - reflectvaluecompare  # Check for comparing reflect.Value values with == or reflect.DeepEqual
+        # - shadow               # Check for possible unintended shadowing of variables
+        # - sortslice            # Check the argument type of sort.Slice
+        # - timeformat           # Check for calls of (time.Time).Format or time.Parse with 2006-02-01
+        # - unusedwrite          # Check for unused writes
     nolintlint:
       # Disable to ensure that all nolint directives actually have an effect.
       # Default: false

--- a/node/pkg/common/scissors_test.go
+++ b/node/pkg/common/scissors_test.go
@@ -24,6 +24,7 @@ func getCounterValue(metric *prometheus.CounterVec, runnableName string) float64
 
 func throwNil(ctx context.Context) error {
 	var x *int = nil
+	//nolint:govet // This test function is specifically checking for nil errors, so being flagged for `nilness` is expected
 	*x = 5
 	return nil
 }

--- a/node/pkg/query/query.go
+++ b/node/pkg/query/query.go
@@ -366,15 +366,15 @@ func handleQueryRequestsImpl(
 
 				// Build the list of per chain response publications and the overall query response publication.
 				responses := []*PerChainQueryResponse{}
-				for _, resp := range pq.responses {
-					if resp == nil {
-						qLogger.Error("unexpected null response in pending query!", zap.String("requestID", resp.RequestID), zap.Int("requestIdx", resp.RequestIdx))
+				for _, pqResp := range pq.responses {
+					if pqResp == nil {
+						qLogger.Error("unexpected nil response in pending query!", zap.String("requestID", resp.RequestID))
 						continue
 					}
 
 					responses = append(responses, &PerChainQueryResponse{
-						ChainId:  resp.ChainId,
-						Response: resp.Response,
+						ChainId:  pqResp.ChainId,
+						Response: pqResp.Response,
 					})
 				}
 


### PR DESCRIPTION
- Adds nilness lint to govet
- Configures golangci to clearly show what checks are disabled for govet
- Fixes existing lint violations
- Rename error variables to prevent shadowing issues