### PR TITLE
node: Fix gossipAdvertiseAddress variable shadowing

### DIFF
--- a/node/pkg/p2p/p2p.go
+++ b/node/pkg/p2p/p2p.go
@@ -269,7 +269,8 @@ func NewHost(logger *zap.Logger, ctx context.Context, networkID string, bootstra
 	// check & render address once for use in the AddrsFactory below
 	var gossipAdvertiseAddress multiaddr.Multiaddr
 	if components.GossipAdvertiseAddress != "" {
-		gossipAdvertiseAddress, err := multiaddr.NewMultiaddr(fmt.Sprintf("/ip4/%s/udp/%d", components.GossipAdvertiseAddress, components.Port))
+		var err error
+		gossipAdvertiseAddress, err = multiaddr.NewMultiaddr(fmt.Sprintf("/ip4/%s/udp/%d", components.GossipAdvertiseAddress, components.Port))
 		if err != nil {
 			// If the multiaddr is specified incorrectly, blow up
 			logger.Fatal("error with the specified gossip address",


### PR DESCRIPTION
Resolves https://github.com/asymmetric-research/wormhole-llm-issues/issues/71.

Address discovery was supposed to be disabled historically if `gossipAdvertiseAddress` was defined. However we've been short circuiting this behaviour. So this one line change will have a material impact. I think the change is ok but just highlighting as it's worth double checking.