### PR TITLE
ci: fix amd64 tilt up

### DIFF
--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -1,6 +1,9 @@
 # syntax=docker.io/docker/dockerfile:1.3@sha256:42399d4635eddd7a9b8a24be879d2f9a930d0ed040a61324cfdf59ef1357b3b2
 FROM node:22.16-alpine3.22@sha256:41e4389f3d988d2ed55392df4db1420ad048ae53324a8e2b7c6d19508288107e as cli-build
 
+# fetch scripts/guardian-set-init.sh deps
+RUN apk update && apk add bash g++ make python3 curl jq findutils
+
 # Copy package.json & package-lock.json by themselves to create a cache layer
 COPY clients/js/package.json clients/js/package-lock.json /clients/js/
 

--- a/ethereum/Dockerfile
+++ b/ethereum/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker.io/docker/dockerfile:1.3@sha256:42399d4635eddd7a9b8a24be879d2f9a930d0ed040a61324cfdf59ef1357b3b2
 FROM const-gen AS const-export
 FROM --platform=linux/amd64 ghcr.io/foundry-rs/foundry:v1.0.0@sha256:d12a373ec950de170d5461014ef9320ba0fb6e0db6f87835999d0fcf3820370e as foundry
-FROM node:22.16-bullseye-slim@sha256:550b434f7edc3a1875860657a3e306752358029c957280809ae6395ab296faeb
+FROM --platform=linux/amd64 node:22.16-bullseye-slim@sha256:550b434f7edc3a1875860657a3e306752358029c957280809ae6395ab296faeb
 
 # npm wants to clone random Git repositories - lovely.
 # RUN apk add git python make build-base


### PR DESCRIPTION
I ran into an issue with being unable to tilt up due to missing dependencies and then a rosetta error likely due to pulling an arm64 image after an amd64 one. With these changes I was able to successfully `tilt up`