### PR TITLE
node: add exhaustruct lint for MessagePublication

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -118,9 +118,8 @@ linters:
         # Regular expressions must match complete canonical struct package/name/structname.
         # If this list is empty, all structs are tested.
         # Default: []
-        - ./+governor.tokenConfigEntry$
-        # TODO: MessagePublications _should_ be exhaustive but this will require many changes.
-        - ./_common.MessagePublication$
+        - .+/MessagePublication$
+        - .+/common\.MessagePublication$
       exclude:
         - .+/cobra\.Command$
         - .+/http\.Client$

--- a/node/hack/accountant/send_obs.go
+++ b/node/hack/accountant/send_obs.go
@@ -116,6 +116,8 @@ func testSubmit(
 		EmitterAddress:   EmitterAddress,
 		ConsistencyLevel: uint8(15),
 		Payload:          Payload,
+		IsReobservation:  false,
+		Unreliable:       false,
 	}
 
 	msgs := []*common.MessagePublication{&msg}
@@ -181,6 +183,8 @@ func testBatch(
 		EmitterAddress:   EmitterAddress,
 		ConsistencyLevel: uint8(15),
 		Payload:          Payload,
+		IsReobservation:  false,
+		Unreliable:       false,
 	}
 	msgs = append(msgs, &msg1)
 
@@ -195,6 +199,8 @@ func testBatch(
 		EmitterAddress:   EmitterAddress,
 		ConsistencyLevel: uint8(15),
 		Payload:          Payload,
+		IsReobservation:  false,
+		Unreliable:       false,
 	}
 	msgs = append(msgs, &msg2)
 
@@ -260,6 +266,8 @@ func testBatchWithcommitted(
 		EmitterAddress:   EmitterAddress,
 		ConsistencyLevel: uint8(15),
 		Payload:          Payload,
+		IsReobservation:  false,
+		Unreliable:       false,
 	}
 	msgs = append(msgs, &msg1)
 
@@ -283,6 +291,8 @@ func testBatchWithcommitted(
 		EmitterAddress:   EmitterAddress,
 		ConsistencyLevel: uint8(15),
 		Payload:          Payload,
+		IsReobservation:  false,
+		Unreliable:       false,
 	}
 	msgs = append(msgs, &msg2)
 
@@ -352,6 +362,8 @@ func testBatchWithDigestError(
 		EmitterAddress:   EmitterAddress,
 		ConsistencyLevel: uint8(15),
 		Payload:          Payload,
+		IsReobservation:  false,
+		Unreliable:       false,
 	}
 	msgs = append(msgs, &msg1)
 
@@ -375,6 +387,8 @@ func testBatchWithDigestError(
 		EmitterAddress:   EmitterAddress,
 		ConsistencyLevel: uint8(15),
 		Payload:          Payload,
+		IsReobservation:  false,
+		Unreliable:       false,
 	}
 	msgs = append(msgs, &msg2)
 
@@ -474,6 +488,8 @@ func testBigBatch(
 			EmitterAddress:   EmitterAddress,
 			ConsistencyLevel: uint8(15),
 			Payload:          Payload,
+			IsReobservation:  false,
+			Unreliable:       false,
 		}
 
 		msgs = append(msgs, &msg)

--- a/node/pkg/accountant/watcher.go
+++ b/node/pkg/accountant/watcher.go
@@ -187,6 +187,8 @@ func (acct *Accountant) processPendingTransfer(xfer *WasmObservation, tag string
 		EmitterAddress:   xfer.EmitterAddress,
 		Payload:          xfer.Payload,
 		ConsistencyLevel: xfer.ConsistencyLevel,
+		IsReobservation:  false,
+		Unreliable:       false,
 	}
 
 	msgId := msg.MessageIDString()

--- a/node/pkg/adminrpc/adminserver.go
+++ b/node/pkg/adminrpc/adminserver.go
@@ -972,6 +972,7 @@ func (s *nodePrivilegedService) InjectGovernanceVAA(ctx context.Context, req *no
 			EmitterChain:     v.EmitterChain,
 			EmitterAddress:   v.EmitterAddress,
 			Payload:          v.Payload,
+			IsReobservation:  false,
 			Unreliable:       false,
 		}
 

--- a/node/pkg/common/chainlock.go
+++ b/node/pkg/common/chainlock.go
@@ -364,6 +364,7 @@ func UnmarshalMessagePublication(data []byte) (*MessagePublication, error) {
 		return nil, errors.New("message is too short")
 	}
 
+	//nolint:exhaustruct // these fields are intentionally omitted
 	msg := &MessagePublication{}
 
 	reader := bytes.NewReader(data[:])
@@ -445,6 +446,7 @@ func (m *MessagePublication) UnmarshalBinary(data []byte) error {
 		return ErrInputSize{Msg: "data too short", Got: len(data), Want: marshaledMsgLenMin}
 	}
 
+	//nolint:exhaustruct // these fields are intentionally omitted
 	mp := &MessagePublication{}
 
 	// Set up deserialization

--- a/node/pkg/watchers/algorand/watcher.go
+++ b/node/pkg/watchers/algorand/watcher.go
@@ -189,6 +189,7 @@ func lookAtTxn(e *Watcher, t types.SignedTxnInBlock, b types.Block, logger *zap.
 			Payload:          obs.payload,
 			ConsistencyLevel: 0,
 			IsReobservation:  isReobservation,
+			Unreliable:       false,
 		}
 
 		algorandMessagesConfirmed.Inc()

--- a/node/pkg/watchers/aptos/watcher.go
+++ b/node/pkg/watchers/aptos/watcher.go
@@ -380,6 +380,7 @@ func (e *Watcher) observeData(logger *zap.Logger, data gjson.Result, nativeSeq u
 		Payload:          pl,
 		ConsistencyLevel: uint8(consistencyLevel.Uint()), // #nosec G115 -- This is validated above
 		IsReobservation:  isReobservation,
+		Unreliable:       false,
 	}
 
 	aptosMessagesConfirmed.WithLabelValues(e.networkID).Inc()

--- a/node/pkg/watchers/cosmwasm/watcher.go
+++ b/node/pkg/watchers/cosmwasm/watcher.go
@@ -603,6 +603,8 @@ func EventsToMessagePublications(contract string, txHash string, events []gjson.
 			EmitterAddress:   senderAddress,
 			Payload:          payloadValue,
 			ConsistencyLevel: 0, // Instant finality
+			IsReobservation:  false,
+			Unreliable:       false,
 		}
 		msgs = append(msgs, messagePublication)
 	}

--- a/node/pkg/watchers/evm/by_transaction.go
+++ b/node/pkg/watchers/evm/by_transaction.go
@@ -84,6 +84,8 @@ func MessageEventsForTransaction(
 			EmitterAddress:   PadAddress(ev.Sender),
 			Payload:          ev.Payload,
 			ConsistencyLevel: ev.ConsistencyLevel,
+			IsReobservation:  false,
+			Unreliable:       false,
 		}
 
 		msgs = append(msgs, message)

--- a/node/pkg/watchers/evm/watcher.go
+++ b/node/pkg/watchers/evm/watcher.go
@@ -925,6 +925,8 @@ func (w *Watcher) postMessage(
 		EmitterAddress:   PadAddress(ev.Sender),
 		Payload:          ev.Payload,
 		ConsistencyLevel: ev.ConsistencyLevel,
+		IsReobservation:  false,
+		Unreliable:       false,
 	}
 
 	ethMessagesObserved.WithLabelValues(w.networkName).Inc()

--- a/node/pkg/watchers/near/tx_processing.go
+++ b/node/pkg/watchers/near/tx_processing.go
@@ -245,6 +245,7 @@ func (e *Watcher) processWormholeLog(logger *zap.Logger, _ context.Context, job 
 		Payload:          pl,
 		ConsistencyLevel: 0,
 		IsReobservation:  job.isReobservation,
+		Unreliable:       false,
 	}
 
 	if job.isReobservation {

--- a/node/pkg/watchers/sui/watcher.go
+++ b/node/pkg/watchers/sui/watcher.go
@@ -339,6 +339,7 @@ func (e *Watcher) inspectBody(ctx context.Context, logger *zap.Logger, body SuiR
 		Payload:          fields.Payload,
 		ConsistencyLevel: *fields.ConsistencyLevel,
 		IsReobservation:  isReobservation,
+		Unreliable:       false,
 	}
 
 	// Verifies the observation through the Sui transaction verifier, if enabled, followed


### PR DESCRIPTION
https://golangci-lint.run/docs/linters/configuration/#exhaustruct (Checks each field is initialized)

The syntax for the `include` rule was broken probably since forever, my bad.
This fixes the detection of MessagePublication and the violations. In each case this preserves existing behaviour, as the default value for `bool` when not specified is false.