### PR TITLE
evm: adds verifiable build for delegated guardians contract

### DIFF
--- a/ethereum/Makefile
+++ b/ethereum/Makefile
@@ -82,3 +82,9 @@ test-push0: dependencies
 
 clean:
 	rm -rf .env node_modules build flattened build-forge ethers-contracts lib/forge-std lib/openzeppelin-contracts
+
+
+verifiable-delegated-guardians-build:
+	mkdir -p verifiable-delegated-guardians-build
+	touch -m verifiable-delegated-guardians-build
+	docker build --file ./delegated-guardians-build.Dockerfile . --tag delegated-guardians-evm-build --output type=local,dest=verifiable-delegated-guardians-build

--- a/ethereum/Makefile
+++ b/ethereum/Makefile
@@ -53,7 +53,7 @@ build: forge_dependencies node_modules ${SOURCE_FILES}
 flattened/%.sol: contracts/%.sol node_modules
 	./sh/flatten.sh
 
-.PHONY: flattened
+.PHONY: flattened verifiable-delegated-guardians-build
 flattened: $(patsubst contracts/%, flattened/%, $(FLATTEN_FILES))
 
 .env: .env.test

--- a/ethereum/delegated-guardians-build.Dockerfile
+++ b/ethereum/delegated-guardians-build.Dockerfile
@@ -1,0 +1,50 @@
+FROM ghcr.io/foundry-rs/foundry:v1.5.1@sha256:3a70bfa9bd2c732a767bb60d12c8770b40e8f9b6cca28efc4b12b1be81c7f28e AS builder
+
+# Foundry image runs as foundry user by default
+# We need root to both run apt and to write files to the filesystem
+USER root
+RUN apt-get --quiet update && apt-get --quiet --no-install-recommends --yes install jq wget
+USER foundry
+
+# Preflight
+
+WORKDIR /app
+COPY foundry.toml foundry.toml
+
+RUN SOLC_VERSION=$(forge config | grep "^solc =" | sed 's/solc = //' | sed 's/"//g'); \
+    if [ -z "$SOLC_VERSION" ]; then echo "SOLC_VERSION not set"; exit 1; fi; \
+    wget --progress=dot:giga --output-document=solc "https://github.com/ethereum/solidity/releases/download/v$SOLC_VERSION/solc-static-linux" && chmod +x solc
+
+
+COPY contracts/delegated_guardians contracts/delegated_guardians
+COPY contracts/libraries/external/BytesLib.sol contracts/libraries/external/BytesLib.sol
+COPY contracts/interfaces/IWormhole.sol contracts/interfaces/IWormhole.sol
+
+# forge logs "errors" and warnings to the standard output
+# Luckily, the only warning here is that forge's solidity compiler cache is missing.
+# However, we need to drop it to have a valid JSON.
+# See https://github.com/foundry-rs/foundry/issues/13034
+
+# Prepare compiler input. NOTE: jq must be pre-applied to "clean" the output from forge.
+# Otherwise solc aborts with duplicated key/newline problems.
+
+RUN forge verify-contract \
+    --show-standard-json-input \
+    0x0000000000000000000000000000000000000000 \
+    contracts/delegated_guardians/WormholeDelegatedGuardians.sol:WormholeDelegatedGuardians \
+    | sed '1d' \
+    | jq '.' > WormholeDelegatedGuardians.input.json
+
+# Compile contract(s).
+
+RUN ./solc --standard-json WormholeDelegatedGuardians.input.json > WormholeDelegatedGuardians.output.json && \
+    SOLC_ERR=$(jq '.errors[]? | select(.severity == "error")' WormholeDelegatedGuardians.output.json) && \
+    if [ ! -z "$SOLC_ERR" ]; then \
+        echo "Error detected during solc execution."; \
+        echo "$SOLC_ERR"; \
+        exit 2; \
+    fi
+
+# Consolidate all generated output
+FROM scratch AS foundry-export
+COPY --from=builder /app/*.input.json /app/*.output.json /

--- a/ethereum/delegated-guardians-build.Dockerfile.dockerignore
+++ b/ethereum/delegated-guardians-build.Dockerfile.dockerignore
@@ -1,0 +1,12 @@
+*
+
+!contracts
+!foundry.toml
+
+!contracts/delegated_guardians
+!contracts/libraries
+!contracts/interfaces
+
+!contracts/delegated_guardians/*
+!contracts/interfaces/IWormhole.sol
+!contracts/libraries/external/BytesLib.sol


### PR DESCRIPTION
Note that I didn't add `verifiable-delegated-guardians-build` to the `.gitignore` because we could commit the output to the monorepo later.