### PR TITLE
node(governor): fix initialization of flow cancel corridors

### DIFF
--- a/node/pkg/governor/flow_cancel_corridors.go
+++ b/node/pkg/governor/flow_cancel_corridors.go
@@ -16,7 +16,11 @@ func FlowCancelCorridors() []corridor {
 }
 
 func ValidateCorridors(input []corridor) bool {
-	seen := make([]corridor, len(input))
+	if len(input) == 0 {
+		return false
+	}
+
+	seen := make([]corridor, 0, len(input))
 	for _, p := range input {
 		// This check is needed when there is exactly one pipe. Otherwise, the seen loop detects this.
 		if !p.valid() {


### PR DESCRIPTION
The code was using the wrong `make` structure and so was actually filling the slice with a bunch of empty corridors and appending entries from `input` to the end of the slice.