### PR TITLE
fix: add NEAR address support and RPC override to info origin command

### DIFF
--- a/clients/js/src/cmds/info/origin.ts
+++ b/clients/js/src/cmds/info/origin.ts
@@ -8,42 +8,44 @@ import { toChain } from "@wormhole-foundation/sdk-base";
 export const command = "origin <chain> <address>";
 export const desc = `Print the origin chain and address of the asset that corresponds to the given chain and address.`;
 export const builder = (y: typeof yargs) =>
-  y
-    .positional("chain", {
-      describe:
-        "Chain that wrapped asset came from. To see a list of supported chains, run `worm chains`",
-      type: "string",
-      demandOption: true,
-    } as const)
-    .positional("address", {
-      describe: "Address of wrapped asset on origin chain",
-      type: "string",
-      demandOption: true,
-    })
-    .option("network", {
-      alias: "n",
-      describe: "Network of target chain",
-      choices: ["mainnet", "testnet", "devnet"],
-      default: "mainnet",
-      demandOption: false,
-    } as const)
-    .option("rpc", RPC_OPTIONS);
+	y
+		.positional("chain", {
+			describe:
+				"Chain that wrapped asset came from. To see a list of supported chains, run `worm chains`",
+			type: "string",
+			demandOption: true,
+		} as const)
+		.positional("address", {
+			describe: "Address of wrapped asset on origin chain",
+			type: "string",
+			demandOption: true,
+		})
+		.option("network", {
+			alias: "n",
+			describe: "Network of target chain",
+			choices: ["mainnet", "testnet", "devnet"],
+			default: "mainnet",
+			demandOption: false,
+		} as const)
+		.option("rpc", RPC_OPTIONS);
 export const handler = async (
-  argv: Awaited<ReturnType<typeof builder>["argv"]>
+	argv: Awaited<ReturnType<typeof builder>["argv"]>,
 ) => {
-  const consoleWarnTemp = console.warn;
-  console.warn = () => {};
+	const consoleWarnTemp = console.warn;
+	console.warn = () => {};
 
-  const network = getNetwork(argv.network);
-  const res = await getOriginalAsset(
-    chainToChain(argv.chain),
-    network,
-    argv.address
-  );
-  console.log({
-    ...res,
-    assetAddress: tryUint8ArrayToNative(res.assetAddress, toChain(res.chainId)),
-  });
+	const network = getNetwork(argv.network);
 
-  console.warn = consoleWarnTemp;
+	const res = await getOriginalAsset(
+		chainToChain(argv.chain),
+		network,
+		argv.address,
+		argv.rpc,
+	);
+	console.log({
+		...res,
+		assetAddress: tryUint8ArrayToNative(res.assetAddress, toChain(res.chainId)),
+	});
+
+	console.warn = consoleWarnTemp;
 };

--- a/clients/js/src/cmds/info/origin.ts
+++ b/clients/js/src/cmds/info/origin.ts
@@ -42,16 +42,6 @@ export const handler = async (
 		argv.address,
 		argv.rpc,
 	);
-	const chainName = toChain(res.chainId);
-
-	/**
-	 * This is a ridiculous patch for the following issue
-	 * worm info origin ethereum 0xb4b9dc1c77bdbb135ea907fd5a08094d98883a35 -n mainnet
-	 * Error: uint8ArrayToNative: Use tryHexToNativeStringNear instead.
-	 *  at c1d (/Users/kinsyu/Documents/repos/wormhole/clients/js/build/main.js:650:91470)
-	 *  at Object.I36 [as handler] (/Users/kinsyu/Documents/repos/wormhole/clients/js/build/main.js:839:40058)
-	 *  at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
-	 */
 
 	console.log({
 		...res,

--- a/clients/js/src/cmds/info/origin.ts
+++ b/clients/js/src/cmds/info/origin.ts
@@ -1,11 +1,9 @@
 import yargs from "yargs";
-import { getOriginalAsset, getProviderForChain } from "../../chains/generic";
+import { getOriginalAsset } from "../../chains/generic";
 import { RPC_OPTIONS } from "../../consts";
 import { getNetwork, chainToChain } from "../../utils";
-import { tryUint8ArrayToNative, uint8ArrayToHex } from "../../sdk/array";
-import { contracts, toChain } from "@wormhole-foundation/sdk-base";
-
-import { tryHexToNativeStringNear } from "@certusone/wormhole-sdk";
+import { tryUint8ArrayToNative } from "../../sdk/array";
+import { toChain } from "@wormhole-foundation/sdk-base";
 
 export const command = "origin <chain> <address>";
 export const desc = `Print the origin chain and address of the asset that corresponds to the given chain and address.`;
@@ -54,37 +52,14 @@ export const handler = async (
 	 *  at Object.I36 [as handler] (/Users/kinsyu/Documents/repos/wormhole/clients/js/build/main.js:839:40058)
 	 *  at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
 	 */
-	if (chainName === "Near") {
-		const h = uint8ArrayToHex(res.assetAddress);
-		const provider = await getProviderForChain("Near", network, {
-			rpc: argv.rpc,
-		});
-		const chainName = toChain(res.chainId);
 
-		const tokenBridgeAddress = contracts.tokenBridge.get(network, chainName);
-		if (!tokenBridgeAddress) {
-			throw Error("Coudln't find Token Bridge address for Near");
-		}
-
-		const nearAddress = await tryHexToNativeStringNear(
-			provider,
-			tokenBridgeAddress,
-			h,
-		);
-
-		console.log({
-			...res,
-			assetAddress: nearAddress,
-		});
-	} else {
-		console.log({
-			...res,
-			assetAddress: tryUint8ArrayToNative(
-				res.assetAddress,
-				toChain(res.chainId),
-			),
-		});
-	}
+	console.log({
+		...res,
+		assetAddress: await tryUint8ArrayToNative(
+			res.assetAddress,
+			toChain(res.chainId),
+		),
+	});
 
 	console.warn = consoleWarnTemp;
 };

--- a/clients/js/src/cmds/info/origin.ts
+++ b/clients/js/src/cmds/info/origin.ts
@@ -1,9 +1,11 @@
 import yargs from "yargs";
-import { getOriginalAsset } from "../../chains/generic";
+import { getOriginalAsset, getProviderForChain } from "../../chains/generic";
 import { RPC_OPTIONS } from "../../consts";
 import { getNetwork, chainToChain } from "../../utils";
-import { tryUint8ArrayToNative } from "../../sdk/array";
-import { toChain } from "@wormhole-foundation/sdk-base";
+import { tryUint8ArrayToNative, uint8ArrayToHex } from "../../sdk/array";
+import { contracts, toChain } from "@wormhole-foundation/sdk-base";
+
+import { tryHexToNativeStringNear } from "@certusone/wormhole-sdk";
 
 export const command = "origin <chain> <address>";
 export const desc = `Print the origin chain and address of the asset that corresponds to the given chain and address.`;
@@ -42,10 +44,47 @@ export const handler = async (
 		argv.address,
 		argv.rpc,
 	);
-	console.log({
-		...res,
-		assetAddress: tryUint8ArrayToNative(res.assetAddress, toChain(res.chainId)),
-	});
+	const chainName = toChain(res.chainId);
+
+	/**
+	 * This is a ridiculous patch for the following issue
+	 * worm info origin ethereum 0xb4b9dc1c77bdbb135ea907fd5a08094d98883a35 -n mainnet
+	 * Error: uint8ArrayToNative: Use tryHexToNativeStringNear instead.
+	 *  at c1d (/Users/kinsyu/Documents/repos/wormhole/clients/js/build/main.js:650:91470)
+	 *  at Object.I36 [as handler] (/Users/kinsyu/Documents/repos/wormhole/clients/js/build/main.js:839:40058)
+	 *  at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+	 */
+	if (chainName === "Near") {
+		const h = uint8ArrayToHex(res.assetAddress);
+		const provider = await getProviderForChain("Near", network, {
+			rpc: argv.rpc,
+		});
+		const chainName = toChain(res.chainId);
+
+		const tokenBridgeAddress = contracts.tokenBridge.get(network, chainName);
+		if (!tokenBridgeAddress) {
+			throw Error("Coudln't find Token Bridge address for Near");
+		}
+
+		const nearAddress = await tryHexToNativeStringNear(
+			provider,
+			tokenBridgeAddress,
+			h,
+		);
+
+		console.log({
+			...res,
+			assetAddress: nearAddress,
+		});
+	} else {
+		console.log({
+			...res,
+			assetAddress: tryUint8ArrayToNative(
+				res.assetAddress,
+				toChain(res.chainId),
+			),
+		});
+	}
 
 	console.warn = consoleWarnTemp;
 };

--- a/clients/js/src/sdk/array.ts
+++ b/clients/js/src/sdk/array.ts
@@ -1,37 +1,41 @@
 import { arrayify, zeroPad } from "@ethersproject/bytes";
 import { PublicKey } from "@solana/web3.js";
 import {
-  hexValue,
-  hexZeroPad,
-  keccak256,
-  sha256,
-  stripZeros,
+	hexValue,
+	hexZeroPad,
+	keccak256,
+	sha256,
+	stripZeros,
 } from "ethers/lib/utils";
 import { bech32 } from "bech32";
 import {
-  Chain,
-  ChainId,
-  chainToChainId,
-  chainToPlatform,
-  toChain,
-  toChainId,
+	type Chain,
+	type ChainId,
+	chainToChainId,
+	chainToPlatform,
+	contracts,
+	type Network,
+	toChain,
+	toChainId,
 } from "@wormhole-foundation/sdk-base";
 import {
-  PlatformToChains,
-  UniversalAddress,
-  encoding,
+	type PlatformToChains,
+	UniversalAddress,
+	encoding,
 } from "@wormhole-foundation/sdk";
 import {
-  chainToNativeDenoms,
-  CosmwasmAddress,
+	chainToNativeDenoms,
+	CosmwasmAddress,
 } from "@wormhole-foundation/sdk-cosmwasm";
 import { isValidSuiAddress } from "@mysten/sui.js";
 import { sha3_256 } from "js-sha3";
 import {
-  nativeStringToHexAlgorand,
-  uint8ArrayToNativeStringAlgorand,
+	nativeStringToHexAlgorand,
+	uint8ArrayToNativeStringAlgorand,
 } from "@certusone/wormhole-sdk/lib/esm/algorand";
 import { isValidSuiType } from "@certusone/wormhole-sdk/lib/esm/sui";
+import { getProviderForChain } from "../chains/generic";
+import { tryHexToNativeStringNear } from "@certusone/wormhole-sdk";
 
 /**
  *
@@ -53,36 +57,36 @@ import { isValidSuiType } from "@certusone/wormhole-sdk/lib/esm/sui";
 export const isHexNativeTerra = (h: string): boolean => h.startsWith("01");
 
 const isLikely20ByteCosmwasm = (h: string): boolean =>
-  h.startsWith("000000000000000000000000");
+	h.startsWith("000000000000000000000000");
 
 export const nativeTerraHexToDenom = (h: string): string =>
-  Buffer.from(stripZeros(hexToUint8Array(h.substr(2)))).toString("ascii");
+	Buffer.from(stripZeros(hexToUint8Array(h.substr(2)))).toString("ascii");
 
 export const uint8ArrayToHex = (a: Uint8Array): string =>
-  encoding.hex.encode(a);
+	encoding.hex.encode(a);
 
 export const hexToUint8Array = (h: string): Uint8Array =>
-  encoding.hex.decode(h);
+	encoding.hex.decode(h);
 
 export function canonicalAddress(humanAddress: string) {
-  return new Uint8Array(bech32.fromWords(bech32.decode(humanAddress).words));
+	return new Uint8Array(bech32.fromWords(bech32.decode(humanAddress).words));
 }
 
 export function humanAddress(
-  hrp: string,
-  canonicalAddress: Uint8Array
+	hrp: string,
+	canonicalAddress: Uint8Array,
 ): string {
-  return CosmwasmAddress.encode(hrp, canonicalAddress);
+	return CosmwasmAddress.encode(hrp, canonicalAddress);
 }
 
 export function buildTokenId(
-  chain: Exclude<PlatformToChains<"Cosmwasm">, "Seda">,
-  address: string
+	chain: Exclude<PlatformToChains<"Cosmwasm">, "Seda">,
+	address: string,
 ) {
-  return (
-    (chainToNativeDenoms("Mainnet", chain) === address ? "01" : "00") +
-    keccak256(Buffer.from(address, "utf-8")).substring(4)
-  );
+	return (
+		(chainToNativeDenoms("Mainnet", chain) === address ? "01" : "00") +
+		keccak256(Buffer.from(address, "utf-8")).substring(4)
+	);
 }
 
 /**
@@ -93,77 +97,94 @@ export function buildTokenId(
  * @throws if address is not the right length for the given chain
  */
 
-export const tryUint8ArrayToNative = (
-  a: Uint8Array,
-  chain: ChainId | Chain
-): string => {
-  const chainName = toChain(chain);
-  if (chainToPlatform(chainName) === "Evm") {
-    // if (isEVMChain(chainId)) {
-    return hexZeroPad(hexValue(a), 20);
-  } else if (chainToPlatform(chainName) === "Solana") {
-    return new PublicKey(a).toString();
-  } else if (chainName === "Terra" || chainName === "Terra2") {
-    const h = uint8ArrayToHex(a);
-    if (isHexNativeTerra(h)) {
-      return nativeTerraHexToDenom(h);
-    } else {
-      if (chainName === "Terra2" && !isLikely20ByteCosmwasm(h)) {
-        // terra 2 has 32 byte addresses for contracts and 20 for wallets
-        return humanAddress("terra", a);
-      }
-      return humanAddress("terra", a.slice(-20));
-    }
-  } else if (chainName === "Injective") {
-    const h = uint8ArrayToHex(a);
-    return humanAddress("inj", isLikely20ByteCosmwasm(h) ? a.slice(-20) : a);
-  } else if (chainName === "Algorand") {
-    return uint8ArrayToNativeStringAlgorand(a);
-  } else if (chainName == "Wormchain") {
-    const h = uint8ArrayToHex(a);
-    return humanAddress(
-      "wormhole",
-      isLikely20ByteCosmwasm(h) ? a.slice(-20) : a
-    );
-  } else if (chainName === "Xpla") {
-    const h = uint8ArrayToHex(a);
-    return humanAddress("xpla", isLikely20ByteCosmwasm(h) ? a.slice(-20) : a);
-  } else if (chainName === "Sei") {
-    const h = uint8ArrayToHex(a);
-    return humanAddress("sei", isLikely20ByteCosmwasm(h) ? a.slice(-20) : a);
-  } else if (chainName === "Near") {
-    throw Error("uint8ArrayToNative: Use tryHexToNativeStringNear instead.");
-  } else if (chainName === "Osmosis") {
-    throw Error("uint8ArrayToNative: Osmosis not supported yet.");
-  } else if (chainName === "Cosmoshub") {
-    throw Error("uint8ArrayToNative: CosmosHub not supported yet.");
-  } else if (chainName === "Evmos") {
-    throw Error("uint8ArrayToNative: Evmos not supported yet.");
-  } else if (chainName === "Kujira") {
-    throw Error("uint8ArrayToNative: Kujira not supported yet.");
-  } else if (chainName === "Neutron") {
-    throw Error("uint8ArrayToNative: Neutron not supported yet.");
-  } else if (chainName === "Celestia") {
-    throw Error("uint8ArrayToNative: Celestia not supported yet.");
-  } else if (chainName === "Stargaze") {
-    throw Error("uint8ArrayToNative: Stargaze not supported yet.");
-  } else if (chainName === "Seda") {
-    throw Error("uint8ArrayToNative: Seda not supported yet.");
-  } else if (chainName === "Dymension") {
-    throw Error("uint8ArrayToNative: Dymension not supported yet.");
-  } else if (chainName === "Provenance") {
-    throw Error("uint8ArrayToNative: Provenance not supported yet.");
-  } else if (chainName === "Sui") {
-    throw Error("uint8ArrayToNative: Sui not supported yet.");
-  } else if (chainName === "Aptos") {
-    throw Error("uint8ArrayToNative: Aptos not supported yet.");
-  } else if (chainName === "Btc") {
-    throw Error("uint8ArrayToNative: Btc not supported");
-  } else {
-    // This case is never reached
-    // const _: never = chainName;
-    throw Error("Don't know how to convert address for chain " + chainName);
-  }
+export const tryUint8ArrayToNative = async (
+	a: Uint8Array,
+	chain: ChainId | Chain,
+	network?: Network,
+	rpc?: string,
+): Promise<string> => {
+	const chainName = toChain(chain);
+	if (chainToPlatform(chainName) === "Evm") {
+		// if (isEVMChain(chainId)) {
+		return hexZeroPad(hexValue(a), 20);
+	} else if (chainToPlatform(chainName) === "Solana") {
+		return new PublicKey(a).toString();
+	} else if (chainName === "Terra" || chainName === "Terra2") {
+		const h = uint8ArrayToHex(a);
+		if (isHexNativeTerra(h)) {
+			return nativeTerraHexToDenom(h);
+		} else {
+			if (chainName === "Terra2" && !isLikely20ByteCosmwasm(h)) {
+				// terra 2 has 32 byte addresses for contracts and 20 for wallets
+				return humanAddress("terra", a);
+			}
+			return humanAddress("terra", a.slice(-20));
+		}
+	} else if (chainName === "Injective") {
+		const h = uint8ArrayToHex(a);
+		return humanAddress("inj", isLikely20ByteCosmwasm(h) ? a.slice(-20) : a);
+	} else if (chainName === "Algorand") {
+		return uint8ArrayToNativeStringAlgorand(a);
+	} else if (chainName === "Wormchain") {
+		const h = uint8ArrayToHex(a);
+		return humanAddress(
+			"wormhole",
+			isLikely20ByteCosmwasm(h) ? a.slice(-20) : a,
+		);
+	} else if (chainName === "Xpla") {
+		const h = uint8ArrayToHex(a);
+		return humanAddress("xpla", isLikely20ByteCosmwasm(h) ? a.slice(-20) : a);
+	} else if (chainName === "Sei") {
+		const h = uint8ArrayToHex(a);
+		return humanAddress("sei", isLikely20ByteCosmwasm(h) ? a.slice(-20) : a);
+	} else if (chainName === "Near") {
+		const h = uint8ArrayToHex(a);
+
+		const provider = await getProviderForChain("Near", network ?? "Mainnet", {
+			rpc: rpc,
+		});
+		const chainName = toChain(chain);
+
+		const tokenBridgeAddress = contracts.tokenBridge.get(
+			network ?? "Mainnet",
+			chainName,
+		);
+		if (!tokenBridgeAddress) {
+			throw Error("Coudln't find Token Bridge address for Near");
+		}
+
+		return tryHexToNativeStringNear(provider, tokenBridgeAddress, h);
+	} else if (chainName === "Osmosis") {
+		throw Error("uint8ArrayToNative: Osmosis not supported yet.");
+	} else if (chainName === "Cosmoshub") {
+		throw Error("uint8ArrayToNative: CosmosHub not supported yet.");
+	} else if (chainName === "Evmos") {
+		throw Error("uint8ArrayToNative: Evmos not supported yet.");
+	} else if (chainName === "Kujira") {
+		throw Error("uint8ArrayToNative: Kujira not supported yet.");
+	} else if (chainName === "Neutron") {
+		throw Error("uint8ArrayToNative: Neutron not supported yet.");
+	} else if (chainName === "Celestia") {
+		throw Error("uint8ArrayToNative: Celestia not supported yet.");
+	} else if (chainName === "Stargaze") {
+		throw Error("uint8ArrayToNative: Stargaze not supported yet.");
+	} else if (chainName === "Seda") {
+		throw Error("uint8ArrayToNative: Seda not supported yet.");
+	} else if (chainName === "Dymension") {
+		throw Error("uint8ArrayToNative: Dymension not supported yet.");
+	} else if (chainName === "Provenance") {
+		throw Error("uint8ArrayToNative: Provenance not supported yet.");
+	} else if (chainName === "Sui") {
+		throw Error("uint8ArrayToNative: Sui not supported yet.");
+	} else if (chainName === "Aptos") {
+		throw Error("uint8ArrayToNative: Aptos not supported yet.");
+	} else if (chainName === "Btc") {
+		throw Error("uint8ArrayToNative: Btc not supported");
+	} else {
+		// This case is never reached
+		// const _: never = chainName;
+		throw Error("Don't know how to convert address for chain " + chainName);
+	}
 };
 
 /**
@@ -174,10 +195,13 @@ export const tryUint8ArrayToNative = (
  * @throws if address is not the right length for the given chain
  */
 export const tryHexToNativeAssetString = (h: string, c: ChainId): string =>
-  c === chainToChainId("Algorand")
-    ? // Algorand assets are represented by their asset ids, not an address
-      new UniversalAddress(h).toNative("Algorand").toBigInt().toString()
-    : new UniversalAddress(h).toNative(toChain(c)).toString();
+	c === chainToChainId("Algorand")
+		? // Algorand assets are represented by their asset ids, not an address
+			new UniversalAddress(h)
+				.toNative("Algorand")
+				.toBigInt()
+				.toString()
+		: new UniversalAddress(h).toNative(toChain(c)).toString();
 
 /**
  *
@@ -187,57 +211,57 @@ export const tryHexToNativeAssetString = (h: string, c: ChainId): string =>
  * @throws if address is a malformed string for the given chain id
  */
 export const tryNativeToHexString = (
-  address: string,
-  chain: ChainId | Chain
+	address: string,
+	chain: ChainId | Chain,
 ): string => {
-  const chainName = toChain(chain);
-  if (chainToPlatform(chainName) === "Evm") {
-    return uint8ArrayToHex(zeroPad(arrayify(address), 32));
-  } else if (chainToPlatform(chainName) === "Solana") {
-    return uint8ArrayToHex(zeroPad(new PublicKey(address).toBytes(), 32));
-  } else if (chainName === "Terra") {
-    if (chainToNativeDenoms("Mainnet", chainName) === address) {
-      return (
-        "01" +
-        uint8ArrayToHex(
-          zeroPad(new Uint8Array(Buffer.from(address, "ascii")), 31)
-        )
-      );
-    } else {
-      return uint8ArrayToHex(zeroPad(canonicalAddress(address), 32));
-    }
-  } else if (
-    chainName === "Terra2" ||
-    chainName === "Injective" ||
-    chainName === "Xpla" ||
-    chainName === "Sei"
-  ) {
-    return buildTokenId(chainName, address);
-  } else if (chainName === "Algorand") {
-    return nativeStringToHexAlgorand(address);
-  } else if (chainName == "Wormchain") {
-    return uint8ArrayToHex(zeroPad(canonicalAddress(address), 32));
-  } else if (chainName === "Near") {
-    return uint8ArrayToHex(arrayify(sha256(Buffer.from(address))));
-  } else if (chainName === "Sui") {
-    if (!isValidSuiType(address) && isValidSuiAddress(address)) {
-      return uint8ArrayToHex(
-        zeroPad(arrayify(address, { allowMissingPrefix: true }), 32)
-      );
-    }
-    throw Error("nativeToHexString: Sui types not supported yet.");
-  } else if (chainName === "Aptos") {
-    if (isValidAptosType(address)) {
-      return getExternalAddressFromType(address);
-    }
+	const chainName = toChain(chain);
+	if (chainToPlatform(chainName) === "Evm") {
+		return uint8ArrayToHex(zeroPad(arrayify(address), 32));
+	} else if (chainToPlatform(chainName) === "Solana") {
+		return uint8ArrayToHex(zeroPad(new PublicKey(address).toBytes(), 32));
+	} else if (chainName === "Terra") {
+		if (chainToNativeDenoms("Mainnet", chainName) === address) {
+			return (
+				"01" +
+				uint8ArrayToHex(
+					zeroPad(new Uint8Array(Buffer.from(address, "ascii")), 31),
+				)
+			);
+		} else {
+			return uint8ArrayToHex(zeroPad(canonicalAddress(address), 32));
+		}
+	} else if (
+		chainName === "Terra2" ||
+		chainName === "Injective" ||
+		chainName === "Xpla" ||
+		chainName === "Sei"
+	) {
+		return buildTokenId(chainName, address);
+	} else if (chainName === "Algorand") {
+		return nativeStringToHexAlgorand(address);
+	} else if (chainName == "Wormchain") {
+		return uint8ArrayToHex(zeroPad(canonicalAddress(address), 32));
+	} else if (chainName === "Near") {
+		return uint8ArrayToHex(arrayify(sha256(Buffer.from(address))));
+	} else if (chainName === "Sui") {
+		if (!isValidSuiType(address) && isValidSuiAddress(address)) {
+			return uint8ArrayToHex(
+				zeroPad(arrayify(address, { allowMissingPrefix: true }), 32),
+			);
+		}
+		throw Error("nativeToHexString: Sui types not supported yet.");
+	} else if (chainName === "Aptos") {
+		if (isValidAptosType(address)) {
+			return getExternalAddressFromType(address);
+		}
 
-    return uint8ArrayToHex(
-      zeroPad(arrayify(address, { allowMissingPrefix: true }), 32)
-    );
-  } else {
-    // If this case is reached
-    throw Error(`nativeToHexString: ${chainName} not supported yet.`);
-  }
+		return uint8ArrayToHex(
+			zeroPad(arrayify(address, { allowMissingPrefix: true }), 32),
+		);
+	} else {
+		// If this case is reached
+		throw Error(`nativeToHexString: ${chainName} not supported yet.`);
+	}
 };
 
 /**
@@ -248,11 +272,11 @@ export const tryNativeToHexString = (
  * @throws if address is a malformed string for the given chain id
  */
 export function tryNativeToUint8Array(
-  address: string,
-  chain: ChainId | Chain
+	address: string,
+	chain: ChainId | Chain,
 ): Uint8Array {
-  const chainId = toChainId(chain);
-  return hexToUint8Array(tryNativeToHexString(address, chainId));
+	const chainId = toChainId(chain);
+	return hexToUint8Array(tryNativeToHexString(address, chainId));
 }
 
 /**
@@ -261,7 +285,7 @@ export function tryNativeToUint8Array(
  * @returns Whether or not given string is a valid type
  */
 export const isValidAptosType = (str: string): boolean =>
-  /^(0x)?[0-9a-fA-F]+::\w+::\w+$/.test(str);
+	/^(0x)?[0-9a-fA-F]+::\w+::\w+$/.test(str);
 
 /**
  * Hashes the given type. Because fully qualified types are a concept unique to Aptos, this
@@ -270,8 +294,8 @@ export const isValidAptosType = (str: string): boolean =>
  * @returns External address corresponding to given type
  */
 export const getExternalAddressFromType = (
-  fullyQualifiedType: string
+	fullyQualifiedType: string,
 ): string => {
-  // hash the type so it fits into 32 bytes
-  return sha3_256(fullyQualifiedType);
+	// hash the type so it fits into 32 bytes
+	return sha3_256(fullyQualifiedType);
 };


### PR DESCRIPTION
## Summary
- Fixes error when querying origin information for NEAR addresses by implementing proper NEAR address resolution
- Adds RPC override capability to the `info origin` command for more flexible querying