### PR TITLE
node(near): Add archival RPC fallback with alternating retry

### DIFF
--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -118,8 +118,9 @@ var (
 	algorandAlgodToken   *string
 	algorandAppID        *uint64
 
-	nearRPC      *string
-	nearContract *string
+	nearRPC         *string
+	nearArchivalRPC *string
+	nearContract    *string
 
 	wormchainURL *string
 
@@ -371,6 +372,7 @@ func init() {
 	algorandAppID = NodeCmd.Flags().Uint64("algorandAppID", 0, "Algorand app id")
 
 	nearRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "nearRPC", "Near RPC URL", "http://near:3030", []string{"http", "https"})
+	nearArchivalRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "nearArchivalRPC", "Near Archival RPC URL (optional, for historical data fallback)", "https://archival-rpc.mainnet.near.org", []string{"http", "https"})
 	nearContract = NodeCmd.Flags().String("nearContract", "", "Near contract")
 
 	wormchainURL = node.RegisterFlagWithValidationOrFail(NodeCmd, "wormchainURL", "Wormhole-chain gRPC URL", "wormchain:9090", []string{""})
@@ -1671,10 +1673,11 @@ func runNode(cmd *cobra.Command, args []string) {
 
 	if shouldStart(nearRPC) {
 		wc := &near.WatcherConfig{
-			NetworkID: "near",
-			ChainID:   vaa.ChainIDNear,
-			Rpc:       *nearRPC,
-			Contract:  *nearContract,
+			NetworkID:   "near",
+			ChainID:     vaa.ChainIDNear,
+			Rpc:         *nearRPC,
+			ArchivalRpc: *nearArchivalRPC,
+			Contract:    *nearContract,
 		}
 		watcherConfigs = append(watcherConfigs, wc)
 	}

--- a/node/pkg/watchers/near/config.go
+++ b/node/pkg/watchers/near/config.go
@@ -11,10 +11,11 @@ import (
 )
 
 type WatcherConfig struct {
-	NetworkID watchers.NetworkID // human readable name
-	ChainID   vaa.ChainID        // ChainID
-	Rpc       string
-	Contract  string
+	NetworkID   watchers.NetworkID // human readable name
+	ChainID     vaa.ChainID        // ChainID
+	Rpc         string
+	ArchivalRpc string
+	Contract    string
 }
 
 func (wc *WatcherConfig) GetNetworkID() watchers.NetworkID {
@@ -35,5 +36,5 @@ func (wc *WatcherConfig) Create(
 	env common.Environment,
 ) (supervisor.Runnable, interfaces.Reobserver, error) {
 	var mainnet = (env == common.MainNet)
-	return NewWatcher(wc.Rpc, wc.Contract, msgC, obsvReqC, mainnet).Run, nil, nil
+	return NewWatcher(wc.Rpc, wc.ArchivalRpc, wc.Contract, msgC, obsvReqC, mainnet).Run, nil, nil
 }

--- a/node/pkg/watchers/near/nearapi/nearapi_test.go
+++ b/node/pkg/watchers/near/nearapi/nearapi_test.go
@@ -57,7 +57,7 @@ func TestNearApi(t *testing.T) {
 	mockServer := mockserver.NewForwardingCachingServer(logger, "https://rpc.mainnet.near.org", "mock/apitest/", nil)
 	mockHttpServer := httptest.NewServer(mockServer)
 
-	api := nearapi.NewNearApiImpl(nearapi.NewHttpNearRpc(mockHttpServer.URL))
+	api := nearapi.NewNearApiImpl(nearapi.NewHttpNearRpc(mockHttpServer.URL, mockHttpServer.URL))
 
 	// ---Test---
 	b1, err := api.GetBlock(ctx, "5uNbd6DTxC3kes7JS6o5LeE7e7rF8kXHZqpzYrtVJfmz")

--- a/node/pkg/watchers/near/watcher.go
+++ b/node/pkg/watchers/near/watcher.go
@@ -67,6 +67,7 @@ type (
 		mainnet         bool
 		wormholeAccount string // name of the Wormhole Account on the NEAR blockchain
 		nearRPC         string
+		nearArchivalRPC string
 
 		// external channels
 		msgC          chan<- *common.MessagePublication   // validated (SECURITY: and only validated!) observations go into this channel
@@ -94,6 +95,7 @@ type (
 // NewWatcher creates a new Near appid watcher
 func NewWatcher(
 	nearRPC string,
+	nearArchivalRPC string,
 	wormholeContract string,
 	msgC chan<- *common.MessagePublication,
 	obsvReqC <-chan *gossipv1.ObservationRequest,
@@ -103,6 +105,7 @@ func NewWatcher(
 		mainnet:                      mainnet,
 		wormholeAccount:              wormholeContract,
 		nearRPC:                      nearRPC,
+		nearArchivalRPC:              nearArchivalRPC,
 		msgC:                         msgC,
 		obsvReqC:                     obsvReqC,
 		readinessSync:                common.MustConvertChainIdToReadinessSyncing(vaa.ChainIDNear),
@@ -285,7 +288,7 @@ func (e *Watcher) Run(ctx context.Context) error {
 
 	e.errC = make(chan error)
 
-	e.nearAPI = nearapi.NewNearApiImpl(nearapi.NewHttpNearRpc(e.nearRPC))
+	e.nearAPI = nearapi.NewNearApiImpl(nearapi.NewHttpNearRpc(e.nearRPC, e.nearArchivalRPC))
 	e.finalizer = newFinalizer(e.eventChan, e.nearAPI, e.mainnet)
 
 	p2p.DefaultRegistry.SetNetworkStats(vaa.ChainIDNear, &gossipv1.Heartbeat_Network{

--- a/node/pkg/watchers/near/watcher_test.go
+++ b/node/pkg/watchers/near/watcher_test.go
@@ -100,7 +100,7 @@ func (testCase *testCase) run(ctx context.Context) error {
 	msgC := make(chan *common.MessagePublication)
 	obsvReqC := make(chan *gossipv1.ObservationRequest, 50)
 	mainnet := true // we set mainnet to true because the testdata was collected on mainnet.
-	w := NewWatcher(mockHttpServer.URL, testCase.wormholeContract, msgC, obsvReqC, mainnet)
+	w := NewWatcher(mockHttpServer.URL, mockHttpServer.URL, testCase.wormholeContract, msgC, obsvReqC, mainnet)
 
 	// Run the watcher
 	if err := supervisor.Run(ctx, "nearwatch", w.Run); err != nil {


### PR DESCRIPTION
## Problem

Historical NEAR transactions were timing out on the public RPC but could be retrieved almost instantly from the archival node. This caused unnecessary delays and potential failures when processing older transactions.

Example transaction: 283AsnKK48piLmWc18cRbUkoTbCMScCy9PTD6tqpeBo3

Test results:
- Public RPC (rpc.mainnet.near.org): TIMEOUT after 10+ seconds
- Archival RPC (archival-rpc.mainnet.near.org): SUCCESS in 0.369 seconds

The public RPC nodes have recent blocks cached but may not retain historical data, while archival nodes maintain the complete blockchain history but may be slower for recent queries.

## Solution

Implemented an alternating retry strategy that switches between regular and archival RPC endpoints:
- Retry 1: regular RPC (fast for recent data)
- Retry 2: archival RPC (complete historical data)
- Retry 3: regular RPC
- Retry 4: archival RPC
- And so on until timeout...

This ensures historical transactions hit the archival node early (2nd attempt) while still preferring the faster regular RPC for recent data. All existing timeout and exponential backoff behavior is preserved.

## Changes

1. **Command-line flag** (cmd/guardiand/node.go):
   - Added --nearArchivalRPC flag with default value: https://archival-rpc.mainnet.near.org

2. **Configuration** (pkg/watchers/near/config.go):
   - Added ArchivalRpc field to WatcherConfig
   - Wired archival RPC through to watcher initialization

3. **Watcher** (pkg/watchers/near/watcher.go):
   - Added nearArchivalRPC field to Watcher struct
   - Updated NewWatcher() to accept archival RPC parameter

4. **RPC Client** (pkg/watchers/near/nearapi/nearapi.go):
   - Added nearArchivalRpc field to HttpNearRpc struct
   - Updated NewHttpNearRpc() to accept both RPC URLs
   - Implemented alternating retry logic in Query() method:
     * Added retry attempt counter
     * Alternates between regular (odd) and archival (even) attempts * Maintains existing timeout and backoff behavior

5. **Tests**:
   - Updated test signatures to pass archival RPC parameter
   - All existing tests pass with no behavioral changes

## Testing

Verified with existing test suite:
- pkg/watchers/near: PASS
- pkg/watchers/near/nearapi: PASS

No other flow changes - only adds archival fallback to existing retry logic.