### PR TITLE
node: Fix `SignExistingVAA`

### DIFF
--- a/node/pkg/adminrpc/adminserver.go
+++ b/node/pkg/adminrpc/adminserver.go
@@ -1416,7 +1416,7 @@ func (s *nodePrivilegedService) SignExistingVAA(ctx context.Context, req *nodev1
 	signature := [ecdsaSignatureLength]byte{}
 	copy(signature[:], sig)
 
-	newVAA.Signatures = append(v.Signatures, &vaa.Signature{
+	newVAA.Signatures = append(newVAA.Signatures, &vaa.Signature{
 		Index:     uint8(localGuardianIndex), // #nosec G115 -- The length of newGS is constrained to a uint8 above
 		Signature: signature,
 	})

--- a/node/pkg/adminrpc/adminserver_test.go
+++ b/node/pkg/adminrpc/adminserver_test.go
@@ -294,6 +294,24 @@ func TestSignExistingVAA_Valid(t *testing.T) {
 	require.Equal(t, v2, res.Vaa)
 }
 
+func TestSignExistingVAA_ValidMutatedSet(t *testing.T) {
+	signers, gsAddrs := generateGuardianSigners(5)
+	s := setupAdminServerForVAASigning(0, gsAddrs)
+
+	v := generateMockVAA(0, signers, t)
+
+	gsAddrs = append(gsAddrs[1:], s.guardianAddress) // We lose the first Guardian so the index changes for every Guardian
+	res, err := s.SignExistingVAA(context.Background(), &nodev1.SignExistingVAARequest{
+		Vaa:                 v,
+		NewGuardianAddrs:    addrsToHexStrings(gsAddrs),
+		NewGuardianSetIndex: 1,
+	})
+
+	require.NoError(t, err)
+	v2 := generateMockVAA(1, append(signers[1:], s.guardianSigner), t)
+	require.Equal(t, v2, res.Vaa)
+}
+
 const govGuardianSetIndex = uint32(4)
 
 var govTimestamp = time.Now()


### PR DESCRIPTION
In `SignExistingVAA` we were writing the signatures with the indices of the previous Guardian set back into `newVAA.Signatures` just after correcting the index on line 1399. The end result was a VAA using the wrong Guardian indexes for the signatures; still manually correctable but not ideal.

This PR makes the small 1 line fix and adds a test that mutates that existing Guardian set (drops the first Guardian to trigger an index change for every other Guardian). The new test failed with the previous logic, passes with the fix.