### PR TITLE
solana: reclaim rent for old accounts

### DIFF
--- a/solana/bridge/program/src/api.rs
+++ b/solana/bridge/program/src/api.rs
@@ -13,3 +13,15 @@ pub use initialize::*;
 pub use post_message::*;
 pub use post_vaa::*;
 pub use verify_signature::*;
+
+/// Retention window (in seconds) for closing `PostedMessage` / `PostedVAA`
+/// accounts. 30 days on mainnet / devnet / Fogo; 1 day on Solana testnet so
+/// we can exercise the reclaim flow end-to-end without waiting a month.
+///
+/// Dispatched at compile time via `crate::solana_env`, so no runtime branch.
+/// The classifier itself is covered by unit tests in `lib.rs`, which is why
+/// we don't need a separate test for this match arm.
+pub(crate) const RETENTION_PERIOD: i64 = match crate::solana_env(env!("BRIDGE_ADDRESS")) {
+    Some(crate::SolanaEnv::Testnet) => 24 * 60 * 60,
+    _ => 30 * 24 * 60 * 60,
+};

--- a/solana/bridge/program/src/api.rs
+++ b/solana/bridge/program/src/api.rs
@@ -1,9 +1,13 @@
+pub mod close_posted_message;
+pub mod close_signature_set_and_posted_vaa;
 pub mod governance;
 pub mod initialize;
 pub mod post_message;
 pub mod post_vaa;
 pub mod verify_signature;
 
+pub use close_posted_message::*;
+pub use close_signature_set_and_posted_vaa::*;
 pub use governance::*;
 pub use initialize::*;
 pub use post_message::*;

--- a/solana/bridge/program/src/api/close_posted_message.rs
+++ b/solana/bridge/program/src/api/close_posted_message.rs
@@ -69,8 +69,8 @@ pub fn close_posted_message(
         return Err(InvalidProgramOwner.into());
     }
 
-    // 2-4. Parse and validate the message, extracting data for the event.
-    let message_data = {
+    // 2-4. Parse and validate the message, capturing full account data for the event.
+    let account_data = {
         let data = accs.message.data.borrow();
         if data.len() < 3 {
             return Err(InvalidAccountPrefix.into());
@@ -89,16 +89,16 @@ pub fn close_posted_message(
             return Err(MessageWithinRetentionWindow.into());
         }
 
-        message_data
+        data.to_vec()
         // data borrow dropped here
     };
 
-    // 5. Emit Anchor CPI event with the full message data.
+    // 5. Emit Anchor CPI event with the full account data (prefix + message).
     emit_message_event(
         ctx,
         &accs.event_authority,
         &accs.self_program,
-        &message_data,
+        &account_data,
     )?;
 
     // 6. Close the account: transfer lamports to fee_collector.
@@ -114,12 +114,12 @@ pub fn close_posted_message(
     Ok(())
 }
 
-/// Emit an Anchor-compliant CPI event containing the full MessageData.
+/// Emit an Anchor-compliant CPI event containing the full account data.
 fn emit_message_event(
     ctx: &ExecutionContext,
     event_authority: &Info,
     self_program: &Info,
-    message_data: &MessageData,
+    account_data: &[u8],
 ) -> Result<()> {
     // Verify self_program is actually our program.
     if self_program.key != ctx.program_id {
@@ -133,14 +133,11 @@ fn emit_message_event(
         return Err(InvalidEventAuthority.into());
     }
 
-    // Build instruction data: selector + discriminator + borsh(message_data).
-    let serialized = message_data
-        .try_to_vec()
-        .map_err(|_| SolitaireError::ProgramError(ProgramError::InvalidAccountData))?;
-    let mut ix_data = Vec::with_capacity(8 + 8 + serialized.len());
+    // Build instruction data: selector + discriminator + raw account data.
+    let mut ix_data = Vec::with_capacity(8 + 8 + account_data.len());
     ix_data.extend_from_slice(&EVENT_IX_TAG_LE);
     ix_data.extend_from_slice(&MESSAGE_ACCOUNT_CLOSED_DISCRIMINATOR);
-    ix_data.extend_from_slice(&serialized);
+    ix_data.extend_from_slice(account_data);
 
     let ix = Instruction {
         program_id: *ctx.program_id,

--- a/solana/bridge/program/src/api/close_posted_message.rs
+++ b/solana/bridge/program/src/api/close_posted_message.rs
@@ -27,8 +27,7 @@ use solitaire::{
     *,
 };
 
-/// 30 days in seconds.
-const RETENTION_PERIOD: i64 = 30 * 24 * 60 * 60;
+use super::RETENTION_PERIOD;
 
 /// Event discriminator: SHA256("event:MessageAccountClosed")[0..8].
 pub const MESSAGE_ACCOUNT_CLOSED_DISCRIMINATOR: [u8; 8] =
@@ -84,7 +83,7 @@ pub fn close_posted_message(
         let message_data = MessageData::try_from_slice(&data[3..])
             .map_err(|_| SolitaireError::ProgramError(ProgramError::InvalidAccountData))?;
 
-        // Check retention: submission_time must be at or before (now - 30 days).
+        // Check retention: submission_time must be at or before (now - RETENTION_PERIOD).
         if (message_data.submission_time as i64) > accs.clock.unix_timestamp - RETENTION_PERIOD {
             return Err(MessageWithinRetentionWindow.into());
         }

--- a/solana/bridge/program/src/api/close_posted_message.rs
+++ b/solana/bridge/program/src/api/close_posted_message.rs
@@ -1,0 +1,154 @@
+use crate::{
+    accounts::{
+        Bridge,
+        FeeCollector,
+    },
+    error::Error::{
+        InvalidAccountPrefix,
+        InvalidEventAuthority,
+        InvalidProgramOwner,
+        MessageWithinRetentionWindow,
+    },
+    MessageData,
+};
+use solana_program::{
+    instruction::{
+        AccountMeta,
+        Instruction,
+    },
+    program::invoke_signed,
+    program_error::ProgramError,
+    pubkey::Pubkey,
+    sysvar::clock::Clock,
+};
+use solitaire::{
+    EVENT_AUTHORITY_SEED,
+    EVENT_IX_TAG_LE,
+    *,
+};
+
+/// 30 days in seconds.
+const RETENTION_PERIOD: i64 = 30 * 24 * 60 * 60;
+
+/// Event discriminator: SHA256("event:MessageAccountClosed")[0..8].
+pub const MESSAGE_ACCOUNT_CLOSED_DISCRIMINATOR: [u8; 8] =
+    [0x9e, 0xf6, 0x1b, 0xc2, 0x24, 0x14, 0x28, 0xb9];
+
+#[derive(FromAccounts)]
+pub struct ClosePostedMessage<'b> {
+    /// Bridge config, used to update last_lamports.
+    pub bridge: Mut<Bridge<'b, { AccountState::Initialized }>>,
+
+    /// The posted message account to close. Must have "msg" or "msu" prefix.
+    /// Uses Info to avoid Persist serializing back into a zeroed account.
+    pub message: Mut<Info<'b>>,
+
+    /// Fee collector PDA to receive the reclaimed lamports.
+    pub fee_collector: Mut<FeeCollector<'b>>,
+
+    /// Clock for timestamp validation.
+    pub clock: Sysvar<'b, Clock>,
+
+    /// Event authority PDA for Anchor CPI event signing.
+    pub event_authority: Info<'b>,
+
+    /// This program (for self-CPI).
+    pub self_program: Info<'b>,
+}
+
+#[derive(Default, BorshSerialize, BorshDeserialize)]
+pub struct ClosePostedMessageData {}
+
+pub fn close_posted_message(
+    ctx: &ExecutionContext,
+    accs: &mut ClosePostedMessage,
+    _data: ClosePostedMessageData,
+) -> Result<()> {
+    // 1. Verify account is owned by this program.
+    if accs.message.owner != ctx.program_id {
+        return Err(InvalidProgramOwner.into());
+    }
+
+    // 2-4. Parse and validate the message, extracting data for the event.
+    let message_data = {
+        let data = accs.message.data.borrow();
+        if data.len() < 3 {
+            return Err(InvalidAccountPrefix.into());
+        }
+
+        let prefix = &data[0..3];
+        if prefix != b"msg" && prefix != b"msu" {
+            return Err(InvalidAccountPrefix.into());
+        }
+
+        let message_data = MessageData::try_from_slice(&data[3..])
+            .map_err(|_| SolitaireError::ProgramError(ProgramError::InvalidAccountData))?;
+
+        // Check retention: submission_time must be at or before (now - 30 days).
+        if (message_data.submission_time as i64) > accs.clock.unix_timestamp - RETENTION_PERIOD {
+            return Err(MessageWithinRetentionWindow.into());
+        }
+
+        message_data
+        // data borrow dropped here
+    };
+
+    // 5. Emit Anchor CPI event with the full message data.
+    emit_message_event(
+        ctx,
+        &accs.event_authority,
+        &accs.self_program,
+        &message_data,
+    )?;
+
+    // 6. Close the account: transfer lamports to fee_collector.
+    let message_lamports = accs.message.lamports();
+    **accs.fee_collector.lamports.borrow_mut() += message_lamports;
+    **accs.message.lamports.borrow_mut() = 0;
+    accs.message.data.borrow_mut().fill(0);
+    accs.message.assign(&solana_program::system_program::id());
+
+    // 7. Update bridge.last_lamports to prevent fee waiver.
+    accs.bridge.last_lamports = accs.fee_collector.lamports();
+
+    Ok(())
+}
+
+/// Emit an Anchor-compliant CPI event containing the full MessageData.
+fn emit_message_event(
+    ctx: &ExecutionContext,
+    event_authority: &Info,
+    self_program: &Info,
+    message_data: &MessageData,
+) -> Result<()> {
+    // Verify self_program is actually our program.
+    if self_program.key != ctx.program_id {
+        return Err(InvalidEventAuthority.into());
+    }
+
+    // Compute event authority PDA and verify.
+    let (expected_authority, bump) =
+        Pubkey::find_program_address(&[EVENT_AUTHORITY_SEED], ctx.program_id);
+    if event_authority.key != &expected_authority {
+        return Err(InvalidEventAuthority.into());
+    }
+
+    // Build instruction data: selector + discriminator + borsh(message_data).
+    let serialized = message_data
+        .try_to_vec()
+        .map_err(|_| SolitaireError::ProgramError(ProgramError::InvalidAccountData))?;
+    let mut ix_data = Vec::with_capacity(8 + 8 + serialized.len());
+    ix_data.extend_from_slice(&EVENT_IX_TAG_LE);
+    ix_data.extend_from_slice(&MESSAGE_ACCOUNT_CLOSED_DISCRIMINATOR);
+    ix_data.extend_from_slice(&serialized);
+
+    let ix = Instruction {
+        program_id: *ctx.program_id,
+        accounts: vec![AccountMeta::new_readonly(expected_authority, true)],
+        data: ix_data,
+    };
+
+    invoke_signed(&ix, ctx.accounts, &[&[EVENT_AUTHORITY_SEED, &[bump]]])?;
+
+    Ok(())
+}

--- a/solana/bridge/program/src/api/close_posted_message.rs
+++ b/solana/bridge/program/src/api/close_posted_message.rs
@@ -6,6 +6,7 @@ use crate::{
     error::Error::{
         InvalidAccountPrefix,
         InvalidProgramOwner,
+        MathOverflow,
         MessageWithinRetentionWindow,
     },
     MessageData,
@@ -96,7 +97,11 @@ pub fn close_posted_message(
 
     // 7. Close the account: transfer lamports to fee_collector.
     let message_lamports = accs.message.lamports();
-    **accs.fee_collector.lamports.borrow_mut() += message_lamports;
+    **accs.fee_collector.lamports.borrow_mut() = accs
+        .fee_collector
+        .lamports()
+        .checked_add(message_lamports)
+        .ok_or(MathOverflow)?;
     **accs.message.lamports.borrow_mut() = 0;
     accs.message.data.borrow_mut().fill(0);
     accs.message.assign(&solana_program::system_program::id());

--- a/solana/bridge/program/src/api/close_posted_message.rs
+++ b/solana/bridge/program/src/api/close_posted_message.rs
@@ -10,6 +10,7 @@ use crate::{
         MessageWithinRetentionWindow,
     },
     MessageData,
+    OUR_CHAIN_ID,
 };
 use solana_program::{
     program_error::ProgramError,
@@ -72,6 +73,26 @@ pub fn close_posted_message(
 
         let message_data = MessageData::try_from_slice(&data[3..])
             .map_err(|_| SolitaireError::ProgramError(ProgramError::InvalidAccountData))?;
+
+        // Defense-in-depth shape checks. All three are invariants that
+        // post_message has always upheld, so a posted_message that fails any
+        // of them is either corrupt or impersonating a different account
+        // type. We refuse to close it (and reclaim rent into a different
+        // account) under those conditions.
+        //
+        // - submission_time is set to clock.unix_timestamp at post time and
+        //   would only be 0 for a synthetic / cosplay account.
+        // - vaa_time is *only* written by post_vaa, which targets a separate
+        //   "vaa"-prefixed account; a "msg"/"msu" account always has 0 here.
+        // - emitter_chain is set to OUR_CHAIN_ID at post time.
+        if message_data.submission_time == 0
+            || message_data.vaa_time != 0
+            || message_data.emitter_chain != OUR_CHAIN_ID
+        {
+            return Err(SolitaireError::ProgramError(
+                ProgramError::InvalidAccountData,
+            ));
+        }
 
         // Check retention: submission_time must be at or before (now - RETENTION_PERIOD).
         if (message_data.submission_time as i64) > accs.clock.unix_timestamp - RETENTION_PERIOD {

--- a/solana/bridge/program/src/api/close_posted_message.rs
+++ b/solana/bridge/program/src/api/close_posted_message.rs
@@ -5,27 +5,16 @@ use crate::{
     },
     error::Error::{
         InvalidAccountPrefix,
-        InvalidEventAuthority,
         InvalidProgramOwner,
         MessageWithinRetentionWindow,
     },
     MessageData,
 };
 use solana_program::{
-    instruction::{
-        AccountMeta,
-        Instruction,
-    },
-    program::invoke_signed,
     program_error::ProgramError,
-    pubkey::Pubkey,
     sysvar::clock::Clock,
 };
-use solitaire::{
-    EVENT_AUTHORITY_SEED,
-    EVENT_IX_TAG_LE,
-    *,
-};
+use solitaire::*;
 
 use super::RETENTION_PERIOD;
 
@@ -92,59 +81,28 @@ pub fn close_posted_message(
         // data borrow dropped here
     };
 
-    // 5. Emit Anchor CPI event with the full account data (prefix + message).
-    emit_message_event(
+    // 5. Verify self_program (used as the CPI target) really is this program.
+    if accs.self_program.key != ctx.program_id {
+        return Err(InvalidProgramOwner.into());
+    }
+
+    // 6. Emit Anchor CPI event with the full account data (prefix + message).
+    emit_event_cpi(
         ctx,
         &accs.event_authority,
-        &accs.self_program,
+        &MESSAGE_ACCOUNT_CLOSED_DISCRIMINATOR,
         &account_data,
     )?;
 
-    // 6. Close the account: transfer lamports to fee_collector.
+    // 7. Close the account: transfer lamports to fee_collector.
     let message_lamports = accs.message.lamports();
     **accs.fee_collector.lamports.borrow_mut() += message_lamports;
     **accs.message.lamports.borrow_mut() = 0;
     accs.message.data.borrow_mut().fill(0);
     accs.message.assign(&solana_program::system_program::id());
 
-    // 7. Update bridge.last_lamports to prevent fee waiver.
+    // 8. Update bridge.last_lamports to prevent fee waiver.
     accs.bridge.last_lamports = accs.fee_collector.lamports();
-
-    Ok(())
-}
-
-/// Emit an Anchor-compliant CPI event containing the full account data.
-fn emit_message_event(
-    ctx: &ExecutionContext,
-    event_authority: &Info,
-    self_program: &Info,
-    account_data: &[u8],
-) -> Result<()> {
-    // Verify self_program is actually our program.
-    if self_program.key != ctx.program_id {
-        return Err(InvalidEventAuthority.into());
-    }
-
-    // Compute event authority PDA and verify.
-    let (expected_authority, bump) =
-        Pubkey::find_program_address(&[EVENT_AUTHORITY_SEED], ctx.program_id);
-    if event_authority.key != &expected_authority {
-        return Err(InvalidEventAuthority.into());
-    }
-
-    // Build instruction data: selector + discriminator + raw account data.
-    let mut ix_data = Vec::with_capacity(8 + 8 + account_data.len());
-    ix_data.extend_from_slice(&EVENT_IX_TAG_LE);
-    ix_data.extend_from_slice(&MESSAGE_ACCOUNT_CLOSED_DISCRIMINATOR);
-    ix_data.extend_from_slice(account_data);
-
-    let ix = Instruction {
-        program_id: *ctx.program_id,
-        accounts: vec![AccountMeta::new_readonly(expected_authority, true)],
-        data: ix_data,
-    };
-
-    invoke_signed(&ix, ctx.accounts, &[&[EVENT_AUTHORITY_SEED, &[bump]]])?;
 
     Ok(())
 }

--- a/solana/bridge/program/src/api/close_posted_message.rs
+++ b/solana/bridge/program/src/api/close_posted_message.rs
@@ -95,7 +95,10 @@ pub fn close_posted_message(
         &account_data,
     )?;
 
-    // 7. Close the account: transfer lamports to fee_collector.
+    // 7. Close the account: drain lamports, truncate data, hand back to system program.
+    // Using realloc(0, false) (rather than fill(0) on the existing buffer) makes the
+    // account match every other "closed" definition in the bridge: zero data length,
+    // zero lamports, owned by the system program.
     let message_lamports = accs.message.lamports();
     **accs.fee_collector.lamports.borrow_mut() = accs
         .fee_collector
@@ -103,7 +106,7 @@ pub fn close_posted_message(
         .checked_add(message_lamports)
         .ok_or(MathOverflow)?;
     **accs.message.lamports.borrow_mut() = 0;
-    accs.message.data.borrow_mut().fill(0);
+    accs.message.realloc(0, false)?;
     accs.message.assign(&solana_program::system_program::id());
 
     // 8. Update bridge.last_lamports to prevent fee waiver.

--- a/solana/bridge/program/src/api/close_signature_set_and_posted_vaa.rs
+++ b/solana/bridge/program/src/api/close_signature_set_and_posted_vaa.rs
@@ -1,0 +1,165 @@
+use crate::{
+    accounts::{
+        Bridge,
+        FeeCollector,
+        GuardianSet,
+        GuardianSetDerivationData,
+        PostedVAA,
+        PostedVAADerivationData,
+        SignatureSetData,
+    },
+    api::post_vaa::check_active,
+    error::Error::{
+        GuardianSetStillActive,
+        InvalidDerivedAccount,
+        InvalidProgramOwner,
+        MessageWithinRetentionWindow,
+    },
+    MessageData,
+};
+use solana_program::{
+    program_error::ProgramError,
+    pubkey::Pubkey,
+    sysvar::clock::Clock,
+};
+use solitaire::{
+    processors::seeded::Seeded,
+    *,
+};
+
+/// 30 days in seconds.
+const RETENTION_PERIOD: i64 = 30 * 24 * 60 * 60;
+
+/// Default submission_time for accounts created before the submission_time
+/// field was populated. Gives legacy accounts a 30-day grace period from
+/// this date (10 April 2026) instead of being immediately closable.
+const DEFAULT_SUBMISSION_TIME: u32 = 1775833078;
+
+#[derive(FromAccounts)]
+pub struct CloseSignatureSetAndPostedVAA<'b> {
+    /// Bridge config, used to update last_lamports.
+    pub bridge: Mut<Bridge<'b, { AccountState::Initialized }>>,
+
+    /// The signature set account to close.
+    /// Uses Info to avoid Persist serializing back into a zeroed account.
+    pub signature_set: Mut<Info<'b>>,
+
+    /// The PostedVAA account derived from the signature set's hash.
+    /// May or may not be initialized. Uses Info for manual handling.
+    pub posted_vaa: Mut<Info<'b>>,
+
+    /// The guardian set used to verify the signature set.
+    pub guardian_set: GuardianSet<'b, { AccountState::Initialized }>,
+
+    /// Fee collector PDA to receive the reclaimed lamports.
+    pub fee_collector: Mut<FeeCollector<'b>>,
+
+    /// Clock for timestamp validation.
+    pub clock: Sysvar<'b, Clock>,
+}
+
+#[derive(Default, BorshSerialize, BorshDeserialize)]
+pub struct CloseSignatureSetAndPostedVAAData {}
+
+pub fn close_signature_set_and_posted_vaa(
+    ctx: &ExecutionContext,
+    accs: &mut CloseSignatureSetAndPostedVAA,
+    _data: CloseSignatureSetAndPostedVAAData,
+) -> Result<()> {
+    // 1. Verify signature_set is owned by this program.
+    if accs.signature_set.owner != ctx.program_id {
+        return Err(InvalidProgramOwner.into());
+    }
+
+    // 2. Parse SignatureSetData.
+    let sig_data = {
+        let data = accs.signature_set.data.borrow();
+        SignatureSetData::try_from_slice(&data)
+            .map_err(|_| SolitaireError::ProgramError(ProgramError::InvalidAccountData))?
+    };
+
+    // 3. Verify PostedVAA PDA derivation matches the hash from the SignatureSet.
+    let msg_derivation = PostedVAADerivationData {
+        payload_hash: sig_data.hash.to_vec(),
+    };
+    let expected_vaa_seeds =
+        PostedVAA::<'_, { AccountState::MaybeInitialized }>::seeds(&msg_derivation);
+    let expected_vaa_seeds_ref: Vec<&[u8]> =
+        expected_vaa_seeds.iter().map(|s| s.as_slice()).collect();
+    let (expected_vaa_key, _) =
+        Pubkey::find_program_address(&expected_vaa_seeds_ref, ctx.program_id);
+    if accs.posted_vaa.key != &expected_vaa_key {
+        return Err(InvalidDerivedAccount.into());
+    }
+
+    // 4. Determine if PostedVAA is initialised
+    let vaa_initialized = accs.posted_vaa.data_len() > 0 && accs.posted_vaa.owner == ctx.program_id;
+
+    // 5. Branched validation.
+    if vaa_initialized {
+        // 5a. PostedVAA is initialised: check retention window.
+        let vaa_data = {
+            let data = accs.posted_vaa.data.borrow();
+            if data.len() < 3 {
+                return Err(SolitaireError::ProgramError(
+                    ProgramError::InvalidAccountData,
+                ));
+            }
+            // sanity check: the prefix should be "vaa" for a PostedVAA account
+            // (technically redundant because we checked the derivation, but we
+            // follow the principle of not silently dropping bytes even when we
+            // think we know what they are).
+            if &data[0..3] != b"vaa" {
+                return Err(SolitaireError::ProgramError(
+                    ProgramError::InvalidAccountData,
+                ));
+            }
+            MessageData::try_from_slice(&data[3..])
+                .map_err(|_| SolitaireError::ProgramError(ProgramError::InvalidAccountData))?
+        };
+
+        let submission_time = if vaa_data.submission_time == 0 {
+            DEFAULT_SUBMISSION_TIME
+        } else {
+            vaa_data.submission_time
+        };
+
+        if (submission_time as i64) > accs.clock.unix_timestamp - RETENTION_PERIOD {
+            return Err(MessageWithinRetentionWindow.into());
+        }
+
+        // Close PostedVAA: transfer lamports to fee_collector.
+        let vaa_lamports = accs.posted_vaa.lamports();
+        **accs.fee_collector.lamports.borrow_mut() += vaa_lamports;
+        **accs.posted_vaa.lamports.borrow_mut() = 0;
+        accs.posted_vaa.data.borrow_mut().fill(0);
+        accs.posted_vaa
+            .assign(&solana_program::system_program::id());
+    } else {
+        // 5b. PostedVAA is NOT initialised: check guardian set is expired.
+        // Verify the guardian set derivation matches the signature set's index.
+        let gs_derivation = GuardianSetDerivationData {
+            index: sig_data.guardian_set_index,
+        };
+        accs.guardian_set
+            .verify_derivation(ctx.program_id, &gs_derivation)?;
+
+        // The guardian set must NOT be active (i.e. it must be expired).
+        if check_active(&accs.guardian_set, &accs.clock).is_ok() {
+            return Err(GuardianSetStillActive.into());
+        }
+    }
+
+    // 6. Close signature_set: transfer lamports to fee_collector.
+    let sig_lamports = accs.signature_set.lamports();
+    **accs.fee_collector.lamports.borrow_mut() += sig_lamports;
+    **accs.signature_set.lamports.borrow_mut() = 0;
+    accs.signature_set.data.borrow_mut().fill(0);
+    accs.signature_set
+        .assign(&solana_program::system_program::id());
+
+    // 7. Update bridge.last_lamports to prevent fee waiver.
+    accs.bridge.last_lamports = accs.fee_collector.lamports();
+
+    Ok(())
+}

--- a/solana/bridge/program/src/api/close_signature_set_and_posted_vaa.rs
+++ b/solana/bridge/program/src/api/close_signature_set_and_posted_vaa.rs
@@ -27,8 +27,7 @@ use solitaire::{
     *,
 };
 
-/// 30 days in seconds.
-const RETENTION_PERIOD: i64 = 30 * 24 * 60 * 60;
+use super::RETENTION_PERIOD;
 
 /// Default submission_time for accounts created before the submission_time
 /// field was populated. Gives legacy accounts a 30-day grace period from

--- a/solana/bridge/program/src/api/close_signature_set_and_posted_vaa.rs
+++ b/solana/bridge/program/src/api/close_signature_set_and_posted_vaa.rs
@@ -13,6 +13,7 @@ use crate::{
         GuardianSetStillActive,
         InvalidDerivedAccount,
         InvalidProgramOwner,
+        MathOverflow,
         MessageWithinRetentionWindow,
     },
     MessageData,
@@ -129,7 +130,11 @@ pub fn close_signature_set_and_posted_vaa(
 
         // Close PostedVAA: transfer lamports to fee_collector.
         let vaa_lamports = accs.posted_vaa.lamports();
-        **accs.fee_collector.lamports.borrow_mut() += vaa_lamports;
+        **accs.fee_collector.lamports.borrow_mut() = accs
+            .fee_collector
+            .lamports()
+            .checked_add(vaa_lamports)
+            .ok_or(MathOverflow)?;
         **accs.posted_vaa.lamports.borrow_mut() = 0;
         accs.posted_vaa.data.borrow_mut().fill(0);
         accs.posted_vaa
@@ -151,7 +156,11 @@ pub fn close_signature_set_and_posted_vaa(
 
     // 6. Close signature_set: transfer lamports to fee_collector.
     let sig_lamports = accs.signature_set.lamports();
-    **accs.fee_collector.lamports.borrow_mut() += sig_lamports;
+    **accs.fee_collector.lamports.borrow_mut() = accs
+        .fee_collector
+        .lamports()
+        .checked_add(sig_lamports)
+        .ok_or(MathOverflow)?;
     **accs.signature_set.lamports.borrow_mut() = 0;
     accs.signature_set.data.borrow_mut().fill(0);
     accs.signature_set

--- a/solana/bridge/program/src/api/close_signature_set_and_posted_vaa.rs
+++ b/solana/bridge/program/src/api/close_signature_set_and_posted_vaa.rs
@@ -41,6 +41,18 @@ pub struct CloseSignatureSetAndPostedVAA<'b> {
     pub bridge: Mut<Bridge<'b, { AccountState::Initialized }>>,
 
     /// The signature set account to close.
+    ///
+    /// Constraints (verified in the handler — SignatureSet has no magic
+    /// prefix, so each one matters):
+    ///   1. Owned by the core bridge program.
+    ///   2. Bytes parse exactly into a `SignatureSetData` (try_from_slice
+    ///      enforces both "no leftover bytes" and "no missing bytes"; this
+    ///      is the primary defense against arbitrary-account-close attacks
+    ///      since there is no discriminator).
+    ///   3. Its `hash` derives the `posted_vaa` account passed below.
+    ///   4. If `posted_vaa` is uninitialized: the `guardian_set` whose
+    ///      index matches `sig_data.guardian_set_index` must be expired.
+    ///
     /// Uses Info to avoid Persist serializing back into a zeroed account.
     pub signature_set: Mut<Info<'b>>,
 
@@ -121,6 +133,25 @@ pub fn close_signature_set_and_posted_vaa(
             MessageData::try_from_slice(&data[3..])
                 .map_err(|_| SolitaireError::ProgramError(ProgramError::InvalidAccountData))?
         };
+
+        // Defense-in-depth shape checks for the PostedVAA. post_vaa fills all
+        // three of these out of the verified VAA, so a posted_vaa that fails
+        // any of them is either corrupt or a different account masquerading
+        // under a "vaa" prefix — refuse to close it.
+        //
+        //   - vaa_version: legitimate VAAs are version 1 or higher.
+        //   - vaa_time: legitimate VAAs always carry a non-zero timestamp.
+        //   - vaa_signature_account: pins the close to the *specific*
+        //     signature_set that verified this VAA, blocking pairings with
+        //     unrelated signature sets that happen to share a payload hash.
+        if vaa_data.vaa_version == 0
+            || vaa_data.vaa_time == 0
+            || &vaa_data.vaa_signature_account != accs.signature_set.key
+        {
+            return Err(SolitaireError::ProgramError(
+                ProgramError::InvalidAccountData,
+            ));
+        }
 
         let submission_time = if vaa_data.submission_time == 0 {
             DEFAULT_SUBMISSION_TIME

--- a/solana/bridge/program/src/api/close_signature_set_and_posted_vaa.rs
+++ b/solana/bridge/program/src/api/close_signature_set_and_posted_vaa.rs
@@ -92,8 +92,12 @@ pub fn close_signature_set_and_posted_vaa(
         return Err(InvalidDerivedAccount.into());
     }
 
-    // 4. Determine if PostedVAA is initialised
-    let vaa_initialized = accs.posted_vaa.data_len() > 0 && accs.posted_vaa.owner == ctx.program_id;
+    // 4. Determine if PostedVAA is initialised. We use the same conjunction
+    // (lamports + data + owner) the bridge uses elsewhere for "live" accounts;
+    // after a close (below) all three become zero/system-owned at once.
+    let vaa_initialized = accs.posted_vaa.lamports() > 0
+        && accs.posted_vaa.data_len() > 0
+        && accs.posted_vaa.owner == ctx.program_id;
 
     // 5. Branched validation.
     if vaa_initialized {
@@ -128,7 +132,7 @@ pub fn close_signature_set_and_posted_vaa(
             return Err(MessageWithinRetentionWindow.into());
         }
 
-        // Close PostedVAA: transfer lamports to fee_collector.
+        // Close PostedVAA: drain lamports, truncate data, hand back to system program.
         let vaa_lamports = accs.posted_vaa.lamports();
         **accs.fee_collector.lamports.borrow_mut() = accs
             .fee_collector
@@ -136,7 +140,7 @@ pub fn close_signature_set_and_posted_vaa(
             .checked_add(vaa_lamports)
             .ok_or(MathOverflow)?;
         **accs.posted_vaa.lamports.borrow_mut() = 0;
-        accs.posted_vaa.data.borrow_mut().fill(0);
+        accs.posted_vaa.realloc(0, false)?;
         accs.posted_vaa
             .assign(&solana_program::system_program::id());
     } else {
@@ -154,7 +158,7 @@ pub fn close_signature_set_and_posted_vaa(
         }
     }
 
-    // 6. Close signature_set: transfer lamports to fee_collector.
+    // 6. Close signature_set: drain lamports, truncate data, hand back to system program.
     let sig_lamports = accs.signature_set.lamports();
     **accs.fee_collector.lamports.borrow_mut() = accs
         .fee_collector
@@ -162,7 +166,7 @@ pub fn close_signature_set_and_posted_vaa(
         .checked_add(sig_lamports)
         .ok_or(MathOverflow)?;
     **accs.signature_set.lamports.borrow_mut() = 0;
-    accs.signature_set.data.borrow_mut().fill(0);
+    accs.signature_set.realloc(0, false)?;
     accs.signature_set
         .assign(&solana_program::system_program::id());
 

--- a/solana/bridge/program/src/api/post_vaa.rs
+++ b/solana/bridge/program/src/api/post_vaa.rs
@@ -156,7 +156,7 @@ pub fn post_vaa(ctx: &ExecutionContext, accs: &mut PostVAA, vaa: PostVAAData) ->
 
 /// A guardian set must not have expired.
 #[inline(always)]
-fn check_active<'r>(
+pub(crate) fn check_active<'r>(
     guardian_set: &GuardianSet<'r, { AccountState::Initialized }>,
     clock: &Sysvar<'r, Clock>,
 ) -> Result<()> {

--- a/solana/bridge/program/src/api/post_vaa.rs
+++ b/solana/bridge/program/src/api/post_vaa.rs
@@ -147,6 +147,7 @@ pub fn post_vaa(ctx: &ExecutionContext, accs: &mut PostVAA, vaa: PostVAAData) ->
     accs.message.vaa_version = vaa.version;
     accs.message.vaa_time = vaa.timestamp;
     accs.message.vaa_signature_account = *accs.signature_set.info().key;
+    accs.message.submission_time = accs.clock.unix_timestamp as u32;
     accs.message
         .create(&msg_derivation, ctx, accs.payer.key, Exempt)?;
 

--- a/solana/bridge/program/src/error.rs
+++ b/solana/bridge/program/src/error.rs
@@ -26,6 +26,12 @@ pub enum Error {
     VAAInvalid,
     InvalidPayloadLength,
     EmitterChanged,
+    InvalidAccountPrefix,
+    MessageWithinRetentionWindow,
+    InvalidDerivedAccount,
+    GuardianSetStillActive,
+    InvalidProgramOwner,
+    InvalidEventAuthority,
 }
 
 /// Errors thrown by the program will bubble up to the solitaire wrapper, which needs a way to

--- a/solana/bridge/program/src/error.rs
+++ b/solana/bridge/program/src/error.rs
@@ -31,7 +31,6 @@ pub enum Error {
     InvalidDerivedAccount,
     GuardianSetStillActive,
     InvalidProgramOwner,
-    InvalidEventAuthority,
 }
 
 /// Errors thrown by the program will bubble up to the solitaire wrapper, which needs a way to

--- a/solana/bridge/program/src/instructions.rs
+++ b/solana/bridge/program/src/instructions.rs
@@ -36,6 +36,8 @@ use crate::{
         SequenceDerivationData,
     },
     types::ConsistencyLevel,
+    ClosePostedMessageData,
+    CloseSignatureSetAndPostedVAAData,
     InitializeData,
     PostMessageData,
     PostVAAData,
@@ -417,6 +419,65 @@ pub fn transfer_fees(
         data: (
             crate::instruction::Instruction::TransferFees,
             TransferFeesData {},
+        )
+            .try_to_vec()
+            .unwrap(),
+    }
+}
+
+pub fn close_posted_message(program_id: Pubkey, message: Pubkey) -> Instruction {
+    let bridge = Bridge::<'_, { AccountState::Initialized }>::key(None, &program_id);
+    let fee_collector = FeeCollector::key(None, &program_id);
+    let (event_authority, _) =
+        Pubkey::find_program_address(&[solitaire::EVENT_AUTHORITY_SEED], &program_id);
+
+    Instruction {
+        program_id,
+        accounts: vec![
+            AccountMeta::new(bridge, false),
+            AccountMeta::new(message, false),
+            AccountMeta::new(fee_collector, false),
+            AccountMeta::new_readonly(sysvar::clock::id(), false),
+            AccountMeta::new_readonly(event_authority, false),
+            AccountMeta::new_readonly(program_id, false),
+        ],
+        data: (
+            crate::instruction::Instruction::ClosePostedMessage,
+            ClosePostedMessageData {},
+        )
+            .try_to_vec()
+            .unwrap(),
+    }
+}
+
+pub fn close_signature_set_and_posted_vaa(
+    program_id: Pubkey,
+    signature_set: Pubkey,
+    posted_vaa: Pubkey,
+    guardian_set_index: u32,
+) -> Instruction {
+    let bridge = Bridge::<'_, { AccountState::Initialized }>::key(None, &program_id);
+    let guardian_set = GuardianSet::<'_, { AccountState::Initialized }>::key(
+        &GuardianSetDerivationData {
+            index: guardian_set_index,
+        },
+        &program_id,
+    );
+    let fee_collector = FeeCollector::key(None, &program_id);
+
+    Instruction {
+        program_id,
+        accounts: vec![
+            AccountMeta::new(bridge, false),
+            AccountMeta::new(signature_set, false),
+            AccountMeta::new(posted_vaa, false),
+            AccountMeta::new_readonly(guardian_set, false),
+            AccountMeta::new(fee_collector, false),
+            AccountMeta::new_readonly(sysvar::clock::id(), false),
+        ],
+        data: (
+            crate::instruction::Instruction::CloseSignatureSetAndPostedVAA,
+            CloseSignatureSetAndPostedVAAData {},
         )
             .try_to_vec()
             .unwrap(),

--- a/solana/bridge/program/src/lib.rs
+++ b/solana/bridge/program/src/lib.rs
@@ -123,6 +123,7 @@ pub use vaa::{
 };
 
 solitaire! {
+    @event_cpi,
     Initialize         => initialize,
     PostMessage        => post_message,
     PostVAA            => post_vaa,

--- a/solana/bridge/program/src/lib.rs
+++ b/solana/bridge/program/src/lib.rs
@@ -80,6 +80,8 @@ pub use accounts::{
 pub mod api;
 
 pub use api::{
+    close_posted_message,
+    close_signature_set_and_posted_vaa,
     initialize,
     post_message,
     post_message_unreliable,
@@ -89,6 +91,10 @@ pub use api::{
     upgrade_contract,
     upgrade_guardian_set,
     verify_signatures,
+    ClosePostedMessage,
+    ClosePostedMessageData,
+    CloseSignatureSetAndPostedVAA,
+    CloseSignatureSetAndPostedVAAData,
     Initialize,
     InitializeData,
     PostMessage,
@@ -108,6 +114,7 @@ pub use api::{
     UpgradeGuardianSetData,
     VerifySignatures,
     VerifySignaturesData,
+    MESSAGE_ACCOUNT_CLOSED_DISCRIMINATOR,
 };
 
 pub mod error;
@@ -124,13 +131,15 @@ pub use vaa::{
 
 solitaire! {
     @event_cpi,
-    Initialize         => initialize,
-    PostMessage        => post_message,
-    PostVAA            => post_vaa,
-    SetFees            => set_fees,
-    TransferFees       => transfer_fees,
-    UpgradeContract    => upgrade_contract,
-    UpgradeGuardianSet => upgrade_guardian_set,
-    VerifySignatures   => verify_signatures,
-    PostMessageUnreliable        => post_message_unreliable,
+    Initialize                    => initialize,
+    PostMessage                   => post_message,
+    PostVAA                       => post_vaa,
+    SetFees                       => set_fees,
+    TransferFees                  => transfer_fees,
+    UpgradeContract               => upgrade_contract,
+    UpgradeGuardianSet            => upgrade_guardian_set,
+    VerifySignatures              => verify_signatures,
+    PostMessageUnreliable         => post_message_unreliable,
+    ClosePostedMessage            => close_posted_message,
+    CloseSignatureSetAndPostedVAA => close_signature_set_and_posted_vaa,
 }

--- a/solana/bridge/program/src/lib.rs
+++ b/solana/bridge/program/src/lib.rs
@@ -40,6 +40,126 @@ const _: () = {
     assert!(parse_u16_const("65535") == 65535);
 };
 
+// Canonical base58 program ids for the core bridge on the three Solana
+// clusters. These are the same values as in solana/Makefile
+// (`bridge_ADDRESS_solana_{mainnet,testnet,devnet}`).
+pub const SOLANA_MAINNET_BRIDGE_ADDRESS: &str = "worm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMTth";
+pub const SOLANA_TESTNET_BRIDGE_ADDRESS: &str = "3u8hJUVTA4jH1wYAyUur7FFZVQ8H635K3tSHHF4ssjQ5";
+pub const SOLANA_DEVNET_BRIDGE_ADDRESS: &str = "Bridge1p5gheXUvJ6jGWGeCsgPKgnE3YgdGKRVCMY9o";
+
+/// Which Solana cluster this bridge program was built for. Determined by
+/// comparing the build-time `BRIDGE_ADDRESS` against the known program ids.
+/// A return value of `None` from `solana_env` means the build targets a
+/// non-Solana SVM (e.g. Fogo) or an unrecognised address.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SolanaEnv {
+    Mainnet,
+    Testnet,
+    Devnet,
+}
+
+/// Const-friendly `&str` byte-wise equality.
+const fn str_eq(a: &str, b: &str) -> bool {
+    let a = a.as_bytes();
+    let b = b.as_bytes();
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut i = 0;
+    while i < a.len() {
+        if a[i] != b[i] {
+            return false;
+        }
+        i += 1;
+    }
+    true
+}
+
+/// Classify a bridge program id (base58) into a Solana cluster. Returns
+/// `None` for non-Solana SVMs (e.g. Fogo) and any unrecognised address.
+///
+/// Evaluates fully at compile time, so it can be used in `const` contexts
+/// that switch behaviour based on the target cluster (see `api::RETENTION_PERIOD`).
+pub const fn solana_env(program_id_b58: &str) -> Option<SolanaEnv> {
+    if str_eq(program_id_b58, SOLANA_MAINNET_BRIDGE_ADDRESS) {
+        Some(SolanaEnv::Mainnet)
+    } else if str_eq(program_id_b58, SOLANA_TESTNET_BRIDGE_ADDRESS) {
+        Some(SolanaEnv::Testnet)
+    } else if str_eq(program_id_b58, SOLANA_DEVNET_BRIDGE_ADDRESS) {
+        Some(SolanaEnv::Devnet)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod solana_env_tests {
+    use super::*;
+
+    #[test]
+    fn classifies_mainnet() {
+        assert_eq!(
+            solana_env("worm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMTth"),
+            Some(SolanaEnv::Mainnet),
+        );
+    }
+
+    #[test]
+    fn classifies_testnet() {
+        assert_eq!(
+            solana_env("3u8hJUVTA4jH1wYAyUur7FFZVQ8H635K3tSHHF4ssjQ5"),
+            Some(SolanaEnv::Testnet),
+        );
+    }
+
+    #[test]
+    fn classifies_devnet() {
+        assert_eq!(
+            solana_env("Bridge1p5gheXUvJ6jGWGeCsgPKgnE3YgdGKRVCMY9o"),
+            Some(SolanaEnv::Devnet),
+        );
+    }
+
+    #[test]
+    fn rejects_fogo_addresses() {
+        // Fogo is a non-Solana SVM; its bridge addresses must classify as None.
+        assert_eq!(
+            solana_env("BhnQyKoQQgpuRTRo6D8Emz93PvXCYfVgHhnrR4T3qhw4"),
+            None,
+            "Fogo testnet should classify as non-Solana",
+        );
+        assert_eq!(
+            solana_env("worm2mrQkG1B1KTz37erMfWN8anHkSK24nzca7UD8BB"),
+            None,
+            "Fogo mainnet should classify as non-Solana",
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_addresses() {
+        assert_eq!(solana_env(""), None);
+        assert_eq!(solana_env("not-a-real-address"), None);
+        // A near-miss: the mainnet address with a single character changed.
+        assert_eq!(
+            solana_env("Xorm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMTth"),
+            None,
+        );
+    }
+
+    #[test]
+    fn rejects_length_mismatch() {
+        // Prefixes / extensions of a valid address must not match.
+        assert_eq!(
+            solana_env("worm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMT"),
+            None
+        );
+        assert_eq!(
+            solana_env("worm2ZoG2kUd4vFXhvjh93UUH596ayRfgQ2MgjNMThh"),
+            None
+        );
+    }
+}
+
 #[cfg(feature = "instructions")]
 pub mod instructions;
 

--- a/solana/bridge/program/tests/common.rs
+++ b/solana/bridge/program/tests/common.rs
@@ -18,6 +18,7 @@ use solana_program_test::{
     BanksClient,
     BanksClientError,
     ProgramTest,
+    ProgramTestContext,
 };
 use solana_sdk::{
     commitment_config::CommitmentLevel,
@@ -74,16 +75,16 @@ mod helpers {
 
     /// Initialize the test environment, spins up a solana-test-validator in the background so that
     /// each test has a fresh environment to work within.
-    pub async fn setup() -> (BanksClient, Keypair, Pubkey) {
+    pub async fn setup() -> (ProgramTestContext, Pubkey) {
         let program = env::var("BRIDGE_PROGRAM")
             .unwrap_or_else(|_| "Bridge1p5gheXUvJ6jGWGeCsgPKgnE3YgdGKRVCMY9o".to_string())
             .parse::<Pubkey>()
             .unwrap();
         let builder = ProgramTest::new("bridge", program, processor!(instruction::solitaire));
 
-        let (client, payer, _) = builder.start().await;
+        let context = builder.start_with_context().await;
 
-        (client, payer, program)
+        (context, program)
     }
 
     /// Fetch account data, the loop is there to re-attempt until data is available.
@@ -462,5 +463,82 @@ mod helpers {
             CommitmentLevel::Processed,
         )
         .await
+    }
+
+    pub async fn close_posted_message(
+        client: &mut BanksClient,
+        program: &Pubkey,
+        payer: &Keypair,
+        message: Pubkey,
+    ) -> Result<(), BanksClientError> {
+        execute(
+            client,
+            payer,
+            &[payer],
+            &[instructions::close_posted_message(*program, message)],
+            CommitmentLevel::Processed,
+        )
+        .await
+    }
+
+    pub async fn close_signature_set_and_posted_vaa(
+        client: &mut BanksClient,
+        program: &Pubkey,
+        payer: &Keypair,
+        signature_set: Pubkey,
+        posted_vaa: Pubkey,
+        guardian_set_index: u32,
+    ) -> Result<(), BanksClientError> {
+        execute(
+            client,
+            payer,
+            &[payer],
+            &[instructions::close_signature_set_and_posted_vaa(
+                *program,
+                signature_set,
+                posted_vaa,
+                guardian_set_index,
+            )],
+            CommitmentLevel::Processed,
+        )
+        .await
+    }
+
+    /// Get the account's raw data, or None if the account doesn't exist.
+    pub async fn get_account_data_raw(
+        client: &mut BanksClient,
+        account: Pubkey,
+    ) -> Option<Vec<u8>> {
+        client.get_account(account).await.unwrap().map(|a| a.data)
+    }
+
+    /// Directly patch the submission_time in a PostedMessage or PostedVAA account
+    /// so it falls outside the 30-day retention window.
+    ///
+    /// We use direct account manipulation instead of `warp_to_slot` because
+    /// warping millions of slots (needed to advance the Clock sysvar by 30+
+    /// days) destabilises the solana-program-test bank, causing unrelated
+    /// `Custom(0)` failures on subsequent transactions.
+    ///
+    /// Layout of PostedMessage / PostedVAA account data:
+    ///   [0..3]   prefix ("msg" / "msu" / "vaa")
+    ///   [3]      vaa_version       (u8)
+    ///   [4]      consistency_level (u8)
+    ///   [5..9]   vaa_time          (u32 LE)
+    ///   [9..41]  vaa_signature_account (Pubkey, 32 bytes)
+    ///   [41..45] submission_time   (u32 LE)  <-- this is the field we patch
+    pub async fn set_submission_time(
+        ctx: &mut ProgramTestContext,
+        account: Pubkey,
+        submission_time: u32,
+    ) {
+        let mut account_data = ctx
+            .banks_client
+            .get_account(account)
+            .await
+            .unwrap()
+            .unwrap();
+        account_data.data[41..45].copy_from_slice(&submission_time.to_le_bytes());
+        ctx.set_account(&account, &account_data.into());
     }
 }

--- a/solana/bridge/program/tests/common.rs
+++ b/solana/bridge/program/tests/common.rs
@@ -536,8 +536,23 @@ mod helpers {
             .banks_client
             .get_account(account)
             .await
-            .unwrap()
-            .unwrap();
+            .expect("banks_client get_account failed")
+            .expect("cannot patch submission_time: account does not exist");
+        // The hard-coded 41..45 slice below would silently corrupt unrelated
+        // bytes if the layout shifted or the wrong account was passed in.
+        // Sanity-check the size and the magic prefix so a layout change
+        // surfaces as an explicit panic.
+        assert!(
+            account_data.data.len() >= 45,
+            "set_submission_time: account data too short ({} bytes, need >=45)",
+            account_data.data.len()
+        );
+        let prefix = &account_data.data[..3];
+        assert!(
+            matches!(prefix, b"msg" | b"msu" | b"vaa"),
+            "set_submission_time: unexpected account prefix {:?}",
+            prefix
+        );
         account_data.data[41..45].copy_from_slice(&submission_time.to_le_bytes());
         ctx.set_account(&account, &account_data.into());
     }

--- a/solana/bridge/program/tests/common.rs
+++ b/solana/bridge/program/tests/common.rs
@@ -138,7 +138,7 @@ mod helpers {
         emitter_chain: u16,
     ) -> (PostVAAData, [u8; 32], [u8; 32]) {
         let vaa = PostVAAData {
-            version: 0,
+            version: 1,
             guardian_set_index,
 
             // Body part

--- a/solana/bridge/program/tests/integration.rs
+++ b/solana/bridge/program/tests/integration.rs
@@ -1578,3 +1578,80 @@ async fn upgrade_contract() {
     .await
     .unwrap();
 }
+
+#[test]
+fn test_event_ix_tag_matches_sha256() {
+    // EVENT_IX_TAG should equal SHA256("anchor:event")[0..8] read as a big-endian u64.
+    let hash = solana_program::hash::hash(b"anchor:event");
+    let mut tag_bytes = [0u8; 8];
+    tag_bytes.copy_from_slice(&hash.to_bytes()[..8]);
+    let expected = u64::from_be_bytes(tag_bytes);
+
+    assert_eq!(
+        solitaire::EVENT_IX_TAG,
+        expected,
+        "EVENT_IX_TAG must equal SHA256(\"anchor:event\")[..8] as BE u64"
+    );
+    assert_eq!(
+        solitaire::EVENT_IX_TAG_LE,
+        expected.to_le_bytes(),
+        "EVENT_IX_TAG_LE must be the little-endian encoding"
+    );
+}
+
+/// Verify that the event CPI guard rejects external callers. Only the program
+/// itself (via invoke_signed with the event authority PDA) should be able to
+/// invoke the event CPI path.
+#[tokio::test]
+async fn test_event_cpi_guard_rejects_external_call() {
+    let (ref mut _context, ref mut test_ctx, ref program) = initialize().await;
+    let (client, payer) = (&mut test_ctx.banks_client, &test_ctx.payer);
+
+    let (event_authority, _) = Pubkey::find_program_address(&[b"__event_authority"], program);
+
+    // Case 1: Pass the correct event authority PDA, but it can't be a signer
+    // because only the program itself can sign for its own PDAs.
+    let ix_unsigned_pda = solana_program::instruction::Instruction {
+        program_id: *program,
+        accounts: vec![solana_program::instruction::AccountMeta::new_readonly(
+            event_authority,
+            false,
+        )],
+        data: solitaire::EVENT_IX_TAG_LE.to_vec(),
+    };
+    let result = common::execute(
+        client,
+        payer,
+        &[payer],
+        &[ix_unsigned_pda],
+        CommitmentLevel::Processed,
+    )
+    .await;
+    assert!(
+        result.is_err(),
+        "Event CPI must reject when event authority PDA is not a signer"
+    );
+
+    // Case 2: Pass a random keypair that IS a signer, but is not the PDA.
+    let fake_authority = Keypair::new();
+    let ix_wrong_signer = solana_program::instruction::Instruction {
+        program_id: *program,
+        accounts: vec![solana_program::instruction::AccountMeta::new_readonly(
+            fake_authority.pubkey(),
+            true,
+        )],
+        data: solitaire::EVENT_IX_TAG_LE.to_vec(),
+    };
+    let result = common::execute(
+        client,
+        payer,
+        &[payer, &fake_authority],
+        &[ix_wrong_signer],
+        CommitmentLevel::Processed,
+    )
+    .await;
+    assert!(
+        result.is_err(),
+        "Event CPI must reject when signer is not the event authority PDA"
+    );
+}

--- a/solana/bridge/program/tests/integration.rs
+++ b/solana/bridge/program/tests/integration.rs
@@ -4,10 +4,7 @@ use solana_program::{
     pubkey::Pubkey,
     system_instruction,
 };
-use solana_program_test::{
-    tokio,
-    BanksClient,
-};
+use solana_program_test::tokio;
 use solana_sdk::{
     commitment_config::CommitmentLevel,
     signature::{
@@ -45,6 +42,7 @@ use bridge::{
 };
 use primitive_types::U256;
 use solana_program::rent::Rent;
+use solana_program_test::ProgramTestContext;
 
 mod common;
 
@@ -78,7 +76,7 @@ impl Sequencer {
     }
 }
 
-async fn initialize() -> (Context, BanksClient, Keypair, Pubkey) {
+async fn initialize() -> (Context, ProgramTestContext, Pubkey) {
     let (public_keys, secret_keys) = common::generate_keys(6);
     let context = Context {
         public: public_keys,
@@ -87,7 +85,7 @@ async fn initialize() -> (Context, BanksClient, Keypair, Pubkey) {
             sequences: std::collections::HashMap::new(),
         },
     };
-    let (mut client, payer, program) = common::setup().await;
+    let (mut test_ctx, program) = common::setup().await;
 
     // Use a timestamp from a few seconds earlier for testing to simulate thread::sleep();
     let now = std::time::SystemTime::now()
@@ -96,9 +94,15 @@ async fn initialize() -> (Context, BanksClient, Keypair, Pubkey) {
         .as_secs()
         - 10;
 
-    common::initialize(&mut client, program, &payer, &context.public, 500)
-        .await
-        .unwrap();
+    common::initialize(
+        &mut test_ctx.banks_client,
+        program,
+        &test_ctx.payer,
+        &context.public,
+        500,
+    )
+    .await
+    .unwrap();
 
     // Verify the initial bridge state is as expected.
     let bridge_key = Bridge::<'_, { AccountState::Uninitialized }>::key(None, &program);
@@ -108,9 +112,9 @@ async fn initialize() -> (Context, BanksClient, Keypair, Pubkey) {
     );
 
     // Fetch account states.
-    let bridge: BridgeData = common::get_account_data(&mut client, bridge_key).await;
+    let bridge: BridgeData = common::get_account_data(&mut test_ctx.banks_client, bridge_key).await;
     let guardian_set: GuardianSetData =
-        common::get_account_data(&mut client, guardian_set_key).await;
+        common::get_account_data(&mut test_ctx.banks_client, guardian_set_key).await;
 
     // Bridge Config should be as expected.
     assert_eq!(bridge.guardian_set_index, 0);
@@ -122,12 +126,13 @@ async fn initialize() -> (Context, BanksClient, Keypair, Pubkey) {
     assert_eq!(guardian_set.keys, context.public);
     assert!(guardian_set.creation_time as u64 > now);
 
-    (context, client, payer, program)
+    (context, test_ctx, program)
 }
 
 #[tokio::test]
 async fn bridge_messages() {
-    let (ref mut context, ref mut client, ref payer, ref program) = initialize().await;
+    let (ref mut context, ref mut test_ctx, ref program) = initialize().await;
+    let (client, payer) = (&mut test_ctx.banks_client, &test_ctx.payer);
 
     // Data/Nonce used for emitting a message we want to prove exists. Run this twice to make sure
     // that duplicate data does not clash.
@@ -315,7 +320,8 @@ async fn bridge_messages() {
 // length.
 #[tokio::test]
 async fn test_bridge_messages_unreliable() {
-    let (ref mut context, ref mut client, ref payer, ref program) = initialize().await;
+    let (ref mut context, ref mut test_ctx, ref program) = initialize().await;
+    let (client, payer) = (&mut test_ctx.banks_client, &test_ctx.payer);
 
     // Data/Nonce used for emitting a message we want to prove exists. Run this twice to make sure
     // that duplicate data does not clash.
@@ -433,7 +439,8 @@ async fn test_bridge_messages_unreliable() {
 
 #[tokio::test]
 async fn test_bridge_messages_unreliable_do_not_override_reliable() {
-    let (ref mut _context, ref mut client, ref payer, ref program) = initialize().await;
+    let (ref mut _context, ref mut test_ctx, ref program) = initialize().await;
+    let (client, payer) = (&mut test_ctx.banks_client, &test_ctx.payer);
 
     let emitter = Keypair::new();
     let message_key = Keypair::new();
@@ -475,7 +482,8 @@ async fn bridge_works_after_transfer_fees() {
     // This test aims to ensure that the bridge remains operational after the
     // fees have been transferred out.
     // NOTE: the bridge is initialised to take a minimum of 500 in fees.
-    let (ref mut context, ref mut client, ref payer, ref program) = initialize().await;
+    let (ref mut context, ref mut test_ctx, ref program) = initialize().await;
+    let (client, payer) = (&mut test_ctx.banks_client, &test_ctx.payer);
     let fee_collector = FeeCollector::key(None, program);
     let initial_balance = common::get_account_balance(client, fee_collector).await;
 
@@ -551,7 +559,8 @@ async fn bridge_works_after_transfer_fees() {
 // DoSd by someone funding derived accounts making CreateAccount fail.
 #[tokio::test]
 async fn test_bridge_message_prefunded_account() {
-    let (ref mut context, ref mut client, ref payer, ref program) = initialize().await;
+    let (ref mut context, ref mut test_ctx, ref program) = initialize().await;
+    let (client, payer) = (&mut test_ctx.banks_client, &test_ctx.payer);
 
     // Data/Nonce used for emitting a message we want to prove exists. Run this twice to make sure
     // that duplicate data does not clash.
@@ -623,7 +632,8 @@ async fn test_bridge_message_prefunded_account() {
 
 #[tokio::test]
 async fn invalid_emitter() {
-    let (ref mut context, ref mut client, ref payer, ref program) = initialize().await;
+    let (ref mut context, ref mut test_ctx, ref program) = initialize().await;
+    let (client, payer) = (&mut test_ctx.banks_client, &test_ctx.payer);
 
     // Generate a message we want to persist.
     let message = [0u8; 32].to_vec();
@@ -668,7 +678,8 @@ async fn invalid_emitter() {
 #[tokio::test]
 async fn guardian_set_change() {
     // Initialize a wormhole bridge on Solana to test with.
-    let (ref mut context, ref mut client, ref payer, ref program) = initialize().await;
+    let (ref mut context, ref mut test_ctx, ref program) = initialize().await;
+    let (client, payer) = (&mut test_ctx.banks_client, &test_ctx.payer);
 
     // Use a timestamp from a few seconds earlier for testing to simulate thread::sleep();
     let now = std::time::SystemTime::now()
@@ -858,7 +869,8 @@ async fn guardian_set_change() {
 #[tokio::test]
 async fn guardian_set_change_fails() {
     // Initialize a wormhole bridge on Solana to test with.
-    let (ref mut context, ref mut client, ref payer, ref program) = initialize().await;
+    let (ref mut context, ref mut test_ctx, ref program) = initialize().await;
+    let (client, payer) = (&mut test_ctx.banks_client, &test_ctx.payer);
 
     // Use a random emitter key to confirm the bridge rejects transactions from non-governance key.
     let emitter = Keypair::new();
@@ -904,7 +916,8 @@ async fn guardian_set_change_fails() {
 #[tokio::test]
 async fn set_fees() {
     // Initialize a wormhole bridge on Solana to test with.
-    let (ref mut context, ref mut client, ref payer, ref program) = initialize().await;
+    let (ref mut context, ref mut test_ctx, ref program) = initialize().await;
+    let (client, payer) = (&mut test_ctx.banks_client, &test_ctx.payer);
     let emitter = Keypair::from_bytes(&GOVERNANCE_KEY).unwrap();
     let sequence = context.seq.next(emitter.pubkey().to_bytes());
 
@@ -1053,7 +1066,8 @@ async fn set_fees() {
 #[tokio::test]
 async fn set_fees_fails() {
     // Initialize a wormhole bridge on Solana to test with.
-    let (ref mut context, ref mut client, ref payer, ref program) = initialize().await;
+    let (ref mut context, ref mut test_ctx, ref program) = initialize().await;
+    let (client, payer) = (&mut test_ctx.banks_client, &test_ctx.payer);
 
     // Use a random key to confirm only the governance key is respected.
     let emitter = Keypair::new();
@@ -1102,7 +1116,8 @@ async fn set_fees_fails() {
 #[tokio::test]
 async fn free_fees() {
     // Initialize a wormhole bridge on Solana to test with.
-    let (ref mut context, ref mut client, ref payer, ref program) = initialize().await;
+    let (ref mut context, ref mut test_ctx, ref program) = initialize().await;
+    let (client, payer) = (&mut test_ctx.banks_client, &test_ctx.payer);
     let emitter = Keypair::from_bytes(&GOVERNANCE_KEY).unwrap();
     let sequence = context.seq.next(emitter.pubkey().to_bytes());
 
@@ -1230,7 +1245,8 @@ async fn free_fees() {
 #[tokio::test]
 async fn transfer_fees() {
     // Initialize a wormhole bridge on Solana to test with.
-    let (ref mut context, ref mut client, ref payer, ref program) = initialize().await;
+    let (ref mut context, ref mut test_ctx, ref program) = initialize().await;
+    let (client, payer) = (&mut test_ctx.banks_client, &test_ctx.payer);
     let emitter = Keypair::from_bytes(&GOVERNANCE_KEY).unwrap();
     let sequence = context.seq.next(emitter.pubkey().to_bytes());
 
@@ -1289,7 +1305,8 @@ async fn transfer_fees() {
 #[tokio::test]
 async fn transfer_fees_fails() {
     // Initialize a wormhole bridge on Solana to test with.
-    let (ref mut context, ref mut client, ref payer, ref program) = initialize().await;
+    let (ref mut context, ref mut test_ctx, ref program) = initialize().await;
+    let (client, payer) = (&mut test_ctx.banks_client, &test_ctx.payer);
 
     // Use an invalid emitter.
     let emitter = Keypair::new();
@@ -1350,7 +1367,8 @@ async fn transfer_fees_fails() {
 #[tokio::test]
 async fn transfer_too_much() {
     // Initialize a wormhole bridge on Solana to test with.
-    let (ref mut context, ref mut client, ref payer, ref program) = initialize().await;
+    let (ref mut context, ref mut test_ctx, ref program) = initialize().await;
+    let (client, payer) = (&mut test_ctx.banks_client, &test_ctx.payer);
     let emitter = Keypair::from_bytes(&GOVERNANCE_KEY).unwrap();
     let sequence = context.seq.next(emitter.pubkey().to_bytes());
 
@@ -1410,7 +1428,8 @@ async fn transfer_too_much() {
 #[tokio::test]
 async fn foreign_bridge_messages() {
     // Initialize a wormhole bridge on Solana to test with.
-    let (ref mut context, ref mut client, ref payer, ref program) = initialize().await;
+    let (ref mut context, ref mut test_ctx, ref program) = initialize().await;
+    let (client, payer) = (&mut test_ctx.banks_client, &test_ctx.payer);
     let nonce = rand::thread_rng().gen();
     let message = [0u8; 32].to_vec();
     let emitter = Keypair::new();
@@ -1462,7 +1481,8 @@ async fn foreign_bridge_messages() {
 #[tokio::test]
 async fn transfer_total_fails() {
     // Initialize a wormhole bridge on Solana to test with.
-    let (ref mut context, ref mut client, ref payer, ref program) = initialize().await;
+    let (ref mut context, ref mut test_ctx, ref program) = initialize().await;
+    let (client, payer) = (&mut test_ctx.banks_client, &test_ctx.payer);
     let emitter = Keypair::from_bytes(&GOVERNANCE_KEY).unwrap();
     let sequence = context.seq.next(emitter.pubkey().to_bytes());
 
@@ -1531,7 +1551,8 @@ async fn transfer_total_fails() {
 #[ignore]
 async fn upgrade_contract() {
     // Initialize a wormhole bridge on Solana to test with.
-    let (ref mut context, ref mut client, ref payer, ref program) = initialize().await;
+    let (ref mut context, ref mut test_ctx, ref program) = initialize().await;
+    let (client, payer) = (&mut test_ctx.banks_client, &test_ctx.payer);
 
     // New Contract Address
     // let new_contract = Pubkey::new_unique();
@@ -1580,6 +1601,16 @@ async fn upgrade_contract() {
 }
 
 #[test]
+fn test_message_account_closed_discriminator_matches_sha256() {
+    let hash = solana_program::hash::hash(b"event:MessageAccountClosed");
+    let expected = &hash.to_bytes()[..8];
+    assert_eq!(
+        bridge::MESSAGE_ACCOUNT_CLOSED_DISCRIMINATOR, expected,
+        "MESSAGE_ACCOUNT_CLOSED_DISCRIMINATOR must equal SHA256(\"event:MessageAccountClosed\")[..8]"
+    );
+}
+
+#[test]
 fn test_event_ix_tag_matches_sha256() {
     // EVENT_IX_TAG should equal SHA256("anchor:event")[0..8] read as a big-endian u64.
     let hash = solana_program::hash::hash(b"anchor:event");
@@ -1607,7 +1638,8 @@ async fn test_event_cpi_guard_rejects_external_call() {
     let (ref mut _context, ref mut test_ctx, ref program) = initialize().await;
     let (client, payer) = (&mut test_ctx.banks_client, &test_ctx.payer);
 
-    let (event_authority, _) = Pubkey::find_program_address(&[b"__event_authority"], program);
+    let (event_authority, _) =
+        Pubkey::find_program_address(&[solitaire::EVENT_AUTHORITY_SEED], program);
 
     // Case 1: Pass the correct event authority PDA, but it can't be a signer
     // because only the program itself can sign for its own PDAs.
@@ -1653,5 +1685,522 @@ async fn test_event_cpi_guard_rejects_external_call() {
     assert!(
         result.is_err(),
         "Event CPI must reject when signer is not the event authority PDA"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Rent Reclamation Tests
+// ---------------------------------------------------------------------------
+
+/// Submission time 29 days in the past -- still inside the 30-day retention window.
+fn recent_submission_time() -> u32 {
+    (std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+        - 29 * 24 * 60 * 60) as u32
+}
+
+/// Submission time 31 days in the past, just barely outside the 30-day retention window.
+fn old_submission_time() -> u32 {
+    (std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+        - 31 * 24 * 60 * 60) as u32
+}
+
+#[tokio::test]
+async fn test_post_vaa_sets_submission_time() {
+    let (ref mut context, ref mut test_ctx, ref program) = initialize().await;
+    let client = &mut test_ctx.banks_client;
+    let payer = &test_ctx.payer;
+
+    let emitter = Keypair::new();
+    let nonce = rand::thread_rng().gen();
+    let message = [0u8; 32].to_vec();
+    let sequence = context.seq.next(emitter.pubkey().to_bytes());
+
+    // Post a message and verify signatures.
+    common::post_message(
+        client,
+        program,
+        payer,
+        &emitter,
+        None,
+        nonce,
+        message.clone(),
+        10_000,
+    )
+    .await
+    .unwrap();
+
+    let (vaa, body, _) = common::generate_vaa(&emitter, message, nonce, sequence, 0, 1);
+    let signature_set = common::verify_signatures(client, program, payer, body, &context.secret, 0)
+        .await
+        .unwrap();
+    common::post_vaa(client, program, payer, signature_set, vaa)
+        .await
+        .unwrap();
+
+    // Verify submission_time is set on the PostedVAA.
+    let message_key = PostedVAA::<'_, { AccountState::MaybeInitialized }>::key(
+        &PostedVAADerivationData {
+            payload_hash: body.to_vec(),
+        },
+        program,
+    );
+    let posted_vaa: PostedVAAData = common::get_account_data(client, message_key).await;
+    assert!(
+        posted_vaa.message.submission_time > 0,
+        "PostVAA should set submission_time"
+    );
+}
+
+#[tokio::test]
+async fn test_close_posted_message_rejects_recent() {
+    let (ref mut _context, ref mut test_ctx, ref program) = initialize().await;
+    let client = &mut test_ctx.banks_client;
+    let payer = &test_ctx.payer;
+
+    let emitter = Keypair::new();
+    let nonce = rand::thread_rng().gen();
+    let message = [1u8; 32].to_vec();
+
+    // Post a message (reliable, "msg" prefix).
+    let message_key = common::post_message(
+        client, program, payer, &emitter, None, nonce, message, 10_000,
+    )
+    .await
+    .unwrap();
+
+    // Immediately try to close -- should fail (within retention window).
+    let result = common::close_posted_message(client, program, payer, message_key).await;
+    assert!(result.is_err(), "Should reject closing a recent message");
+}
+
+/// Verify the retention boundary: a message whose submission_time is 29 days ago
+/// (inside the 30-day window) should still be rejected.
+#[tokio::test]
+async fn test_close_posted_message_rejects_within_retention_window() {
+    let (ref mut _context, ref mut test_ctx, ref program) = initialize().await;
+
+    let emitter = Keypair::new();
+    let nonce = rand::thread_rng().gen();
+    let message = [9u8; 32].to_vec();
+
+    let message_key = common::post_message(
+        &mut test_ctx.banks_client,
+        program,
+        &test_ctx.payer,
+        &emitter,
+        None,
+        nonce,
+        message,
+        10_000,
+    )
+    .await
+    .unwrap();
+
+    // Set submission_time to 29 days ago -- still inside the 30-day retention window.
+    common::set_submission_time(test_ctx, message_key, recent_submission_time()).await;
+
+    let result = common::close_posted_message(
+        &mut test_ctx.banks_client,
+        program,
+        &test_ctx.payer,
+        message_key,
+    )
+    .await;
+    assert!(
+        result.is_err(),
+        "Should reject closing a message still within the 30-day retention window"
+    );
+}
+
+#[tokio::test]
+async fn test_close_posted_message_happy_path() {
+    let (ref mut _context, ref mut test_ctx, ref program) = initialize().await;
+
+    let emitter = Keypair::new();
+    let nonce = rand::thread_rng().gen();
+    let message = [2u8; 32].to_vec();
+    let fee_collector = FeeCollector::<'_>::key(None, program);
+
+    // Post a message.
+    let message_key = common::post_message(
+        &mut test_ctx.banks_client,
+        program,
+        &test_ctx.payer,
+        &emitter,
+        None,
+        nonce,
+        message,
+        10_000,
+    )
+    .await
+    .unwrap();
+
+    // Record balances before close.
+    let fee_collector_before =
+        common::get_account_balance(&mut test_ctx.banks_client, fee_collector).await;
+    let message_lamports =
+        common::get_account_balance(&mut test_ctx.banks_client, message_key).await;
+
+    // Set submission_time to 0 (epoch) so it passes the 30-day retention check.
+    common::set_submission_time(test_ctx, message_key, old_submission_time()).await;
+
+    // Close the message.
+    common::close_posted_message(
+        &mut test_ctx.banks_client,
+        program,
+        &test_ctx.payer,
+        message_key,
+    )
+    .await
+    .unwrap();
+
+    // Verify: fee_collector received the lamports.
+    let fee_collector_after =
+        common::get_account_balance(&mut test_ctx.banks_client, fee_collector).await;
+    assert_eq!(
+        fee_collector_after,
+        fee_collector_before + message_lamports,
+        "Fee collector should receive message account lamports"
+    );
+
+    // Verify: message account is closed (empty data or doesn't exist).
+    let msg_data = common::get_account_data_raw(&mut test_ctx.banks_client, message_key).await;
+    assert!(
+        msg_data.is_none() || msg_data.unwrap().iter().all(|&b| b == 0),
+        "Message account should be closed"
+    );
+
+    // Verify: bridge.last_lamports is updated.
+    let bridge_key = Bridge::<'_, { AccountState::Uninitialized }>::key(None, program);
+    let bridge: BridgeData = common::get_account_data(&mut test_ctx.banks_client, bridge_key).await;
+    assert_eq!(
+        bridge.last_lamports, fee_collector_after,
+        "bridge.last_lamports should be updated"
+    );
+}
+
+#[tokio::test]
+async fn test_close_posted_message_unreliable() {
+    let (ref mut _context, ref mut test_ctx, ref program) = initialize().await;
+
+    let emitter = Keypair::new();
+    let nonce = rand::thread_rng().gen();
+    let message = [3u8; 32].to_vec();
+    let message_key = Keypair::new();
+
+    // Post an unreliable message ("msu" prefix).
+    common::post_message_unreliable(
+        &mut test_ctx.banks_client,
+        program,
+        &test_ctx.payer,
+        &emitter,
+        &message_key,
+        nonce,
+        message,
+        10_000,
+    )
+    .await
+    .unwrap();
+
+    // Set submission_time to 0 so it passes the retention check.
+    common::set_submission_time(test_ctx, message_key.pubkey(), old_submission_time()).await;
+
+    // Close should succeed for "msu" prefix too.
+    common::close_posted_message(
+        &mut test_ctx.banks_client,
+        program,
+        &test_ctx.payer,
+        message_key.pubkey(),
+    )
+    .await
+    .unwrap();
+
+    // Verify account is closed.
+    let data = common::get_account_data_raw(&mut test_ctx.banks_client, message_key.pubkey()).await;
+    assert!(
+        data.is_none() || data.unwrap().iter().all(|&b| b == 0),
+        "Unreliable message account should be closed"
+    );
+}
+
+#[tokio::test]
+async fn test_close_signature_set_and_posted_vaa_happy_path() {
+    let (ref mut context, ref mut test_ctx, ref program) = initialize().await;
+
+    let emitter = Keypair::new();
+    let nonce = rand::thread_rng().gen();
+    let message = [4u8; 32].to_vec();
+    let sequence = context.seq.next(emitter.pubkey().to_bytes());
+    let fee_collector = FeeCollector::<'_>::key(None, program);
+
+    // Post message, verify signatures, post VAA.
+    common::post_message(
+        &mut test_ctx.banks_client,
+        program,
+        &test_ctx.payer,
+        &emitter,
+        None,
+        nonce,
+        message.clone(),
+        10_000,
+    )
+    .await
+    .unwrap();
+
+    let (vaa, body, _) = common::generate_vaa(&emitter, message, nonce, sequence, 0, 1);
+    let signature_set = common::verify_signatures(
+        &mut test_ctx.banks_client,
+        program,
+        &test_ctx.payer,
+        body,
+        &context.secret,
+        0,
+    )
+    .await
+    .unwrap();
+    common::post_vaa(
+        &mut test_ctx.banks_client,
+        program,
+        &test_ctx.payer,
+        signature_set,
+        vaa,
+    )
+    .await
+    .unwrap();
+
+    let posted_vaa_key = PostedVAA::<'_, { AccountState::MaybeInitialized }>::key(
+        &PostedVAADerivationData {
+            payload_hash: body.to_vec(),
+        },
+        program,
+    );
+
+    // Record balances.
+    let fee_collector_before =
+        common::get_account_balance(&mut test_ctx.banks_client, fee_collector).await;
+    let sig_lamports = common::get_account_balance(&mut test_ctx.banks_client, signature_set).await;
+    let vaa_lamports =
+        common::get_account_balance(&mut test_ctx.banks_client, posted_vaa_key).await;
+
+    // Set submission_time to 0 on the PostedVAA so it passes the retention check.
+    common::set_submission_time(test_ctx, posted_vaa_key, old_submission_time()).await;
+
+    // Close both.
+    common::close_signature_set_and_posted_vaa(
+        &mut test_ctx.banks_client,
+        program,
+        &test_ctx.payer,
+        signature_set,
+        posted_vaa_key,
+        0,
+    )
+    .await
+    .unwrap();
+
+    // Verify fee_collector received all lamports.
+    let fee_collector_after =
+        common::get_account_balance(&mut test_ctx.banks_client, fee_collector).await;
+    assert_eq!(
+        fee_collector_after,
+        fee_collector_before + sig_lamports + vaa_lamports,
+        "Fee collector should receive both accounts' lamports"
+    );
+
+    // Verify both accounts are closed.
+    let sig_data = common::get_account_data_raw(&mut test_ctx.banks_client, signature_set).await;
+    assert!(
+        sig_data.is_none() || sig_data.unwrap().iter().all(|&b| b == 0),
+        "Signature set should be closed"
+    );
+    let vaa_data = common::get_account_data_raw(&mut test_ctx.banks_client, posted_vaa_key).await;
+    assert!(
+        vaa_data.is_none() || vaa_data.unwrap().iter().all(|&b| b == 0),
+        "PostedVAA should be closed"
+    );
+}
+
+#[tokio::test]
+async fn test_close_signature_set_and_posted_vaa_rejects_recent() {
+    let (ref mut context, ref mut test_ctx, ref program) = initialize().await;
+
+    let emitter = Keypair::new();
+    let nonce = rand::thread_rng().gen();
+    let message = [5u8; 32].to_vec();
+    let sequence = context.seq.next(emitter.pubkey().to_bytes());
+
+    // Full flow: post message, verify sigs, post VAA.
+    common::post_message(
+        &mut test_ctx.banks_client,
+        program,
+        &test_ctx.payer,
+        &emitter,
+        None,
+        nonce,
+        message.clone(),
+        10_000,
+    )
+    .await
+    .unwrap();
+
+    let (vaa, body, _) = common::generate_vaa(&emitter, message, nonce, sequence, 0, 1);
+    let signature_set = common::verify_signatures(
+        &mut test_ctx.banks_client,
+        program,
+        &test_ctx.payer,
+        body,
+        &context.secret,
+        0,
+    )
+    .await
+    .unwrap();
+    common::post_vaa(
+        &mut test_ctx.banks_client,
+        program,
+        &test_ctx.payer,
+        signature_set,
+        vaa,
+    )
+    .await
+    .unwrap();
+
+    let posted_vaa_key = PostedVAA::<'_, { AccountState::MaybeInitialized }>::key(
+        &PostedVAADerivationData {
+            payload_hash: body.to_vec(),
+        },
+        program,
+    );
+
+    // Immediately try to close -- should fail (recent VAA).
+    let result = common::close_signature_set_and_posted_vaa(
+        &mut test_ctx.banks_client,
+        program,
+        &test_ctx.payer,
+        signature_set,
+        posted_vaa_key,
+        0,
+    )
+    .await;
+    assert!(
+        result.is_err(),
+        "Should reject closing recent sig set + VAA"
+    );
+}
+
+#[tokio::test]
+async fn test_close_signature_set_no_vaa_active_guardian_rejects() {
+    let (ref mut context, ref mut test_ctx, ref program) = initialize().await;
+
+    let emitter = Keypair::new();
+    let nonce = rand::thread_rng().gen();
+    let message = [6u8; 32].to_vec();
+    let sequence = context.seq.next(emitter.pubkey().to_bytes());
+
+    // Post message and verify signatures, but do NOT post VAA.
+    common::post_message(
+        &mut test_ctx.banks_client,
+        program,
+        &test_ctx.payer,
+        &emitter,
+        None,
+        nonce,
+        message.clone(),
+        10_000,
+    )
+    .await
+    .unwrap();
+
+    let (_, body, _) = common::generate_vaa(&emitter, message, nonce, sequence, 0, 1);
+    let signature_set = common::verify_signatures(
+        &mut test_ctx.banks_client,
+        program,
+        &test_ctx.payer,
+        body,
+        &context.secret,
+        0,
+    )
+    .await
+    .unwrap();
+
+    // The PostedVAA PDA doesn't exist (never posted).
+    let posted_vaa_key = PostedVAA::<'_, { AccountState::MaybeInitialized }>::key(
+        &PostedVAADerivationData {
+            payload_hash: body.to_vec(),
+        },
+        program,
+    );
+
+    // Try to close with active guardian set -- should fail.
+    let result = common::close_signature_set_and_posted_vaa(
+        &mut test_ctx.banks_client,
+        program,
+        &test_ctx.payer,
+        signature_set,
+        posted_vaa_key,
+        0,
+    )
+    .await;
+    assert!(
+        result.is_err(),
+        "Should reject closing sig set when guardian set is still active"
+    );
+}
+
+#[tokio::test]
+async fn test_fee_enforcement_after_close() {
+    let (ref mut _context, ref mut test_ctx, ref program) = initialize().await;
+
+    let emitter = Keypair::new();
+    let nonce = rand::thread_rng().gen();
+    let message = [7u8; 32].to_vec();
+
+    // Post a message.
+    let message_key = common::post_message(
+        &mut test_ctx.banks_client,
+        program,
+        &test_ctx.payer,
+        &emitter,
+        None,
+        nonce,
+        message.clone(),
+        10_000,
+    )
+    .await
+    .unwrap();
+
+    // Set submission_time to 0 so it passes retention check, then close.
+    common::set_submission_time(test_ctx, message_key, old_submission_time()).await;
+
+    common::close_posted_message(
+        &mut test_ctx.banks_client,
+        program,
+        &test_ctx.payer,
+        message_key,
+    )
+    .await
+    .unwrap();
+
+    // Now post another message -- fee should still be enforced.
+    let nonce2 = rand::thread_rng().gen();
+    let message2 = [8u8; 32].to_vec();
+    let result = common::post_message(
+        &mut test_ctx.banks_client,
+        program,
+        &test_ctx.payer,
+        &emitter,
+        None,
+        nonce2,
+        message2,
+        10_000,
+    )
+    .await;
+    assert!(
+        result.is_ok(),
+        "Should still be able to post messages after close"
     );
 }

--- a/solana/bridge/program/tests/integration.rs
+++ b/solana/bridge/program/tests/integration.rs
@@ -1893,6 +1893,7 @@ async fn test_close_posted_message_unreliable() {
     let nonce = rand::thread_rng().gen();
     let message = [3u8; 32].to_vec();
     let message_key = Keypair::new();
+    let fee_collector = FeeCollector::<'_>::key(None, program);
 
     // Post an unreliable message ("msu" prefix).
     common::post_message_unreliable(
@@ -1908,6 +1909,12 @@ async fn test_close_posted_message_unreliable() {
     .await
     .unwrap();
 
+    // Record balances before close.
+    let fee_collector_before =
+        common::get_account_balance(&mut test_ctx.banks_client, fee_collector).await;
+    let message_lamports =
+        common::get_account_balance(&mut test_ctx.banks_client, message_key.pubkey()).await;
+
     // Backdate submission_time to 31 days ago so it passes the retention check.
     common::set_submission_time(test_ctx, message_key.pubkey(), old_submission_time()).await;
 
@@ -1921,11 +1928,28 @@ async fn test_close_posted_message_unreliable() {
     .await
     .unwrap();
 
-    // Verify account is closed.
+    // Verify: fee_collector received the lamports.
+    let fee_collector_after =
+        common::get_account_balance(&mut test_ctx.banks_client, fee_collector).await;
+    assert_eq!(
+        fee_collector_after,
+        fee_collector_before + message_lamports,
+        "Fee collector should receive unreliable message account lamports"
+    );
+
+    // Verify: account is closed.
     let data = common::get_account_data_raw(&mut test_ctx.banks_client, message_key.pubkey()).await;
     assert!(
         data.is_none() || data.unwrap().iter().all(|&b| b == 0),
         "Unreliable message account should be closed"
+    );
+
+    // Verify: bridge.last_lamports is updated.
+    let bridge_key = Bridge::<'_, { AccountState::Uninitialized }>::key(None, program);
+    let bridge: BridgeData = common::get_account_data(&mut test_ctx.banks_client, bridge_key).await;
+    assert_eq!(
+        bridge.last_lamports, fee_collector_after,
+        "bridge.last_lamports should be updated after closing unreliable message"
     );
 }
 
@@ -2022,6 +2046,14 @@ async fn test_close_signature_set_and_posted_vaa_happy_path() {
     assert!(
         vaa_data.is_none() || vaa_data.unwrap().iter().all(|&b| b == 0),
         "PostedVAA should be closed"
+    );
+
+    // Verify: bridge.last_lamports is updated.
+    let bridge_key = Bridge::<'_, { AccountState::Uninitialized }>::key(None, program);
+    let bridge: BridgeData = common::get_account_data(&mut test_ctx.banks_client, bridge_key).await;
+    assert_eq!(
+        bridge.last_lamports, fee_collector_after,
+        "bridge.last_lamports should be updated after closing sig set + VAA"
     );
 }
 
@@ -2148,6 +2180,92 @@ async fn test_close_signature_set_no_vaa_active_guardian_rejects() {
     assert!(
         result.is_err(),
         "Should reject closing sig set when guardian set is still active"
+    );
+}
+
+#[tokio::test]
+async fn test_close_signature_set_rejects_wrong_data_length() {
+    // SignatureSet has no magic prefix; the security argument for closing it
+    // rests in part on `try_from_slice` rejecting both leftover and missing
+    // bytes. Pad a real signature_set's data with one extra byte and confirm
+    // the close instruction refuses it. (Also exercises the case where the
+    // PostedVAA is past its retention window and would otherwise be eligible
+    // for close, so we know the rejection comes from the parse, not the
+    // surrounding checks.)
+    let (ref mut context, ref mut test_ctx, ref program) = initialize().await;
+
+    let emitter = Keypair::new();
+    let nonce = rand::thread_rng().gen();
+    let message = [9u8; 32].to_vec();
+    let sequence = context.seq.next(emitter.pubkey().to_bytes());
+
+    common::post_message(
+        &mut test_ctx.banks_client,
+        program,
+        &test_ctx.payer,
+        &emitter,
+        None,
+        nonce,
+        message.clone(),
+        10_000,
+    )
+    .await
+    .unwrap();
+
+    let (vaa, body, _) = common::generate_vaa(&emitter, message, nonce, sequence, 0, 1);
+    let signature_set = common::verify_signatures(
+        &mut test_ctx.banks_client,
+        program,
+        &test_ctx.payer,
+        body,
+        &context.secret,
+        0,
+    )
+    .await
+    .unwrap();
+    common::post_vaa(
+        &mut test_ctx.banks_client,
+        program,
+        &test_ctx.payer,
+        signature_set,
+        vaa,
+    )
+    .await
+    .unwrap();
+
+    let posted_vaa_key = PostedVAA::<'_, { AccountState::MaybeInitialized }>::key(
+        &PostedVAADerivationData {
+            payload_hash: body.to_vec(),
+        },
+        program,
+    );
+
+    // Backdate so retention isn't what causes the rejection.
+    common::set_submission_time(test_ctx, posted_vaa_key, old_submission_time()).await;
+
+    // Append one byte to the signature_set's data so try_from_slice has
+    // leftover input and refuses to parse.
+    let mut sig_account = test_ctx
+        .banks_client
+        .get_account(signature_set)
+        .await
+        .unwrap()
+        .unwrap();
+    sig_account.data.push(0);
+    test_ctx.set_account(&signature_set, &sig_account.into());
+
+    let result = common::close_signature_set_and_posted_vaa(
+        &mut test_ctx.banks_client,
+        program,
+        &test_ctx.payer,
+        signature_set,
+        posted_vaa_key,
+        0,
+    )
+    .await;
+    assert!(
+        result.is_err(),
+        "Should reject closing a signature_set whose data length doesn't match SignatureSetData"
     );
 }
 

--- a/solana/bridge/program/tests/integration.rs
+++ b/solana/bridge/program/tests/integration.rs
@@ -1847,7 +1847,7 @@ async fn test_close_posted_message_happy_path() {
     let message_lamports =
         common::get_account_balance(&mut test_ctx.banks_client, message_key).await;
 
-    // Set submission_time to 0 (epoch) so it passes the 30-day retention check.
+    // Backdate submission_time to 31 days ago so it passes the 30-day retention check.
     common::set_submission_time(test_ctx, message_key, old_submission_time()).await;
 
     // Close the message.
@@ -1908,7 +1908,7 @@ async fn test_close_posted_message_unreliable() {
     .await
     .unwrap();
 
-    // Set submission_time to 0 so it passes the retention check.
+    // Backdate submission_time to 31 days ago so it passes the retention check.
     common::set_submission_time(test_ctx, message_key.pubkey(), old_submission_time()).await;
 
     // Close should succeed for "msu" prefix too.
@@ -1988,7 +1988,7 @@ async fn test_close_signature_set_and_posted_vaa_happy_path() {
     let vaa_lamports =
         common::get_account_balance(&mut test_ctx.banks_client, posted_vaa_key).await;
 
-    // Set submission_time to 0 on the PostedVAA so it passes the retention check.
+    // Backdate submission_time on the PostedVAA to 31 days ago so it passes the retention check.
     common::set_submission_time(test_ctx, posted_vaa_key, old_submission_time()).await;
 
     // Close both.
@@ -2173,7 +2173,7 @@ async fn test_fee_enforcement_after_close() {
     .await
     .unwrap();
 
-    // Set submission_time to 0 so it passes retention check, then close.
+    // Backdate submission_time to 31 days ago so it passes retention check, then close.
     common::set_submission_time(test_ctx, message_key, old_submission_time()).await;
 
     common::close_posted_message(

--- a/solana/bridge/program/tests/integration.rs
+++ b/solana/bridge/program/tests/integration.rs
@@ -199,7 +199,7 @@ async fn bridge_messages() {
         let signatures: SignatureSetData = common::get_account_data(client, signature_set).await;
 
         // Verify on chain Message
-        assert_eq!(posted_message.message.vaa_version, 0);
+        assert_eq!(posted_message.message.vaa_version, 1);
         assert_eq!(
             posted_message.message.consistency_level,
             ConsistencyLevel::Confirmed as u8
@@ -287,7 +287,7 @@ async fn bridge_messages() {
     let signatures: SignatureSetData = common::get_account_data(client, signature_set).await;
 
     // Verify on chain Message
-    assert_eq!(posted_message.message.vaa_version, 0);
+    assert_eq!(posted_message.message.vaa_version, 1);
     assert_eq!(
         posted_message.message.consistency_level,
         ConsistencyLevel::Confirmed as u8
@@ -382,7 +382,7 @@ async fn test_bridge_messages_unreliable() {
         let signatures: SignatureSetData = common::get_account_data(client, signature_set).await;
 
         // Verify on chain vaa
-        assert_eq!(posted_message.message.vaa_version, 0);
+        assert_eq!(posted_message.message.vaa_version, 1);
         assert_eq!(posted_message.message.vaa_signature_account, signature_set);
         assert_eq!(posted_message.message.nonce, nonce);
         assert_eq!(posted_message.message.sequence, sequence);
@@ -771,7 +771,7 @@ async fn guardian_set_change() {
     let guardian_set: GuardianSetData = common::get_account_data(client, guardian_set_key).await;
 
     // Verify on chain Message
-    assert_eq!(posted_message.message.vaa_version, 0);
+    assert_eq!(posted_message.message.vaa_version, 1);
     assert_eq!(
         posted_message.message.consistency_level,
         ConsistencyLevel::Confirmed as u8
@@ -841,7 +841,7 @@ async fn guardian_set_change() {
     let signatures: SignatureSetData = common::get_account_data(client, signature_set).await;
 
     // Verify on chain Message
-    assert_eq!(posted_message.message.vaa_version, 0);
+    assert_eq!(posted_message.message.vaa_version, 1);
     assert_eq!(
         posted_message.message.consistency_level,
         ConsistencyLevel::Confirmed as u8
@@ -1034,7 +1034,7 @@ async fn set_fees() {
     let signatures: SignatureSetData = common::get_account_data(client, signature_set).await;
 
     // Verify on chain Message
-    assert_eq!(posted_message.message.vaa_version, 0);
+    assert_eq!(posted_message.message.vaa_version, 1);
     assert_eq!(
         posted_message.message.consistency_level,
         ConsistencyLevel::Confirmed as u8
@@ -1213,7 +1213,7 @@ async fn free_fees() {
     let signatures: SignatureSetData = common::get_account_data(client, signature_set).await;
 
     // Verify on chain Message
-    assert_eq!(posted_message.message.vaa_version, 0);
+    assert_eq!(posted_message.message.vaa_version, 1);
     assert_eq!(
         posted_message.message.consistency_level,
         ConsistencyLevel::Confirmed as u8
@@ -1458,7 +1458,7 @@ async fn foreign_bridge_messages() {
     let posted_message: PostedVAAData = common::get_account_data(client, message_key).await;
     let signatures: SignatureSetData = common::get_account_data(client, signature_set).await;
 
-    assert_eq!(posted_message.message.vaa_version, 0);
+    assert_eq!(posted_message.message.vaa_version, 1);
     assert_eq!(posted_message.message.vaa_signature_account, signature_set);
     assert_eq!(posted_message.message.nonce, nonce);
     assert_eq!(posted_message.message.sequence, sequence);

--- a/solana/solitaire/program/src/event_cpi.rs
+++ b/solana/solitaire/program/src/event_cpi.rs
@@ -1,0 +1,64 @@
+//! Anchor-compatible event emission via self-CPI.
+//!
+//! Programs built with `solitaire!{ @event_cpi, ... }` install a dispatch
+//! guard that intercepts self-CPIs prefixed with [`crate::EVENT_IX_TAG_LE`],
+//! returning `Ok` without dispatching to a handler. The observable effect of
+//! such a CPI is the log line emitted by the runtime — off-chain indexers
+//! match those lines by `discriminator` to extract typed events.
+
+use solana_program::{
+    account_info::AccountInfo,
+    instruction::{
+        AccountMeta,
+        Instruction,
+    },
+    program::invoke_signed,
+    pubkey::Pubkey,
+};
+
+use crate::{
+    error::SolitaireError,
+    ExecutionContext,
+    Result,
+    EVENT_AUTHORITY_SEED,
+    EVENT_IX_TAG_LE,
+};
+
+/// Emit an Anchor-style event by self-invoking the current program with the
+/// `__event_authority` PDA as the sole signing account. The full instruction
+/// data is `EVENT_IX_TAG_LE || discriminator || payload`.
+///
+/// `event_authority` must be the PDA derived from [`EVENT_AUTHORITY_SEED`] for
+/// `ctx.program_id`; otherwise [`SolitaireError::InvalidDerive`] is returned.
+/// The caller is expected to have separately verified that the program-self
+/// account it provides matches `ctx.program_id`.
+pub fn emit_event_cpi(
+    ctx: &ExecutionContext,
+    event_authority: &AccountInfo,
+    discriminator: &[u8; 8],
+    payload: &[u8],
+) -> Result<()> {
+    let (expected_authority, bump) =
+        Pubkey::find_program_address(&[EVENT_AUTHORITY_SEED], ctx.program_id);
+    if event_authority.key != &expected_authority {
+        return Err(SolitaireError::InvalidDerive(
+            *event_authority.key,
+            expected_authority,
+        ));
+    }
+
+    let mut ix_data =
+        Vec::with_capacity(EVENT_IX_TAG_LE.len() + discriminator.len() + payload.len());
+    ix_data.extend_from_slice(&EVENT_IX_TAG_LE);
+    ix_data.extend_from_slice(discriminator);
+    ix_data.extend_from_slice(payload);
+
+    let ix = Instruction {
+        program_id: *ctx.program_id,
+        accounts: vec![AccountMeta::new_readonly(expected_authority, true)],
+        data: ix_data,
+    };
+
+    invoke_signed(&ix, ctx.accounts, &[&[EVENT_AUTHORITY_SEED, &[bump]]])?;
+    Ok(())
+}

--- a/solana/solitaire/program/src/lib.rs
+++ b/solana/solitaire/program/src/lib.rs
@@ -57,6 +57,13 @@ pub use crate::{
 /// Library name and version to print in entrypoint. Must be evaluated in this crate in order to do the right thing
 pub const PKG_NAME_VERSION: &str = concat!(env!("CARGO_PKG_NAME"), " ", env!("CARGO_PKG_VERSION"));
 
+// Anchor-compatible discriminator: SHA256("anchor:event")[..8]
+pub const EVENT_IX_TAG: u64 = 0x1d9acb512ea545e4;
+pub const EVENT_IX_TAG_LE: [u8; 8] = EVENT_IX_TAG.to_le_bytes();
+
+/// Seed for the Anchor event authority PDA.
+pub const EVENT_AUTHORITY_SEED: &[u8] = b"__event_authority";
+
 pub struct ExecutionContext<'a, 'b: 'a> {
     /// A reference to the program_id of the current program.
     pub program_id: &'a Pubkey,

--- a/solana/solitaire/program/src/lib.rs
+++ b/solana/solitaire/program/src/lib.rs
@@ -25,6 +25,7 @@ pub use borsh::{
 
 // Expose all submodules for consumption.
 pub mod error;
+pub mod event_cpi;
 pub mod macros;
 pub mod processors;
 pub mod types;
@@ -37,6 +38,7 @@ pub use crate::{
         Result,
         SolitaireError,
     },
+    event_cpi::emit_event_cpi,
     macros::*,
     processors::{
         keyed::Keyed,

--- a/solana/solitaire/program/src/macros.rs
+++ b/solana/solitaire/program/src/macros.rs
@@ -24,9 +24,50 @@ macro_rules! trace_impl {
 /// - A set of functions which take as arguments the enum fields.
 /// - A Dispatcher that deserializes bytes into the enum and dispatches the function call.
 /// - A set of client calls scoped to the module `api` that can generate instructions.
+///
+/// Use `@event_cpi,` before the instruction list to opt-in to Anchor-style event CPI support.
+/// This adds a dispatch guard that handles the Anchor event CPI selector (`0xe445a52e51cb9a1d`)
+/// by verifying the `__event_authority` PDA is a signer and returning Ok.
 #[macro_export]
 macro_rules! solitaire {
+    { @event_cpi, $($row:ident => $fn:ident),+ $(,)* } => {
+        $crate::solitaire_inner!(@event_cpi; $($row => $fn),+);
+    };
     { $($row:ident => $fn:ident),+ $(,)* } => {
+        $crate::solitaire_inner!(@no_event; $($row => $fn),+);
+    };
+}
+
+/// Conditionally emits the Anchor event CPI guard in dispatch.
+#[macro_export]
+macro_rules! solitaire_event_guard {
+    (@event_cpi, $p:ident, $a:ident, $d:ident) => {
+        // Handle Anchor event CPI (self-invocation for event emission).
+        if $d.len() >= 8 && $d[..8] == $crate::EVENT_IX_TAG_LE {
+            if $a.is_empty() || !$a[0].is_signer {
+                return Err(SolitaireError::InvalidSigner(
+                    solana_program::pubkey::Pubkey::default(),
+                ));
+            }
+            let (expected_authority, _) = solana_program::pubkey::Pubkey::find_program_address(
+                &[$crate::EVENT_AUTHORITY_SEED],
+                $p,
+            );
+            if $a[0].key != &expected_authority {
+                return Err(SolitaireError::InvalidSigner(*$a[0].key));
+            }
+            return Ok(());
+        }
+    };
+    (@no_event, $p:ident, $a:ident, $d:ident) => {
+        // No event CPI support.
+    };
+}
+
+/// Inner implementation macro. Do not call directly; use `solitaire!` instead.
+#[macro_export]
+macro_rules! solitaire_inner {
+    { @$mode:ident; $($row:ident => $fn:ident),+ } => {
         pub mod instruction {
             use super::*;
             use borsh::{
@@ -82,6 +123,8 @@ macro_rules! solitaire {
             /// This entrypoint is generated from the enum above, it deserializes incoming bytes
             /// and automatically dispatches to the correct method.
             pub fn dispatch<'a, 'b: 'a, 'c>(p: &Pubkey, a: &'c [AccountInfo<'b>], d: &[u8]) -> Result<()> {
+                $crate::solitaire_event_guard!(@$mode, p, a, d);
+
                 match d[0] {
                     $(
                         n if n == Instruction::$row as u8 => $row::execute(p, a, &d[1..]),

--- a/solana/solitaire/program/src/macros.rs
+++ b/solana/solitaire/program/src/macros.rs
@@ -44,10 +44,13 @@ macro_rules! solitaire_event_guard {
     (@event_cpi, $p:ident, $a:ident, $d:ident) => {
         // Handle Anchor event CPI (self-invocation for event emission).
         if $d.len() >= 8 && $d[..8] == $crate::EVENT_IX_TAG_LE {
-            if $a.is_empty() || !$a[0].is_signer {
+            if $a.is_empty() {
                 return Err(SolitaireError::InvalidSigner(
                     solana_program::pubkey::Pubkey::default(),
                 ));
+            }
+            if !$a[0].is_signer {
+                return Err(SolitaireError::InvalidSigner(*$a[0].key));
             }
             let (expected_authority, _) = solana_program::pubkey::Pubkey::find_program_address(
                 &[$crate::EVENT_AUTHORITY_SEED],


### PR DESCRIPTION
This PR extends the Wormhole program on Solana with new instructions to allow closing old accounts to reclaim their rent.
An old account is one that can safely be closed because it has already surved its purpose. This includes signature set accounts corresponding to VAAs that were submitted more than 30 days ago, the posted VAA data itself, and posted message accounts.
Since there is no on-chain guarantee that a posted message has actually been observed, when closing a posted message account, the handler re-emits an identical message via a space (and cost) efficient cpi event mechanism.

The reclaimed rent from these accounts goes into the fee collector account, which has been used to collect messaging fees.