### PR TITLE
node: allow more nodes per guardian

### DIFF
--- a/node/pkg/common/guardianset.go
+++ b/node/pkg/common/guardianset.go
@@ -41,7 +41,7 @@ const MaxGuardianCount = 19
 //
 // There currently isn't any state clean up, so the value is on the high side to prevent
 // accidentally reaching the limit due to operational mistakes.
-const MaxNodesPerGuardian = 15
+const MaxNodesPerGuardian = 30
 
 // MaxStateAge specified the maximum age of state entries in seconds. Expired entries are purged
 // from the state by Cleanup().


### PR DESCRIPTION
This changes allows more guardians (in testnet) to share the same key.