### PR TITLE
chore(node): increase delegate observation window

### DIFF
--- a/node/pkg/p2p/p2p.go
+++ b/node/pkg/p2p/p2p.go
@@ -114,7 +114,12 @@ var signedManagerTransactionPrefix = []byte("signed_manager_transaction_0000000|
 // heartbeatMaxTimeDifference specifies the maximum time difference between the local clock and the timestamp in incoming heartbeat messages. Heartbeats that are this old or this much into the future will be dropped. This value should encompass clock skew and network delay.
 var heartbeatMaxTimeDifference = time.Minute * 15
 var observationRequestMaxTimeDifference = time.Minute * 15
-var delegateObservationMaxTimeDifference = time.Minute * 15
+
+// allow for delegate observations to be re-delivered in a longer timeframe (30 days)
+// without another mechanism, such as delegate VAAs or batch delegate observations from multiple guardians,
+// this is necessary to facilitate re-observations that span multiple hours or days due to outages as not all
+// delegates necessarily have historical state to re-observe within the same recent timeframe
+var delegateObservationMaxTimeDifference = time.Hour * 24 * 30
 var managerTransactionMaxTimeDifference = time.Minute * 15
 
 func heartbeatDigest(b []byte) eth_common.Hash {


### PR DESCRIPTION
This PR increases the delegate observation window to facilitate recovery of messages that did not receive a quorum of attestations within the [1 hour cleanup window](https://github.com/wormhole-foundation/wormhole/blob/ddea6805abb06a123604c13f76b7ede9ee76c274/node/pkg/processor/cleanup.go#L82).

An example of this issue is visible from the delegate observations made for this message: https://api.wormholescan.io/api/v1/observations/delegate/59/0000000000000000000000005d4c6f2235d508b1e5a324c078b66cda2f5e7d5d/5955

<img width="517" height="291" alt="image" src="https://github.com/user-attachments/assets/dc5e8085-8023-4967-8373-4d1ffc7f3b38" />
<img width="538" height="292" alt="image" src="https://github.com/user-attachments/assets/4b7b7ee9-8c4d-40d9-b3e9-a0760410589b" />

Only 4 guardians originally observed the message and then only 4 guardians were able to re-observe it within 1 hour of one-another.

Increasing this timeout will allow a quorum of guardians prior signatures to be re-broadcast within the cleanup window.