### PR TITLE
add Fernando to /sdk/vaa as CODEOWNER

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -31,7 +31,7 @@
 /sdk/js-wasm/ @evan-gray @kev1n-peters
 /sdk/js/ @evan-gray @kev1n-peters @panoel
 /sdk/rust/ @Daniel-Aaron-Bloom
-/sdk/vaa/ @evan-gray @panoel @SEJeff
+/sdk/vaa/ @evan-gray @panoel @SEJeff @fergarrui
 /spydk/ @evan-gray
 /testing/ @evan-gray
 /wormchain/contracts/tools/ @evan-gray @kev1n-peters @panoel


### PR DESCRIPTION
https://github.com/wormhole-foundation/wormhole/pull/4509/files#diff-819aefcd70bf3c71ae94124e472e87de33ad6e4183062887f6ac90b493123249 made me realize adding him to /sdk/ only wasn't sufficient to cover chain expansion PRs