### PR TITLE
node: Update mutex handling in processor

### DIFF
--- a/node/pkg/processor/processor.go
+++ b/node/pkg/processor/processor.go
@@ -424,9 +424,8 @@ func (p *Processor) Run(ctx context.Context) error {
 				oldChains = oldDgc.ReadAll()
 			}
 
+			// This mutex is unlocked at the end of this select case
 			dgConfig.mu.Lock()
-			defer dgConfig.mu.Unlock()
-
 			chains := dgConfig.Chains
 
 			// Log details for removed chain configs
@@ -509,6 +508,7 @@ func (p *Processor) Run(ctx context.Context) error {
 			if err := p.dgc.Set(chains); err != nil {
 				p.logger.Error("delegate guardian config update failed", zap.Error(err))
 			}
+			dgConfig.mu.Unlock()
 		case k := <-p.msgC:
 			if k == nil {
 				p.logger.Error("received nil MessagePublication from msgC channel")


### PR DESCRIPTION
Resolves https://github.com/asymmetric-research/wormhole-llm-issues/issues/68.

The previous `defer` wasn't actually releasing the mutex during the loop.