### PR TITLE
node: Support multiple transfers per tx in the Accountant audit flow

### DIFF
--- a/node/pkg/accountant/accountant_test.go
+++ b/node/pkg/accountant/accountant_test.go
@@ -405,7 +405,7 @@ func TestForDeadlock(t *testing.T) {
 	assert.Equal(t, msg2, *resultMsg2)
 }
 
-func TestAuditMapSize(t *testing.T) {
+func TestNumPendingEntries(t *testing.T) {
 	pe1 := &pendingEntry{msgId: "1"}
 	pe2 := &pendingEntry{msgId: "2"}
 	pe3 := &pendingEntry{msgId: "3"}
@@ -416,12 +416,46 @@ func TestAuditMapSize(t *testing.T) {
 		"4-ddeeff": {pe4},
 	}
 
-	assert.Equal(t, 4, auditMapSize(tmpMap))
+	assert.Equal(t, 4, numPendingEntries(tmpMap))
 }
 
-func TestAuditMapSizeEmpty(t *testing.T) {
+func TestNumPendingEntriesEmpty(t *testing.T) {
 	tmpMap := map[string][]*pendingEntry{}
-	assert.Equal(t, 0, auditMapSize(tmpMap))
+	assert.Equal(t, 0, numPendingEntries(tmpMap))
+}
+
+func TestNumPendingEntriesNilMap(t *testing.T) {
+	var tmpMap map[string][]*pendingEntry
+	assert.Equal(t, 0, numPendingEntries(tmpMap))
+}
+
+func TestNumPendingEntriesEmptySlices(t *testing.T) {
+	tmpMap := map[string][]*pendingEntry{
+		"1-aa": {},
+		"2-bb": {},
+		"3-cc": {},
+		"4-dd": {},
+		"5-ee": {},
+	}
+	assert.Equal(t, 0, numPendingEntries(tmpMap))
+}
+
+func TestNumPendingEntriesAllNilValues(t *testing.T) {
+	tmpMap := map[string][]*pendingEntry{
+		"2-aabbcc": {nil, nil, nil},
+	}
+	assert.Equal(t, 0, numPendingEntries(tmpMap))
+}
+
+func TestNumPendingEntriesMixedNils(t *testing.T) {
+	pe1 := &pendingEntry{msgId: "1"}
+	pe2 := &pendingEntry{msgId: "2"}
+
+	tmpMap := map[string][]*pendingEntry{
+		"2-aabbcc": {pe1, nil, pe2, nil},
+		"4-ddeeff": {nil},
+	}
+	assert.Equal(t, 2, numPendingEntries(tmpMap))
 }
 
 func TestCreateAuditMapMultipleTransfersSameTxHash(t *testing.T) {
@@ -482,7 +516,7 @@ func TestCreateAuditMapMultipleTransfersSameTxHash(t *testing.T) {
 
 	// There should be one key in the map (the shared audit key) with two entries.
 	assert.Equal(t, 1, len(tmpMap))
-	assert.Equal(t, 2, auditMapSize(tmpMap))
+	assert.Equal(t, 2, numPendingEntries(tmpMap))
 
 	key := pe1.makeAuditKey()
 	entries, exists := tmpMap[key]
@@ -543,7 +577,7 @@ func TestCreateAuditMapDifferentTxHashes(t *testing.T) {
 
 	// There should be two keys in the map, each with one entry.
 	assert.Equal(t, 2, len(tmpMap))
-	assert.Equal(t, 2, auditMapSize(tmpMap))
+	assert.Equal(t, 2, numPendingEntries(tmpMap))
 
 	entries1, exists := tmpMap[pe1.makeAuditKey()]
 	require.Equal(t, true, exists)
@@ -605,7 +639,7 @@ func TestCreateAuditMapFiltersNTT(t *testing.T) {
 
 	// createAuditMap(false) should only contain the non-NTT transfer.
 	baseMap := acct.createAuditMap(false)
-	assert.Equal(t, 1, auditMapSize(baseMap))
+	assert.Equal(t, 1, numPendingEntries(baseMap))
 	key := pe1.makeAuditKey()
 	entries, exists := baseMap[key]
 	require.Equal(t, true, exists)
@@ -614,7 +648,7 @@ func TestCreateAuditMapFiltersNTT(t *testing.T) {
 
 	// createAuditMap(true) should only contain the NTT transfer.
 	nttMap := acct.createAuditMap(true)
-	assert.Equal(t, 1, auditMapSize(nttMap))
+	assert.Equal(t, 1, numPendingEntries(nttMap))
 	entries, exists = nttMap[key]
 	require.Equal(t, true, exists)
 	assert.Equal(t, 1, len(entries))

--- a/node/pkg/accountant/accountant_test.go
+++ b/node/pkg/accountant/accountant_test.go
@@ -404,3 +404,219 @@ func TestForDeadlock(t *testing.T) {
 	resultMsg2 := <-acctChan
 	assert.Equal(t, msg2, *resultMsg2)
 }
+
+func TestAuditMapSize(t *testing.T) {
+	pe1 := &pendingEntry{msgId: "1"}
+	pe2 := &pendingEntry{msgId: "2"}
+	pe3 := &pendingEntry{msgId: "3"}
+	pe4 := &pendingEntry{msgId: "4"}
+
+	tmpMap := map[string][]*pendingEntry{
+		"2-aabbcc": {pe1, pe2, pe3},
+		"4-ddeeff": {pe4},
+	}
+
+	assert.Equal(t, 4, auditMapSize(tmpMap))
+}
+
+func TestAuditMapSizeEmpty(t *testing.T) {
+	tmpMap := map[string][]*pendingEntry{}
+	assert.Equal(t, 0, auditMapSize(tmpMap))
+}
+
+func TestCreateAuditMapMultipleTransfersSameTxHash(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop()
+	obsvReqWriteC := make(chan *gossipv1.ObservationRequest, 10)
+	acctChan := make(chan *common.MessagePublication, 10)
+	acct := newAccountantForTest(t, logger, ctx, enforceAccountant, obsvReqWriteC, acctChan, nil)
+	require.NotNil(t, acct)
+
+	emitterAddr, _ := vaa.StringToAddress("0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16")
+	payloadBytes := buildMockTransferPayloadBytes(1,
+		vaa.ChainIDEthereum,
+		"0x707f9118e33a9b8998bea41dd0d46f38bb963fc8",
+		vaa.ChainIDPolygon,
+		"0x707f9118e33a9b8998bea41dd0d46f38bb963fc8",
+		1.25,
+	)
+
+	// Two transfers from the same transaction (same TxID and EmitterChain) but different sequences.
+	txID := hashToTxID("0x06f541f5ecfc43407c31587aa6ac3a689e8960f36dc23c332db5510dfc6a4063")
+
+	msg1 := &common.MessagePublication{
+		TxID:             txID,
+		Timestamp:        time.Unix(int64(1654543099), 0),
+		Nonce:            uint32(1),
+		Sequence:         uint64(1),
+		EmitterChain:     vaa.ChainIDEthereum,
+		EmitterAddress:   emitterAddr,
+		ConsistencyLevel: uint8(32),
+		Payload:          payloadBytes,
+	}
+
+	msg2 := &common.MessagePublication{
+		TxID:             txID,
+		Timestamp:        time.Unix(int64(1654543099), 0),
+		Nonce:            uint32(2),
+		Sequence:         uint64(2),
+		EmitterChain:     vaa.ChainIDEthereum,
+		EmitterAddress:   emitterAddr,
+		ConsistencyLevel: uint8(32),
+		Payload:          payloadBytes,
+	}
+
+	// Manually add both transfers to the pending map (they have different msgIds because of different sequences).
+	pe1 := &pendingEntry{msg: msg1, msgId: msg1.MessageIDString(), digest: "digest1"}
+	pe2 := &pendingEntry{msg: msg2, msgId: msg2.MessageIDString(), digest: "digest2"}
+	pe1.setUpdTime()
+	pe2.setUpdTime()
+	acct.pendingTransfers[pe1.msgId] = pe1
+	acct.pendingTransfers[pe2.msgId] = pe2
+
+	// Verify the two messages have different msgIds but the same audit key.
+	require.NotEqual(t, pe1.msgId, pe2.msgId)
+	require.Equal(t, pe1.makeAuditKey(), pe2.makeAuditKey())
+
+	tmpMap := acct.createAuditMap(false)
+
+	// There should be one key in the map (the shared audit key) with two entries.
+	assert.Equal(t, 1, len(tmpMap))
+	assert.Equal(t, 2, auditMapSize(tmpMap))
+
+	key := pe1.makeAuditKey()
+	entries, exists := tmpMap[key]
+	require.Equal(t, true, exists)
+	assert.Equal(t, 2, len(entries))
+}
+
+func TestCreateAuditMapDifferentTxHashes(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop()
+	obsvReqWriteC := make(chan *gossipv1.ObservationRequest, 10)
+	acctChan := make(chan *common.MessagePublication, 10)
+	acct := newAccountantForTest(t, logger, ctx, enforceAccountant, obsvReqWriteC, acctChan, nil)
+	require.NotNil(t, acct)
+
+	emitterAddr, _ := vaa.StringToAddress("0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16")
+	payloadBytes := buildMockTransferPayloadBytes(3,
+		vaa.ChainIDBSC,
+		"0x0290fb167208af455bb137780163b7b7a9a10c16",
+		vaa.ChainIDEthereum,
+		"0x0290fb167208af455bb137780163b7b7a9a10c16",
+		2.50,
+	)
+
+	msg1 := &common.MessagePublication{
+		TxID:             hashToTxID("0x06f541f5ecfc43407c31587aa6ac3a689e8960f36dc23c332db5510dfc6a4063"),
+		Timestamp:        time.Unix(int64(1654543099), 0),
+		Nonce:            uint32(1),
+		Sequence:         uint64(1),
+		EmitterChain:     vaa.ChainIDEthereum,
+		EmitterAddress:   emitterAddr,
+		ConsistencyLevel: uint8(32),
+		Payload:          payloadBytes,
+	}
+
+	msg2 := &common.MessagePublication{
+		TxID:             hashToTxID("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+		Timestamp:        time.Unix(int64(1654543099), 0),
+		Nonce:            uint32(1),
+		Sequence:         uint64(2),
+		EmitterChain:     vaa.ChainIDEthereum,
+		EmitterAddress:   emitterAddr,
+		ConsistencyLevel: uint8(32),
+		Payload:          payloadBytes,
+	}
+
+	pe1 := &pendingEntry{msg: msg1, msgId: msg1.MessageIDString(), digest: "digest1"}
+	pe2 := &pendingEntry{msg: msg2, msgId: msg2.MessageIDString(), digest: "digest2"}
+	pe1.setUpdTime()
+	pe2.setUpdTime()
+	acct.pendingTransfers[pe1.msgId] = pe1
+	acct.pendingTransfers[pe2.msgId] = pe2
+
+	// Verify the two messages have different audit keys.
+	require.NotEqual(t, pe1.makeAuditKey(), pe2.makeAuditKey())
+
+	tmpMap := acct.createAuditMap(false)
+
+	// There should be two keys in the map, each with one entry.
+	assert.Equal(t, 2, len(tmpMap))
+	assert.Equal(t, 2, auditMapSize(tmpMap))
+
+	entries1, exists := tmpMap[pe1.makeAuditKey()]
+	require.Equal(t, true, exists)
+	assert.Equal(t, 1, len(entries1))
+
+	entries2, exists := tmpMap[pe2.makeAuditKey()]
+	require.Equal(t, true, exists)
+	assert.Equal(t, 1, len(entries2))
+}
+
+func TestCreateAuditMapFiltersNTT(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.NewNop()
+	obsvReqWriteC := make(chan *gossipv1.ObservationRequest, 10)
+	acctChan := make(chan *common.MessagePublication, 10)
+	acct := newAccountantForTest(t, logger, ctx, enforceAccountant, obsvReqWriteC, acctChan, nil)
+	require.NotNil(t, acct)
+
+	emitterAddr, _ := vaa.StringToAddress("0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16")
+	payloadBytes := buildMockTransferPayloadBytes(1,
+		vaa.ChainIDEthereum,
+		"0x707f9118e33a9b8998bea41dd0d46f38bb963fc8",
+		vaa.ChainIDPolygon,
+		"0x707f9118e33a9b8998bea41dd0d46f38bb963fc8",
+		1.25,
+	)
+
+	// Two transfers with the same TxID but different NTT flags.
+	txID := hashToTxID("0x06f541f5ecfc43407c31587aa6ac3a689e8960f36dc23c332db5510dfc6a4063")
+
+	msg1 := &common.MessagePublication{
+		TxID:             txID,
+		Timestamp:        time.Unix(int64(1654543099), 0),
+		Nonce:            uint32(1),
+		Sequence:         uint64(1),
+		EmitterChain:     vaa.ChainIDEthereum,
+		EmitterAddress:   emitterAddr,
+		ConsistencyLevel: uint8(32),
+		Payload:          payloadBytes,
+	}
+
+	msg2 := &common.MessagePublication{
+		TxID:             txID,
+		Timestamp:        time.Unix(int64(1654543099), 0),
+		Nonce:            uint32(2),
+		Sequence:         uint64(2),
+		EmitterChain:     vaa.ChainIDEthereum,
+		EmitterAddress:   emitterAddr,
+		ConsistencyLevel: uint8(32),
+		Payload:          payloadBytes,
+	}
+
+	pe1 := &pendingEntry{msg: msg1, msgId: msg1.MessageIDString(), digest: "digest1", isNTT: false}
+	pe2 := &pendingEntry{msg: msg2, msgId: msg2.MessageIDString(), digest: "digest2", isNTT: true}
+	pe1.setUpdTime()
+	pe2.setUpdTime()
+	acct.pendingTransfers[pe1.msgId] = pe1
+	acct.pendingTransfers[pe2.msgId] = pe2
+
+	// createAuditMap(false) should only contain the non-NTT transfer.
+	baseMap := acct.createAuditMap(false)
+	assert.Equal(t, 1, auditMapSize(baseMap))
+	key := pe1.makeAuditKey()
+	entries, exists := baseMap[key]
+	require.Equal(t, true, exists)
+	assert.Equal(t, 1, len(entries))
+	assert.Equal(t, pe1.msgId, entries[0].msgId)
+
+	// createAuditMap(true) should only contain the NTT transfer.
+	nttMap := acct.createAuditMap(true)
+	assert.Equal(t, 1, auditMapSize(nttMap))
+	entries, exists = nttMap[key]
+	require.Equal(t, true, exists)
+	assert.Equal(t, 1, len(entries))
+	assert.Equal(t, pe2.msgId, entries[0].msgId)
+}

--- a/node/pkg/accountant/audit.go
+++ b/node/pkg/accountant/audit.go
@@ -129,22 +129,33 @@ func (acct *Accountant) audit(ctx context.Context) error {
 // runAudit is the entry point for the audit of the pending transfer map. It creates a temporary map of all pending transfers and invokes the main audit function.
 func (acct *Accountant) runAudit() {
 	tmpMap := acct.createAuditMap(false)
-	acct.logger.Debug("in AuditPendingTransfers: starting base audit", zap.Int("numPending", len(tmpMap)))
+	acct.logger.Debug("in AuditPendingTransfers: starting base audit", zap.Int("numPending", auditMapSize(tmpMap)))
 	acct.performAudit(tmpMap, acct.wormchainConn, acct.contract)
 	acct.logger.Debug("in AuditPendingTransfers: finished base audit")
 
 	tmpMap = acct.createAuditMap(true)
-	acct.logger.Debug("in AuditPendingTransfers: starting ntt audit", zap.Int("numPending", len(tmpMap)))
+	acct.logger.Debug("in AuditPendingTransfers: starting ntt audit", zap.Int("numPending", auditMapSize(tmpMap)))
 	acct.performAudit(tmpMap, acct.nttWormchainConn, acct.nttContract)
 	acct.logger.Debug("in AuditPendingTransfers: finished ntt audit")
 }
 
+// auditMapSize returns the total number of pending entries across all keys in the audit map.
+func auditMapSize(tmpMap map[string][]*pendingEntry) int {
+	n := 0
+	for _, entries := range tmpMap {
+		n += len(entries)
+	}
+	return n
+}
+
 // createAuditMap creates a temporary map of all pending transfers. It grabs the pending transfer lock.
-func (acct *Accountant) createAuditMap(isNTT bool) map[string]*pendingEntry {
+// The map is keyed by chain-txHash (the audit key). Multiple transfers may share the same key if they
+// originate from the same transaction, so each key maps to a slice of pending entries.
+func (acct *Accountant) createAuditMap(isNTT bool) map[string][]*pendingEntry {
 	acct.pendingTransfersLock.Lock()
 	defer acct.pendingTransfersLock.Unlock()
 
-	tmpMap := make(map[string]*pendingEntry)
+	tmpMap := make(map[string][]*pendingEntry)
 	for _, pe := range acct.pendingTransfers {
 		if pe.isNTT == isNTT {
 			if pe.hasBeenPendingForTooLong() {
@@ -153,7 +164,7 @@ func (acct *Accountant) createAuditMap(isNTT bool) map[string]*pendingEntry {
 			}
 			key := pe.makeAuditKey()
 			acct.logger.Debug("will audit pending transfer", zap.String("msgId", pe.msgId), zap.String("moKey", key), zap.Bool("submitPending", pe.submitPending()), zap.Stringer("lastUpdateTime", pe.updTime()))
-			tmpMap[key] = pe
+			tmpMap[key] = append(tmpMap[key], pe)
 		}
 	}
 
@@ -169,26 +180,30 @@ func (pe *pendingEntry) hasBeenPendingForTooLong() bool {
 
 // performAudit audits the temporary map against the smart contract. It is meant to be run in a go routine. It takes a temporary map of all pending transfers
 // and validates that against what is reported by the smart contract. For more details, please see the prologue of this file.
-func (acct *Accountant) performAudit(tmpMap map[string]*pendingEntry, wormchainConn AccountantWormchainConn, contract string) {
+func (acct *Accountant) performAudit(tmpMap map[string][]*pendingEntry, wormchainConn AccountantWormchainConn, contract string) {
 	acct.logger.Debug("entering performAudit", zap.String("contract", contract))
 	missingObservations, err := acct.queryMissingObservations(wormchainConn, contract)
 	if err != nil {
 		acct.logger.Error("unable to perform audit, failed to query missing observations", zap.Error(err))
-		for _, pe := range tmpMap {
-			acct.logger.Error("unsure of status of pending transfer due to query error", zap.String("msgId", pe.msgId))
+		for _, entries := range tmpMap {
+			for _, pe := range entries {
+				acct.logger.Error("unsure of status of pending transfer due to query error", zap.String("msgId", pe.msgId))
+			}
 		}
 		return
 	}
 
 	for _, mo := range missingObservations {
 		key := mo.makeAuditKey()
-		pe, exists := tmpMap[key]
+		entries, exists := tmpMap[key]
 		if exists {
-			if acct.submitObservation(pe) {
-				auditErrors.Inc()
-				acct.logger.Error("contract reported pending observation as missing, resubmitted it", zap.String("msgID", pe.msgId))
-			} else {
-				acct.logger.Info("contract reported pending observation as missing but it is queued up to be submitted, skipping it", zap.String("msgID", pe.msgId))
+			for _, pe := range entries {
+				if acct.submitObservation(pe) {
+					auditErrors.Inc()
+					acct.logger.Error("contract reported pending observation as missing, resubmitted it", zap.String("msgID", pe.msgId))
+				} else {
+					acct.logger.Info("contract reported pending observation as missing but it is queued up to be submitted, skipping it", zap.String("msgID", pe.msgId))
+				}
 			}
 
 			delete(tmpMap, key)
@@ -197,18 +212,20 @@ func (acct *Accountant) performAudit(tmpMap map[string]*pendingEntry, wormchainC
 		}
 	}
 
-	if len(tmpMap) != 0 {
+	if auditMapSize(tmpMap) != 0 {
 		var keys []TransferKey
 		var pendingTransfers []*pendingEntry
-		for _, pe := range tmpMap {
-			keys = append(keys, TransferKey{EmitterChain: uint16(pe.msg.EmitterChain), EmitterAddress: pe.msg.EmitterAddress, Sequence: pe.msg.Sequence})
-			pendingTransfers = append(pendingTransfers, pe)
+		for _, entries := range tmpMap {
+			for _, pe := range entries {
+				keys = append(keys, TransferKey{EmitterChain: uint16(pe.msg.EmitterChain), EmitterAddress: pe.msg.EmitterAddress, Sequence: pe.msg.Sequence})
+				pendingTransfers = append(pendingTransfers, pe)
+			}
 		}
 
 		transferDetails, err := acct.queryBatchTransferStatus(keys, wormchainConn, contract)
 		if err != nil {
 			acct.logger.Error("unable to finish audit, failed to query for transfer statuses", zap.Error(err))
-			for _, pe := range tmpMap {
+			for _, pe := range pendingTransfers {
 				acct.logger.Error("unsure of status of pending transfer due to query error", zap.String("msgId", pe.msgId))
 			}
 			return

--- a/node/pkg/accountant/audit.go
+++ b/node/pkg/accountant/audit.go
@@ -129,21 +129,26 @@ func (acct *Accountant) audit(ctx context.Context) error {
 // runAudit is the entry point for the audit of the pending transfer map. It creates a temporary map of all pending transfers and invokes the main audit function.
 func (acct *Accountant) runAudit() {
 	tmpMap := acct.createAuditMap(false)
-	acct.logger.Debug("in AuditPendingTransfers: starting base audit", zap.Int("numPending", auditMapSize(tmpMap)))
+	acct.logger.Debug("in AuditPendingTransfers: starting base audit", zap.Int("numPending", numPendingEntries(tmpMap)))
 	acct.performAudit(tmpMap, acct.wormchainConn, acct.contract)
 	acct.logger.Debug("in AuditPendingTransfers: finished base audit")
 
 	tmpMap = acct.createAuditMap(true)
-	acct.logger.Debug("in AuditPendingTransfers: starting ntt audit", zap.Int("numPending", auditMapSize(tmpMap)))
+	acct.logger.Debug("in AuditPendingTransfers: starting ntt audit", zap.Int("numPending", numPendingEntries(tmpMap)))
 	acct.performAudit(tmpMap, acct.nttWormchainConn, acct.nttContract)
 	acct.logger.Debug("in AuditPendingTransfers: finished ntt audit")
 }
 
-// auditMapSize returns the total number of pending entries across all keys in the audit map.
-func auditMapSize(tmpMap map[string][]*pendingEntry) int {
+// numPendingEntries returns the total number of non-nil pending entries across all keys
+// in the audit map. Nil entries are skipped so a slice of nils does not inflate the count.
+func numPendingEntries(tmpMap map[string][]*pendingEntry) int {
 	n := 0
 	for _, entries := range tmpMap {
-		n += len(entries)
+		for _, pe := range entries {
+			if pe != nil {
+				n++
+			}
+		}
 	}
 	return n
 }
@@ -212,11 +217,16 @@ func (acct *Accountant) performAudit(tmpMap map[string][]*pendingEntry, wormchai
 		}
 	}
 
-	if auditMapSize(tmpMap) != 0 {
+	if len(tmpMap) != 0 {
 		var keys []TransferKey
 		var pendingTransfers []*pendingEntry
 		for _, entries := range tmpMap {
 			for _, pe := range entries {
+				// Skip nil entries
+				if pe == nil {
+					continue
+				}
+
 				keys = append(keys, TransferKey{EmitterChain: uint16(pe.msg.EmitterChain), EmitterAddress: pe.msg.EmitterAddress, Sequence: pe.msg.Sequence})
 				pendingTransfers = append(pendingTransfers, pe)
 			}

--- a/node/pkg/accountant/audit.go
+++ b/node/pkg/accountant/audit.go
@@ -162,6 +162,10 @@ func (acct *Accountant) createAuditMap(isNTT bool) map[string][]*pendingEntry {
 
 	tmpMap := make(map[string][]*pendingEntry)
 	for _, pe := range acct.pendingTransfers {
+		// Skip over nil entries
+		if pe == nil {
+			continue
+		}
 		if pe.isNTT == isNTT {
 			if pe.hasBeenPendingForTooLong() {
 				auditErrors.Inc()
@@ -192,6 +196,10 @@ func (acct *Accountant) performAudit(tmpMap map[string][]*pendingEntry, wormchai
 		acct.logger.Error("unable to perform audit, failed to query missing observations", zap.Error(err))
 		for _, entries := range tmpMap {
 			for _, pe := range entries {
+				// We already do a nil check in `createAuditMap`, but we'll do the same here
+				if pe == nil {
+					continue
+				}
 				acct.logger.Error("unsure of status of pending transfer due to query error", zap.String("msgId", pe.msgId))
 			}
 		}
@@ -203,6 +211,10 @@ func (acct *Accountant) performAudit(tmpMap map[string][]*pendingEntry, wormchai
 		entries, exists := tmpMap[key]
 		if exists {
 			for _, pe := range entries {
+				// We already do a nil check in `createAuditMap`, but we'll do the same here
+				if pe == nil {
+					continue
+				}
 				if acct.submitObservation(pe) {
 					auditErrors.Inc()
 					acct.logger.Error("contract reported pending observation as missing, resubmitted it", zap.String("msgID", pe.msgId))
@@ -222,7 +234,7 @@ func (acct *Accountant) performAudit(tmpMap map[string][]*pendingEntry, wormchai
 		var pendingTransfers []*pendingEntry
 		for _, entries := range tmpMap {
 			for _, pe := range entries {
-				// Skip nil entries
+				// We already do a nil check in `createAuditMap`, but we'll do the same here
 				if pe == nil {
 					continue
 				}
@@ -236,12 +248,20 @@ func (acct *Accountant) performAudit(tmpMap map[string][]*pendingEntry, wormchai
 		if err != nil {
 			acct.logger.Error("unable to finish audit, failed to query for transfer statuses", zap.Error(err))
 			for _, pe := range pendingTransfers {
+				// We already do a nil check in `createAuditMap`, but we'll do the same here
+				if pe == nil {
+					continue
+				}
 				acct.logger.Error("unsure of status of pending transfer due to query error", zap.String("msgId", pe.msgId))
 			}
 			return
 		}
 
 		for _, pe := range pendingTransfers {
+			// There should be no nil entries, but we'll skip to be safe
+			if pe == nil {
+				continue
+			}
 			status, exists := transferDetails[pe.msgId]
 			if !exists {
 				if acct.submitObservation(pe) {


### PR DESCRIPTION
The Accountant correctly tracks pending transfers by full Wormhole message ID, but its audit recovery path temporarily re-keys those transfers by `(emitterChain, txHash)` instead. That key is not unique when a single EVM transaction emits multiple covered token-bridge messages.

We make a change here to support the audit flow for multiple transfers in a single transaction.