### PR TITLE
node(p2p): Remove carve-out for 0 timestamps

### DIFF
--- a/node/pkg/p2p/p2p.go
+++ b/node/pkg/p2p/p2p.go
@@ -1097,12 +1097,8 @@ func processSignedObservationRequest(s *gossipv1.SignedObservationRequest, gs *c
 	// TODO: implement per-guardian rate limiting
 
 	// Perform timestamp validation
-	// Since this is a version upgrade, we need to accept a timestamp of 0.
-	// Shortly after all have upgraded, we will remove this conditional check.
-	if h.Timestamp != 0 {
-		if time.Until(time.Unix(0, h.Timestamp)).Abs() > observationRequestMaxTimeDifference {
-			return nil, fmt.Errorf("reobservation request is too old or too far into the future")
-		}
+	if time.Until(time.Unix(0, h.Timestamp)).Abs() > observationRequestMaxTimeDifference {
+		return nil, fmt.Errorf("reobservation request is too old or too far into the future")
 	}
 
 	return &h, nil

--- a/node/pkg/p2p/p2p_test.go
+++ b/node/pkg/p2p/p2p_test.go
@@ -160,12 +160,12 @@ func TestSignedObservation(t *testing.T) {
 			guardianAddress: gAddr[:],
 			expectSuccess:   true,
 		},
-		// Old protobuf version still works (initially, this will change)
+		// Timestamp must be initialized (non-zero)
 		{
 			timestamp:       0,
 			guardianSigner:  guardianSigner,
 			guardianAddress: gAddr[:],
-			expectSuccess:   true,
+			expectSuccess:   false,
 		},
 		// Invalid key signed the data
 		{


### PR DESCRIPTION
#4501 added a temporary exception for messages with a timestamp of zero in order to support messages issued before the new field was added. All Guardians have upgraded to a version where this field is always set, so the exception can be removed.