### PR TITLE
EVM Watcher Security Improvements

### DIFF
--- a/node/pkg/txverifier/evm.go
+++ b/node/pkg/txverifier/evm.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	geth "github.com/ethereum/go-ethereum/core/types"
-	gethTypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/wormhole-foundation/wormhole/sdk/vaa"
 	"go.uber.org/zap"
 )
@@ -433,7 +432,7 @@ func (tv *TransferVerifier[evmClient, connector]) parseReceipt(
 		zap.String("txHash", receipt.TxHash.String()),
 	)
 
-	if receipt.Status != gethTypes.ReceiptStatusSuccessful {
+	if receipt.Status != geth.ReceiptStatusSuccessful {
 		return nil, errors.Join(
 			ErrInvalidReceiptArgument,
 			errors.New("non-success transaction status"),

--- a/node/pkg/txverifier/evm.go
+++ b/node/pkg/txverifier/evm.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	geth "github.com/ethereum/go-ethereum/core/types"
+	gethTypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/wormhole-foundation/wormhole/sdk/vaa"
-
 	"go.uber.org/zap"
 )
 
@@ -433,7 +433,7 @@ func (tv *TransferVerifier[evmClient, connector]) parseReceipt(
 		zap.String("txHash", receipt.TxHash.String()),
 	)
 
-	if receipt.Status != 1 {
+	if receipt.Status != gethTypes.ReceiptStatusSuccessful {
 		return nil, errors.Join(
 			ErrInvalidReceiptArgument,
 			errors.New("non-success transaction status"),

--- a/node/pkg/watchers/evm/by_transaction.go
+++ b/node/pkg/watchers/evm/by_transaction.go
@@ -10,6 +10,7 @@ import (
 	"github.com/certusone/wormhole/node/pkg/common"
 	eth_common "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	gethTypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/wormhole-foundation/wormhole/sdk/vaa"
 )
 
@@ -65,7 +66,7 @@ func MessageEventsForTransaction(
 	// However, relying on that invariant is brittle - we connect to a lot of
 	// EVM-compatible chains which might accidentally break this API contract
 	// and return logs for failed transactions. Check explicitly instead.
-	if receipt.Status != 1 {
+	if receipt.Status != gethTypes.ReceiptStatusSuccessful {
 		return nil, 0, nil, fmt.Errorf("non-success transaction status: %d", receipt.Status)
 	}
 

--- a/node/pkg/watchers/evm/by_transaction.go
+++ b/node/pkg/watchers/evm/by_transaction.go
@@ -30,7 +30,7 @@ func isLogValid(l types.Log, contract eth_common.Address) bool {
 	if l.Removed {
 		return false
 	}
-	// SECURITY: Verify the log was produced by our contract.
+	// SECURITY: Verify the log was produced by the supplied contract.
 	if l.Address != contract {
 		return false
 	}

--- a/node/pkg/watchers/evm/by_transaction.go
+++ b/node/pkg/watchers/evm/by_transaction.go
@@ -21,12 +21,12 @@ var (
 	LogMessagePublishedTopic = eth_common.HexToHash("0x6eb224fb001ed210e379b335e35efe88672a8ce935d981a6896b27ffdf52a3b2")
 )
 
-// isLogValid checks that a log entry was emitted by the expected contract,
+// isValidCoreBridgeMessagePublicationLog checks that a log entry was emitted by the expected contract,
 // has the expected LogMessagePublished event topic, and has not been removed
 // due to a chain reorganization. This is called from both the real-time
-// subscription path (postMessage) and the reobservation path
-// (MessageEventsForTransaction) to ensure consistent validation.
-func isLogValid(l types.Log, contract eth_common.Address) bool {
+// subscription path, postMessage, and the reobservation path,
+// MessageEventsForTransaction, to ensure consistent validation.
+func isValidCoreBridgeMessagePublicationLog(l types.Log, contract eth_common.Address) bool {
 	// SECURITY: Reject logs that have been flagged as removed due to a chain reorg.
 	if l.Removed {
 		return false
@@ -84,7 +84,7 @@ func MessageEventsForTransaction(
 			continue
 		}
 
-		if !isLogValid(*l, contract) {
+		if !isValidCoreBridgeMessagePublicationLog(*l, contract) {
 			continue
 		}
 

--- a/node/pkg/watchers/evm/by_transaction_test.go
+++ b/node/pkg/watchers/evm/by_transaction_test.go
@@ -1,0 +1,73 @@
+package evm
+
+import (
+	"testing"
+
+	eth_common "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	testContract  = eth_common.HexToAddress("0x98f3c9e6E3fAce36bAAd05FE09d375Ef1464288B")
+	wrongContract = eth_common.HexToAddress("0x0000000000000000000000000000000000000001")
+	wrongTopic    = eth_common.HexToHash("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+)
+
+func validLog() types.Log {
+	return types.Log{
+		Address: testContract,
+		Topics:  []eth_common.Hash{LogMessagePublishedTopic},
+		Removed: false,
+	}
+}
+
+func TestIsLogValid_ValidLog(t *testing.T) {
+	l := validLog()
+	assert.True(t, isLogValid(l, testContract))
+}
+
+func TestIsLogValid_Removed(t *testing.T) {
+	l := validLog()
+	l.Removed = true
+	assert.False(t, isLogValid(l, testContract))
+}
+
+func TestIsLogValid_WrongContract(t *testing.T) {
+	l := validLog()
+	l.Address = wrongContract
+	assert.False(t, isLogValid(l, testContract))
+}
+
+func TestIsLogValid_WrongTopic(t *testing.T) {
+	l := validLog()
+	l.Topics = []eth_common.Hash{wrongTopic}
+	assert.False(t, isLogValid(l, testContract))
+}
+
+func TestIsLogValid_EmptyTopics(t *testing.T) {
+	l := validLog()
+	l.Topics = []eth_common.Hash{}
+	assert.False(t, isLogValid(l, testContract))
+}
+
+func TestIsLogValid_MultipleTopics_CorrectFirst(t *testing.T) {
+	l := validLog()
+	l.Topics = []eth_common.Hash{LogMessagePublishedTopic, wrongTopic}
+	assert.True(t, isLogValid(l, testContract))
+}
+
+func TestIsLogValid_MultipleTopics_WrongFirst(t *testing.T) {
+	l := validLog()
+	l.Topics = []eth_common.Hash{wrongTopic, LogMessagePublishedTopic}
+	assert.False(t, isLogValid(l, testContract))
+}
+
+func TestIsLogValid_AllInvalid(t *testing.T) {
+	l := types.Log{
+		Address: wrongContract,
+		Topics:  []eth_common.Hash{wrongTopic},
+		Removed: true,
+	}
+	assert.False(t, isLogValid(l, testContract))
+}

--- a/node/pkg/watchers/evm/by_transaction_test.go
+++ b/node/pkg/watchers/evm/by_transaction_test.go
@@ -22,52 +22,52 @@ func validLog() types.Log {
 	}
 }
 
-func TestIsLogValid_ValidLog(t *testing.T) {
+func TestisValidCoreBridgeMessagePublicationLog_ValidLog(t *testing.T) {
 	l := validLog()
-	assert.True(t, isLogValid(l, testContract))
+	assert.True(t, isValidCoreBridgeMessagePublicationLog(l, testContract))
 }
 
-func TestIsLogValid_Removed(t *testing.T) {
+func TestisValidCoreBridgeMessagePublicationLog_Removed(t *testing.T) {
 	l := validLog()
 	l.Removed = true
-	assert.False(t, isLogValid(l, testContract))
+	assert.False(t, isValidCoreBridgeMessagePublicationLog(l, testContract))
 }
 
-func TestIsLogValid_WrongContract(t *testing.T) {
+func TestisValidCoreBridgeMessagePublicationLog_WrongContract(t *testing.T) {
 	l := validLog()
 	l.Address = wrongContract
-	assert.False(t, isLogValid(l, testContract))
+	assert.False(t, isValidCoreBridgeMessagePublicationLog(l, testContract))
 }
 
-func TestIsLogValid_WrongTopic(t *testing.T) {
+func TestisValidCoreBridgeMessagePublicationLog_WrongTopic(t *testing.T) {
 	l := validLog()
 	l.Topics = []eth_common.Hash{wrongTopic}
-	assert.False(t, isLogValid(l, testContract))
+	assert.False(t, isValidCoreBridgeMessagePublicationLog(l, testContract))
 }
 
-func TestIsLogValid_EmptyTopics(t *testing.T) {
+func TestisValidCoreBridgeMessagePublicationLog_EmptyTopics(t *testing.T) {
 	l := validLog()
 	l.Topics = []eth_common.Hash{}
-	assert.False(t, isLogValid(l, testContract))
+	assert.False(t, isValidCoreBridgeMessagePublicationLog(l, testContract))
 }
 
-func TestIsLogValid_MultipleTopics_CorrectFirst(t *testing.T) {
+func TestisValidCoreBridgeMessagePublicationLog_MultipleTopics_CorrectFirst(t *testing.T) {
 	l := validLog()
 	l.Topics = []eth_common.Hash{LogMessagePublishedTopic, wrongTopic}
-	assert.True(t, isLogValid(l, testContract))
+	assert.True(t, isValidCoreBridgeMessagePublicationLog(l, testContract))
 }
 
-func TestIsLogValid_MultipleTopics_WrongFirst(t *testing.T) {
+func TestisValidCoreBridgeMessagePublicationLog_MultipleTopics_WrongFirst(t *testing.T) {
 	l := validLog()
 	l.Topics = []eth_common.Hash{wrongTopic, LogMessagePublishedTopic}
-	assert.False(t, isLogValid(l, testContract))
+	assert.False(t, isValidCoreBridgeMessagePublicationLog(l, testContract))
 }
 
-func TestIsLogValid_AllInvalid(t *testing.T) {
+func TestisValidCoreBridgeMessagePublicationLog_AllInvalid(t *testing.T) {
 	l := types.Log{
 		Address: wrongContract,
 		Topics:  []eth_common.Hash{wrongTopic},
 		Removed: true,
 	}
-	assert.False(t, isLogValid(l, testContract))
+	assert.False(t, isValidCoreBridgeMessagePublicationLog(l, testContract))
 }

--- a/node/pkg/watchers/evm/by_transaction_test.go
+++ b/node/pkg/watchers/evm/by_transaction_test.go
@@ -22,48 +22,48 @@ func validLog() types.Log {
 	}
 }
 
-func testisValidCoreBridgeMessagePublicationLog_WrongTopic_ValidLog(t *testing.T) {
+func TestIsValidCoreBridgeMessagePublicationLogValidLog(t *testing.T) {
 	l := validLog()
 	assert.True(t, isValidCoreBridgeMessagePublicationLog(l, testContract))
 }
 
-func testisValidCoreBridgeMessagePublicationLog_WrongTopic_Removed(t *testing.T) {
+func TestIsValidCoreBridgeMessagePublicationLogRemoved(t *testing.T) {
 	l := validLog()
 	l.Removed = true
 	assert.False(t, isValidCoreBridgeMessagePublicationLog(l, testContract))
 }
 
-func testisValidCoreBridgeMessagePublicationLog_WrongTopic_WrongContract(t *testing.T) {
+func TestIsValidCoreBridgeMessagePublicationLogWrongContract(t *testing.T) {
 	l := validLog()
 	l.Address = wrongContract
 	assert.False(t, isValidCoreBridgeMessagePublicationLog(l, testContract))
 }
 
-func testisValidCoreBridgeMessagePublicationLog_WrongTopic_WrongTopic(t *testing.T) {
+func TestIsValidCoreBridgeMessagePublicationLogWrongTopic(t *testing.T) {
 	l := validLog()
 	l.Topics = []eth_common.Hash{wrongTopic}
 	assert.False(t, isValidCoreBridgeMessagePublicationLog(l, testContract))
 }
 
-func testisValidCoreBridgeMessagePublicationLog_WrongTopic_EmptyTopics(t *testing.T) {
+func TestIsValidCoreBridgeMessagePublicationLogEmptyTopics(t *testing.T) {
 	l := validLog()
 	l.Topics = []eth_common.Hash{}
 	assert.False(t, isValidCoreBridgeMessagePublicationLog(l, testContract))
 }
 
-func testisValidCoreBridgeMessagePublicationLog_WrongTopic_MultipleTopics_CorrectFirst(t *testing.T) {
+func TestIsValidCoreBridgeMessagePublicationLogMultipleTopics_CorrectFirst(t *testing.T) {
 	l := validLog()
 	l.Topics = []eth_common.Hash{LogMessagePublishedTopic, wrongTopic}
 	assert.True(t, isValidCoreBridgeMessagePublicationLog(l, testContract))
 }
 
-func testisValidCoreBridgeMessagePublicationLog_WrongTopic_MultipleTopics_WrongFirst(t *testing.T) {
+func TestIsValidCoreBridgeMessagePublicationLogMultipleTopics_WrongFirst(t *testing.T) {
 	l := validLog()
 	l.Topics = []eth_common.Hash{wrongTopic, LogMessagePublishedTopic}
 	assert.False(t, isValidCoreBridgeMessagePublicationLog(l, testContract))
 }
 
-func testisValidCoreBridgeMessagePublicationLog_WrongTopic_AllInvalid(t *testing.T) {
+func TestIsValidCoreBridgeMessagePublicationLogAllInvalid(t *testing.T) {
 	l := types.Log{
 		Address: wrongContract,
 		Topics:  []eth_common.Hash{wrongTopic},

--- a/node/pkg/watchers/evm/by_transaction_test.go
+++ b/node/pkg/watchers/evm/by_transaction_test.go
@@ -22,48 +22,48 @@ func validLog() types.Log {
 	}
 }
 
-func TestisValidCoreBridgeMessagePublicationLog_ValidLog(t *testing.T) {
+func testisValidCoreBridgeMessagePublicationLog_WrongTopic_ValidLog(t *testing.T) {
 	l := validLog()
 	assert.True(t, isValidCoreBridgeMessagePublicationLog(l, testContract))
 }
 
-func TestisValidCoreBridgeMessagePublicationLog_Removed(t *testing.T) {
+func testisValidCoreBridgeMessagePublicationLog_WrongTopic_Removed(t *testing.T) {
 	l := validLog()
 	l.Removed = true
 	assert.False(t, isValidCoreBridgeMessagePublicationLog(l, testContract))
 }
 
-func TestisValidCoreBridgeMessagePublicationLog_WrongContract(t *testing.T) {
+func testisValidCoreBridgeMessagePublicationLog_WrongTopic_WrongContract(t *testing.T) {
 	l := validLog()
 	l.Address = wrongContract
 	assert.False(t, isValidCoreBridgeMessagePublicationLog(l, testContract))
 }
 
-func TestisValidCoreBridgeMessagePublicationLog_WrongTopic(t *testing.T) {
+func testisValidCoreBridgeMessagePublicationLog_WrongTopic_WrongTopic(t *testing.T) {
 	l := validLog()
 	l.Topics = []eth_common.Hash{wrongTopic}
 	assert.False(t, isValidCoreBridgeMessagePublicationLog(l, testContract))
 }
 
-func TestisValidCoreBridgeMessagePublicationLog_EmptyTopics(t *testing.T) {
+func testisValidCoreBridgeMessagePublicationLog_WrongTopic_EmptyTopics(t *testing.T) {
 	l := validLog()
 	l.Topics = []eth_common.Hash{}
 	assert.False(t, isValidCoreBridgeMessagePublicationLog(l, testContract))
 }
 
-func TestisValidCoreBridgeMessagePublicationLog_MultipleTopics_CorrectFirst(t *testing.T) {
+func testisValidCoreBridgeMessagePublicationLog_WrongTopic_MultipleTopics_CorrectFirst(t *testing.T) {
 	l := validLog()
 	l.Topics = []eth_common.Hash{LogMessagePublishedTopic, wrongTopic}
 	assert.True(t, isValidCoreBridgeMessagePublicationLog(l, testContract))
 }
 
-func TestisValidCoreBridgeMessagePublicationLog_MultipleTopics_WrongFirst(t *testing.T) {
+func testisValidCoreBridgeMessagePublicationLog_WrongTopic_MultipleTopics_WrongFirst(t *testing.T) {
 	l := validLog()
 	l.Topics = []eth_common.Hash{wrongTopic, LogMessagePublishedTopic}
 	assert.False(t, isValidCoreBridgeMessagePublicationLog(l, testContract))
 }
 
-func TestisValidCoreBridgeMessagePublicationLog_AllInvalid(t *testing.T) {
+func testisValidCoreBridgeMessagePublicationLog_WrongTopic_AllInvalid(t *testing.T) {
 	l := types.Log{
 		Address: wrongContract,
 		Topics:  []eth_common.Hash{wrongTopic},

--- a/node/pkg/watchers/evm/connectors/batch_poller.go
+++ b/node/pkg/watchers/evm/connectors/batch_poller.go
@@ -174,6 +174,8 @@ func (b *BatchPollConnector) pollBlocks(ctx context.Context, sink chan<- *NewBlo
 	}
 
 	for idx, newBlock := range newBlocks {
+
+		// SECURITY: Assumptions about blocks finalization. If block X is CL, and X+2 is a CL, assumes that X+1 is a CL.
 		if newBlock.Number.Cmp(prevBlocks[idx].Number) > 0 {
 			// If there is a gap between prev and new, we have to look up the hashes for the missing ones. Do that in batches.
 			newBlockNum := newBlock.Number.Uint64()

--- a/node/pkg/watchers/evm/connectors/batch_poller.go
+++ b/node/pkg/watchers/evm/connectors/batch_poller.go
@@ -175,7 +175,9 @@ func (b *BatchPollConnector) pollBlocks(ctx context.Context, sink chan<- *NewBlo
 
 	for idx, newBlock := range newBlocks {
 
-		// SECURITY: Assumptions about blocks finalization. If block X is CL, and X+2 is a CL, assumes that X+1 is a CL.
+		// SECURITY: Assumptions about block finalization.
+		// If block X is a specific consistency level (CL), and X+2 is a CL, assumes that X+1 is a CL too.
+		// Finalization should theoretically be linear. So, this should be safe.
 		if newBlock.Number.Cmp(prevBlocks[idx].Number) > 0 {
 			// If there is a gap between prev and new, we have to look up the hashes for the missing ones. Do that in batches.
 			newBlockNum := newBlock.Number.Uint64()

--- a/node/pkg/watchers/evm/custom_consistency_level.go
+++ b/node/pkg/watchers/evm/custom_consistency_level.go
@@ -138,7 +138,7 @@ func (w *Watcher) cclEnable(ctx context.Context) error {
 
 // cclHandleMessage is called for new observations that have the consistency level set to custom handling.
 // It reads the configuration for the emitter and updates the `pendingMessage` object for custom handling.
-// SECURITY: This function SHOULD NOT modify the actual data signed in the VAA. Otherwise, replay protection is broken.
+// SECURITY: This function MUST NOT modify the actual data signed in the VAA. Otherwise, replay protection is broken.
 func (w *Watcher) cclHandleMessage(parentCtx context.Context, pe *pendingMessage, emitterAddr ethCommon.Address) {
 	if !w.cclEnabled {
 		w.cclLogger.Error("received an observation with custom handling but the feature is not enabled, treating as finalized", zap.String("msgId", pe.message.MessageIDString()))

--- a/node/pkg/watchers/evm/watcher.go
+++ b/node/pkg/watchers/evm/watcher.go
@@ -174,6 +174,7 @@ type (
 		height           uint64
 		effectiveCL      uint8
 		additionalBlocks uint64
+		logIndex         uint // block-level log index for O(1) receipt log lookup
 	}
 )
 
@@ -568,6 +569,7 @@ func (w *Watcher) Run(parentCtx context.Context) error {
 					}
 
 					// Don't process the observation if we haven't reached the desired block height yet.
+					// CCL 'additionalBlocks' after consistency Level handling.
 					if pLock.height+pLock.additionalBlocks > blockNumberU {
 						continue
 					}
@@ -579,6 +581,7 @@ func (w *Watcher) Run(parentCtx context.Context) error {
 					queryLatency.WithLabelValues(w.networkName, "transaction_receipt").Observe(time.Since(msm).Seconds())
 					cancel()
 
+					// SECURITY: Protection against reorgs that remove or change observations
 					// If the node returns an error after waiting expectedConfirmation blocks,
 					// it means the chain reorged and the transaction was orphaned. The
 					// TransactionReceipt call is using the same websocket connection than the
@@ -603,6 +606,7 @@ func (w *Watcher) Run(parentCtx context.Context) error {
 						continue
 					}
 
+					// SECURITY: Check that the tx succeeded.
 					// This should never happen - if we got this far, it means that logs were emitted,
 					// which is only possible if the transaction succeeded. We check it anyway just
 					// in case the EVM implementation is buggy.
@@ -669,6 +673,46 @@ func (w *Watcher) Run(parentCtx context.Context) error {
 						)
 						delete(w.pending, key)
 						ethMessagesOrphaned.WithLabelValues(w.networkName, "blockhash_mismatch").Inc()
+						continue
+					}
+
+					// SECURITY: Defense-in-depth validation of the finalized receipt log.
+					// After confirming the block hash matches, verify the specific log entry
+					// in the receipt is still valid (not reorg'd, correct contract, correct topic).
+					if len(tx.Logs) == 0 {
+						logger.Error("finalized receipt has no logs",
+							zap.String("msgId", pLock.message.MessageIDString()),
+							zap.String("txHash", pLock.message.TxIDString()),
+						)
+						delete(w.pending, key)
+						continue
+					}
+					firstLogIndex := tx.Logs[0].Index
+					if pLock.logIndex < firstLogIndex {
+						logger.Error("log index is before the first log in the receipt",
+							zap.String("msgId", pLock.message.MessageIDString()),
+							zap.String("txHash", pLock.message.TxIDString()),
+						)
+						delete(w.pending, key)
+						continue
+					}
+
+					// O(1) lookup by using relative indexing into the logs
+					pos := pLock.logIndex - firstLogIndex
+					if pos >= uint(len(tx.Logs)) {
+						logger.Error("log index is beyond the last log in the receipt",
+							zap.String("msgId", pLock.message.MessageIDString()),
+							zap.String("txHash", pLock.message.TxIDString()),
+						)
+						delete(w.pending, key)
+						continue
+					}
+					if !isLogValid(*tx.Logs[pos], w.contract) {
+						logger.Error("finalized receipt log failed validation",
+							zap.String("msgId", pLock.message.MessageIDString()),
+							zap.String("txHash", pLock.message.TxIDString()),
+						)
+						delete(w.pending, key)
 						continue
 					}
 
@@ -916,12 +960,24 @@ func (w *Watcher) postMessage(
 	ev *ethabi.AbiLogMessagePublished,
 	blockTime uint64,
 ) {
+	// SECURITY: Defense-in-depth validation of the subscription event.
+	// The subscription filter should guarantee these, but we verify independently
+	// in case the RPC node or connector delivers unexpected events.
+	// This calls the same validation used by the reobservation path in by_transaction.go.
+	if !isLogValid(ev.Raw, w.contract) {
+		w.logger.Error("subscription delivered unexpected event",
+			zap.Stringer("contract", ev.Raw.Address),
+			zap.String("txHash", ev.Raw.TxHash.Hex()),
+		)
+		return
+	}
+
 	msg := &common.MessagePublication{
 		TxID:             ev.Raw.TxHash.Bytes(),
 		Timestamp:        time.Unix(int64(blockTime), 0), // #nosec G115 -- This conversion is safe indefinitely
 		Nonce:            ev.Nonce,
 		Sequence:         ev.Sequence,
-		EmitterChain:     w.chainID,
+		EmitterChain:     w.chainID, // SECURITY: Hardcoded chain id from watcher
 		EmitterAddress:   PadAddress(ev.Sender),
 		Payload:          ev.Payload,
 		ConsistencyLevel: ev.ConsistencyLevel,
@@ -943,6 +999,31 @@ func (w *Watcher) postMessage(
 			zap.Uint8("ConsistencyLevel", ev.ConsistencyLevel),
 		)
 
+		// SECURITY: Defense-in-depth check of transaction status.
+		// The EVM invariant is that failed transactions cannot emit logs, but we verify
+		// explicitly in case an EVM-compatible chain breaks this contract.
+		msm := time.Now()
+		receiptCtx, receiptCancel := context.WithTimeout(parentCtx, 5*time.Second)
+		receipt, err := w.ethConn.TransactionReceipt(receiptCtx, ev.Raw.TxHash)
+		receiptCancel()
+		queryLatency.WithLabelValues(w.networkName, "transaction_receipt").Observe(time.Since(msm).Seconds())
+		if err != nil {
+			w.logger.Error("failed to get transaction receipt for instant message",
+				zap.String("msgId", msg.MessageIDString()),
+				zap.String("txHash", msg.TxIDString()),
+				zap.Error(err),
+			)
+			return
+		}
+		if receipt.Status != 1 {
+			w.logger.Error("instant message transaction has non-success status",
+				zap.String("msgId", msg.MessageIDString()),
+				zap.String("txHash", msg.TxIDString()),
+				zap.Uint64("status", receipt.Status),
+			)
+			return
+		}
+
 		verifyCtx, cancel := context.WithCancel(parentCtx)
 		defer cancel()
 
@@ -961,6 +1042,7 @@ func (w *Watcher) postMessage(
 		message:     msg,
 		height:      ev.Raw.BlockNumber,
 		effectiveCL: ev.ConsistencyLevel, // Initially from event; may be overridden by CCL contract
+		logIndex:    ev.Raw.Index,        // Block-level log index for receipt validation
 	}
 
 	if msg.ConsistencyLevel == vaa.ConsistencyLevelCustom {
@@ -1014,6 +1096,7 @@ func canRetryGetBlockTime(err error) bool {
 // Modifies the verificationState field of the message as a side-effect.
 // Even if an invalid Transfer is detected, the message will still be published. It is the responsibility of the calling code to handle
 // a status of Rejected.
+// SECURITY: should be the only location where the watcher's msgC channel is written to.
 // Note that the result of verification is not returned by this function, but can be accessed directly via the reference to message.
 func (w *Watcher) verifyAndPublish(
 	// Must be non-nil and have verificationState equal to NotVerified.

--- a/node/pkg/watchers/evm/watcher.go
+++ b/node/pkg/watchers/evm/watcher.go
@@ -690,7 +690,7 @@ func (w *Watcher) Run(parentCtx context.Context) error {
 					// Note that `tx` here is actually a receipt
 					txHash := eth_common.Hash(pLock.message.TxID)
 
-					// SECURITY: The TxHash existing within the particular block hash guarentees
+					// SECURITY: The TxHash existing within the particular block hash guarantees
 					// that the event exists without being modified. We don't
 					// check for the event mutating into something that's invalid (wrong event type, etc.)
 					// because of this.

--- a/node/pkg/watchers/evm/watcher.go
+++ b/node/pkg/watchers/evm/watcher.go
@@ -610,7 +610,7 @@ func (w *Watcher) Run(parentCtx context.Context) error {
 					// This should never happen - if we got this far, it means that logs were emitted,
 					// which is only possible if the transaction succeeded. We check it anyway just
 					// in case the EVM implementation is buggy.
-					if tx.Status != 1 {
+					if tx.Status != gethTypes.ReceiptStatusSuccessful {
 						logger.Error("transaction receipt with non-success status",
 							zap.String("msgId", pLock.message.MessageIDString()),
 							zap.String("txHash", pLock.message.TxIDString()),
@@ -703,6 +703,16 @@ func (w *Watcher) Run(parentCtx context.Context) error {
 						logger.Error("log index is beyond the last log in the receipt",
 							zap.String("msgId", pLock.message.MessageIDString()),
 							zap.String("txHash", pLock.message.TxIDString()),
+						)
+						delete(w.pending, key)
+						continue
+					}
+
+					if tx.Logs[pos].Index != pLock.logIndex {
+						logger.Error("log index mismatch — receipt logs are not contiguous",
+							zap.String("msgId", pLock.message.MessageIDString()),
+							zap.Uint64("expected", uint64(pLock.logIndex)),
+							zap.Uint64("actual", uint64(tx.Logs[pos].Index)),
 						)
 						delete(w.pending, key)
 						continue
@@ -1001,7 +1011,7 @@ func (w *Watcher) postMessage(
 
 		// SECURITY: Defense-in-depth check of transaction status.
 		// The EVM invariant is that failed transactions cannot emit logs, but we verify
-		// explicitly in case an EVM-compatible chain breaks this contract.
+		// explicitly in case an EVM-compatible chain breaks this invariant.
 		msm := time.Now()
 		receiptCtx, receiptCancel := context.WithTimeout(parentCtx, 5*time.Second)
 		receipt, err := w.ethConn.TransactionReceipt(receiptCtx, ev.Raw.TxHash)
@@ -1015,7 +1025,7 @@ func (w *Watcher) postMessage(
 			)
 			return
 		}
-		if receipt.Status != 1 {
+		if receipt.Status != gethTypes.ReceiptStatusSuccessful {
 			w.logger.Error("instant message transaction has non-success status",
 				zap.String("msgId", msg.MessageIDString()),
 				zap.String("txHash", msg.TxIDString()),

--- a/node/pkg/watchers/evm/watcher.go
+++ b/node/pkg/watchers/evm/watcher.go
@@ -174,7 +174,6 @@ type (
 		height           uint64
 		effectiveCL      uint8
 		additionalBlocks uint64
-		logIndex         uint // block-level log index for O(1) receipt log lookup
 	}
 )
 
@@ -676,56 +675,6 @@ func (w *Watcher) Run(parentCtx context.Context) error {
 						continue
 					}
 
-					// SECURITY: Defense-in-depth validation of the finalized receipt log.
-					// After confirming the block hash matches, verify the specific log entry
-					// in the receipt is still valid (not reorg'd, correct contract, correct topic).
-					if len(tx.Logs) == 0 {
-						logger.Error("finalized receipt has no logs",
-							zap.String("msgId", pLock.message.MessageIDString()),
-							zap.String("txHash", pLock.message.TxIDString()),
-						)
-						delete(w.pending, key)
-						continue
-					}
-					firstLogIndex := tx.Logs[0].Index
-					if pLock.logIndex < firstLogIndex {
-						logger.Error("log index is before the first log in the receipt",
-							zap.String("msgId", pLock.message.MessageIDString()),
-							zap.String("txHash", pLock.message.TxIDString()),
-						)
-						delete(w.pending, key)
-						continue
-					}
-
-					// O(1) lookup by using relative indexing into the logs
-					pos := pLock.logIndex - firstLogIndex
-					if pos >= uint(len(tx.Logs)) {
-						logger.Error("log index is beyond the last log in the receipt",
-							zap.String("msgId", pLock.message.MessageIDString()),
-							zap.String("txHash", pLock.message.TxIDString()),
-						)
-						delete(w.pending, key)
-						continue
-					}
-
-					if tx.Logs[pos].Index != pLock.logIndex {
-						logger.Error("log index mismatch — receipt logs are not contiguous",
-							zap.String("msgId", pLock.message.MessageIDString()),
-							zap.Uint64("expected", uint64(pLock.logIndex)),
-							zap.Uint64("actual", uint64(tx.Logs[pos].Index)),
-						)
-						delete(w.pending, key)
-						continue
-					}
-					if !isLogValid(*tx.Logs[pos], w.contract) {
-						logger.Error("finalized receipt log failed validation",
-							zap.String("msgId", pLock.message.MessageIDString()),
-							zap.String("txHash", pLock.message.TxIDString()),
-						)
-						delete(w.pending, key)
-						continue
-					}
-
 					logger.Info("observation confirmed",
 						zap.String("msgId", pLock.message.MessageIDString()),
 						zap.String("txHash", pLock.message.TxIDString()),
@@ -740,6 +689,11 @@ func (w *Watcher) Run(parentCtx context.Context) error {
 
 					// Note that `tx` here is actually a receipt
 					txHash := eth_common.Hash(pLock.message.TxID)
+
+					// SECURITY: The TxHash existing within the particular block hash guarentees
+					// that the event exists without being modified. We don't
+					// check for the event mutating into something that's invalid (wrong event type, etc.)
+					// because of this.
 					pubErr := w.verifyAndPublish(pLock.message, ctx, txHash, tx)
 					if pubErr != nil {
 						logger.Error("could not publish message",
@@ -1037,7 +991,7 @@ func (w *Watcher) postMessage(
 		verifyCtx, cancel := context.WithCancel(parentCtx)
 		defer cancel()
 
-		pubErr := w.verifyAndPublish(msg, verifyCtx, ev.Raw.TxHash, nil)
+		pubErr := w.verifyAndPublish(msg, verifyCtx, ev.Raw.TxHash, receipt)
 		if pubErr != nil {
 			w.logger.Error("could not publish message: transfer verification failed",
 				zap.String("msgId", msg.MessageIDString()),
@@ -1052,7 +1006,6 @@ func (w *Watcher) postMessage(
 		message:     msg,
 		height:      ev.Raw.BlockNumber,
 		effectiveCL: ev.ConsistencyLevel, // Initially from event; may be overridden by CCL contract
-		logIndex:    ev.Raw.Index,        // Block-level log index for receipt validation
 	}
 
 	if msg.ConsistencyLevel == vaa.ConsistencyLevelCustom {

--- a/node/pkg/watchers/evm/watcher.go
+++ b/node/pkg/watchers/evm/watcher.go
@@ -568,7 +568,8 @@ func (w *Watcher) Run(parentCtx context.Context) error {
 					}
 
 					// Don't process the observation if we haven't reached the desired block height yet.
-					// CCL 'additionalBlocks' after consistency Level handling.
+					// CCL 'additionalBlocks' is used after consistency level handling.
+					// For instance, we need to wait for FINAL consistency level and then five more blocks.
 					if pLock.height+pLock.additionalBlocks > blockNumberU {
 						continue
 					}
@@ -928,7 +929,7 @@ func (w *Watcher) postMessage(
 	// The subscription filter should guarantee these, but we verify independently
 	// in case the RPC node or connector delivers unexpected events.
 	// This calls the same validation used by the reobservation path in by_transaction.go.
-	if !isLogValid(ev.Raw, w.contract) {
+	if !isValidCoreBridgeMessagePublicationLog(ev.Raw, w.contract) {
 		w.logger.Error("subscription delivered unexpected event",
 			zap.Stringer("contract", ev.Raw.Address),
 			zap.String("txHash", ev.Raw.TxHash.Hex()),
@@ -1059,7 +1060,7 @@ func canRetryGetBlockTime(err error) bool {
 // Modifies the verificationState field of the message as a side-effect.
 // Even if an invalid Transfer is detected, the message will still be published. It is the responsibility of the calling code to handle
 // a status of Rejected.
-// SECURITY: should be the only location where the watcher's msgC channel is written to.
+// SECURITY: MUST be the only location where the watcher's msgC channel is written to.
 // Note that the result of verification is not returned by this function, but can be accessed directly via the reference to message.
 func (w *Watcher) verifyAndPublish(
 	// Must be non-nil and have verificationState equal to NotVerified.


### PR DESCRIPTION
We support a large number of EVM chains. There are several invariants that we currently rely on that we should probably explicitly check for that we were not. Specifically, we assume that the EVM subscription will return only logs matching the filter. We assume that a failed Tx will not have any logs. New checks have been added below. 

- Tx Status. 
- Contract emitter. 
- Event type 
- LogRemoved is false. 
