### PR TITLE
ci: Add govet shadow detection

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -144,6 +144,11 @@ linters:
         - sloppyLen
         - underef
         - unslice
+    # TODO: Add this later.
+    # gosec:
+    #   config:
+    #     global:
+    #       audit: true
     govet:
       # The following list includes all the linters that are disabled by default.
       # Uncomment any of these to enable them:
@@ -159,7 +164,7 @@ linters:
         - lostcancel           # Check that context cancel functions are called
         - nilness              # Check for redundant or impossible nil comparisons
         - reflectvaluecompare  # Check for comparing reflect.Value values with == or reflect.DeepEqual
-        # - shadow               # Check for possible unintended shadowing of variables
+        - shadow               # Check for possible unintended shadowing of variables
         - sigchanyzer          # Check for unbuffered channels with signal.Notify
         - slog                 # Check for invalid structured logging calls
         - sortslice            # Check the argument type of sort.Slice

--- a/node/cmd/ccq/p2p.go
+++ b/node/cmd/ccq/p2p.go
@@ -68,9 +68,9 @@ func runP2P(
 
 	if len(protectedPeers) != 0 {
 		for _, peerID := range protectedPeers {
-			decodedPeerID, err := peer.Decode(peerID)
-			if err != nil {
-				logger.Error("error decoding protected ccq ID", zap.String("peerID", peerID), zap.Error(err))
+			decodedPeerID, peerErr := peer.Decode(peerID)
+			if peerErr != nil {
+				logger.Error("error decoding protected ccq ID", zap.String("peerID", peerID), zap.Error(peerErr))
 				continue
 			}
 			logger.Info("protecting ccq peer", zap.String("peerID", peerID))
@@ -152,7 +152,7 @@ func runP2P(
 					for _, p := range bootstrappers {
 						if _, exists := peerMap[p.ID.String()]; !exists {
 							logger.Info("attempting to reconnect to peer", zap.String("peer", p.ID.String()))
-							if err := h.Connect(ctx, p); err != nil {
+							if err = h.Connect(ctx, p); err != nil {
 								logger.Error("failed to reconnect to peer", zap.String("peer", p.ID.String()), zap.Error(err))
 							} else {
 								logger.Info("Reconnected to peer", zap.String("peer", p.ID.String()))
@@ -211,7 +211,7 @@ func runP2P(
 				logger.Info("query response received from gossip", zap.String("peerID", peerID), zap.Any("requestId", requestSignature))
 				if loggingMap.ShouldLogResponse(requestSignature) {
 					var queryRequest query.QueryRequest
-					if err := queryRequest.Unmarshal(queryResponse.Request.QueryRequest); err == nil {
+					if unmarshalErr := queryRequest.Unmarshal(queryResponse.Request.QueryRequest); unmarshalErr == nil {
 						logger.Info("logging response", zap.String("peerID", peerID), zap.Any("requestId", requestSignature), zap.Any("request", queryRequest), zap.Any("response", queryResponse))
 					} else {
 						logger.Error("logging response (failed to unmarshal request)", zap.String("peerID", peerID), zap.Any("requestId", requestSignature), zap.Any("response", queryResponse))

--- a/node/cmd/ccq/query_server.go
+++ b/node/cmd/ccq/query_server.go
@@ -99,9 +99,9 @@ func runQueryServer(cmd *cobra.Command, args []string) {
 	}
 
 	if *verifyPermissions {
-		_, err := parseConfigFile(*permFile, env)
-		if err != nil {
-			fmt.Println(err)
+		_, parseErr := parseConfigFile(*permFile, env)
+		if parseErr != nil {
+			fmt.Println(parseErr)
 			os.Exit(1)
 		}
 		os.Exit(0)
@@ -151,9 +151,9 @@ func runQueryServer(cmd *cobra.Command, args []string) {
 			"version":   version.Version(),
 		}
 
-		tm, err := telemetry.NewLokiCloudLogger(context.Background(), logger, *telemetryLokiURL, "ccq_server", true, labels)
-		if err != nil {
-			logger.Fatal("Failed to initialize telemetry", zap.Error(err))
+		tm, lokiErr := telemetry.NewLokiCloudLogger(context.Background(), logger, *telemetryLokiURL, "ccq_server", true, labels)
+		if lokiErr != nil {
+			logger.Fatal("Failed to initialize telemetry", zap.Error(lokiErr))
 		}
 
 		defer tm.Close()
@@ -215,9 +215,8 @@ func runQueryServer(cmd *cobra.Command, args []string) {
 	go func() {
 		s := NewHTTPServer(*listenAddr, p2pSub.topicReq, permissions, signerKey, pendingResponses, logger, env, loggingMap)
 		logger.Sugar().Infof("Server listening on %s", *listenAddr)
-		err := s.ListenAndServe()
-		if err != nil && err != http.ErrServerClosed {
-			logger.Fatal("Server closed unexpectedly", zap.Error(err))
+		if serveErr := s.ListenAndServe(); serveErr != nil && serveErr != http.ErrServerClosed {
+			logger.Fatal("Server closed unexpectedly", zap.Error(serveErr))
 		}
 	}()
 
@@ -227,9 +226,8 @@ func runQueryServer(cmd *cobra.Command, args []string) {
 		statServer = NewStatusServer(*statusAddr, logger, env)
 		go func() {
 			logger.Sugar().Infof("Status server listening on %s", *statusAddr)
-			err := statServer.httpServer.ListenAndServe()
-			if err != nil && err != http.ErrServerClosed {
-				logger.Fatal("Status server closed unexpectedly", zap.Error(err))
+			if serveErr := statServer.httpServer.ListenAndServe(); serveErr != nil && serveErr != http.ErrServerClosed {
+				logger.Fatal("Status server closed unexpectedly", zap.Error(serveErr))
 			}
 		}()
 	}

--- a/node/cmd/guardiand/adminclient.go
+++ b/node/cmd/guardiand/adminclient.go
@@ -818,8 +818,8 @@ func buildDelegateSignaturesBroadcasts(vaaID string, apiObservations []wormholes
 
 			var sentTimestamp int64
 			if obs.SentTimestamp != "" {
-				t, err := time.Parse(time.RFC3339, obs.SentTimestamp)
-				if err != nil {
+				t, timeParseErr := time.Parse(time.RFC3339, obs.SentTimestamp)
+				if timeParseErr != nil {
 					continue
 				}
 				sentTimestamp = t.Unix()
@@ -926,8 +926,8 @@ func runBroadcastDelegateSignatures(cmd *cobra.Command, args []string) {
 	}
 
 	var apiObservations []wormholescanDelegateObservation
-	if err := json.NewDecoder(httpResp.Body).Decode(&apiObservations); err != nil {
-		log.Fatalf("failed to decode API response: %v", err)
+	if jsonDecodeErr := json.NewDecoder(httpResp.Body).Decode(&apiObservations); jsonDecodeErr != nil {
+		log.Fatalf("failed to decode API response: %v", jsonDecodeErr)
 	}
 
 	broadcasts, err := buildDelegateSignaturesBroadcasts(vaaID, apiObservations)
@@ -1053,10 +1053,10 @@ func runChainGovernorResetReleaseTimer(cmd *cobra.Command, args []string) {
 	// defaults to 1 day if num_days isn't specified
 	numDays := uint32(1)
 	if len(args) > 1 {
-		numDaysArg, err := strconv.Atoi(args[1])
+		numDaysArg, parseErr := strconv.Atoi(args[1])
 
-		if numDaysArg > math.MaxUint32 || err != nil {
-			log.Fatalf("invalid num_days: %v", err)
+		if numDaysArg > math.MaxUint32 || parseErr != nil {
+			log.Fatalf("invalid num_days: %v", parseErr)
 		}
 
 		numDays = uint32(numDaysArg) // #nosec G115 -- This is validated above
@@ -1183,12 +1183,12 @@ func runSignExistingVaasFromCSV(cmd *cobra.Command, args []string) {
 	oldVAAReader := csv.NewReader(oldVAAFile)
 	numOldVAAs := 0
 	for {
-		row, err := oldVAAReader.Read()
-		if err != nil {
-			if err == io.EOF {
+		row, readErr := oldVAAReader.Read()
+		if readErr != nil {
+			if readErr == io.EOF {
 				break
 			}
-			log.Fatalf("failed to parse VAA CSV: %v", err)
+			log.Fatalf("failed to parse VAA CSV: %v", readErr)
 		}
 		if len(row) != 2 {
 			log.Fatalf("row [%d] does not have 2 elements", numOldVAAs)

--- a/node/cmd/guardiand/admintemplate.go
+++ b/node/cmd/guardiand/admintemplate.go
@@ -1413,18 +1413,18 @@ func runDelegatedManagerSetUpdateTemplate(cmd *cobra.Command, args []string) {
 		// Use raw manager set bytes if provided
 		managerSet = strings.TrimPrefix(*delegatedManagerSet, "0x")
 		// Validate it's valid hex
-		if _, err := hex.DecodeString(managerSet); err != nil {
-			log.Fatal("invalid manager-set (expected hex): ", err)
+		if _, hexErr := hex.DecodeString(managerSet); hexErr != nil {
+			log.Fatal("invalid manager-set (expected hex): ", hexErr)
 		}
 	} else if *delegatedManagerThreshold != "" && *delegatedManagerNumKeys != "" && *delegatedManagerPublicKeys != "" {
 		// Build secp256k1 multisig manager set from components
-		threshold, err := strconv.ParseUint(*delegatedManagerThreshold, 10, 8)
-		if err != nil {
-			log.Fatal("failed to parse threshold as uint8: ", err)
+		threshold, thresholdErr := strconv.ParseUint(*delegatedManagerThreshold, 10, 8)
+		if thresholdErr != nil {
+			log.Fatal("failed to parse threshold as uint8: ", thresholdErr)
 		}
-		numKeys, err := strconv.ParseUint(*delegatedManagerNumKeys, 10, 8)
-		if err != nil {
-			log.Fatal("failed to parse num-keys as uint8: ", err)
+		numKeys, numKeysErr := strconv.ParseUint(*delegatedManagerNumKeys, 10, 8)
+		if numKeysErr != nil {
+			log.Fatal("failed to parse num-keys as uint8: ", numKeysErr)
 		}
 		publicKeyStrs := strings.Split(*delegatedManagerPublicKeys, ",")
 
@@ -1432,9 +1432,9 @@ func runDelegatedManagerSetUpdateTemplate(cmd *cobra.Command, args []string) {
 		publicKeys := make([][vaa.CompressedSecp256k1PublicKeyLength]byte, len(publicKeyStrs))
 		for i, pkStr := range publicKeyStrs {
 			pkHex := strings.TrimPrefix(strings.TrimSpace(pkStr), "0x")
-			pkBytes, err := hex.DecodeString(pkHex)
-			if err != nil {
-				log.Fatalf("public key %d is not valid hex: %v", i, err)
+			pkBytes, pkErr := hex.DecodeString(pkHex)
+			if pkErr != nil {
+				log.Fatalf("public key %d is not valid hex: %v", i, pkErr)
 			}
 			if len(pkBytes) != vaa.CompressedSecp256k1PublicKeyLength {
 				log.Fatalf("public key %d has invalid length: expected %d bytes, got %d", i, vaa.CompressedSecp256k1PublicKeyLength, len(pkBytes))
@@ -1447,9 +1447,9 @@ func runDelegatedManagerSetUpdateTemplate(cmd *cobra.Command, args []string) {
 			N:          uint8(numKeys),
 			PublicKeys: publicKeys,
 		}
-		managerSetBytes, err := managerSetStruct.Serialize()
-		if err != nil {
-			log.Fatal("failed to serialize manager set: ", err)
+		managerSetBytes, serializeErr := managerSetStruct.Serialize()
+		if serializeErr != nil {
+			log.Fatal("failed to serialize manager set: ", serializeErr)
 		}
 		managerSet = hex.EncodeToString(managerSetBytes)
 	} else {

--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -645,9 +645,9 @@ func runNode(cmd *cobra.Command, args []string) {
 	if env == common.UnsafeDevNet {
 		// Use the hostname as nodeName. For production, we don't want to do this to
 		// prevent accidentally leaking sensitive hostnames.
-		hostname, err := os.Hostname()
-		if err != nil {
-			panic(err)
+		hostname, hostErr := os.Hostname()
+		if hostErr != nil {
+			panic(hostErr)
 		}
 		*nodeName = hostname
 
@@ -665,9 +665,9 @@ func runNode(cmd *cobra.Command, args []string) {
 
 	// In devnet mode, we automatically set a number of flags that rely on deterministic keys.
 	if env == common.UnsafeDevNet {
-		g0key, err := peer.IDFromPrivateKey(devnet.DeterministicP2PPrivKeyByIndex(0))
-		if err != nil {
-			panic(err)
+		g0key, keyErr := peer.IDFromPrivateKey(devnet.DeterministicP2PPrivKeyByIndex(0))
+		if keyErr != nil {
+			panic(keyErr)
 		}
 
 		// Use the first guardian node as bootstrap
@@ -754,9 +754,9 @@ func runNode(cmd *cobra.Command, args []string) {
 	if env == common.UnsafeDevNet {
 		// Only if the signer is file-based should we generate the deterministic key and write it to disk
 		if st, _, _ := guardiansigner.ParseSignerUri(*guardianSignerUri); st == guardiansigner.FileSignerType {
-			err := devnet.GenerateAndStoreDevnetGuardianKey(*guardianKeyPath)
-			if err != nil {
-				logger.Fatal("failed to generate devnet guardian key", zap.Error(err))
+			genErr := devnet.GenerateAndStoreDevnetGuardianKey(*guardianKeyPath)
+			if genErr != nil {
+				logger.Fatal("failed to generate devnet guardian key", zap.Error(genErr))
 			}
 		}
 	}
@@ -777,22 +777,22 @@ func runNode(cmd *cobra.Command, args []string) {
 	// Load p2p private key
 	var p2pKey libp2p_crypto.PrivKey
 	if env == common.UnsafeDevNet {
-		idx, err := devnet.GetDevnetIndex()
-		if err != nil {
+		idx, idxErr := devnet.GetDevnetIndex()
+		if idxErr != nil {
 			logger.Fatal("Failed to parse hostname - are we running in devnet?")
 		}
 		p2pKey = devnet.DeterministicP2PPrivKeyByIndex(int64(idx))
 
 		if idx != 0 {
-			firstGuardianName, err := devnet.GetFirstGuardianNameFromBootstrapPeers(*p2pBootstrap)
-			if err != nil {
-				logger.Fatal("failed to get first guardian name from bootstrap peers", zap.String("bootstrapPeers", *p2pBootstrap), zap.Error(err))
+			firstGuardianName, lookupErr := devnet.GetFirstGuardianNameFromBootstrapPeers(*p2pBootstrap)
+			if lookupErr != nil {
+				logger.Fatal("failed to get first guardian name from bootstrap peers", zap.String("bootstrapPeers", *p2pBootstrap), zap.Error(lookupErr))
 			}
 			// try to connect to guardian-0
 			for {
 				//nolint:noctx // TODO: this should be refactored to use context.
-				_, err := net.LookupIP(firstGuardianName)
-				if err == nil {
+				_, resolveErr := net.LookupIP(firstGuardianName)
+				if resolveErr == nil {
 					break
 				}
 				logger.Info(fmt.Sprintf("Error resolving %s. Trying again...", firstGuardianName))

--- a/node/cmd/spy/spy.go
+++ b/node/cmd/spy/spy.go
@@ -300,14 +300,14 @@ func runSpy(cmd *cobra.Command, args []string) {
 		if *p2pNetworkID != "" || *p2pBootstrap != "" {
 			logger.Fatal(`If "--env" is specified, "--network" and "--bootstrap" may not be specified`)
 		}
-		env, err := common.ParseEnvironment(*envStr)
-		if err != nil || (env != common.MainNet && env != common.TestNet) {
+		env, envErr := common.ParseEnvironment(*envStr)
+		if envErr != nil || (env != common.MainNet && env != common.TestNet) {
 			logger.Fatal(`Invalid value for "--env", should be "mainnet" or "testnet"`)
 		}
 		*p2pNetworkID = p2p.GetNetworkId(env)
-		*p2pBootstrap, err = p2p.GetBootstrapPeers(env)
-		if err != nil {
-			logger.Fatal("failed to determine p2p bootstrap peers", zap.String("env", string(env)), zap.Error(err))
+		*p2pBootstrap, envErr = p2p.GetBootstrapPeers(env)
+		if envErr != nil {
+			logger.Fatal("failed to determine p2p bootstrap peers", zap.String("env", string(env)), zap.Error(envErr))
 		}
 	} else {
 		// If they don't specify --env, then --network and --bootstrap are required.
@@ -363,8 +363,8 @@ func runSpy(cmd *cobra.Command, args []string) {
 			logger.Fatal(`If "--ethRPC" is specified, "--ethContract" must also be specified`)
 		}
 		s.vaaVerifier = NewVaaVerifier(logger, *ethRPC, *ethContract)
-		if err := s.vaaVerifier.GetInitialGuardianSet(); err != nil {
-			logger.Fatal(`Failed to read initial guardian set for VAA verification`, zap.Error(err))
+		if verifierErr := s.vaaVerifier.GetInitialGuardianSet(); verifierErr != nil {
+			logger.Fatal(`Failed to read initial guardian set for VAA verification`, zap.Error(verifierErr))
 		}
 	}
 
@@ -377,8 +377,8 @@ func runSpy(cmd *cobra.Command, args []string) {
 			case v := <-signedInC:
 				logger.Info("Received signed VAA",
 					zap.Any("vaa", v.Vaa))
-				if err := s.PublishSignedVAA(v.Vaa); err != nil {
-					logger.Error("failed to publish signed VAA", zap.Error(err), zap.Any("vaa", v.Vaa))
+				if pubErr := s.PublishSignedVAA(v.Vaa); pubErr != nil {
+					logger.Error("failed to publish signed VAA", zap.Error(pubErr), zap.Any("vaa", v.Vaa))
 				}
 			}
 		}

--- a/node/cmd/spy/spy_test.go
+++ b/node/cmd/spy/spy_test.go
@@ -171,19 +171,19 @@ func TestSpyHandleGossipVAA(t *testing.T) {
 	go func() {
 		defer close(doneCh)
 		// receive is a blocking call, it will keep receiving/looping until the pipe breaks.
-		signedVAA, err := stream.Recv()
-		if errors.Is(err, io.EOF) {
+		signedVAA, recvErr := stream.Recv()
+		if errors.Is(recvErr, io.EOF) {
 			t.Log("the SignedVAA stream has closed, err == io.EOF. going to break.")
 			t.Fail()
 			return
 		}
-		if err != nil {
+		if recvErr != nil {
 			t.Log("SubscribeSignedVAA returned an error.")
 			t.Fail()
 			return
 		}
-		parsedRes, err := vaa.Unmarshal(signedVAA.VaaBytes)
-		if err != nil {
+		parsedRes, unmarshalErr := vaa.Unmarshal(signedVAA.VaaBytes)
+		if unmarshalErr != nil {
 			t.Log("failed unmarshaling VAA from response")
 			t.Fail()
 			return
@@ -236,19 +236,19 @@ func TestSpyHandleEmitterFilter(t *testing.T) {
 	go func() {
 		defer close(doneCh)
 		// receive is a blocking call, it will keep receiving/looping until the pipe breaks.
-		signedVAA, err := emitterFilterStream.Recv()
-		if errors.Is(err, io.EOF) {
+		signedVAA, recvErr := emitterFilterStream.Recv()
+		if errors.Is(recvErr, io.EOF) {
 			t.Log("the SignedVAA stream has closed, err == io.EOF. going to break.")
 			t.Fail()
 			return
 		}
-		if err != nil {
+		if recvErr != nil {
 			t.Log("SubscribeSignedVAA returned an error.")
 			t.Fail()
 			return
 		}
-		_, err = vaa.Unmarshal(signedVAA.VaaBytes)
-		if err != nil {
+		_, unmarshalErr := vaa.Unmarshal(signedVAA.VaaBytes)
+		if unmarshalErr != nil {
 			t.Log("failed unmarshaling VAA from response")
 			t.Fail()
 			return

--- a/node/cmd/txverifier/sui.go
+++ b/node/cmd/txverifier/sui.go
@@ -110,7 +110,7 @@ func runTransferVerifierSui(cmd *cobra.Command, args []string) {
 			"version":   version.Version(),
 		}
 
-		tm, err := telemetry.NewLokiCloudLogger(
+		tm, lokiErr := telemetry.NewLokiCloudLogger(
 			context.Background(),
 			logger,
 			*telemetryLokiUrl,
@@ -119,8 +119,8 @@ func runTransferVerifierSui(cmd *cobra.Command, args []string) {
 			false,
 			labels,
 		)
-		if err != nil {
-			logger.Fatal("Failed to initialize telemetry", zap.Error(err))
+		if lokiErr != nil {
+			logger.Fatal("Failed to initialize telemetry", zap.Error(lokiErr))
 		}
 
 		defer tm.Close()
@@ -152,10 +152,10 @@ func runTransferVerifierSui(cmd *cobra.Command, args []string) {
 	// Process a single digest and exit
 	if *suiDigest != "" {
 		logger.Info("Processing single digest", zap.String("txDigeset", *suiDigest))
-		valid, err := suiTransferVerifier.ProcessDigest(ctx, *suiDigest, "", logger)
+		valid, processErr := suiTransferVerifier.ProcessDigest(ctx, *suiDigest, "", logger)
 
-		if err != nil {
-			logger.Error("Error validating the digest", zap.Error(err))
+		if processErr != nil {
+			logger.Error("Error validating the digest", zap.Error(processErr))
 		}
 
 		logger.Info("Validation completed", zap.Bool("valid", valid))
@@ -164,16 +164,16 @@ func runTransferVerifierSui(cmd *cobra.Command, args []string) {
 	}
 
 	if *suiProcessWormholeScanEvents {
-		digests, err := pullDigestsFromWormholeScan(ctx, logger)
-		if err != nil {
-			logger.Fatal("Error pulling digests from WormholeScan", zap.Error(err))
+		digests, pullErr := pullDigestsFromWormholeScan(ctx, logger)
+		if pullErr != nil {
+			logger.Fatal("Error pulling digests from WormholeScan", zap.Error(pullErr))
 		}
 		// TODO: check the result of each digest against an expected outcome. Some digests
 		// link to token attestations, which the transfer verifier doesn't handle.
 		for _, digest := range digests {
-			_, err := suiTransferVerifier.ProcessDigest(ctx, digest, "", logger)
-			if err != nil {
-				logger.Error(err.Error())
+			_, processErr := suiTransferVerifier.ProcessDigest(ctx, digest, "", logger)
+			if processErr != nil {
+				logger.Error(processErr.Error())
 			}
 		}
 	}
@@ -193,9 +193,9 @@ func runTransferVerifierSui(cmd *cobra.Command, args []string) {
 	var latestTimestamp int
 	for _, event := range initialEvents {
 		if event.Timestamp != nil {
-			timestampInt, err := strconv.Atoi(*event.Timestamp)
-			if err != nil {
-				logger.Error("Error converting timestamp to int", zap.Error(err))
+			timestampInt, atoiErr := strconv.Atoi(*event.Timestamp)
+			if atoiErr != nil {
+				logger.Error("Error converting timestamp to int", zap.Error(atoiErr))
 				continue
 			}
 			if timestampInt > latestTimestamp {

--- a/node/hack/encrypt/encrypt.go
+++ b/node/hack/encrypt/encrypt.go
@@ -18,8 +18,8 @@ func main() {
 
 	// Generate 128-bit key
 	key := make([]byte, 16)
-	if _, err := rand.Read(key); err != nil {
-		log.Fatalf("failed to generate key: %v", err)
+	if _, keyErr := rand.Read(key); keyErr != nil {
+		log.Fatalf("failed to generate key: %v", keyErr)
 	}
 
 	// Log key as base64 string

--- a/node/hack/evm_test/wstest.go
+++ b/node/hack/evm_test/wstest.go
@@ -49,8 +49,8 @@ func main() {
 	}
 
 	logger.Info("Connecting to websocket endpoint", zap.String("webSocket", *rpc))
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx, rootCancel := context.WithCancel(context.Background())
+	defer rootCancel()
 
 	rawClient, err := ethRpc.DialContext(ctx, *rpc)
 	if err != nil {
@@ -98,10 +98,10 @@ func main() {
 			logger.Fatal("Failed to create filter", zap.Error(err))
 		}
 
-		timeout, cancel := context.WithTimeout(ctx, 15*time.Second)
+		watchCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 		defer cancel()
 		messageC := make(chan *ethAbi.AbiLogMessagePublished, 2)
-		messageSub, err := filterer.WatchLogMessagePublished(&ethBind.WatchOpts{Context: timeout}, messageC, nil)
+		messageSub, err := filterer.WatchLogMessagePublished(&ethBind.WatchOpts{Context: watchCtx}, messageC, nil)
 		if err != nil {
 			logger.Fatal("Failed to subscribe to events", zap.Error(err))
 		}
@@ -130,7 +130,7 @@ func main() {
 	go func() {
 		<-sigterm
 		logger.Info("Received sigterm. exiting.")
-		cancel()
+		rootCancel()
 	}()
 
 	// Wait for either a shutdown or a fatal error from the permissions watcher.

--- a/node/hack/query/ccqlistener/ccqlistener.go
+++ b/node/hack/query/ccqlistener/ccqlistener.go
@@ -208,9 +208,9 @@ func main() {
 		to, _ := hex.DecodeString("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")
 
 		for _, method := range methods {
-			data, err := wethAbi.Pack(method)
-			if err != nil {
-				panic(err)
+			data, packErr := wethAbi.Pack(method)
+			if packErr != nil {
+				panic(packErr)
 			}
 
 			callData = append(callData, &query.EthCallData{

--- a/node/hack/query/send_req.go
+++ b/node/hack/query/send_req.go
@@ -128,12 +128,12 @@ func main() {
 		logger.Info("Running Solana account test")
 
 		// Start of query creation...
-		account1, err := solana.PublicKeyFromBase58("Bridge1p5gheXUvJ6jGWGeCsgPKgnE3YgdGKRVCMY9o")
-		if err != nil {
+		account1, pkErr := solana.PublicKeyFromBase58("Bridge1p5gheXUvJ6jGWGeCsgPKgnE3YgdGKRVCMY9o")
+		if pkErr != nil {
 			panic("solana account1 is invalid")
 		}
-		account2, err := solana.PublicKeyFromBase58("B6RHG3mfcckmrYN1UhmJzyS1XX3fZKbkeUcpJe9Sy3FE")
-		if err != nil {
+		account2, pkErr := solana.PublicKeyFromBase58("B6RHG3mfcckmrYN1UhmJzyS1XX3fZKbkeUcpJe9Sy3FE")
+		if pkErr != nil {
 			panic("solana account2 is invalid")
 		}
 		callRequest := &query.SolanaAccountQueryRequest{
@@ -143,9 +143,9 @@ func main() {
 			Accounts:        [][query.SolanaPublicKeyLength]byte{account1, account2},
 		}
 
-		nonce, err := random.Uint32()
-		if err != nil {
-			panic(err)
+		nonce, nonceErr := random.Uint32()
+		if nonceErr != nil {
+			panic(nonceErr)
 		}
 		queryRequest := &query.QueryRequest{
 			Nonce: nonce,
@@ -178,9 +178,9 @@ func main() {
 			},
 		}
 
-		nonce, err := random.Uint32()
-		if err != nil {
-			panic(err)
+		nonce, nonceErr := random.Uint32()
+		if nonceErr != nil {
+			panic(nonceErr)
 		}
 		queryRequest := &query.QueryRequest{
 			Nonce: nonce,
@@ -211,9 +211,9 @@ func main() {
 	to, _ := hex.DecodeString("DDb64fE46a91D46ee29420539FC25FD07c5FEa3E")
 
 	for _, method := range methods {
-		data, err := wethAbi.Pack(method)
-		if err != nil {
-			panic(err)
+		data, packErr := wethAbi.Pack(method)
+		if packErr != nil {
+			panic(packErr)
 		}
 
 		callData = append(callData, &query.EthCallData{
@@ -295,9 +295,9 @@ const (
 )
 
 func createQueryRequest(callRequest *query.EthCallQueryRequest) *query.QueryRequest {
-	nonce, err := random.Uint32()
-	if err != nil {
-		panic(err)
+	nonce, nonceErr := random.Uint32()
+	if nonceErr != nil {
+		panic(nonceErr)
 	}
 	queryRequest := &query.QueryRequest{
 		Nonce: nonce,
@@ -320,9 +320,9 @@ func createQueryRequestWithMultipleRequests(callRequests []*query.EthCallQueryRe
 		})
 	}
 
-	nonce, err := random.Uint32()
-	if err != nil {
-		panic(err)
+	nonce, nonceErr := random.Uint32()
+	if nonceErr != nil {
+		panic(nonceErr)
 	}
 	queryRequest := &query.QueryRequest{
 		Nonce:           nonce,

--- a/node/hack/repair_eth/repair_eth.go
+++ b/node/hack/repair_eth/repair_eth.go
@@ -304,17 +304,17 @@ func main() {
 			RpcBackfill:    true,
 			BackfillNodes:  sdk.PublicRPCEndpoints,
 		}
-		resp, err := admin.FindMissingMessages(ctx, &msg)
-		if err != nil {
-			log.Fatalf("failed to run find FindMissingMessages RPC: %v", err)
+		resp, rpcErr := admin.FindMissingMessages(ctx, &msg)
+		if rpcErr != nil {
+			log.Fatalf("failed to run find FindMissingMessages RPC: %v", rpcErr)
 		}
 
 		msgs := []*db.VAAID{}
 		for _, id := range resp.MissingMessages {
 			fmt.Println(id)
-			vId, err := db.VaaIDFromString(id)
-			if err != nil {
-				log.Fatalf("failed to parse VAAID: %v", err)
+			vId, parseErr := db.VaaIDFromString(id)
+			if parseErr != nil {
+				log.Fatalf("failed to parse VAAID: %v", parseErr)
 			}
 			if *vId == polygonIgnoredVaa {
 				log.Printf("Ignored message: %+v", &polygonIgnoredVaa)
@@ -344,9 +344,9 @@ func main() {
 	// Press enter to continue if not in dryRun mode
 	if !*dryRun {
 		fmt.Println("Press enter to continue")
-		_, err := fmt.Scanln()
-		if err != nil {
-			log.Printf("Scanln error: %s\n", err)
+		_, scanErr := fmt.Scanln()
+		if scanErr != nil {
+			log.Printf("Scanln error: %s\n", scanErr)
 		}
 	}
 
@@ -433,8 +433,8 @@ func main() {
 			}
 
 			var seq uint64
-			if m, err := ethAbi.Unpack("LogMessagePublished", b); err != nil {
-				log.Fatalf("failed to unpack log data for %s: %v", l.TransactionHash, err)
+			if m, unpackErr := ethAbi.Unpack("LogMessagePublished", b); unpackErr != nil {
+				log.Fatalf("failed to unpack log data for %s: %v", l.TransactionHash, unpackErr)
 			} else {
 				seq = m[0].(uint64)
 			}

--- a/node/hack/repair_solana/repair.go
+++ b/node/hack/repair_solana/repair.go
@@ -78,9 +78,9 @@ func main() {
 		msgs := make([]*db.VAAID, len(resp.MissingMessages))
 		for i, id := range resp.MissingMessages {
 			fmt.Println(id)
-			vId, err := db.VaaIDFromString(id)
-			if err != nil {
-				log.Fatalf("failed to parse VAAID: %v", err)
+			vId, parseErr := db.VaaIDFromString(id)
+			if parseErr != nil {
+				log.Fatalf("failed to parse VAAID: %v", parseErr)
 			}
 			msgs[i] = vId
 		}

--- a/node/pkg/accountant/submit_obs.go
+++ b/node/pkg/accountant/submit_obs.go
@@ -434,8 +434,8 @@ func GetObservationResponses(txResp *sdktx.BroadcastTxResponse) (map[string]Obse
 	}
 
 	var msg sdktypes.TxMsgData
-	if err := msg.Unmarshal(data); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal data: %w", err)
+	if unmarshalErr := msg.Unmarshal(data); unmarshalErr != nil {
+		return nil, fmt.Errorf("failed to unmarshal data: %w", unmarshalErr)
 	}
 
 	if len(msg.Data) == 0 {
@@ -443,8 +443,8 @@ func GetObservationResponses(txResp *sdktx.BroadcastTxResponse) (map[string]Obse
 	}
 
 	var execContractResp wasmdtypes.MsgExecuteContractResponse
-	if err := execContractResp.Unmarshal(msg.Data[0].Data); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal ExecuteContractResponse: %w", err)
+	if unmarshalErr := execContractResp.Unmarshal(msg.Data[0].Data); unmarshalErr != nil {
+		return nil, fmt.Errorf("failed to unmarshal ExecuteContractResponse: %w", unmarshalErr)
 	}
 
 	var responses ObservationResponses

--- a/node/pkg/accountant/watcher.go
+++ b/node/pkg/accountant/watcher.go
@@ -46,14 +46,14 @@ func (acct *Accountant) watcher(ctx context.Context, isNTT bool) error {
 		return fmt.Errorf("failed to establish %s tendermint connection: %w", tag, err)
 	}
 
-	if err := tmConn.Start(); err != nil {
+	if startErr := tmConn.Start(); startErr != nil {
 		connectionErrors.Inc()
-		return fmt.Errorf("failed to start %s tendermint connection: %w", tag, err)
+		return fmt.Errorf("failed to start %s tendermint connection: %w", tag, startErr)
 	}
 	defer func() {
-		if err := tmConn.Stop(); err != nil {
+		if stopErr := tmConn.Stop(); stopErr != nil {
 			connectionErrors.Inc()
-			acct.logger.Error(fmt.Sprintf("acctwatch: failed to stop %s tendermint connection", tag), zap.Error(err))
+			acct.logger.Error(fmt.Sprintf("acctwatch: failed to stop %s tendermint connection", tag), zap.Error(stopErr))
 		}
 	}()
 

--- a/node/pkg/adminrpc/adminserver.go
+++ b/node/pkg/adminrpc/adminserver.go
@@ -1444,9 +1444,9 @@ func (s *nodePrivilegedService) SignExistingVAA(ctx context.Context, req *nodev1
 			return nil, fmt.Errorf("internal error")
 		}
 	} else {
-		evmGs, err := s.evmConnector.GetGuardianSet(ctx, v.GuardianSetIndex)
-		if err != nil {
-			return nil, fmt.Errorf("failed to load guardian set [%d]: %w", v.GuardianSetIndex, err)
+		evmGs, gsErr := s.evmConnector.GetGuardianSet(ctx, v.GuardianSetIndex)
+		if gsErr != nil {
+			return nil, fmt.Errorf("failed to load guardian set [%d]: %w", v.GuardianSetIndex, gsErr)
 		}
 		gs = &common.GuardianSet{
 			Keys:  evmGs.Keys,

--- a/node/pkg/common/chainlock_test.go
+++ b/node/pkg/common/chainlock_test.go
@@ -836,8 +836,8 @@ func TestSafeRead(t *testing.T) {
 
 			// Fill slice with zeroes.
 			data := make([]byte, tt.size)
-			if _, err := f.Write(data); err != nil {
-				require.NoError(t, err)
+			if _, writeErr := f.Write(data); writeErr != nil {
+				require.NoError(t, writeErr)
 			}
 
 			// File pointer is at EOF at this point. Reset to the start.

--- a/node/pkg/common/nodekey.go
+++ b/node/pkg/common/nodekey.go
@@ -15,14 +15,14 @@ func GetOrCreateNodeKey(logger *zap.Logger, path string) (crypto.PrivKey, error)
 		if os.IsNotExist(err) {
 			logger.Info("No node key found, generating a new one...", zap.String("path", path))
 
-			priv, _, err := crypto.GenerateKeyPair(crypto.Ed25519, -1)
-			if err != nil {
-				panic(err)
+			priv, _, genErr := crypto.GenerateKeyPair(crypto.Ed25519, -1)
+			if genErr != nil {
+				panic(genErr)
 			}
 
-			s, err := crypto.MarshalPrivateKey(priv)
-			if err != nil {
-				panic(err)
+			s, marshalErr := crypto.MarshalPrivateKey(priv)
+			if marshalErr != nil {
+				panic(marshalErr)
 			}
 
 			err = os.WriteFile(path, s, 0600)

--- a/node/pkg/db/accountant.go
+++ b/node/pkg/db/accountant.go
@@ -77,16 +77,16 @@ func (d *Database) AcctGetData(logger *zap.Logger) ([]*common.MessagePublication
 			for it.Seek(prefixBytes); it.ValidForPrefix(prefixBytes); it.Next() {
 				item := it.Item()
 				key := item.Key()
-				val, err := item.ValueCopy(nil)
-				if err != nil {
-					return err
+				val, copyErr := item.ValueCopy(nil)
+				if copyErr != nil {
+					return copyErr
 				}
 
 				if acctIsPendingTransfer(key) {
 					var pt common.MessagePublication
-					err := json.Unmarshal(val, &pt)
-					if err != nil {
-						logger.Error("failed to unmarshal pending transfer for key", zap.String("key", string(key[:])), zap.Error(err))
+					unmarshalErr := json.Unmarshal(val, &pt)
+					if unmarshalErr != nil {
+						logger.Error("failed to unmarshal pending transfer for key", zap.String("key", string(key[:])), zap.Error(unmarshalErr))
 						continue
 					}
 

--- a/node/pkg/db/db.go
+++ b/node/pkg/db/db.go
@@ -194,17 +194,17 @@ func (d *Database) FindEmitterSequenceGap(prefix VAAID) (resp []uint64, firstSeq
 		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
 			item := it.Item()
 			key := item.Key()
-			err := item.Value(func(val []byte) error {
-				v, err := vaa.Unmarshal(val)
-				if err != nil {
-					return fmt.Errorf("failed to unmarshal VAA for %s: %v", string(key), err)
+			valueErr := item.Value(func(val []byte) error {
+				v, unmarshalErr := vaa.Unmarshal(val)
+				if unmarshalErr != nil {
+					return fmt.Errorf("failed to unmarshal VAA for %s: %v", string(key), unmarshalErr)
 				}
 
 				seqs[v.Sequence] = true
 				return nil
 			})
-			if err != nil {
-				return err
+			if valueErr != nil {
+				return valueErr
 			}
 		}
 

--- a/node/pkg/db/db_test.go
+++ b/node/pkg/db/db_test.go
@@ -143,11 +143,11 @@ func TestStoreSignedVAABatch(t *testing.T) {
 
 	// Verify all the VAAs are in the database.
 	for _, v := range vaaBatch {
-		storedBytes, err := db.GetSignedVAABytes(*VaaIDFromVAA(v))
-		require.NoError(t, err)
+		storedBytes, getErr := db.GetSignedVAABytes(*VaaIDFromVAA(v))
+		require.NoError(t, getErr)
 
-		origBytes, err := v.Marshal()
-		require.NoError(t, err)
+		origBytes, marshalErr := v.Marshal()
+		require.NoError(t, marshalErr)
 
 		assert.True(t, bytes.Equal(origBytes, storedBytes))
 	}
@@ -252,8 +252,8 @@ func BenchmarkVaaLookup(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		randId := math_rand.Intn(250000) //nolint
 		randId = 250000 - (i / 18)
-		vaaId, err := VaaIDFromString(fmt.Sprintf("4/000000000000000000000000b6f6d86a8f9879a9c87f643768d9efc38c1da6e7/%d", randId))
-		assert.NoError(b, err)
+		vaaId, idErr := VaaIDFromString(fmt.Sprintf("4/000000000000000000000000b6f6d86a8f9879a9c87f643768d9efc38c1da6e7/%d", randId))
+		assert.NoError(b, idErr)
 		vaaIds <- vaaId
 	}
 

--- a/node/pkg/db/governor.go
+++ b/node/pkg/db/governor.go
@@ -413,8 +413,8 @@ func (d *Database) StoreTransfer(t *Transfer) error {
 	}
 
 	err = d.db.Update(func(txn *badger.Txn) error {
-		if err := txn.Set(TransferMsgID(t), b); err != nil {
-			return err
+		if setErr := txn.Set(TransferMsgID(t), b); setErr != nil {
+			return setErr
 		}
 		return nil
 	})

--- a/node/pkg/db/purge_vaas_test.go
+++ b/node/pkg/db/purge_vaas_test.go
@@ -33,10 +33,10 @@ func countVAAs(d *Database, chainId vaa.ChainID) (numThisChain int, numOtherChai
 		for it.Rewind(); it.Valid(); it.Next() {
 			item := it.Item()
 			key := item.Key()
-			err := item.Value(func(val []byte) error {
-				v, err := vaa.Unmarshal(val)
-				if err != nil {
-					return fmt.Errorf("failed to unmarshal VAA for %s: %v", string(key), err)
+			valueErr := item.Value(func(val []byte) error {
+				v, unmarshalErr := vaa.Unmarshal(val)
+				if unmarshalErr != nil {
+					return fmt.Errorf("failed to unmarshal VAA for %s: %v", string(key), unmarshalErr)
 				}
 
 				if v.EmitterChain == chainId {
@@ -47,8 +47,8 @@ func countVAAs(d *Database, chainId vaa.ChainID) (numThisChain int, numOtherChai
 
 				return nil
 			})
-			if err != nil {
-				return err
+			if valueErr != nil {
+				return valueErr
 			}
 		}
 		return nil

--- a/node/pkg/governor/governor.go
+++ b/node/pkg/governor/governor.go
@@ -204,11 +204,11 @@ func (ce *chainEntry) addFlowCancelTransfer(transfer transfer) error {
 // instead of a `transfer` argument.
 // Validation of transfer data is performed by other methods: see addFlowCancelTransfer, newTransferFromDbTransfer.
 func (ce *chainEntry) addFlowCancelTransferFromDbTransfer(dbTransfer *guardianDB.Transfer) error {
-	transfer, err := newTransferFromDbTransfer(dbTransfer)
+	transferFromDb, err := newTransferFromDbTransfer(dbTransfer)
 	if err != nil {
 		return err
 	}
-	err = ce.addFlowCancelTransfer(transfer.inverse())
+	err = ce.addFlowCancelTransfer(transferFromDb.inverse())
 	if err != nil {
 		return err
 	}
@@ -664,7 +664,7 @@ func (gov *ChainGovernor) processMsgForTime(msg *common.MessagePublication, now 
 	}
 
 	// Check that the transfer is valid before writing to the database.
-	transfer, err := newTransferFromDbTransfer(&dbTransfer)
+	transferFromDb, err := newTransferFromDbTransfer(&dbTransfer)
 	if err != nil {
 		return false, err
 	}
@@ -687,10 +687,10 @@ func (gov *ChainGovernor) processMsgForTime(msg *common.MessagePublication, now 
 	// - If the USDC version of Solana is flow cancelled, we also want to decrease the Governor usage for Sui.
 	// - We do this by adding an 'inverse' transfer to Sui's chainEntry that contains a negative `transfer.ScaledValue`.
 	// - This will cause the summed value of Sui to decrease.
-	emitterChainEntry.transfers = append(emitterChainEntry.transfers, transfer)
+	emitterChainEntry.transfers = append(emitterChainEntry.transfers, transferFromDb)
 
 	if gov.flowCancelEnabled {
-		_, err = gov.tryAddFlowCancelTransfer(&transfer)
+		_, err = gov.tryAddFlowCancelTransfer(&transferFromDb)
 		if err != nil {
 			// Don't interrupt the control flow when a flow cancel fails. Instead, fail open and allow
 			// the transfers to be processed normally. The only consequence is that the outbound limit
@@ -928,7 +928,7 @@ func (gov *ChainGovernor) checkPendingForTime(now time.Time) ([]*common.MessageP
 							Hash:           pe.hash,
 						}
 
-						transfer, err := newTransferFromDbTransfer(&dbTransfer)
+						transferFromDb, err := newTransferFromDbTransfer(&dbTransfer)
 						if err != nil {
 							// Should never occur unless dbTransfer.Value overflows MaxInt64
 							gov.logger.Error("could not convert dbTransfer to transfer",
@@ -949,7 +949,7 @@ func (gov *ChainGovernor) checkPendingForTime(now time.Time) ([]*common.MessageP
 							return nil, err
 						}
 
-						ce.transfers = append(ce.transfers, transfer)
+						ce.transfers = append(ce.transfers, transferFromDb)
 
 						gov.msgsSeen[pe.hash] = transferComplete
 						if gov.flowCancelEnabled {
@@ -958,7 +958,7 @@ func (gov *ChainGovernor) checkPendingForTime(now time.Time) ([]*common.MessageP
 							// Note that the inverse, flow-cancelling transfers are not stored in the database; they only
 							// exist in memory. When the Guardian is restarted, the flow cancelling transfers
 							// will be reconstructed manually.
-							_, err := gov.tryAddFlowCancelTransfer(&transfer)
+							_, err := gov.tryAddFlowCancelTransfer(&transferFromDb)
 							if err != nil {
 								gov.logger.Error("Error when attempting to add a flow cancel transfer",
 									zap.Error(err),

--- a/node/pkg/governor/governor_db.go
+++ b/node/pkg/governor/governor_db.go
@@ -214,17 +214,17 @@ func (gov *ChainGovernor) reloadTransfer(xfer *db.Transfer) error {
 		)
 	}
 
-	transfer, err := newTransferFromDbTransfer(xfer)
+	transferFromDb, err := newTransferFromDbTransfer(xfer)
 	if err != nil {
 		return err
 	}
-	ce.transfers = append(ce.transfers, transfer)
+	ce.transfers = append(ce.transfers, transferFromDb)
 
 	// Reload flow-cancel transfers for the TargetChain. This is important when the node restarts so that a corresponding,
 	// inverse transfer is added to the TargetChain. This is already done during the `ProcessMsgForTime` and
 	// `CheckPending` loops but those functions do not capture flow-cancelling when the node is restarted.
 	if gov.flowCancelEnabled {
-		_, err := gov.tryAddFlowCancelTransfer(&transfer)
+		_, err := gov.tryAddFlowCancelTransfer(&transferFromDb)
 		if err != nil {
 			return err
 		}

--- a/node/pkg/governor/governor_prices.go
+++ b/node/pkg/governor/governor_prices.go
@@ -166,7 +166,7 @@ func (gov *ChainGovernor) queryCoinGecko(ctx context.Context) error {
 
 	for queryIdx, query := range gov.coinGeckoQueries {
 		<-throttle
-		query := query + "&" + params.Encode()
+		query = query + "&" + params.Encode()
 		thisResult, err := gov.queryCoinGeckoChunk(query)
 		if err != nil {
 			gov.logger.Error("CoinGecko query failed", zap.Error(err), zap.Int("queryIdx", queryIdx), zap.String("query", query))

--- a/node/pkg/governor/governor_test.go
+++ b/node/pkg/governor/governor_test.go
@@ -232,9 +232,9 @@ func TestSumAllFromToday(t *testing.T) {
 	transferTime, err := time.Parse("Jan 2, 2006 at 3:04pm (MST)", "Jun 1, 2022 at 11:00am (CST)")
 	require.NoError(t, err)
 	dbTransfer := &guardianDB.Transfer{ScaledValue: 125000, Timestamp: transferTime}
-	transfer, err := newTransferFromDbTransfer(dbTransfer)
+	transferFromDb, err := newTransferFromDbTransfer(dbTransfer)
 	require.NoError(t, err)
-	transfers = append(transfers, transfer)
+	transfers = append(transfers, transferFromDb)
 	sum, updatedTransfers, err := gov.trimAndSumValue(transfers, now.Add(-time.Hour*24))
 	require.NoError(t, err)
 	assert.Equal(t, uint64(125000), uint64(sum)) // #nosec G115 -- If this overflowed the test would fail anyway
@@ -450,8 +450,8 @@ func TestChainEntrySumExceedsDailyLimit(t *testing.T) {
 	require.NoError(t, err)
 
 	var transfers_from_emitter []transfer
-	transferTime, err := time.Parse("2006-Jan-02", "2024-Feb-19")
-	require.NoError(t, err)
+	transferTime, timeErr := time.Parse("2006-Jan-02", "2024-Feb-19")
+	require.NoError(t, timeErr)
 
 	emitterTransferValue := uint64(125000)
 
@@ -460,11 +460,11 @@ func TestChainEntrySumExceedsDailyLimit(t *testing.T) {
 
 	// Create a lot of transfers. Their total value should exceed `emitterLimit`
 	for i := 0; i < 25; i++ {
-		transfer, err := newTransferFromDbTransfer(&guardianDB.Transfer{ScaledValue: emitterTransferValue, Timestamp: transferTime})
-		require.NoError(t, err)
+		transferFromDb, transferErr := newTransferFromDbTransfer(&guardianDB.Transfer{ScaledValue: emitterTransferValue, Timestamp: transferTime})
+		require.NoError(t, transferErr)
 		transfers_from_emitter = append(
 			transfers_from_emitter,
-			transfer,
+			transferFromDb,
 		)
 	}
 
@@ -501,11 +501,11 @@ func TestTrimAndSumValueOverflowErrors(t *testing.T) {
 
 	emitterChainId := vaa.ChainIDSolana
 
-	transfer, err := newTransferFromDbTransfer(&guardianDB.Transfer{ScaledValue: math.MaxInt64, Timestamp: transferTime})
+	transferFromDb, err := newTransferFromDbTransfer(&guardianDB.Transfer{ScaledValue: math.MaxInt64, Timestamp: transferTime})
 	require.NoError(t, err)
 	transfer2, err := newTransferFromDbTransfer(&guardianDB.Transfer{ScaledValue: 1, Timestamp: transferTime})
 	require.NoError(t, err)
-	transfers_from_emitter = append(transfers_from_emitter, transfer, transfer2)
+	transfers_from_emitter = append(transfers_from_emitter, transferFromDb, transfer2)
 
 	// Populate chainEntry and ChainGovernor
 	emitter := &chainEntry{
@@ -559,9 +559,9 @@ func TestTrimOneOfTwoTransfers(t *testing.T) {
 	transferTime1, err := time.Parse("Jan 2, 2006 at 3:04pm (MST)", "May 31, 2022 at 11:59am (CST)")
 	require.NoError(t, err)
 	dbTransfer := &guardianDB.Transfer{ScaledValue: 125000, Timestamp: transferTime1}
-	transfer, err := newTransferFromDbTransfer(dbTransfer)
+	transferFromDb, err := newTransferFromDbTransfer(dbTransfer)
 	require.NoError(t, err)
-	transfers = append(transfers, transfer)
+	transfers = append(transfers, transferFromDb)
 
 	// But the second should not.
 	transferTime2, err := time.Parse("Jan 2, 2006 at 3:04pm (MST)", "May 31, 2022 at 1:00pm (CST)")
@@ -3957,8 +3957,8 @@ func Test_SubDollarTransfersAccumulate(t *testing.T) {
 					Payload:          payloadBytes,
 				}
 
-				canPost, err := gov.processMsgForTime(&msg, now)
-				require.NoError(t, err)
+				canPost, processErr := gov.processMsgForTime(&msg, now)
+				require.NoError(t, processErr)
 				assert.True(t, canPost, "transfer %d should be accepted", i)
 			}
 

--- a/node/pkg/governor/mainnet_tokens_test.go
+++ b/node/pkg/governor/mainnet_tokens_test.go
@@ -37,9 +37,9 @@ func TestTokenListAddressSize(t *testing.T) {
 }
 
 func TestTokensHaveGovernedChains(t *testing.T) {
-	chainList := ChainList()
+	localChainList := ChainList()
 	chains := []vaa.ChainID{}
-	for _, chainConfigEntry := range chainList {
+	for _, chainConfigEntry := range localChainList {
 		chains = append(chains, chainConfigEntry.EmitterChainID)
 	}
 

--- a/node/pkg/manager/manager.go
+++ b/node/pkg/manager/manager.go
@@ -503,15 +503,15 @@ func (c *ManagerService) signDogecoinTransaction(
 	// Each input has its own recipient address (from when funds were locked)
 	redeemScripts := make([][]byte, len(payload.Inputs))
 	for i, input := range payload.Inputs {
-		redeemScript, err := dogecoin.BuildRedeemScript(
+		redeemScript, scriptErr := dogecoin.BuildRedeemScript(
 			v.EmitterChain,
 			v.EmitterAddress,
 			input.OriginalRecipientAddress,
 			managerSet.M,
 			managerSet.PublicKeys,
 		)
-		if err != nil {
-			return nil, fmt.Errorf("failed to build redeem script for input %d: %w", i, err)
+		if scriptErr != nil {
+			return nil, fmt.Errorf("failed to build redeem script for input %d: %w", i, scriptErr)
 		}
 		redeemScripts[i] = redeemScript
 	}

--- a/node/pkg/node/publicwebRunnable.go
+++ b/node/pkg/node/publicwebRunnable.go
@@ -57,17 +57,17 @@ func publicwebServiceRunnable(
 	tlsCacheDir string,
 ) supervisor.Runnable {
 	return func(ctx context.Context) error {
-		conn, err := grpc.DialContext(
+		conn, dialErr := grpc.DialContext(
 			ctx,
 			fmt.Sprintf("unix:///%s", upstreamAddr),
 			grpc.WithBlock(),
 			grpc.WithTransportCredentials(insecure.NewCredentials()))
-		if err != nil {
-			return fmt.Errorf("failed to dial upstream: %s", err)
+		if dialErr != nil {
+			return fmt.Errorf("failed to dial upstream: %s", dialErr)
 		}
 
 		gwmux := runtime.NewServeMux()
-		err = publicrpcv1.RegisterPublicRPCServiceHandler(ctx, gwmux, conn)
+		err := publicrpcv1.RegisterPublicRPCServiceHandler(ctx, gwmux, conn)
 		if err != nil {
 			panic(err)
 		}
@@ -115,13 +115,13 @@ func publicwebServiceRunnable(
 
 		// If listenAddr is prefixed by "sd:", look for a matching systemd socket.
 		if strings.HasPrefix(listenAddr, "sd:") {
-			listeners, err := getSDListeners()
-			if err != nil {
-				return fmt.Errorf("failed to get systemd listeners: %w", err)
+			sdListeners, sdErr := getSDListeners()
+			if sdErr != nil {
+				return fmt.Errorf("failed to get systemd listeners: %w", sdErr)
 			}
 
 			addr := listenAddr[3:]
-			for _, v := range listeners {
+			for _, v := range sdListeners {
 				logger.Debug("found systemd socket", zap.String("addr", v.Addr().String()))
 				if v.Addr().String() == addr {
 					listener = v
@@ -129,9 +129,9 @@ func publicwebServiceRunnable(
 			}
 
 			if listener == nil {
-				all := make([]string, len(listeners))
-				for i := range listeners {
-					all[i] = listeners[i].Addr().String()
+				all := make([]string, len(sdListeners))
+				for i := range sdListeners {
+					all[i] = sdListeners[i].Addr().String()
 				}
 				return fmt.Errorf("no valid systemd listeners, got: %s", strings.Join(all, ","))
 			}

--- a/node/pkg/p2p/ccq_p2p.go
+++ b/node/pkg/p2p/ccq_p2p.go
@@ -98,9 +98,9 @@ func (ccq *ccqP2p) run(
 
 	if len(protectedPeers) != 0 {
 		for _, peerId := range protectedPeers {
-			decodedPeerId, err := peer.Decode(peerId)
-			if err != nil {
-				ccq.logger.Error("error decoding protected ccq peer ID", zap.String("peerId", peerId), zap.Error(err))
+			decodedPeerId, peerErr := peer.Decode(peerId)
+			if peerErr != nil {
+				ccq.logger.Error("error decoding protected ccq peer ID", zap.String("peerId", peerId), zap.Error(peerErr))
 				continue
 			}
 			ccq.logger.Info("protecting ccq peer", zap.String("peerId", peerId))

--- a/node/pkg/p2p/p2p.go
+++ b/node/pkg/p2p/p2p.go
@@ -269,13 +269,13 @@ func NewHost(logger *zap.Logger, ctx context.Context, networkID string, bootstra
 	// check & render address once for use in the AddrsFactory below
 	var gossipAdvertiseAddress multiaddr.Multiaddr
 	if components.GossipAdvertiseAddress != "" {
-		var err error
-		gossipAdvertiseAddress, err = multiaddr.NewMultiaddr(fmt.Sprintf("/ip4/%s/udp/%d", components.GossipAdvertiseAddress, components.Port))
-		if err != nil {
+		var addrErr error
+		gossipAdvertiseAddress, addrErr = multiaddr.NewMultiaddr(fmt.Sprintf("/ip4/%s/udp/%d", components.GossipAdvertiseAddress, components.Port))
+		if addrErr != nil {
 			// If the multiaddr is specified incorrectly, blow up
 			logger.Fatal("error with the specified gossip address",
 				zap.String("GossipAdvertiseAddress", components.GossipAdvertiseAddress),
-				zap.Error(err),
+				zap.Error(addrErr),
 			)
 		}
 		logger.Info("Overriding the advertised p2p address",
@@ -376,16 +376,16 @@ func Run(params *RunParams) func(ctx context.Context) error {
 		}
 
 		defer func() {
-			if err := h.Close(); err != nil {
-				logger.Error("error closing the host", zap.Error(err))
+			if closeErr := h.Close(); closeErr != nil {
+				logger.Error("error closing the host", zap.Error(closeErr))
 			}
 		}()
 
 		if len(params.protectedPeers) != 0 {
 			for _, peerId := range params.protectedPeers {
-				decodedPeerId, err := peer.Decode(peerId)
-				if err != nil {
-					logger.Error("error decoding protected peer ID", zap.String("peerId", peerId), zap.Error(err))
+				decodedPeerId, peerErr := peer.Decode(peerId)
+				if peerErr != nil {
+					logger.Error("error decoding protected peer ID", zap.String("peerId", peerId), zap.Error(peerErr))
 					continue
 				}
 				logger.Info("protecting peer", zap.String("peerId", peerId))
@@ -435,8 +435,8 @@ func Run(params *RunParams) func(ctx context.Context) error {
 			}
 
 			defer func() {
-				if err := controlPubsubTopic.Close(); err != nil && !errors.Is(err, context.Canceled) {
-					logger.Error("Error closing the control topic", zap.Error(err))
+				if closeErr := controlPubsubTopic.Close(); closeErr != nil && !errors.Is(closeErr, context.Canceled) {
+					logger.Error("Error closing the control topic", zap.Error(closeErr))
 				}
 			}()
 
@@ -460,8 +460,8 @@ func Run(params *RunParams) func(ctx context.Context) error {
 			}
 
 			defer func() {
-				if err := attestationPubsubTopic.Close(); err != nil && !errors.Is(err, context.Canceled) {
-					logger.Error("Error closing the attestation topic", zap.Error(err))
+				if closeErr := attestationPubsubTopic.Close(); closeErr != nil && !errors.Is(closeErr, context.Canceled) {
+					logger.Error("Error closing the attestation topic", zap.Error(closeErr))
 				}
 			}()
 
@@ -485,8 +485,8 @@ func Run(params *RunParams) func(ctx context.Context) error {
 			}
 
 			defer func() {
-				if err := delegatedAttestationPubsubTopic.Close(); err != nil && !errors.Is(err, context.Canceled) {
-					logger.Error("Error closing the delegated attestation topic", zap.Error(err))
+				if closeErr := delegatedAttestationPubsubTopic.Close(); closeErr != nil && !errors.Is(closeErr, context.Canceled) {
+					logger.Error("Error closing the delegated attestation topic", zap.Error(closeErr))
 				}
 			}()
 
@@ -510,8 +510,8 @@ func Run(params *RunParams) func(ctx context.Context) error {
 			}
 
 			defer func() {
-				if err := vaaPubsubTopic.Close(); err != nil && !errors.Is(err, context.Canceled) {
-					logger.Error("Error closing the vaa topic", zap.Error(err))
+				if closeErr := vaaPubsubTopic.Close(); closeErr != nil && !errors.Is(closeErr, context.Canceled) {
+					logger.Error("Error closing the vaa topic", zap.Error(closeErr))
 				}
 			}()
 
@@ -535,8 +535,8 @@ func Run(params *RunParams) func(ctx context.Context) error {
 			}
 
 			defer func() {
-				if err := managerPubsubTopic.Close(); err != nil && !errors.Is(err, context.Canceled) {
-					logger.Error("Error closing the manager topic", zap.Error(err))
+				if closeErr := managerPubsubTopic.Close(); closeErr != nil && !errors.Is(closeErr, context.Canceled) {
+					logger.Error("Error closing the manager topic", zap.Error(closeErr))
 				}
 			}()
 
@@ -570,8 +570,8 @@ func Run(params *RunParams) func(ctx context.Context) error {
 		if params.ccqEnabled {
 			ccqErrC := make(chan error)
 			ccq := newCcqRunP2p(logger, params.ccqAllowedPeers, params.components)
-			if err := ccq.run(ctx, params.priv, params.guardianSigner, params.networkID, params.ccqBootstrapPeers, params.ccqPort, params.signedQueryReqC, params.queryResponseReadC, params.ccqProtectedPeers, ccqErrC); err != nil {
-				return fmt.Errorf("failed to start p2p for CCQ: %w", err)
+			if runErr := ccq.run(ctx, params.priv, params.guardianSigner, params.networkID, params.ccqBootstrapPeers, params.ccqPort, params.signedQueryReqC, params.queryResponseReadC, params.ccqProtectedPeers, ccqErrC); runErr != nil {
+				return fmt.Errorf("failed to start p2p for CCQ: %w", runErr)
 			}
 			defer ccq.close()
 			go func() {
@@ -661,8 +661,8 @@ func Run(params *RunParams) func(ctx context.Context) error {
 								heartbeat.P2PNodeId = nodeIdBytes
 							}
 
-							if err := params.gst.SetHeartbeat(ourAddr, h.ID(), heartbeat); err != nil {
-								panic(err)
+							if hbErr := params.gst.SetHeartbeat(ourAddr, h.ID(), heartbeat); hbErr != nil {
+								panic(hbErr)
 							}
 							collectNodeMetrics(ourAddr, h.ID(), heartbeat)
 
@@ -676,9 +676,9 @@ func Run(params *RunParams) func(ctx context.Context) error {
 								},
 							}
 
-							b, err := proto.Marshal(&msg)
-							if err != nil {
-								panic(err)
+							b, marshalErr := proto.Marshal(&msg)
+							if marshalErr != nil {
+								panic(marshalErr)
 							}
 							return b
 						}()

--- a/node/pkg/txverifier/evm.go
+++ b/node/pkg/txverifier/evm.go
@@ -778,16 +778,16 @@ func (tv *TransferVerifier[evmClient, connector]) validateReceipt(
 			tv.logger.Debug("skip: irrelevant LogMessagePublished event")
 			continue
 		}
-		msgID, err := tv.MsgID(message)
+		messageID, err := tv.MsgID(message)
 		if err != nil {
 			return nil, err
 		}
 
 		// Record that tokens were requested out of the bridge for this message.
-		if _, exists := receiptSummary.out[msgID]; !exists {
-			receiptSummary.out[msgID] = transferOut{key, message.TransferAmount()}
+		if _, exists := receiptSummary.out[messageID]; !exists {
+			receiptSummary.out[messageID] = transferOut{key, message.TransferAmount()}
 			// Ensure that each message ID is populated in the map.
-			receiptSummary.msgPubResult[msgID] = true
+			receiptSummary.msgPubResult[messageID] = true
 		} else {
 			return nil, errors.New("duplicate message ID in receipt's LogMessagePublished events")
 		}
@@ -834,7 +834,7 @@ func (tv *TransferVerifier[evmClient, connector]) validateReceipt(
 	// To avoid processing these messages individually in the future, we mark them as invalid here.
 	if len(insolventAssets) > 0 {
 		for _, msgPub := range *receipt.MessagePublications {
-			msgID, err := tv.MsgID(msgPub)
+			messageID, err := tv.MsgID(msgPub)
 
 			// Parsing error.
 			if err != nil {
@@ -847,8 +847,8 @@ func (tv *TransferVerifier[evmClient, connector]) validateReceipt(
 			tv.logger.Debug("insolvent assets", zap.String("assets", strings.Join(insolventAssets, ",")))
 			tv.logger.Debug("tokenID", zap.String("tokenID", tokenID))
 			if slices.Contains(insolventAssets, tokenID) {
-				tv.logger.Info("marking message as invalid because it contains an insolvent asset", zap.String("msgID", msgID.String()), zap.String("tokenID", tokenID))
-				receiptSummary.msgPubResult[msgID] = false
+				tv.logger.Info("marking message as invalid because it contains an insolvent asset", zap.String("msgID", messageID.String()), zap.String("tokenID", tokenID))
+				receiptSummary.msgPubResult[messageID] = false
 			}
 		}
 	}

--- a/node/pkg/watchers/evm/ccq.go
+++ b/node/pkg/watchers/evm/ccq.go
@@ -143,12 +143,12 @@ func (w *Watcher) ccqHandleEthCallQueryRequest(ctx context.Context, queryRequest
 	}
 
 	// Verify that the block read was successful.
-	if err := w.ccqVerifyBlockResult(blockError, blockResult); err != nil {
+	if verifyErr := w.ccqVerifyBlockResult(blockError, blockResult); verifyErr != nil {
 		w.ccqLogger.Debug("failed to verify block for eth_call query",
 			zap.String("requestId", requestId),
 			zap.String("block", block),
 			zap.Any("batch", batch),
-			zap.Error(err),
+			zap.Error(verifyErr),
 		)
 		w.ccqSendQueryResponse(queryRequest, query.QueryRetryNeeded, nil)
 		return
@@ -379,26 +379,26 @@ func (w *Watcher) ccqHandleEthCallByTimestampQueryRequest(ctx context.Context, q
 	}
 
 	// Verify the target block read was successful.
-	if err := w.ccqVerifyBlockResult(blockError, blockResult); err != nil {
+	if verifyErr := w.ccqVerifyBlockResult(blockError, blockResult); verifyErr != nil {
 		w.ccqLogger.Debug("failed to verify target block for eth_call_by_timestamp query",
 			zap.String("requestId", requestId),
 			zap.String("block", block),
 			zap.String("nextBlock", nextBlock),
 			zap.Any("batch", batch),
-			zap.Error(err),
+			zap.Error(verifyErr),
 		)
 		w.ccqSendQueryResponse(queryRequest, query.QueryRetryNeeded, nil)
 		return
 	}
 
 	// Verify the following block read was successful.
-	if err := w.ccqVerifyBlockResult(nextBlockError, nextBlockResult); err != nil {
+	if verifyErr := w.ccqVerifyBlockResult(nextBlockError, nextBlockResult); verifyErr != nil {
 		w.ccqLogger.Debug("failed to verify next block for eth_call_by_timestamp query",
 			zap.String("requestId", requestId),
 			zap.String("block", block),
 			zap.String("nextBlock", nextBlock),
 			zap.Any("batch", batch),
-			zap.Error(err),
+			zap.Error(verifyErr),
 		)
 		w.ccqSendQueryResponse(queryRequest, query.QueryRetryNeeded, nil)
 		return
@@ -565,12 +565,12 @@ func (w *Watcher) ccqHandleEthCallWithFinalityQueryRequest(ctx context.Context, 
 	}
 
 	// Verify that the block read was successful.
-	if err := w.ccqVerifyBlockResult(blockError, blockResult); err != nil {
+	if verifyErr := w.ccqVerifyBlockResult(blockError, blockResult); verifyErr != nil {
 		w.ccqLogger.Debug("failed to verify block for eth_call_with_finality query",
 			zap.String("requestId", requestId),
 			zap.String("block", block),
 			zap.Any("batch", batch),
-			zap.Error(err),
+			zap.Error(verifyErr),
 		)
 		w.ccqSendQueryResponse(queryRequest, query.QueryRetryNeeded, nil)
 		return

--- a/node/pkg/watchers/evm/ccq_test.go
+++ b/node/pkg/watchers/evm/ccq_test.go
@@ -47,8 +47,8 @@ func TestCcqCreateBlockRequest(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, tc.blockMethod, blockMethod)
 
-				bytes, err := json.Marshal(callBlockArg)
-				require.NoError(t, err)
+				bytes, marshalErr := json.Marshal(callBlockArg)
+				require.NoError(t, marshalErr)
 				assert.Equal(t, tc.callBlockArgAsJSON, string(bytes))
 			} else {
 				assert.EqualError(t, err, tc.errMsg)

--- a/node/pkg/watchers/evm/connectors/batch_poller_test.go
+++ b/node/pkg/watchers/evm/connectors/batch_poller_test.go
@@ -107,12 +107,12 @@ func (e *mockConnectorForBatchPoller) RawCallContext(ctx context.Context, result
 func (e *mockConnectorForBatchPoller) RawBatchCallContext(ctx context.Context, b []ethRpc.BatchElem) (err error) {
 	e.mutex.Lock()
 	if e.err != nil {
-		err := e.err
+		retErr := e.err
 		if !e.persistentError {
 			e.err = nil
 		}
 		e.mutex.Unlock()
-		return err
+		return retErr
 	}
 
 	for i, entry := range b {

--- a/node/pkg/watchers/evm/watcher.go
+++ b/node/pkg/watchers/evm/watcher.go
@@ -284,8 +284,8 @@ func (w *Watcher) Run(parentCtx context.Context) error {
 	})
 
 	// Verify that we are connecting to the correct chain.
-	if err := w.verifyEvmChainID(ctx, logger, w.url); err != nil {
-		return fmt.Errorf("failed to verify evm chain id: %w", err)
+	if verifyErr := w.verifyEvmChainID(ctx, logger, w.url); verifyErr != nil {
+		return fmt.Errorf("failed to verify evm chain id: %w", verifyErr)
 	}
 
 	// Connect to the node using the appropriate type of connector.
@@ -368,8 +368,8 @@ func (w *Watcher) Run(parentCtx context.Context) error {
 	defer messageSub.Unsubscribe()
 
 	// Fetch initial guardian set
-	if err := w.fetchAndUpdateGuardianSet(ctx, w.ethConn); err != nil {
-		return fmt.Errorf("failed to request guardian set: %v", err)
+	if fetchErr := w.fetchAndUpdateGuardianSet(ctx, w.ethConn); fetchErr != nil {
+		return fmt.Errorf("failed to request guardian set: %v", fetchErr)
 	}
 
 	// Poll for guardian set.
@@ -381,8 +381,8 @@ func (w *Watcher) Run(parentCtx context.Context) error {
 			case <-ctx.Done():
 				return nil
 			case <-t.C:
-				if err := w.fetchAndUpdateGuardianSet(ctx, w.ethConn); err != nil {
-					errC <- fmt.Errorf("failed to request guardian set: %v", err) //nolint:channelcheck // The watcher will exit anyway
+				if pollErr := w.fetchAndUpdateGuardianSet(ctx, w.ethConn); pollErr != nil {
+					errC <- fmt.Errorf("failed to request guardian set: %v", pollErr) //nolint:channelcheck // The watcher will exit anyway
 					return nil
 				}
 			}
@@ -391,8 +391,8 @@ func (w *Watcher) Run(parentCtx context.Context) error {
 
 	// Fetch initial delegated guardian config if configured.
 	if w.dgContractAddr != nil && w.dgConfigC != nil {
-		if err := w.fetchAndUpdateDelegatedGuardianConfig(ctx); err != nil {
-			logger.Warn("failed to fetch initial delegated guardian config", zap.Error(err))
+		if fetchErr := w.fetchAndUpdateDelegatedGuardianConfig(ctx); fetchErr != nil {
+			logger.Warn("failed to fetch initial delegated guardian config", zap.Error(fetchErr))
 		}
 	}
 
@@ -407,8 +407,8 @@ func (w *Watcher) Run(parentCtx context.Context) error {
 				case <-ctx.Done():
 					return nil
 				case <-t.C:
-					if err := w.fetchAndUpdateDelegatedGuardianConfig(ctx); err != nil {
-						errC <- fmt.Errorf("failed to request delegated guardian config: %v", err) //nolint:channelcheck // The watcher will exit anyway
+					if pollErr := w.fetchAndUpdateDelegatedGuardianConfig(ctx); pollErr != nil {
+						errC <- fmt.Errorf("failed to request delegated guardian config: %v", pollErr) //nolint:channelcheck // The watcher will exit anyway
 						return nil
 					}
 				}
@@ -429,7 +429,7 @@ func (w *Watcher) Run(parentCtx context.Context) error {
 					)
 					continue
 				}
-				numObservations, err := w.handleReobservationRequest(
+				numObservations, handleErr := w.handleReobservationRequest(
 					ctx,
 					vaa.ChainID(r.ChainId),
 					r.TxHash,
@@ -437,11 +437,11 @@ func (w *Watcher) Run(parentCtx context.Context) error {
 					atomic.LoadUint64(&w.latestFinalizedBlockNumber),
 					atomic.LoadUint64(&w.latestSafeBlockNumber),
 				)
-				if err != nil {
+				if handleErr != nil {
 					logger.Error("failed to process observation request",
 						zap.Uint32("chainID", r.ChainId),
 						zap.String("txID", hex.EncodeToString(r.TxHash)),
-						zap.Error(err),
+						zap.Error(handleErr),
 					)
 				}
 
@@ -458,8 +458,8 @@ func (w *Watcher) Run(parentCtx context.Context) error {
 		w.ccqStart(ctx, errC)
 	}
 
-	if err := w.cclEnable(ctx); err != nil {
-		return fmt.Errorf("failed to enable custom consistency level: %w", err)
+	if cclErr := w.cclEnable(ctx); cclErr != nil {
+		return fmt.Errorf("failed to enable custom consistency level: %w", cclErr)
 	}
 
 	common.RunWithScissors(ctx, errC, "evm_fetch_messages", func(ctx context.Context) error {
@@ -467,21 +467,21 @@ func (w *Watcher) Run(parentCtx context.Context) error {
 			select {
 			case <-ctx.Done():
 				return nil
-			case err := <-messageSub.Err():
+			case subErr := <-messageSub.Err():
 				ethConnectionErrors.WithLabelValues(w.networkName, "subscription_error").Inc()
-				errC <- fmt.Errorf("error while processing message publication subscription: %w", err) //nolint:channelcheck // The watcher will exit anyway
+				errC <- fmt.Errorf("error while processing message publication subscription: %w", subErr) //nolint:channelcheck // The watcher will exit anyway
 				p2p.DefaultRegistry.AddErrorCount(w.chainID, 1)
 				return nil
 			case ev := <-messageC:
-				blockTime, err := w.getBlockTime(ctx, ev.Raw.BlockHash)
-				if err != nil {
+				blockTime, blockErr := w.getBlockTime(ctx, ev.Raw.BlockHash)
+				if blockErr != nil {
 					ethConnectionErrors.WithLabelValues(w.networkName, "block_by_number_error").Inc()
-					if canRetryGetBlockTime(err) {
+					if canRetryGetBlockTime(blockErr) {
 						go w.waitForBlockTime(ctx, errC, ev)
 						continue
 					}
 					p2p.DefaultRegistry.AddErrorCount(w.chainID, 1)
-					errC <- fmt.Errorf("failed to request timestamp for block %d, hash %s: %w", ev.Raw.BlockNumber, ev.Raw.BlockHash.String(), err) //nolint:channelcheck // The watcher will exit anyway
+					errC <- fmt.Errorf("failed to request timestamp for block %d, hash %s: %w", ev.Raw.BlockNumber, ev.Raw.BlockHash.String(), blockErr) //nolint:channelcheck // The watcher will exit anyway
 					return nil
 				}
 

--- a/node/pkg/watchers/near/nearapi/mock/mock_server.go
+++ b/node/pkg/watchers/near/nearapi/mock/mock_server.go
@@ -150,22 +150,22 @@ func (s *ForwardingCachingServer) ServeHTTP(w http.ResponseWriter, req *http.Req
 		// upstream host is defined so we query upstream and save the response
 		cache_status = "cache_miss"
 
-		proxyReq, err := s.ProxyReq(s.logger, req)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
+		proxyReq, proxyErr := s.ProxyReq(s.logger, req)
+		if proxyErr != nil {
+			http.Error(w, proxyErr.Error(), http.StatusBadRequest)
 			return
 		}
 
 		httpClient := http.Client{}
-		resp, err := httpClient.Do(proxyReq)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadGateway)
+		resp, reqErr := httpClient.Do(proxyReq)
+		if reqErr != nil {
+			http.Error(w, reqErr.Error(), http.StatusBadGateway)
 			return
 		}
 		defer resp.Body.Close()
-		respBody, err := common.SafeRead(resp.Body)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadGateway)
+		respBody, readErr := common.SafeRead(resp.Body)
+		if readErr != nil {
+			http.Error(w, readErr.Error(), http.StatusBadGateway)
 			return
 		}
 

--- a/node/pkg/watchers/near/watcher.go
+++ b/node/pkg/watchers/near/watcher.go
@@ -234,8 +234,8 @@ func (e *Watcher) runTxProcessor(ctx context.Context) error {
 			return ctx.Err()
 
 		case job := <-e.transactionProcessingQueue:
-			err := e.processTx(logger, ctx, job)
-			if err != nil {
+			processErr := e.processTx(logger, ctx, job)
+			if processErr != nil {
 				// transaction processing unsuccessful. Retry if retry_counter not exceeded.
 				if job.retryCounter < txProcRetry {
 					// Log and retry with exponential backoff
@@ -243,14 +243,14 @@ func (e *Watcher) runTxProcessor(ctx context.Context) error {
 						"near.processTx",
 						zap.String("log_msg_type", "tx_processing_retry"),
 						zap.String("tx_hash", job.txHash),
-						zap.String("error", err.Error()),
+						zap.String("error", processErr.Error()),
 					)
 					job.retryCounter++
 					job.delay *= 2
-					err := e.schedule(ctx, job, job.delay)
-					if err != nil {
+					schedErr := e.schedule(ctx, job, job.delay)
+					if schedErr != nil {
 						// Debug-level logging here because it could be very noisy (one log entry for *any* transaction on the NEAR blockchain)
-						logger.Debug("error scheduling transaction processing job", zap.Error(err))
+						logger.Debug("error scheduling transaction processing job", zap.Error(schedErr))
 					}
 				} else {
 					// Warn and do not retry
@@ -258,7 +258,7 @@ func (e *Watcher) runTxProcessor(ctx context.Context) error {
 						"near.processTx",
 						zap.String("log_msg_type", "tx_processing_retries_exceeded"),
 						zap.String("tx_hash", job.txHash),
-						zap.String("error", err.Error()),
+						zap.String("error", processErr.Error()),
 					)
 					p2p.DefaultRegistry.AddErrorCount(vaa.ChainIDNear, 1)
 				}

--- a/node/pkg/watchers/solana/client.go
+++ b/node/pkg/watchers/solana/client.go
@@ -482,8 +482,8 @@ func (s *SolanaWatcher) Run(ctx context.Context) error {
 					rangeEnd := slot
 
 					// Requesting each slot
-					for slot := rangeStart; slot <= rangeEnd; slot++ {
-						_slot := slot
+					for slotIdx := rangeStart; slotIdx <= rangeEnd; slotIdx++ {
+						_slot := slotIdx
 						common.RunWithScissors(ctx, s.errC, "SolanaWatcherSlotFetcher", func(ctx context.Context) error {
 							s.retryFetchBlock(ctx, logger, _slot, 0, false)
 							return nil

--- a/node/pkg/watchers/solana/shim.go
+++ b/node/pkg/watchers/solana/shim.go
@@ -289,9 +289,9 @@ func (s *SolanaWatcher) shimProcessRest(
 	for idx := startIdx; idx < len(innerInstructions); idx++ {
 		inst := innerInstructions[idx]
 		if inst.ProgramIDIndex == whProgramIndex {
-			foundIt, err := shimVerifyCoreMessage(inst.Data)
-			if err != nil {
-				return fmt.Errorf("failed to verify inner core instruction for shim instruction %d, %d: %w", outerIdx, idx, err)
+			foundIt, verifyErr := shimVerifyCoreMessage(inst.Data)
+			if verifyErr != nil {
+				return fmt.Errorf("failed to verify inner core instruction for shim instruction %d, %d: %w", outerIdx, idx, verifyErr)
 			}
 			if foundIt {
 				if verifiedCoreEvent {
@@ -306,9 +306,9 @@ func (s *SolanaWatcher) shimProcessRest(
 			// The shim contract makes a self cross program invocation (self CPI) in the context of `post_message`.
 			// The function discriminator is effectively the event type. It's a contract call that can only be made by the
 			// shim contract because of the PDA signer that is required.
-			thisEvent, err := shimParseMessageEvent(s.shimMessageEventDiscriminator, inst.Data)
-			if err != nil {
-				return fmt.Errorf("failed to parse inner shim message event instruction for shim instruction %d, %d: %w", outerIdx, idx, err)
+			thisEvent, parseErr := shimParseMessageEvent(s.shimMessageEventDiscriminator, inst.Data)
+			if parseErr != nil {
+				return fmt.Errorf("failed to parse inner shim message event instruction for shim instruction %d, %d: %w", outerIdx, idx, parseErr)
 			}
 
 			if thisEvent != nil {

--- a/node/pkg/wormconn/send_tx.go
+++ b/node/pkg/wormconn/send_tx.go
@@ -27,13 +27,13 @@ func (c *ClientConn) SignAndBroadcastTx(ctx context.Context, msg sdktypes.Msg) (
 	}
 
 	var account auth.AccountI
-	if err := c.encCfg.InterfaceRegistry.UnpackAny(resp.Account, &account); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal account info: %w", err)
+	if unpackErr := c.encCfg.InterfaceRegistry.UnpackAny(resp.Account, &account); unpackErr != nil {
+		return nil, fmt.Errorf("failed to unmarshal account info: %w", unpackErr)
 	}
 
 	builder := c.encCfg.TxConfig.NewTxBuilder()
-	if err := builder.SetMsgs(msg); err != nil {
-		return nil, fmt.Errorf("failed to add message to builder: %w", err)
+	if setErr := builder.SetMsgs(msg); setErr != nil {
+		return nil, fmt.Errorf("failed to add message to builder: %w", setErr)
 	}
 	builder.SetGasLimit(2000000) // TODO: Maybe simulate and use the result
 
@@ -48,8 +48,8 @@ func (c *ClientConn) SignAndBroadcastTx(ctx context.Context, msg sdktypes.Msg) (
 		},
 		Sequence: sequence,
 	}
-	if err := builder.SetSignatures(sig); err != nil {
-		return nil, fmt.Errorf("failed to set SignerInfo: %w", err)
+	if sigErr := builder.SetSignatures(sig); sigErr != nil {
+		return nil, fmt.Errorf("failed to set SignerInfo: %w", sigErr)
 	}
 
 	signerData := authsigning.SignerData{
@@ -69,8 +69,8 @@ func (c *ClientConn) SignAndBroadcastTx(ctx context.Context, msg sdktypes.Msg) (
 	if err != nil {
 		return nil, fmt.Errorf("failed to sign tx: %w", err)
 	}
-	if err := builder.SetSignatures(sig); err != nil {
-		return nil, fmt.Errorf("failed to update tx signature: %w", err)
+	if sigErr := builder.SetSignatures(sig); sigErr != nil {
+		return nil, fmt.Errorf("failed to update tx signature: %w", sigErr)
 	}
 
 	txBytes, err := c.encCfg.TxConfig.TxEncoder()(builder.GetTx())

--- a/sdk/vaa/payloads_test.go
+++ b/sdk/vaa/payloads_test.go
@@ -424,35 +424,35 @@ func TestBodySlashingParamsUpdateDeserializeFailureTooLong(t *testing.T) {
 
 func TestBodyCoreRecoverChainIdSerialize(t *testing.T) {
 	expected := "00000000000000000000000000000000000000000000000000000000436f72650500000000000000000000000000000000000000000000000000000000000000010fa0"
-	BodyRecoverChainId := BodyRecoverChainId{
+	bodyRecoverChainID := BodyRecoverChainId{
 		Module:     "Core",
 		EvmChainID: uint256.NewInt(1),
 		NewChainID: 4000,
 	}
-	buf, err := BodyRecoverChainId.Serialize()
+	buf, err := bodyRecoverChainID.Serialize()
 	require.NoError(t, err)
 	assert.Equal(t, expected, hex.EncodeToString(buf))
 }
 
 func TestBodyTokenBridgeRecoverChainIdSerialize(t *testing.T) {
 	expected := "000000000000000000000000000000000000000000546f6b656e4272696467650300000000000000000000000000000000000000000000000000000000000000010fa0"
-	BodyRecoverChainId := BodyRecoverChainId{
+	bodyRecoverChainID := BodyRecoverChainId{
 		Module:     "TokenBridge",
 		EvmChainID: uint256.NewInt(1),
 		NewChainID: 4000,
 	}
-	buf, err := BodyRecoverChainId.Serialize()
+	buf, err := bodyRecoverChainID.Serialize()
 	require.NoError(t, err)
 	assert.Equal(t, expected, hex.EncodeToString(buf))
 }
 
 func TestBodyRecoverChainIdModuleTooLong(t *testing.T) {
-	BodyRecoverChainId := BodyRecoverChainId{
+	bodyRecoverChainID := BodyRecoverChainId{
 		Module:     "ModuleNameIsMoreThanThirtyTwoCharacters",
 		EvmChainID: uint256.NewInt(1),
 		NewChainID: 4000,
 	}
-	buf, err := BodyRecoverChainId.Serialize()
+	buf, err := bodyRecoverChainID.Serialize()
 	require.ErrorContains(t, err, "failed to left pad module: payload longer than 32 bytes")
 	assert.Nil(t, buf)
 }

--- a/sdk/vaa/structs_test.go
+++ b/sdk/vaa/structs_test.go
@@ -290,7 +290,7 @@ func TestVerifySignatures(t *testing.T) {
 	addrs = append(addrs, crypto.PubkeyToAddress(privKey2.PublicKey))
 	addrs = append(addrs, crypto.PubkeyToAddress(privKey3.PublicKey))
 
-	type test struct {
+	type testCase struct {
 		label      string
 		keyOrder   []*ecdsa.PrivateKey
 		addrs      []common.Address
@@ -298,7 +298,7 @@ func TestVerifySignatures(t *testing.T) {
 		result     bool
 	}
 
-	tests := []test{
+	tests := []testCase{
 		{
 			label:      "NoSignerZero",
 			keyOrder:   []*ecdsa.PrivateKey{},
@@ -543,8 +543,8 @@ func TestVerifySignaturesFuzz(t *testing.T) {
 					}
 				}
 
-				test := test{label: "A", keyOrder: keyPair, addrs: addrs, indexOrder: indexPair, result: result}
-				tests = append(tests, test)
+				tc := test{label: "A", keyOrder: keyPair, addrs: addrs, indexOrder: indexPair, result: result}
+				tests = append(tests, tc)
 			}
 		}
 	}
@@ -730,14 +730,14 @@ func TestDecodeTransferPayloadHdr(t *testing.T) {
 				assert.NotNil(t, vaa)
 
 				if len(tc.errString) == 0 {
-					expectedEmitterAddr, err := StringToAddress(tc.emitterAddr)
-					assert.NoError(t, err)
+					expectedEmitterAddr, addrErr := StringToAddress(tc.emitterAddr)
+					assert.NoError(t, addrErr)
 
-					expectedOriginAddress, err := StringToAddress(tc.originAddress)
-					assert.NoError(t, err)
+					expectedOriginAddress, originAddrErr := StringToAddress(tc.originAddress)
+					assert.NoError(t, originAddrErr)
 
-					expectedTargetAddress, err := StringToAddress(tc.targetAddress)
-					assert.NoError(t, err)
+					expectedTargetAddress, targetAddrErr := StringToAddress(tc.targetAddress)
+					assert.NoError(t, targetAddrErr)
 
 					expectedAmount := big.NewInt(tc.amount)
 
@@ -745,8 +745,8 @@ func TestDecodeTransferPayloadHdr(t *testing.T) {
 					assert.Equal(t, expectedEmitterAddr, vaa.EmitterAddress)
 					assert.Equal(t, 133, len(vaa.Payload))
 
-					payload, err := DecodeTransferPayloadHdr(vaa.Payload)
-					assert.NoError(t, err)
+					payload, payloadErr := DecodeTransferPayloadHdr(vaa.Payload)
+					assert.NoError(t, payloadErr)
 					assert.Equal(t, tc.payloadType, payload.Type)
 					assert.Equal(t, tc.originChain, payload.OriginChain)
 					assert.Equal(t, expectedOriginAddress, payload.OriginAddress)


### PR DESCRIPTION
Augment our linting set-up with shadow detection. In practice, most of our variable shadowing involves reusing `err` within the same scope. Even though this is pretty common in Go, we've had a few small bugs where the wrong error was logged, or where this pattern ended up returning a nil error.

To address this, shadowing is now blocked generally in the Go code.