### PR TITLE
sdk: Add VAA ID validation and use it everywhere

### DIFF
--- a/.coverage-baseline
+++ b/.coverage-baseline
@@ -6,8 +6,8 @@ github.com/certusone/wormhole/node 0.0
 github.com/certusone/wormhole/node/cmd 0.0
 github.com/certusone/wormhole/node/cmd/ccq 15.5
 github.com/certusone/wormhole/node/cmd/debug 0.0
-github.com/certusone/wormhole/node/cmd/guardiand 21.6
-github.com/certusone/wormhole/node/cmd/spy 31.5
+github.com/certusone/wormhole/node/cmd/guardiand 21.8
+github.com/certusone/wormhole/node/cmd/spy 31.8
 github.com/certusone/wormhole/node/cmd/txverifier 0.0
 github.com/certusone/wormhole/node/hack/accountant 0.0
 github.com/certusone/wormhole/node/hack/encrypt 0.0
@@ -34,7 +34,7 @@ github.com/certusone/wormhole/node/pkg/gwrelayer 31.9
 github.com/certusone/wormhole/node/pkg/manager 23.3
 github.com/certusone/wormhole/node/pkg/manager/delegatedmanagersetabi 0.0
 github.com/certusone/wormhole/node/pkg/manager/dogecoin 93.8
-github.com/certusone/wormhole/node/pkg/node 65.2
+github.com/certusone/wormhole/node/pkg/node 65.3
 github.com/certusone/wormhole/node/pkg/notary 36.9
 github.com/certusone/wormhole/node/pkg/p2p 40.3
 github.com/certusone/wormhole/node/pkg/processor 10.2
@@ -43,14 +43,14 @@ github.com/certusone/wormhole/node/pkg/proto/node/v1 0.0
 github.com/certusone/wormhole/node/pkg/proto/prometheus/v1 0.0
 github.com/certusone/wormhole/node/pkg/proto/publicrpc/v1 0.0
 github.com/certusone/wormhole/node/pkg/proto/spy/v1 0.0
-github.com/certusone/wormhole/node/pkg/publicrpc 12.4
-github.com/certusone/wormhole/node/pkg/query 69.9
+github.com/certusone/wormhole/node/pkg/publicrpc 52.4
+github.com/certusone/wormhole/node/pkg/query 69.7
 github.com/certusone/wormhole/node/pkg/random 0.0
 github.com/certusone/wormhole/node/pkg/readiness 0.0
 github.com/certusone/wormhole/node/pkg/supervisor 0.0
 github.com/certusone/wormhole/node/pkg/telemetry 16.0
 github.com/certusone/wormhole/node/pkg/telemetry/prom_remote_write 59.5
-github.com/certusone/wormhole/node/pkg/txverifier 54.7
+github.com/certusone/wormhole/node/pkg/txverifier 55.4
 github.com/certusone/wormhole/node/pkg/version 0.0
 github.com/certusone/wormhole/node/pkg/watchers/algorand 30.4
 github.com/certusone/wormhole/node/pkg/watchers/aptos 29.8

--- a/.coverage-baseline
+++ b/.coverage-baseline
@@ -6,8 +6,8 @@ github.com/certusone/wormhole/node 0.0
 github.com/certusone/wormhole/node/cmd 0.0
 github.com/certusone/wormhole/node/cmd/ccq 15.5
 github.com/certusone/wormhole/node/cmd/debug 0.0
-github.com/certusone/wormhole/node/cmd/guardiand 21.6
-github.com/certusone/wormhole/node/cmd/spy 31.1
+github.com/certusone/wormhole/node/cmd/guardiand 21.8
+github.com/certusone/wormhole/node/cmd/spy 31.8
 github.com/certusone/wormhole/node/cmd/txverifier 0.0
 github.com/certusone/wormhole/node/hack/accountant 0.0
 github.com/certusone/wormhole/node/hack/encrypt 0.0
@@ -34,7 +34,7 @@ github.com/certusone/wormhole/node/pkg/gwrelayer 31.9
 github.com/certusone/wormhole/node/pkg/manager 23.3
 github.com/certusone/wormhole/node/pkg/manager/delegatedmanagersetabi 0.0
 github.com/certusone/wormhole/node/pkg/manager/dogecoin 93.8
-github.com/certusone/wormhole/node/pkg/node 65.2
+github.com/certusone/wormhole/node/pkg/node 65.3
 github.com/certusone/wormhole/node/pkg/notary 36.9
 github.com/certusone/wormhole/node/pkg/p2p 40.3
 github.com/certusone/wormhole/node/pkg/processor 10.2
@@ -43,14 +43,14 @@ github.com/certusone/wormhole/node/pkg/proto/node/v1 0.0
 github.com/certusone/wormhole/node/pkg/proto/prometheus/v1 0.0
 github.com/certusone/wormhole/node/pkg/proto/publicrpc/v1 0.0
 github.com/certusone/wormhole/node/pkg/proto/spy/v1 0.0
-github.com/certusone/wormhole/node/pkg/publicrpc 12.4
 github.com/certusone/wormhole/node/pkg/query 70.2
+github.com/certusone/wormhole/node/pkg/publicrpc 52.4
 github.com/certusone/wormhole/node/pkg/random 0.0
 github.com/certusone/wormhole/node/pkg/readiness 0.0
 github.com/certusone/wormhole/node/pkg/supervisor 0.0
 github.com/certusone/wormhole/node/pkg/telemetry 16.0
 github.com/certusone/wormhole/node/pkg/telemetry/prom_remote_write 59.5
-github.com/certusone/wormhole/node/pkg/txverifier 54.7
+github.com/certusone/wormhole/node/pkg/txverifier 55.4
 github.com/certusone/wormhole/node/pkg/version 0.0
 github.com/certusone/wormhole/node/pkg/watchers/algorand 30.4
 github.com/certusone/wormhole/node/pkg/watchers/aptos 29.8

--- a/node/cmd/guardiand/adminclient.go
+++ b/node/cmd/guardiand/adminclient.go
@@ -811,15 +811,15 @@ func buildDelegateSignaturesBroadcasts(vaaID string, apiObservations []wormholes
 			d := &gossipv1.DelegateObservation{
 				Timestamp:         timestamp,
 				Nonce:             ref.Nonce,
-				EmitterChain:      uint32(chainID), // #nosec G115
+				EmitterChain:      uint32(chainID),
 				EmitterAddress:    emitterAddrBytes,
 				Sequence:          ref.Sequence,
-				ConsistencyLevel:  uint32(ref.ConsistencyLevel), // #nosec G115
+				ConsistencyLevel:  uint32(ref.ConsistencyLevel),
 				Payload:           payloadBytes,
 				TxHash:            txHashBytes,
 				Unreliable:        obs.Unreliable,
 				IsReobservation:   obs.IsReobservation,
-				VerificationState: uint32(obs.VerificationState), // #nosec G115
+				VerificationState: uint32(obs.VerificationState),
 				GuardianAddr:      guardianAddrBytes,
 				SentTimestamp:     sentTimestamp,
 			}
@@ -854,15 +854,15 @@ func buildDelegateSignaturesBroadcasts(vaaID string, apiObservations []wormholes
 		broadcasts = append(broadcasts, &gossipv1.DelegateSignaturesBroadcast{
 			Timestamp:          timestamp,
 			Nonce:              ref.Nonce,
-			EmitterChain:       uint32(chainID), // #nosec G115
+			EmitterChain:       uint32(chainID),
 			EmitterAddress:     emitterAddrBytes,
 			Sequence:           ref.Sequence,
-			ConsistencyLevel:   uint32(ref.ConsistencyLevel), // #nosec G115
+			ConsistencyLevel:   uint32(ref.ConsistencyLevel),
 			Payload:            payloadBytes,
 			TxHash:             txHashBytes,
 			Unreliable:         ref.Unreliable,
 			IsReobservation:    ref.IsReobservation,
-			VerificationState:  uint32(ref.VerificationState), // #nosec G115
+			VerificationState:  uint32(ref.VerificationState),
 			Signatures:         signatures,
 			BroadcastTimestamp: time.Now().Unix(),
 		})

--- a/node/cmd/guardiand/adminclient.go
+++ b/node/cmd/guardiand/adminclient.go
@@ -415,7 +415,7 @@ func runInjectGovernanceVAA(cmd *cobra.Command, args []string) {
 }
 
 func runFindMissingMessages(cmd *cobra.Command, args []string) {
-	chainID, err := strconv.Atoi(args[0])
+	chainID, err := vaa.StringToChainID(args[0])
 	if err != nil {
 		log.Fatalf("invalid chain ID: %v", err)
 	}
@@ -431,12 +431,8 @@ func runFindMissingMessages(cmd *cobra.Command, args []string) {
 	}
 	defer conn.Close()
 
-	if chainID > math.MaxUint16 {
-		log.Fatalf("chain ID is not a valid 16 bit unsigned integer: %v", err)
-	}
-
 	msg := nodev1.FindMissingMessagesRequest{
-		EmitterChain:   uint32(chainID), // #nosec G115 -- This conversion is checked above
+		EmitterChain:   uint32(chainID),
 		EmitterAddress: emitterAddress,
 		RpcBackfill:    *shouldBackfill,
 		BackfillNodes:  sdk.PublicRPCEndpoints,
@@ -457,22 +453,9 @@ func runFindMissingMessages(cmd *cobra.Command, args []string) {
 // runDumpVAAByMessageID uses GetSignedVAA to request the given message,
 // then decode and dump the VAA.
 func runDumpVAAByMessageID(cmd *cobra.Command, args []string) {
-	// Parse the {chain,emitter,seq} string.
-	parts := strings.Split(args[0], "/")
-	if len(parts) != 3 {
-		log.Fatalf("invalid message ID: %s", args[0])
-	}
-	chainID, err := strconv.ParseUint(parts[0], 10, 32)
+	vaaID, err := vaa.VAAIDFromString(args[0])
 	if err != nil {
-		log.Fatalf("invalid chain ID: %v", err)
-	}
-	if chainID > math.MaxUint16 {
-		log.Fatalf("chain id must not exceed the max uint16: %v", chainID)
-	}
-	emitterAddress := parts[1]
-	seq, err := strconv.ParseUint(parts[2], 10, 64)
-	if err != nil {
-		log.Fatalf("invalid sequence number: %v", err)
+		log.Fatalf("invalid message ID %q: %v", args[0], err)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -486,9 +469,9 @@ func runDumpVAAByMessageID(cmd *cobra.Command, args []string) {
 
 	msg := publicrpcv1.GetSignedVAARequest{
 		MessageId: &publicrpcv1.MessageID{
-			EmitterChain:   publicrpcv1.ChainID(chainID),
-			EmitterAddress: emitterAddress,
-			Sequence:       seq,
+			EmitterChain:   publicrpcv1.ChainID(vaaID.EmitterChain),
+			EmitterAddress: vaaID.EmitterAddress.String(),
+			Sequence:       vaaID.Sequence,
 		},
 	}
 	resp, err := c.GetSignedVAA(ctx, &msg)
@@ -510,7 +493,7 @@ func runDumpVAAByMessageID(cmd *cobra.Command, args []string) {
 }
 
 func runSendObservationRequest(cmd *cobra.Command, args []string) {
-	chainID, err := parseChainID(args[0])
+	chainID, err := vaa.StringToChainID(args[0])
 	if err != nil {
 		log.Fatalf("invalid chain ID: %v", err)
 	}
@@ -547,7 +530,7 @@ func runSendObservationRequest(cmd *cobra.Command, args []string) {
 }
 
 func runReobserveWithEndpoint(cmd *cobra.Command, args []string) {
-	chainID, err := parseChainID(args[0])
+	chainID, err := vaa.StringToChainID(args[0])
 	if err != nil {
 		log.Fatalf("invalid chain ID: %v", err)
 	}
@@ -696,14 +679,18 @@ func delegateObservationVAAHash(obs *wormholescanDelegateObservation) (string, e
 // broadcast per unique message publication. This is necessary because a DelegateSignaturesBroadcast
 // carries common fields (including TxHash) that must be identical for all signatures in a batch.
 func buildDelegateSignaturesBroadcasts(vaaID string, apiObservations []wormholescanDelegateObservation) ([]*gossipv1.DelegateSignaturesBroadcast, error) {
-	parts := strings.Split(vaaID, "/")
-	if len(parts) != 3 {
-		return nil, fmt.Errorf("vaa_id must be in format chain/emitter/sequence")
-	}
-	chainID := parts[0]
-
 	if len(apiObservations) == 0 {
 		return nil, fmt.Errorf("no delegate observations provided")
+	}
+
+	parsedVAAID, err := vaa.VAAIDFromString(vaaID)
+	if err != nil {
+		return nil, fmt.Errorf("vaa_id must be in format chain/emitter/sequence: %w", err)
+	}
+
+	chainID, err := vaa.KnownChainIDFromNumber(parsedVAAID.EmitterChain)
+	if err != nil {
+		return nil, fmt.Errorf("invalid chain ID: %v", err)
 	}
 
 	// Step 1: Group observations by VAA body hash — pick the group with the most signatures.
@@ -751,11 +738,6 @@ func buildDelegateSignaturesBroadcasts(vaaID string, apiObservations []wormholes
 			mpGroups[h] = g
 		}
 		g.observations = append(g.observations, obs)
-	}
-
-	chainIDParsed, err := vaa.StringToKnownChainID(chainID)
-	if err != nil {
-		return nil, fmt.Errorf("invalid chain ID: %v", err)
 	}
 
 	// Step 3: Build one broadcast per MessagePublicationHash sub-group.
@@ -829,7 +811,7 @@ func buildDelegateSignaturesBroadcasts(vaaID string, apiObservations []wormholes
 			d := &gossipv1.DelegateObservation{
 				Timestamp:         timestamp,
 				Nonce:             ref.Nonce,
-				EmitterChain:      uint32(chainIDParsed), // #nosec G115
+				EmitterChain:      uint32(chainID), // #nosec G115
 				EmitterAddress:    emitterAddrBytes,
 				Sequence:          ref.Sequence,
 				ConsistencyLevel:  uint32(ref.ConsistencyLevel), // #nosec G115
@@ -872,7 +854,7 @@ func buildDelegateSignaturesBroadcasts(vaaID string, apiObservations []wormholes
 		broadcasts = append(broadcasts, &gossipv1.DelegateSignaturesBroadcast{
 			Timestamp:          timestamp,
 			Nonce:              ref.Nonce,
-			EmitterChain:       uint32(chainIDParsed), // #nosec G115
+			EmitterChain:       uint32(chainID), // #nosec G115
 			EmitterAddress:     emitterAddrBytes,
 			Sequence:           ref.Sequence,
 			ConsistencyLevel:   uint32(ref.ConsistencyLevel), // #nosec G115
@@ -896,21 +878,13 @@ func buildDelegateSignaturesBroadcasts(vaaID string, apiObservations []wormholes
 func runBroadcastDelegateSignatures(cmd *cobra.Command, args []string) {
 	vaaID := args[0]
 
-	// Parse VAA ID: chain/emitter/sequence
-	parts := strings.Split(vaaID, "/")
-	if len(parts) != 3 {
-		log.Fatalf("vaa_id must be in format chain/emitter/sequence")
-	}
-	chainID := parts[0]
-	emitterAddr := parts[1]
-	sequence := parts[2]
-
-	if _, err := vaa.StringToKnownChainID(chainID); err != nil {
-		log.Fatalf("invalid chain ID %q: %v", chainID, err)
+	parsedVAAID, err := vaa.VAAIDFromString(vaaID)
+	if err != nil {
+		log.Fatalf("invalid vaa_id %q: %v", vaaID, err)
 	}
 
 	// Fetch delegate observations from wormholescan API.
-	apiURL := fmt.Sprintf("https://api.wormholescan.io/api/v1/observations/delegate/%s/%s/%s", chainID, emitterAddr, sequence)
+	apiURL := fmt.Sprintf("https://api.wormholescan.io/api/v1/observations/delegate/%s", parsedVAAID.String())
 	httpReq, err := http.NewRequestWithContext(context.Background(), http.MethodGet, apiURL, nil)
 	if err != nil {
 		log.Fatalf("failed to create HTTP request: %v", err)

--- a/node/cmd/guardiand/adminclient.go
+++ b/node/cmd/guardiand/adminclient.go
@@ -429,7 +429,7 @@ func runFindMissingMessages(cmd *cobra.Command, args []string) {
 	// This value is later converted to uint32 for use in protobuf, but before that
 	// we should make sure it fits into uint16 to disallow numbers > max.Uint16
 	// from being serialized.
-	chainId, err := strconv.ParseUint(args[0], 10, 16)
+	chainID, err := strconv.ParseUint(args[0], 10, 16)
 	if err != nil {
 		log.Fatalf("invalid chain ID: %v", err)
 	}
@@ -446,7 +446,7 @@ func runFindMissingMessages(cmd *cobra.Command, args []string) {
 	defer conn.Close()
 
 	msg := nodev1.FindMissingMessagesRequest{
-		EmitterChain:   uint32(chainId),
+		EmitterChain:   uint32(chainID),
 		EmitterAddress: emitterAddress,
 		RpcBackfill:    *shouldBackfill,
 		BackfillNodes:  sdk.PublicRPCEndpoints,
@@ -467,22 +467,12 @@ func runFindMissingMessages(cmd *cobra.Command, args []string) {
 // runDumpVAAByMessageID uses GetSignedVAA to request the given message,
 // then decode and dump the VAA.
 func runDumpVAAByMessageID(cmd *cobra.Command, args []string) {
-	// Parse the {chain,emitter,seq} string.
-	parts := strings.Split(args[0], "/")
-	if len(parts) != 3 {
-		log.Fatalf("invalid message ID: %s", args[0])
-	}
 	// Parse string ChainID as uint16 to ensure it fits the vaa.ChainID type.
 	// There is no "known" check here as Guardians may want to dump messages
 	// even for deprecated chains.
-	chainId, err := strconv.ParseUint(parts[0], 10, 16)
+	vaaID, err := vaa.VAAIDFromString(args[0])
 	if err != nil {
-		log.Fatalf("invalid chain ID: %v", err)
-	}
-	emitterAddress := parts[1]
-	seq, err := strconv.ParseUint(parts[2], 10, 64)
-	if err != nil {
-		log.Fatalf("invalid sequence number: %v", err)
+		log.Fatalf("invalid message ID %q: %v", args[0], err)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -496,9 +486,9 @@ func runDumpVAAByMessageID(cmd *cobra.Command, args []string) {
 
 	msg := publicrpcv1.GetSignedVAARequest{
 		MessageId: &publicrpcv1.MessageID{
-			EmitterChain:   publicrpcv1.ChainID(chainId),
-			EmitterAddress: emitterAddress,
-			Sequence:       seq,
+			EmitterChain:   publicrpcv1.ChainID(vaaID.EmitterChain),
+			EmitterAddress: vaaID.EmitterAddress.String(),
+			Sequence:       vaaID.Sequence,
 		},
 	}
 	resp, err := c.GetSignedVAA(ctx, &msg)
@@ -520,7 +510,7 @@ func runDumpVAAByMessageID(cmd *cobra.Command, args []string) {
 }
 
 func runSendObservationRequest(cmd *cobra.Command, args []string) {
-	chainID, err := parseChainID(args[0])
+	chainID, err := vaa.StringToChainID(args[0])
 	if err != nil {
 		log.Fatalf("invalid chain ID: %v", err)
 	}
@@ -557,7 +547,7 @@ func runSendObservationRequest(cmd *cobra.Command, args []string) {
 }
 
 func runReobserveWithEndpoint(cmd *cobra.Command, args []string) {
-	chainID, err := parseChainID(args[0])
+	chainID, err := vaa.StringToChainID(args[0])
 	if err != nil {
 		log.Fatalf("invalid chain ID: %v", err)
 	}
@@ -706,14 +696,18 @@ func delegateObservationVAAHash(obs *wormholescanDelegateObservation) (string, e
 // broadcast per unique message publication. This is necessary because a DelegateSignaturesBroadcast
 // carries common fields (including TxHash) that must be identical for all signatures in a batch.
 func buildDelegateSignaturesBroadcasts(vaaID string, apiObservations []wormholescanDelegateObservation) ([]*gossipv1.DelegateSignaturesBroadcast, error) {
-	parts := strings.Split(vaaID, "/")
-	if len(parts) != 3 {
-		return nil, fmt.Errorf("vaa_id must be in format chain/emitter/sequence")
-	}
-	chainID := parts[0]
-
 	if len(apiObservations) == 0 {
 		return nil, fmt.Errorf("no delegate observations provided")
+	}
+
+	parsedVAAID, err := vaa.VAAIDFromString(vaaID)
+	if err != nil {
+		return nil, fmt.Errorf("vaa_id must be in format chain/emitter/sequence: %w", err)
+	}
+
+	chainID, err := vaa.KnownChainIDFromNumber(parsedVAAID.EmitterChain)
+	if err != nil {
+		return nil, fmt.Errorf("invalid chain ID: %v", err)
 	}
 
 	// Step 1: Group observations by VAA body hash — pick the group with the most signatures.
@@ -761,11 +755,6 @@ func buildDelegateSignaturesBroadcasts(vaaID string, apiObservations []wormholes
 			mpGroups[h] = g
 		}
 		g.observations = append(g.observations, obs)
-	}
-
-	chainIDParsed, err := vaa.StringToKnownChainID(chainID)
-	if err != nil {
-		return nil, fmt.Errorf("invalid chain ID: %v", err)
 	}
 
 	// Step 3: Build one broadcast per MessagePublicationHash sub-group.
@@ -839,15 +828,15 @@ func buildDelegateSignaturesBroadcasts(vaaID string, apiObservations []wormholes
 			d := &gossipv1.DelegateObservation{
 				Timestamp:         timestamp,
 				Nonce:             ref.Nonce,
-				EmitterChain:      uint32(chainIDParsed), // #nosec G115
+				EmitterChain:      uint32(chainID),
 				EmitterAddress:    emitterAddrBytes,
 				Sequence:          ref.Sequence,
-				ConsistencyLevel:  uint32(ref.ConsistencyLevel), // #nosec G115
+				ConsistencyLevel:  uint32(ref.ConsistencyLevel),
 				Payload:           payloadBytes,
 				TxHash:            txHashBytes,
 				Unreliable:        obs.Unreliable,
 				IsReobservation:   obs.IsReobservation,
-				VerificationState: uint32(obs.VerificationState), // #nosec G115
+				VerificationState: uint32(obs.VerificationState),
 				GuardianAddr:      guardianAddrBytes,
 				SentTimestamp:     sentTimestamp,
 			}
@@ -882,15 +871,15 @@ func buildDelegateSignaturesBroadcasts(vaaID string, apiObservations []wormholes
 		broadcasts = append(broadcasts, &gossipv1.DelegateSignaturesBroadcast{
 			Timestamp:          timestamp,
 			Nonce:              ref.Nonce,
-			EmitterChain:       uint32(chainIDParsed), // #nosec G115
+			EmitterChain:       uint32(chainID),
 			EmitterAddress:     emitterAddrBytes,
 			Sequence:           ref.Sequence,
-			ConsistencyLevel:   uint32(ref.ConsistencyLevel), // #nosec G115
+			ConsistencyLevel:   uint32(ref.ConsistencyLevel),
 			Payload:            payloadBytes,
 			TxHash:             txHashBytes,
 			Unreliable:         ref.Unreliable,
 			IsReobservation:    ref.IsReobservation,
-			VerificationState:  uint32(ref.VerificationState), // #nosec G115
+			VerificationState:  uint32(ref.VerificationState),
 			Signatures:         signatures,
 			BroadcastTimestamp: time.Now().Unix(),
 		})
@@ -906,21 +895,13 @@ func buildDelegateSignaturesBroadcasts(vaaID string, apiObservations []wormholes
 func runBroadcastDelegateSignatures(cmd *cobra.Command, args []string) {
 	vaaID := args[0]
 
-	// Parse VAA ID: chain/emitter/sequence
-	parts := strings.Split(vaaID, "/")
-	if len(parts) != 3 {
-		log.Fatalf("vaa_id must be in format chain/emitter/sequence")
-	}
-	chainID := parts[0]
-	emitterAddr := parts[1]
-	sequence := parts[2]
-
-	if _, err := vaa.StringToKnownChainID(chainID); err != nil {
-		log.Fatalf("invalid chain ID %q: %v", chainID, err)
+	parsedVAAID, err := vaa.VAAIDFromString(vaaID)
+	if err != nil {
+		log.Fatalf("invalid vaa_id %q: %v", vaaID, err)
 	}
 
 	// Fetch delegate observations from wormholescan API.
-	apiURL := fmt.Sprintf("https://api.wormholescan.io/api/v1/observations/delegate/%s/%s/%s", chainID, emitterAddr, sequence)
+	apiURL := fmt.Sprintf("https://api.wormholescan.io/api/v1/observations/delegate/%s", parsedVAAID.String())
 	httpReq, err := http.NewRequestWithContext(context.Background(), http.MethodGet, apiURL, nil)
 	if err != nil {
 		log.Fatalf("failed to create HTTP request: %v", err)

--- a/node/cmd/guardiand/admintemplate.go
+++ b/node/cmd/guardiand/admintemplate.go
@@ -475,7 +475,7 @@ func runContractUpgradeTemplate(cmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	chainID, err := parseChainID(*chainID)
+	chainID, err := vaa.StringToChainID(*chainID)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -509,7 +509,7 @@ func runTokenBridgeRegisterChainTemplate(cmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	chainID, err := parseChainID(*chainID)
+	chainID, err := vaa.StringToChainID(*chainID)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -544,7 +544,7 @@ func runTokenBridgeUpgradeContractTemplate(cmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	chainID, err := parseChainID(*chainID)
+	chainID, err := vaa.StringToChainID(*chainID)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -587,7 +587,7 @@ func runRecoverChainIdTemplate(cmd *cobra.Command, args []string) {
 	if *recoverChainIdNewChainId == "" {
 		log.Fatal("--new-chain-id must be specified.")
 	}
-	newChainID, err := parseChainID(*recoverChainIdNewChainId)
+	newChainID, err := vaa.StringToChainID(*recoverChainIdNewChainId)
 	if err != nil {
 		log.Fatal("failed to parse chain id:", err)
 	}
@@ -624,7 +624,7 @@ func runAccountantModifyBalanceTemplate(cmd *cobra.Command, args []string) {
 	if *accountantModifyBalanceTargetChainId == "" {
 		log.Fatal("--target-chain-id must be specified.")
 	}
-	targetChainID, err := parseChainID(*accountantModifyBalanceTargetChainId)
+	targetChainID, err := vaa.StringToChainID(*accountantModifyBalanceTargetChainId)
 	if err != nil {
 		log.Fatal("failed to parse target chain id: ", err)
 	}
@@ -638,14 +638,14 @@ func runAccountantModifyBalanceTemplate(cmd *cobra.Command, args []string) {
 	if *accountantModifyBalanceChainId == "" {
 		log.Fatal("--chain-id must be specified.")
 	}
-	chainID, err := parseChainID(*accountantModifyBalanceChainId)
+	chainID, err := vaa.StringToChainID(*accountantModifyBalanceChainId)
 	if err != nil {
 		log.Fatal("failed to parse chain id: ", err)
 	}
 	if *accountantModifyBalanceTokenChainId == "" {
 		log.Fatal("--token-chain-id must be specified.")
 	}
-	tokenChainID, err := parseChainID(*accountantModifyBalanceTokenChainId)
+	tokenChainID, err := vaa.StringToChainID(*accountantModifyBalanceTokenChainId)
 	if err != nil {
 		log.Fatal("failed to parse token chain id: ", err)
 	}
@@ -719,7 +719,7 @@ func runCircleIntegrationUpdateWormholeFinalityTemplate(cmd *cobra.Command, args
 	if *circleIntegrationChainID == "" {
 		log.Fatal("--chain-id must be specified.")
 	}
-	chainID, err := parseChainID(*circleIntegrationChainID)
+	chainID, err := vaa.StringToChainID(*circleIntegrationChainID)
 	if err != nil {
 		log.Fatal("failed to parse chain id:", err)
 	}
@@ -759,14 +759,14 @@ func runCircleIntegrationRegisterEmitterAndDomainTemplate(cmd *cobra.Command, ar
 	if *circleIntegrationChainID == "" {
 		log.Fatal("--chain-id must be specified.")
 	}
-	chainID, err := parseChainID(*circleIntegrationChainID)
+	chainID, err := vaa.StringToChainID(*circleIntegrationChainID)
 	if err != nil {
 		log.Fatal("failed to parse chain id:", err)
 	}
 	if *circleIntegrationForeignEmitterChainID == "" {
 		log.Fatal("--foreign-emitter-chain-id must be specified.")
 	}
-	foreignEmitterChainId, err := parseChainID(*circleIntegrationForeignEmitterChainID)
+	foreignEmitterChainId, err := vaa.StringToChainID(*circleIntegrationForeignEmitterChainID)
 	if err != nil {
 		log.Fatal("failed to parse foreign emitter chain id as uint8:", err)
 	}
@@ -815,7 +815,7 @@ func runCircleIntegrationUpgradeContractImplementationTemplate(cmd *cobra.Comman
 	if *circleIntegrationChainID == "" {
 		log.Fatal("--chain-id must be specified.")
 	}
-	chainID, err := parseChainID(*circleIntegrationChainID)
+	chainID, err := vaa.StringToChainID(*circleIntegrationChainID)
 	if err != nil {
 		log.Fatal("failed to parse chain id:", err)
 	}
@@ -1113,7 +1113,7 @@ func runIbcUpdateChannelChainTemplate(module nodev1.IbcUpdateChannelChainModule)
 	if *ibcUpdateChannelChainTargetChainId == "" {
 		log.Fatal("--target-chain-id must be specified")
 	}
-	targetChainId, err := parseChainID(*ibcUpdateChannelChainTargetChainId)
+	targetChainId, err := vaa.StringToChainID(*ibcUpdateChannelChainTargetChainId)
 	if err != nil {
 		log.Fatal("failed to parse chain id: ", err)
 	}
@@ -1128,7 +1128,7 @@ func runIbcUpdateChannelChainTemplate(module nodev1.IbcUpdateChannelChainModule)
 	if *ibcUpdateChannelChainChainId == "" {
 		log.Fatal("--chain-id must be specified")
 	}
-	chainId, err := parseChainID(*ibcUpdateChannelChainChainId)
+	chainId, err := vaa.StringToChainID(*ibcUpdateChannelChainChainId)
 	if err != nil {
 		log.Fatal("failed to parse chain id: ", err)
 	}
@@ -1165,7 +1165,7 @@ func runWormholeRelayerSetDefaultDeliveryProviderTemplate(cmd *cobra.Command, ar
 	if err != nil {
 		log.Fatal(err)
 	}
-	chainID, err := parseChainID(*chainID)
+	chainID, err := vaa.StringToChainID(*chainID)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -1195,7 +1195,7 @@ func runWormholeRelayerSetDefaultDeliveryProviderTemplate(cmd *cobra.Command, ar
 }
 
 func runCoreBridgeSetMessageFeeTemplate(cmd *cobra.Command, args []string) {
-	chainID, err := parseChainID(*coreBridgeSetMessageFeeChainId)
+	chainID, err := vaa.StringToChainID(*coreBridgeSetMessageFeeChainId)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -1327,7 +1327,7 @@ func runGeneralPurposeGovernanceEvmCallTemplate(cmd *cobra.Command, args []strin
 	if *governanceTargetChain == "" {
 		log.Fatal("--chain-id must be specified")
 	}
-	chainID, err := parseChainID(*governanceTargetChain)
+	chainID, err := vaa.StringToChainID(*governanceTargetChain)
 	if err != nil {
 		log.Fatal("failed to parse chain id: ", err)
 	}
@@ -1372,7 +1372,7 @@ func runGeneralPurposeGovernanceSolanaCallTemplate(cmd *cobra.Command, args []st
 	if *governanceTargetChain == "" {
 		log.Fatal("--chain-id must be specified")
 	}
-	chainID, err := parseChainID(*governanceTargetChain)
+	chainID, err := vaa.StringToChainID(*governanceTargetChain)
 	if err != nil {
 		log.Fatal("failed to parse chain id: ", err)
 	}
@@ -1421,7 +1421,7 @@ func runGeneralPurposeGovernanceSuiCallTemplate(cmd *cobra.Command, args []strin
 	if *governanceTargetChain == "" {
 		log.Fatal("--chain-id must be specified")
 	}
-	chainID, err := parseChainID(*governanceTargetChain)
+	chainID, err := vaa.StringToChainID(*governanceTargetChain)
 	if err != nil {
 		log.Fatal("failed to parse chain id: ", err)
 	}
@@ -1455,7 +1455,7 @@ func runDelegatedManagerSetUpdateTemplate(cmd *cobra.Command, args []string) {
 	if *delegatedManagerChainId == "" {
 		log.Fatal("--manager-chain-id must be specified")
 	}
-	managerChainId, err := parseChainID(*delegatedManagerChainId)
+	managerChainId, err := vaa.StringToChainID(*delegatedManagerChainId)
 	if err != nil {
 		log.Fatal("failed to parse manager-chain-id: ", err)
 	}
@@ -1576,21 +1576,6 @@ func leftPadAddress(a []byte) (string, error) {
 }
 
 // parseChainID parses a human-readable chain name or a chain ID.
-func parseChainID(name string) (vaa.ChainID, error) {
-	s, err := vaa.ChainIDFromString(name)
-	if err == nil {
-		return s, nil
-	}
-
-	// parse as uint16
-	i, err := strconv.ParseUint(name, 10, 16)
-	if err != nil {
-		return 0, fmt.Errorf("failed to parse as name or uint16: %v", err)
-	}
-
-	return vaa.ChainID(i), nil
-}
-
 func isValidUint256(s string) (bool, error) {
 	i := new(big.Int)
 	i.SetString(s, 10) // Parse in base 10

--- a/node/cmd/guardiand/admintemplate.go
+++ b/node/cmd/guardiand/admintemplate.go
@@ -494,7 +494,7 @@ func runContractUpgradeTemplate(cmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	chainID, err := parseChainID(*chainID)
+	chainID, err := vaa.StringToChainID(*chainID)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -528,7 +528,7 @@ func runTokenBridgeRegisterChainTemplate(cmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	chainID, err := parseChainID(*chainID)
+	chainID, err := vaa.StringToChainID(*chainID)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -563,7 +563,7 @@ func runTokenBridgeUpgradeContractTemplate(cmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	chainID, err := parseChainID(*chainID)
+	chainID, err := vaa.StringToChainID(*chainID)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -680,7 +680,7 @@ func runRecoverChainIdTemplate(cmd *cobra.Command, args []string) {
 	if *recoverChainIdNewChainId == "" {
 		log.Fatal("--new-chain-id must be specified.")
 	}
-	newChainID, err := parseChainID(*recoverChainIdNewChainId)
+	newChainID, err := vaa.StringToChainID(*recoverChainIdNewChainId)
 	if err != nil {
 		log.Fatal("failed to parse chain id:", err)
 	}
@@ -717,7 +717,7 @@ func runAccountantModifyBalanceTemplate(cmd *cobra.Command, args []string) {
 	if *accountantModifyBalanceTargetChainId == "" {
 		log.Fatal("--target-chain-id must be specified.")
 	}
-	targetChainID, err := parseChainID(*accountantModifyBalanceTargetChainId)
+	targetChainID, err := vaa.StringToChainID(*accountantModifyBalanceTargetChainId)
 	if err != nil {
 		log.Fatal("failed to parse target chain id: ", err)
 	}
@@ -731,14 +731,14 @@ func runAccountantModifyBalanceTemplate(cmd *cobra.Command, args []string) {
 	if *accountantModifyBalanceChainId == "" {
 		log.Fatal("--chain-id must be specified.")
 	}
-	chainID, err := parseChainID(*accountantModifyBalanceChainId)
+	chainID, err := vaa.StringToChainID(*accountantModifyBalanceChainId)
 	if err != nil {
 		log.Fatal("failed to parse chain id: ", err)
 	}
 	if *accountantModifyBalanceTokenChainId == "" {
 		log.Fatal("--token-chain-id must be specified.")
 	}
-	tokenChainID, err := parseChainID(*accountantModifyBalanceTokenChainId)
+	tokenChainID, err := vaa.StringToChainID(*accountantModifyBalanceTokenChainId)
 	if err != nil {
 		log.Fatal("failed to parse token chain id: ", err)
 	}
@@ -812,7 +812,7 @@ func runCircleIntegrationUpdateWormholeFinalityTemplate(cmd *cobra.Command, args
 	if *circleIntegrationChainID == "" {
 		log.Fatal("--chain-id must be specified.")
 	}
-	chainID, err := parseChainID(*circleIntegrationChainID)
+	chainID, err := vaa.StringToChainID(*circleIntegrationChainID)
 	if err != nil {
 		log.Fatal("failed to parse chain id:", err)
 	}
@@ -852,14 +852,14 @@ func runCircleIntegrationRegisterEmitterAndDomainTemplate(cmd *cobra.Command, ar
 	if *circleIntegrationChainID == "" {
 		log.Fatal("--chain-id must be specified.")
 	}
-	chainID, err := parseChainID(*circleIntegrationChainID)
+	chainID, err := vaa.StringToChainID(*circleIntegrationChainID)
 	if err != nil {
 		log.Fatal("failed to parse chain id:", err)
 	}
 	if *circleIntegrationForeignEmitterChainID == "" {
 		log.Fatal("--foreign-emitter-chain-id must be specified.")
 	}
-	foreignEmitterChainId, err := parseChainID(*circleIntegrationForeignEmitterChainID)
+	foreignEmitterChainId, err := vaa.StringToChainID(*circleIntegrationForeignEmitterChainID)
 	if err != nil {
 		log.Fatal("failed to parse foreign emitter chain id as uint8:", err)
 	}
@@ -908,7 +908,7 @@ func runCircleIntegrationUpgradeContractImplementationTemplate(cmd *cobra.Comman
 	if *circleIntegrationChainID == "" {
 		log.Fatal("--chain-id must be specified.")
 	}
-	chainID, err := parseChainID(*circleIntegrationChainID)
+	chainID, err := vaa.StringToChainID(*circleIntegrationChainID)
 	if err != nil {
 		log.Fatal("failed to parse chain id:", err)
 	}
@@ -1206,7 +1206,7 @@ func runIbcUpdateChannelChainTemplate(module nodev1.IbcUpdateChannelChainModule)
 	if *ibcUpdateChannelChainTargetChainId == "" {
 		log.Fatal("--target-chain-id must be specified")
 	}
-	targetChainId, err := parseChainID(*ibcUpdateChannelChainTargetChainId)
+	targetChainId, err := vaa.StringToChainID(*ibcUpdateChannelChainTargetChainId)
 	if err != nil {
 		log.Fatal("failed to parse chain id: ", err)
 	}
@@ -1221,7 +1221,7 @@ func runIbcUpdateChannelChainTemplate(module nodev1.IbcUpdateChannelChainModule)
 	if *ibcUpdateChannelChainChainId == "" {
 		log.Fatal("--chain-id must be specified")
 	}
-	chainId, err := parseChainID(*ibcUpdateChannelChainChainId)
+	chainId, err := vaa.StringToChainID(*ibcUpdateChannelChainChainId)
 	if err != nil {
 		log.Fatal("failed to parse chain id: ", err)
 	}
@@ -1258,7 +1258,7 @@ func runWormholeRelayerSetDefaultDeliveryProviderTemplate(cmd *cobra.Command, ar
 	if err != nil {
 		log.Fatal(err)
 	}
-	chainID, err := parseChainID(*chainID)
+	chainID, err := vaa.StringToChainID(*chainID)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -1288,7 +1288,7 @@ func runWormholeRelayerSetDefaultDeliveryProviderTemplate(cmd *cobra.Command, ar
 }
 
 func runCoreBridgeSetMessageFeeTemplate(cmd *cobra.Command, args []string) {
-	chainID, err := parseChainID(*coreBridgeSetMessageFeeChainId)
+	chainID, err := vaa.StringToChainID(*coreBridgeSetMessageFeeChainId)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -1319,7 +1319,7 @@ func runCoreBridgeSetMessageFeeTemplate(cmd *cobra.Command, args []string) {
 }
 
 func runCoreBridgeTransferFeesTemplate(cmd *cobra.Command, args []string) {
-	chainID, err := parseChainID(*coreBridgeTransferFeesChainId)
+	chainID, err := vaa.StringToKnownChainID(*coreBridgeTransferFeesChainId)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -1420,7 +1420,7 @@ func runGeneralPurposeGovernanceEvmCallTemplate(cmd *cobra.Command, args []strin
 	if *governanceTargetChain == "" {
 		log.Fatal("--chain-id must be specified")
 	}
-	chainID, err := parseChainID(*governanceTargetChain)
+	chainID, err := vaa.StringToChainID(*governanceTargetChain)
 	if err != nil {
 		log.Fatal("failed to parse chain id: ", err)
 	}
@@ -1465,7 +1465,7 @@ func runGeneralPurposeGovernanceSolanaCallTemplate(cmd *cobra.Command, args []st
 	if *governanceTargetChain == "" {
 		log.Fatal("--chain-id must be specified")
 	}
-	chainID, err := parseChainID(*governanceTargetChain)
+	chainID, err := vaa.StringToChainID(*governanceTargetChain)
 	if err != nil {
 		log.Fatal("failed to parse chain id: ", err)
 	}
@@ -1514,7 +1514,7 @@ func runGeneralPurposeGovernanceSuiCallTemplate(cmd *cobra.Command, args []strin
 	if *governanceTargetChain == "" {
 		log.Fatal("--chain-id must be specified")
 	}
-	chainID, err := parseChainID(*governanceTargetChain)
+	chainID, err := vaa.StringToChainID(*governanceTargetChain)
 	if err != nil {
 		log.Fatal("failed to parse chain id: ", err)
 	}
@@ -1548,7 +1548,7 @@ func runDelegatedManagerSetUpdateTemplate(cmd *cobra.Command, args []string) {
 	if *delegatedManagerChainId == "" {
 		log.Fatal("--manager-chain-id must be specified")
 	}
-	managerChainId, err := parseChainID(*delegatedManagerChainId)
+	managerChainId, err := vaa.StringToChainID(*delegatedManagerChainId)
 	if err != nil {
 		log.Fatal("failed to parse manager-chain-id: ", err)
 	}
@@ -1666,22 +1666,6 @@ func leftPadAddress(a []byte) (string, error) {
 		return "", errors.New("address longer than 32 bytes")
 	}
 	return hex.EncodeToString(common.LeftPadBytes(a, 32)), nil
-}
-
-// parseChainID parses a human-readable chain name or a chain ID.
-func parseChainID(name string) (vaa.ChainID, error) {
-	s, err := vaa.ChainIDFromString(name)
-	if err == nil {
-		return s, nil
-	}
-
-	// parse as uint16
-	i, err := strconv.ParseUint(name, 10, 16)
-	if err != nil {
-		return 0, fmt.Errorf("failed to parse as name or uint16: %v", err)
-	}
-
-	return vaa.ChainID(i), nil
 }
 
 func isValidUint256(s string) (bool, error) {

--- a/node/cmd/guardiand/admintemplate.go
+++ b/node/cmd/guardiand/admintemplate.go
@@ -1226,7 +1226,7 @@ func runCoreBridgeSetMessageFeeTemplate(cmd *cobra.Command, args []string) {
 }
 
 func runCoreBridgeTransferFeesTemplate(cmd *cobra.Command, args []string) {
-	chainID, err := parseChainID(*coreBridgeTransferFeesChainId)
+	chainID, err := vaa.StringToKnownChainID(*coreBridgeTransferFeesChainId)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -1575,7 +1575,6 @@ func leftPadAddress(a []byte) (string, error) {
 	return hex.EncodeToString(common.LeftPadBytes(a, 32)), nil
 }
 
-// parseChainID parses a human-readable chain name or a chain ID.
 func isValidUint256(s string) (bool, error) {
 	i := new(big.Int)
 	i.SetString(s, 10) // Parse in base 10

--- a/node/cmd/spy/spy.go
+++ b/node/cmd/spy/spy.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
 	"net"
 	"net/http"
 	"os"
@@ -190,11 +189,12 @@ func (s *spyServer) SubscribeSignedVAA(req *spyv1.SubscribeSignedVAARequest, res
 				if err != nil {
 					return status.Error(codes.InvalidArgument, fmt.Sprintf("failed to decode emitter address: %v", err))
 				}
-				if t.EmitterFilter.GetChainId() > math.MaxUint16 {
+				chainID, err := vaa.ChainIDFromNumber(t.EmitterFilter.GetChainId())
+				if err != nil {
 					return status.Error(codes.InvalidArgument, fmt.Sprintf("emitter chain id must be a valid 16 bit unsigned integer: %v", t.EmitterFilter.ChainId.Number()))
 				}
 				fi = append(fi, filterSignedVaa{
-					chainId:     vaa.ChainID(t.EmitterFilter.ChainId), // #nosec G115 -- This is validated above
+					chainId:     chainID,
 					emitterAddr: addr,
 				})
 			default:

--- a/node/hack/repair_eth/repair_eth.go
+++ b/node/hack/repair_eth/repair_eth.go
@@ -314,15 +314,15 @@ func main() {
 		msgs := []*db.VAAID{}
 		for _, id := range resp.MissingMessages {
 			fmt.Println(id)
-			vId, parseErr := db.VaaIDFromString(id)
+			vId, parseErr := vaa.VAAIDFromString(id)
 			if parseErr != nil {
 				log.Fatalf("failed to parse VAAID: %v", parseErr)
 			}
-			if *vId == polygonIgnoredVaa {
+			if vId == polygonIgnoredVaa {
 				log.Printf("Ignored message: %+v", &polygonIgnoredVaa)
 				continue
 			}
-			msgs = append(msgs, vId)
+			msgs = append(msgs, &vId)
 		}
 
 		if len(msgs) == 0 {

--- a/node/hack/repair_eth/repair_eth.go
+++ b/node/hack/repair_eth/repair_eth.go
@@ -313,7 +313,7 @@ func main() {
 		for _, id := range resp.MissingMessages {
 			fmt.Println(id)
 			vId, parseErr := vaa.VAAIDFromString(id)
-			if err != nil {
+			if parseErr != nil {
 				log.Fatalf("failed to parse VAAID: %v", parseErr)
 			}
 			if vId == polygonIgnoredVaa {

--- a/node/hack/repair_eth/repair_eth.go
+++ b/node/hack/repair_eth/repair_eth.go
@@ -312,15 +312,15 @@ func main() {
 		msgs := []*db.VAAID{}
 		for _, id := range resp.MissingMessages {
 			fmt.Println(id)
-			vId, parseErr := db.VaaIDFromString(id)
-			if parseErr != nil {
+			vId, parseErr := vaa.VAAIDFromString(id)
+			if err != nil {
 				log.Fatalf("failed to parse VAAID: %v", parseErr)
 			}
-			if *vId == polygonIgnoredVaa {
+			if vId == polygonIgnoredVaa {
 				log.Printf("Ignored message: %+v", &polygonIgnoredVaa)
 				continue
 			}
-			msgs = append(msgs, vId)
+			msgs = append(msgs, &vId)
 		}
 
 		if len(msgs) == 0 {

--- a/node/hack/repair_solana/repair.go
+++ b/node/hack/repair_solana/repair.go
@@ -79,7 +79,7 @@ func main() {
 		for i, id := range resp.MissingMessages {
 			fmt.Println(id)
 			vId, parseErr := vaa.VAAIDFromString(id)
-			if err != nil {
+			if parseErr != nil {
 				log.Fatalf("failed to parse VAAID: %v", parseErr)
 			}
 			msgs[i] = &vId

--- a/node/hack/repair_solana/repair.go
+++ b/node/hack/repair_solana/repair.go
@@ -78,11 +78,11 @@ func main() {
 		msgs := make([]*db.VAAID, len(resp.MissingMessages))
 		for i, id := range resp.MissingMessages {
 			fmt.Println(id)
-			vId, parseErr := db.VaaIDFromString(id)
-			if parseErr != nil {
+			vId, parseErr := vaa.VAAIDFromString(id)
+			if err != nil {
 				log.Fatalf("failed to parse VAAID: %v", parseErr)
 			}
-			msgs[i] = vId
+			msgs[i] = &vId
 		}
 
 		if len(msgs) == 0 {

--- a/node/hack/repair_solana/repair.go
+++ b/node/hack/repair_solana/repair.go
@@ -78,11 +78,11 @@ func main() {
 		msgs := make([]*db.VAAID, len(resp.MissingMessages))
 		for i, id := range resp.MissingMessages {
 			fmt.Println(id)
-			vId, parseErr := db.VaaIDFromString(id)
+			vId, parseErr := vaa.VAAIDFromString(id)
 			if parseErr != nil {
 				log.Fatalf("failed to parse VAAID: %v", parseErr)
 			}
-			msgs[i] = vId
+			msgs[i] = &vId
 		}
 
 		if len(msgs) == 0 {

--- a/node/pkg/accountant/submit_obs.go
+++ b/node/pkg/accountant/submit_obs.go
@@ -189,7 +189,11 @@ var SubmitObservationPrefix = []byte("acct_sub_obsfig_000000000000000000|")
 var NttSubmitObservationPrefix = []byte("ntt_acct_sub_obsfig_00000000000000|")
 
 func (k TransferKey) String() string {
-	return fmt.Sprintf("%v/%v/%v", k.EmitterChain, hex.EncodeToString(k.EmitterAddress[:]), k.Sequence)
+	return vaa.VAAID{
+		EmitterChain:   vaa.ChainID(k.EmitterChain),
+		EmitterAddress: k.EmitterAddress,
+		Sequence:       k.Sequence,
+	}.String()
 }
 
 //nolint:unparam // error is always nil but is required to satisfy the custom JSON marshal interface.

--- a/node/pkg/adminrpc/adminserver.go
+++ b/node/pkg/adminrpc/adminserver.go
@@ -13,7 +13,6 @@ import (
 	"math/rand"
 	"net/http"
 	"slices"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -153,6 +152,11 @@ func adminGuardianSetUpdateToVAA(req *nodev1.GuardianSetUpdate, timestamp time.T
 // adminContractUpgradeToVAA converts a nodev1.ContractUpgrade message to its canonical VAA representation.
 // Returns an error if the data is invalid.
 func adminContractUpgradeToVAA(req *nodev1.ContractUpgrade, timestamp time.Time, guardianSetIndex uint32, nonce uint32, sequence uint64) (*vaa.VAA, error) {
+	chainID, err := vaa.ChainIDFromNumber(req.ChainId)
+	if err != nil {
+		return nil, errors.New("invalid chain_id")
+	}
+
 	b, err := hex.DecodeString(req.NewContract)
 	if err != nil {
 		return nil, errors.New("invalid new contract address encoding (expected hex)")
@@ -162,15 +166,11 @@ func adminContractUpgradeToVAA(req *nodev1.ContractUpgrade, timestamp time.Time,
 		return nil, errors.New("invalid new_contract address")
 	}
 
-	if req.ChainId > math.MaxUint16 {
-		return nil, errors.New("invalid chain_id")
-	}
-
 	newContractAddress := vaa.Address{}
 	copy(newContractAddress[:], b)
 
 	body, err := vaa.BodyContractUpgrade{
-		ChainID:     vaa.ChainID(req.ChainId),
+		ChainID:     chainID,
 		NewContract: newContractAddress,
 	}.Serialize()
 
@@ -185,7 +185,8 @@ func adminContractUpgradeToVAA(req *nodev1.ContractUpgrade, timestamp time.Time,
 // tokenBridgeRegisterChain converts a nodev1.TokenBridgeRegisterChain message to its canonical VAA representation.
 // Returns an error if the data is invalid.
 func tokenBridgeRegisterChain(req *nodev1.BridgeRegisterChain, timestamp time.Time, guardianSetIndex uint32, nonce uint32, sequence uint64) (*vaa.VAA, error) {
-	if req.ChainId > math.MaxUint16 {
+	chainID, err := vaa.ChainIDFromNumber(req.ChainId)
+	if err != nil {
 		return nil, errors.New("invalid chain_id")
 	}
 
@@ -203,7 +204,7 @@ func tokenBridgeRegisterChain(req *nodev1.BridgeRegisterChain, timestamp time.Ti
 
 	body, err := vaa.BodyTokenBridgeRegisterChain{
 		Module:         req.Module,
-		ChainID:        vaa.ChainID(req.ChainId),
+		ChainID:        chainID,
 		EmitterAddress: emitterAddress,
 	}.Serialize()
 
@@ -218,6 +219,11 @@ func tokenBridgeRegisterChain(req *nodev1.BridgeRegisterChain, timestamp time.Ti
 // recoverChainId converts a nodev1.RecoverChainId message to its canonical VAA representation.
 // Returns an error if the data is invalid.
 func recoverChainId(req *nodev1.RecoverChainId, timestamp time.Time, guardianSetIndex uint32, nonce uint32, sequence uint64) (*vaa.VAA, error) {
+	newChainID, err := vaa.ChainIDFromNumber(req.NewChainId)
+	if err != nil {
+		return nil, errors.New("invalid new_chain_id")
+	}
+
 	evm_chain_id_big := big.NewInt(0)
 	evm_chain_id_big, ok := evm_chain_id_big.SetString(req.EvmChainId, 10)
 	if !ok {
@@ -230,14 +236,10 @@ func recoverChainId(req *nodev1.RecoverChainId, timestamp time.Time, guardianSet
 		return nil, errors.New("evm_chain_id overflow")
 	}
 
-	if req.NewChainId > math.MaxUint16 {
-		return nil, errors.New("invalid new_chain_id")
-	}
-
 	body, err := vaa.BodyRecoverChainId{
 		Module:     req.Module,
 		EvmChainID: evm_chain_id,
-		NewChainID: vaa.ChainID(req.NewChainId),
+		NewChainID: newChainID,
 	}.Serialize()
 
 	if err != nil {
@@ -251,13 +253,16 @@ func recoverChainId(req *nodev1.RecoverChainId, timestamp time.Time, guardianSet
 // accountantModifyBalance converts a nodev1.AccountantModifyBalance message to its canonical VAA representation.
 // Returns an error if the data is invalid.
 func accountantModifyBalance(req *nodev1.AccountantModifyBalance, timestamp time.Time, guardianSetIndex uint32, nonce uint32, sequence uint64) (*vaa.VAA, error) {
-	if req.TargetChainId > math.MaxUint16 {
+	targetChainID, err := vaa.ChainIDFromNumber(req.TargetChainId)
+	if err != nil {
 		return nil, errors.New("invalid target_chain_id")
 	}
-	if req.ChainId > math.MaxUint16 {
+	chainID, err := vaa.ChainIDFromNumber(req.ChainId)
+	if err != nil {
 		return nil, errors.New("invalid chain_id")
 	}
-	if req.TokenChain > math.MaxUint16 {
+	tokenChainID, err := vaa.ChainIDFromNumber(req.TokenChain)
+	if err != nil {
 		return nil, errors.New("invalid token_chain")
 	}
 
@@ -291,11 +296,11 @@ func accountantModifyBalance(req *nodev1.AccountantModifyBalance, timestamp time
 
 	body, err := vaa.BodyAccountantModifyBalance{
 		Module:        req.Module,
-		TargetChainID: vaa.ChainID(req.TargetChainId),
+		TargetChainID: targetChainID,
 
 		Sequence:     req.Sequence,
-		ChainId:      vaa.ChainID(req.ChainId),
-		TokenChain:   vaa.ChainID(req.TokenChain),
+		ChainId:      chainID,
+		TokenChain:   tokenChainID,
 		TokenAddress: tokenAdress,
 		Kind:         uint8(req.Kind), // #nosec G115 -- The `ModificationKind` enum only has 3 values
 		Amount:       amount,
@@ -313,7 +318,8 @@ func accountantModifyBalance(req *nodev1.AccountantModifyBalance, timestamp time
 // tokenBridgeUpgradeContract converts a nodev1.TokenBridgeRegisterChain message to its canonical VAA representation.
 // Returns an error if the data is invalid.
 func tokenBridgeUpgradeContract(req *nodev1.BridgeUpgradeContract, timestamp time.Time, guardianSetIndex uint32, nonce uint32, sequence uint64) (*vaa.VAA, error) {
-	if req.TargetChainId > math.MaxUint16 {
+	targetChainID, err := vaa.ChainIDFromNumber(req.TargetChainId)
+	if err != nil {
 		return nil, errors.New("invalid target_chain_id")
 	}
 
@@ -331,7 +337,7 @@ func tokenBridgeUpgradeContract(req *nodev1.BridgeUpgradeContract, timestamp tim
 
 	body, err := vaa.BodyTokenBridgeUpgradeContract{
 		Module:        req.Module,
-		TargetChainID: vaa.ChainID(req.TargetChainId),
+		TargetChainID: targetChainID,
 		NewContract:   newContract,
 	}.Serialize()
 
@@ -509,7 +515,8 @@ func gatewayIbcComposabilityMwSetContract(
 // circleIntegrationUpdateWormholeFinality converts a nodev1.CircleIntegrationUpdateWormholeFinality to its canonical VAA representation
 // Returns an error if the data is invalid
 func circleIntegrationUpdateWormholeFinality(req *nodev1.CircleIntegrationUpdateWormholeFinality, timestamp time.Time, guardianSetIndex uint32, nonce uint32, sequence uint64) (*vaa.VAA, error) {
-	if req.TargetChainId > math.MaxUint16 {
+	targetChainID, err := vaa.ChainIDFromNumber(req.TargetChainId)
+	if err != nil {
 		return nil, fmt.Errorf("invalid target chain id, must be <= %d", math.MaxUint16)
 	}
 	if req.Finality > math.MaxUint8 {
@@ -517,7 +524,7 @@ func circleIntegrationUpdateWormholeFinality(req *nodev1.CircleIntegrationUpdate
 	}
 
 	body, err := vaa.BodyCircleIntegrationUpdateWormholeFinality{
-		TargetChainID: vaa.ChainID(req.TargetChainId),
+		TargetChainID: targetChainID,
 		Finality:      uint8(req.Finality),
 	}.Serialize()
 
@@ -532,10 +539,12 @@ func circleIntegrationUpdateWormholeFinality(req *nodev1.CircleIntegrationUpdate
 // circleIntegrationRegisterEmitterAndDomain converts a nodev1.CircleIntegrationRegisterEmitterAndDomain to its canonical VAA representation
 // Returns an error if the data is invalid
 func circleIntegrationRegisterEmitterAndDomain(req *nodev1.CircleIntegrationRegisterEmitterAndDomain, timestamp time.Time, guardianSetIndex uint32, nonce uint32, sequence uint64) (*vaa.VAA, error) {
-	if req.TargetChainId > math.MaxUint16 {
+	targetChainID, err := vaa.ChainIDFromNumber(req.TargetChainId)
+	if err != nil {
 		return nil, fmt.Errorf("invalid target chain id, must be <= %d", math.MaxUint16)
 	}
-	if req.ForeignEmitterChainId > math.MaxUint16 {
+	foreignEmitterChainID, err := vaa.ChainIDFromNumber(req.ForeignEmitterChainId)
+	if err != nil {
 		return nil, fmt.Errorf("invalid foreign emitter chain id, must be <= %d", math.MaxUint16)
 	}
 	b, err := hex.DecodeString(req.ForeignEmitterAddress)
@@ -551,8 +560,8 @@ func circleIntegrationRegisterEmitterAndDomain(req *nodev1.CircleIntegrationRegi
 	copy(foreignEmitterAddress[:], b)
 
 	body, err := vaa.BodyCircleIntegrationRegisterEmitterAndDomain{
-		TargetChainID:         vaa.ChainID(req.TargetChainId),
-		ForeignEmitterChainId: vaa.ChainID(req.ForeignEmitterChainId),
+		TargetChainID:         targetChainID,
+		ForeignEmitterChainId: foreignEmitterChainID,
 		ForeignEmitterAddress: foreignEmitterAddress,
 		CircleDomain:          req.CircleDomain,
 	}.Serialize()
@@ -568,7 +577,8 @@ func circleIntegrationRegisterEmitterAndDomain(req *nodev1.CircleIntegrationRegi
 // circleIntegrationUpgradeContractImplementation converts a nodev1.CircleIntegrationUpgradeContractImplementation to its canonical VAA representation
 // Returns an error if the data is invalid
 func circleIntegrationUpgradeContractImplementation(req *nodev1.CircleIntegrationUpgradeContractImplementation, timestamp time.Time, guardianSetIndex uint32, nonce uint32, sequence uint64) (*vaa.VAA, error) {
-	if req.TargetChainId > math.MaxUint16 {
+	targetChainID, err := vaa.ChainIDFromNumber(req.TargetChainId)
+	if err != nil {
 		return nil, fmt.Errorf("invalid target chain id, must be <= %d", math.MaxUint16)
 	}
 	b, err := hex.DecodeString(req.NewImplementationAddress)
@@ -584,7 +594,7 @@ func circleIntegrationUpgradeContractImplementation(req *nodev1.CircleIntegratio
 	copy(newImplementationAddress[:], b)
 
 	body, err := vaa.BodyCircleIntegrationUpgradeContractImplementation{
-		TargetChainID:            vaa.ChainID(req.TargetChainId),
+		TargetChainID:            targetChainID,
 		NewImplementationAddress: newImplementationAddress,
 	}.Serialize()
 
@@ -604,11 +614,13 @@ func ibcUpdateChannelChain(
 	sequence uint64,
 ) (*vaa.VAA, error) {
 	// validate parameters
-	if req.TargetChainId > math.MaxUint16 {
+	targetChainID, err := vaa.ChainIDFromNumber(req.TargetChainId)
+	if err != nil {
 		return nil, fmt.Errorf("invalid target chain id, must be <= %d", math.MaxUint16)
 	}
 
-	if req.ChainId > math.MaxUint16 {
+	chainID, err := vaa.ChainIDFromNumber(req.ChainId)
+	if err != nil {
 		return nil, fmt.Errorf("invalid chain id, must be <= %d", math.MaxUint16)
 	}
 
@@ -630,9 +642,9 @@ func ibcUpdateChannelChain(
 	}
 
 	body, err := vaa.BodyIbcUpdateChannelChain{
-		TargetChainId: vaa.ChainID(req.TargetChainId),
+		TargetChainId: targetChainID,
 		ChannelId:     channelId,
-		ChainId:       vaa.ChainID(req.ChainId),
+		ChainId:       chainID,
 	}.Serialize(module)
 
 	if err != nil {
@@ -646,7 +658,8 @@ func ibcUpdateChannelChain(
 // wormholeRelayerSetDefaultDeliveryProvider converts a nodev1.WormholeRelayerSetDefaultDeliveryProvider message to its canonical VAA representation.
 // Returns an error if the data is invalid.
 func wormholeRelayerSetDefaultDeliveryProvider(req *nodev1.WormholeRelayerSetDefaultDeliveryProvider, timestamp time.Time, guardianSetIndex uint32, nonce uint32, sequence uint64) (*vaa.VAA, error) {
-	if req.ChainId > math.MaxUint16 {
+	chainID, err := vaa.ChainIDFromNumber(req.ChainId)
+	if err != nil {
 		return nil, errors.New("invalid target_chain_id")
 	}
 
@@ -663,7 +676,7 @@ func wormholeRelayerSetDefaultDeliveryProvider(req *nodev1.WormholeRelayerSetDef
 	copy(NewDefaultDeliveryProviderAddress[:], b)
 
 	body, err := vaa.BodyWormholeRelayerSetDefaultDeliveryProvider{
-		ChainID:                           vaa.ChainID(req.ChainId),
+		ChainID:                           chainID,
 		NewDefaultDeliveryProviderAddress: NewDefaultDeliveryProviderAddress,
 	}.Serialize()
 
@@ -797,7 +810,8 @@ func delegatedGuardiansConfigToVaa(req *nodev1.DelegatedGuardiansConfig, timesta
 // delegatedManagerSetUpdateToVaa converts a nodev1.DelegatedManagerSetUpdate message to its canonical VAA representation.
 // Returns an error if the data is invalid.
 func delegatedManagerSetUpdateToVaa(req *nodev1.DelegatedManagerSetUpdate, timestamp time.Time, guardianSetIndex uint32, nonce uint32, sequence uint64) (*vaa.VAA, error) {
-	if req.ManagerChainId > math.MaxUint16 {
+	managerChainID, err := vaa.ChainIDFromNumber(req.ManagerChainId)
+	if err != nil {
 		return nil, errors.New("invalid manager_chain_id")
 	}
 
@@ -807,7 +821,7 @@ func delegatedManagerSetUpdateToVaa(req *nodev1.DelegatedManagerSetUpdate, times
 	}
 
 	body, err := vaa.BodyManagerSetUpdate{
-		ManagerChainID:     vaa.ChainID(req.ManagerChainId),
+		ManagerChainID:     managerChainID,
 		NewManagerSetIndex: req.ManagerSetIndex,
 		NewManagerSet:      managerSetBytes,
 	}.Serialize()
@@ -820,6 +834,11 @@ func delegatedManagerSetUpdateToVaa(req *nodev1.DelegatedManagerSetUpdate, times
 }
 
 func evmCallToVaa(evmCall *nodev1.EvmCall, timestamp time.Time, guardianSetIndex, nonce uint32, sequence uint64) (*vaa.VAA, error) {
+	chainID, err := vaa.ChainIDFromNumber(evmCall.ChainId)
+	if err != nil {
+		return nil, fmt.Errorf("chain id exceeds max uint16: %v", evmCall.ChainId)
+	}
+
 	governanceContract := ethcommon.HexToAddress(evmCall.GovernanceContract)
 	targetContract := ethcommon.HexToAddress(evmCall.TargetContract)
 
@@ -827,12 +846,9 @@ func evmCallToVaa(evmCall *nodev1.EvmCall, timestamp time.Time, guardianSetIndex
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode ABI encoded call: %w", err)
 	}
-	if evmCall.ChainId > math.MaxUint16 {
-		return nil, fmt.Errorf("chain id exceeds max uint16: %v", evmCall.ChainId)
-	}
 
 	body, err := vaa.BodyGeneralPurposeGovernanceEvm{
-		ChainID:            vaa.ChainID(evmCall.ChainId),
+		ChainID:            chainID,
 		GovernanceContract: governanceContract,
 		TargetContract:     targetContract,
 		Payload:            payload,
@@ -847,6 +863,11 @@ func evmCallToVaa(evmCall *nodev1.EvmCall, timestamp time.Time, guardianSetIndex
 }
 
 func solanaCallToVaa(solanaCall *nodev1.SolanaCall, timestamp time.Time, guardianSetIndex, nonce uint32, sequence uint64) (*vaa.VAA, error) {
+	chainID, err := vaa.ChainIDFromNumber(solanaCall.ChainId)
+	if err != nil {
+		return nil, fmt.Errorf("chain id exceeds max uint16: %v", solanaCall.ChainId)
+	}
+
 	address, err := base58.Decode(solanaCall.GovernanceContract)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode base58 governance contract address: %w", err)
@@ -862,12 +883,9 @@ func solanaCallToVaa(solanaCall *nodev1.SolanaCall, timestamp time.Time, guardia
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode instruction: %w", err)
 	}
-	if solanaCall.ChainId > math.MaxUint16 {
-		return nil, fmt.Errorf("chain id exceeds max uint16: %v", solanaCall.ChainId)
-	}
 
 	body, err := vaa.BodyGeneralPurposeGovernanceSolana{
-		ChainID:            vaa.ChainID(solanaCall.ChainId),
+		ChainID:            chainID,
 		GovernanceContract: governanceContract,
 		Instruction:        instruction,
 	}.Serialize()
@@ -881,6 +899,11 @@ func solanaCallToVaa(solanaCall *nodev1.SolanaCall, timestamp time.Time, guardia
 }
 
 func suiCallToVaa(suiCall *nodev1.SuiCall, timestamp time.Time, guardianSetIndex, nonce uint32, sequence uint64) (*vaa.VAA, error) {
+	chainID, err := vaa.ChainIDFromNumber(suiCall.ChainId)
+	if err != nil {
+		return nil, fmt.Errorf("chain id exceeds max uint16: %v", suiCall.ChainId)
+	}
+
 	govContractStr := strings.TrimPrefix(suiCall.GovernanceContract, "0x")
 	address, err := hex.DecodeString(govContractStr)
 	if err != nil {
@@ -897,12 +920,9 @@ func suiCallToVaa(suiCall *nodev1.SuiCall, timestamp time.Time, guardianSetIndex
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode call data: %w", err)
 	}
-	if suiCall.ChainId > math.MaxUint16 {
-		return nil, fmt.Errorf("chain id exceeds max uint16: %v", suiCall.ChainId)
-	}
 
 	body, err := vaa.BodyGeneralPurposeGovernanceSui{
-		ChainID:            vaa.ChainID(suiCall.ChainId),
+		ChainID:            chainID,
 		GovernanceContract: governanceContract,
 		Payload:            callData,
 	}.Serialize()
@@ -1129,14 +1149,15 @@ func (s *nodePrivilegedService) FindMissingMessages(ctx context.Context, req *no
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid emitter address encoding: %v", err)
 	}
-	if req.EmitterChain > math.MaxUint16 {
+	emitterChain, err := vaa.ChainIDFromNumber(req.EmitterChain)
+	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "chain id exceeds max uint16: %v", req.EmitterChain)
 	}
 	emitterAddress := vaa.Address{}
 	copy(emitterAddress[:], b)
 
 	ids, first, last, err := s.db.FindEmitterSequenceGap(guardianDB.VAAID{
-		EmitterChain:   vaa.ChainID(req.EmitterChain),
+		EmitterChain:   emitterChain,
 		EmitterAddress: emitterAddress,
 	})
 	if err != nil {
@@ -1147,7 +1168,7 @@ func (s *nodePrivilegedService) FindMissingMessages(ctx context.Context, req *no
 		c := &http.Client{}
 		unfilled := make([]uint64, 0, len(ids))
 		for _, id := range ids {
-			if ok, err := s.fetchMissing(ctx, req.BackfillNodes, c, vaa.ChainID(req.EmitterChain), emitterAddress.String(), id); err != nil {
+			if ok, err := s.fetchMissing(ctx, req.BackfillNodes, c, emitterChain, emitterAddress.String(), id); err != nil {
 				return nil, status.Errorf(codes.Internal, "failed to backfill VAA: %v", err)
 			} else if ok {
 				continue
@@ -1159,7 +1180,11 @@ func (s *nodePrivilegedService) FindMissingMessages(ctx context.Context, req *no
 
 	resp := make([]string, len(ids))
 	for i, v := range ids {
-		resp[i] = fmt.Sprintf("%d/%s/%d", req.EmitterChain, emitterAddress, v)
+		resp[i] = vaa.VAAID{
+			EmitterChain:   emitterChain,
+			EmitterAddress: emitterAddress,
+			Sequence:       v,
+		}.String()
 	}
 	return &nodev1.FindMissingMessagesResponse{
 		MissingMessages: resp,
@@ -1178,16 +1203,17 @@ func (s *nodePrivilegedService) SendObservationRequest(ctx context.Context, req 
 }
 
 func (s *nodePrivilegedService) ReobserveWithEndpoint(ctx context.Context, req *nodev1.ReobserveWithEndpointRequest) (*nodev1.ReobserveWithEndpointResponse, error) {
-	if req.ChainId > math.MaxUint16 {
+	chainID, err := vaa.ChainIDFromNumber(req.ChainId)
+	if err != nil {
 		return nil, status.Errorf(codes.Internal, "chain %d is not a valid uint16", req.ChainId)
 	}
 
-	watcher := s.reobservers[vaa.ChainID(req.ChainId)]
+	watcher := s.reobservers[chainID]
 	if watcher == nil {
 		return nil, status.Errorf(codes.Internal, "chain %d does not support reobservation by endpoint", req.ChainId)
 	}
 
-	numObservations, err := watcher.Reobserve(ctx, vaa.ChainID(req.ChainId), req.TxHash, req.Url)
+	numObservations, err := watcher.Reobserve(ctx, chainID, req.TxHash, req.Url)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "reobservation failed: %v", err)
 	}
@@ -1672,25 +1698,12 @@ func (s *nodePrivilegedService) GetAndObserveMissingVAAs(ctx context.Context, re
 		missingVAA := missingVAAs[i]
 		// First check to see if this VAA has already been signed
 		// Convert vaaKey to VAAID
-		splits := strings.Split(missingVAA.VaaKey, "/")
-		chainID, err := strconv.Atoi(splits[0])
+		vaaKey, err := vaa.VAAIDFromString(missingVAA.VaaKey)
 		if err != nil {
-			errMsgs += fmt.Sprintf("\nerror converting chainID [%s] to int", missingVAA.VaaKey)
+			errMsgs += fmt.Sprintf("\nerror parsing VAA key [%s]: %v", missingVAA.VaaKey, err)
 			errCounter++
 			continue
 		}
-		if chainID > math.MaxUint16 {
-			errMsgs += fmt.Sprintf("\nchainID [%d] not a valid uint16", chainID)
-			errCounter++
-			continue
-		}
-		sequence, err := strconv.ParseUint(splits[2], 10, 64)
-		if err != nil {
-			errMsgs += fmt.Sprintf("\nerror converting sequence %s to uint64", splits[2])
-			errCounter++
-			continue
-		}
-		vaaKey := guardianDB.VAAID{EmitterChain: vaa.ChainID(chainID), EmitterAddress: vaa.Address([]byte(splits[1])), Sequence: sequence} // #nosec G115 -- This chainId conversion is verified above
 		hasVaa, err := s.db.HasVAA(vaaKey)
 		if err != nil || hasVaa {
 			errMsgs += fmt.Sprintf("\nerror checking for VAA %s", missingVAA.VaaKey)
@@ -1698,12 +1711,13 @@ func (s *nodePrivilegedService) GetAndObserveMissingVAAs(ctx context.Context, re
 			continue
 		}
 		var obsvReq gossipv1.ObservationRequest
-		if missingVAA.Chain > math.MaxUint16 {
+		missingVAAChainID, err := vaa.ChainIDFromNumber(missingVAA.Chain)
+		if err != nil {
 			errMsgs += fmt.Sprintf("\nmissing VAA chainID [%d] not a valid uint16", missingVAA.Chain)
 			errCounter++
 			continue
 		}
-		obsvReq.ChainId = uint32(missingVAA.Chain) // #nosec G115 -- This conversion is checked above
+		obsvReq.ChainId = uint32(missingVAAChainID)
 		obsvReq.TxHash, err = hex.DecodeString(strings.TrimPrefix(missingVAA.Txhash, "0x"))
 		if err != nil {
 			obsvReq.TxHash, err = base58.Decode(missingVAA.Txhash)

--- a/node/pkg/adminrpc/adminserver.go
+++ b/node/pkg/adminrpc/adminserver.go
@@ -13,7 +13,6 @@ import (
 	"math/rand"
 	"net/http"
 	"slices"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -153,6 +152,11 @@ func adminGuardianSetUpdateToVAA(req *nodev1.GuardianSetUpdate, timestamp time.T
 // adminContractUpgradeToVAA converts a nodev1.ContractUpgrade message to its canonical VAA representation.
 // Returns an error if the data is invalid.
 func adminContractUpgradeToVAA(req *nodev1.ContractUpgrade, timestamp time.Time, guardianSetIndex uint32, nonce uint32, sequence uint64) (*vaa.VAA, error) {
+	chainID, err := vaa.ChainIDFromNumber(req.ChainId)
+	if err != nil {
+		return nil, errors.New("invalid chain_id")
+	}
+
 	b, err := hex.DecodeString(req.NewContract)
 	if err != nil {
 		return nil, errors.New("invalid new contract address encoding (expected hex)")
@@ -162,15 +166,11 @@ func adminContractUpgradeToVAA(req *nodev1.ContractUpgrade, timestamp time.Time,
 		return nil, errors.New("invalid new_contract address")
 	}
 
-	if req.ChainId > math.MaxUint16 {
-		return nil, errors.New("invalid chain_id")
-	}
-
 	newContractAddress := vaa.Address{}
 	copy(newContractAddress[:], b)
 
 	body, err := vaa.BodyContractUpgrade{
-		ChainID:     vaa.ChainID(req.ChainId),
+		ChainID:     chainID,
 		NewContract: newContractAddress,
 	}.Serialize()
 
@@ -185,7 +185,8 @@ func adminContractUpgradeToVAA(req *nodev1.ContractUpgrade, timestamp time.Time,
 // tokenBridgeRegisterChain converts a nodev1.TokenBridgeRegisterChain message to its canonical VAA representation.
 // Returns an error if the data is invalid.
 func tokenBridgeRegisterChain(req *nodev1.BridgeRegisterChain, timestamp time.Time, guardianSetIndex uint32, nonce uint32, sequence uint64) (*vaa.VAA, error) {
-	if req.ChainId > math.MaxUint16 {
+	chainID, err := vaa.ChainIDFromNumber(req.ChainId)
+	if err != nil {
 		return nil, errors.New("invalid chain_id")
 	}
 
@@ -203,7 +204,7 @@ func tokenBridgeRegisterChain(req *nodev1.BridgeRegisterChain, timestamp time.Ti
 
 	body, err := vaa.BodyTokenBridgeRegisterChain{
 		Module:         req.Module,
-		ChainID:        vaa.ChainID(req.ChainId),
+		ChainID:        chainID,
 		EmitterAddress: emitterAddress,
 	}.Serialize()
 
@@ -218,6 +219,11 @@ func tokenBridgeRegisterChain(req *nodev1.BridgeRegisterChain, timestamp time.Ti
 // recoverChainId converts a nodev1.RecoverChainId message to its canonical VAA representation.
 // Returns an error if the data is invalid.
 func recoverChainId(req *nodev1.RecoverChainId, timestamp time.Time, guardianSetIndex uint32, nonce uint32, sequence uint64) (*vaa.VAA, error) {
+	newChainID, err := vaa.ChainIDFromNumber(req.NewChainId)
+	if err != nil {
+		return nil, errors.New("invalid new_chain_id")
+	}
+
 	evm_chain_id_big := big.NewInt(0)
 	evm_chain_id_big, ok := evm_chain_id_big.SetString(req.EvmChainId, 10)
 	if !ok {
@@ -230,14 +236,10 @@ func recoverChainId(req *nodev1.RecoverChainId, timestamp time.Time, guardianSet
 		return nil, errors.New("evm_chain_id overflow")
 	}
 
-	if req.NewChainId > math.MaxUint16 {
-		return nil, errors.New("invalid new_chain_id")
-	}
-
 	body, err := vaa.BodyRecoverChainId{
 		Module:     req.Module,
 		EvmChainID: evm_chain_id,
-		NewChainID: vaa.ChainID(req.NewChainId),
+		NewChainID: newChainID,
 	}.Serialize()
 
 	if err != nil {
@@ -251,13 +253,16 @@ func recoverChainId(req *nodev1.RecoverChainId, timestamp time.Time, guardianSet
 // accountantModifyBalance converts a nodev1.AccountantModifyBalance message to its canonical VAA representation.
 // Returns an error if the data is invalid.
 func accountantModifyBalance(req *nodev1.AccountantModifyBalance, timestamp time.Time, guardianSetIndex uint32, nonce uint32, sequence uint64) (*vaa.VAA, error) {
-	if req.TargetChainId > math.MaxUint16 {
+	targetChainID, err := vaa.ChainIDFromNumber(req.TargetChainId)
+	if err != nil {
 		return nil, errors.New("invalid target_chain_id")
 	}
-	if req.ChainId > math.MaxUint16 {
+	chainID, err := vaa.ChainIDFromNumber(req.ChainId)
+	if err != nil {
 		return nil, errors.New("invalid chain_id")
 	}
-	if req.TokenChain > math.MaxUint16 {
+	tokenChainID, err := vaa.ChainIDFromNumber(req.TokenChain)
+	if err != nil {
 		return nil, errors.New("invalid token_chain")
 	}
 
@@ -291,11 +296,11 @@ func accountantModifyBalance(req *nodev1.AccountantModifyBalance, timestamp time
 
 	body, err := vaa.BodyAccountantModifyBalance{
 		Module:        req.Module,
-		TargetChainID: vaa.ChainID(req.TargetChainId),
+		TargetChainID: targetChainID,
 
 		Sequence:     req.Sequence,
-		ChainId:      vaa.ChainID(req.ChainId),
-		TokenChain:   vaa.ChainID(req.TokenChain),
+		ChainId:      chainID,
+		TokenChain:   tokenChainID,
 		TokenAddress: tokenAdress,
 		Kind:         uint8(req.Kind), // #nosec G115 -- The `ModificationKind` enum only has 3 values
 		Amount:       amount,
@@ -361,7 +366,8 @@ func decodePauserAddress(field, s string) ([]byte, error) {
 // tokenBridgeUpgradeContract converts a nodev1.TokenBridgeRegisterChain message to its canonical VAA representation.
 // Returns an error if the data is invalid.
 func tokenBridgeUpgradeContract(req *nodev1.BridgeUpgradeContract, timestamp time.Time, guardianSetIndex uint32, nonce uint32, sequence uint64) (*vaa.VAA, error) {
-	if req.TargetChainId > math.MaxUint16 {
+	targetChainID, err := vaa.ChainIDFromNumber(req.TargetChainId)
+	if err != nil {
 		return nil, errors.New("invalid target_chain_id")
 	}
 
@@ -379,7 +385,7 @@ func tokenBridgeUpgradeContract(req *nodev1.BridgeUpgradeContract, timestamp tim
 
 	body, err := vaa.BodyTokenBridgeUpgradeContract{
 		Module:        req.Module,
-		TargetChainID: vaa.ChainID(req.TargetChainId),
+		TargetChainID: targetChainID,
 		NewContract:   newContract,
 	}.Serialize()
 
@@ -557,7 +563,8 @@ func gatewayIbcComposabilityMwSetContract(
 // circleIntegrationUpdateWormholeFinality converts a nodev1.CircleIntegrationUpdateWormholeFinality to its canonical VAA representation
 // Returns an error if the data is invalid
 func circleIntegrationUpdateWormholeFinality(req *nodev1.CircleIntegrationUpdateWormholeFinality, timestamp time.Time, guardianSetIndex uint32, nonce uint32, sequence uint64) (*vaa.VAA, error) {
-	if req.TargetChainId > math.MaxUint16 {
+	targetChainID, err := vaa.ChainIDFromNumber(req.TargetChainId)
+	if err != nil {
 		return nil, fmt.Errorf("invalid target chain id, must be <= %d", math.MaxUint16)
 	}
 	if req.Finality > math.MaxUint8 {
@@ -565,7 +572,7 @@ func circleIntegrationUpdateWormholeFinality(req *nodev1.CircleIntegrationUpdate
 	}
 
 	body, err := vaa.BodyCircleIntegrationUpdateWormholeFinality{
-		TargetChainID: vaa.ChainID(req.TargetChainId),
+		TargetChainID: targetChainID,
 		Finality:      uint8(req.Finality),
 	}.Serialize()
 
@@ -580,10 +587,12 @@ func circleIntegrationUpdateWormholeFinality(req *nodev1.CircleIntegrationUpdate
 // circleIntegrationRegisterEmitterAndDomain converts a nodev1.CircleIntegrationRegisterEmitterAndDomain to its canonical VAA representation
 // Returns an error if the data is invalid
 func circleIntegrationRegisterEmitterAndDomain(req *nodev1.CircleIntegrationRegisterEmitterAndDomain, timestamp time.Time, guardianSetIndex uint32, nonce uint32, sequence uint64) (*vaa.VAA, error) {
-	if req.TargetChainId > math.MaxUint16 {
+	targetChainID, err := vaa.ChainIDFromNumber(req.TargetChainId)
+	if err != nil {
 		return nil, fmt.Errorf("invalid target chain id, must be <= %d", math.MaxUint16)
 	}
-	if req.ForeignEmitterChainId > math.MaxUint16 {
+	foreignEmitterChainID, err := vaa.ChainIDFromNumber(req.ForeignEmitterChainId)
+	if err != nil {
 		return nil, fmt.Errorf("invalid foreign emitter chain id, must be <= %d", math.MaxUint16)
 	}
 	b, err := hex.DecodeString(req.ForeignEmitterAddress)
@@ -599,8 +608,8 @@ func circleIntegrationRegisterEmitterAndDomain(req *nodev1.CircleIntegrationRegi
 	copy(foreignEmitterAddress[:], b)
 
 	body, err := vaa.BodyCircleIntegrationRegisterEmitterAndDomain{
-		TargetChainID:         vaa.ChainID(req.TargetChainId),
-		ForeignEmitterChainId: vaa.ChainID(req.ForeignEmitterChainId),
+		TargetChainID:         targetChainID,
+		ForeignEmitterChainId: foreignEmitterChainID,
 		ForeignEmitterAddress: foreignEmitterAddress,
 		CircleDomain:          req.CircleDomain,
 	}.Serialize()
@@ -616,7 +625,8 @@ func circleIntegrationRegisterEmitterAndDomain(req *nodev1.CircleIntegrationRegi
 // circleIntegrationUpgradeContractImplementation converts a nodev1.CircleIntegrationUpgradeContractImplementation to its canonical VAA representation
 // Returns an error if the data is invalid
 func circleIntegrationUpgradeContractImplementation(req *nodev1.CircleIntegrationUpgradeContractImplementation, timestamp time.Time, guardianSetIndex uint32, nonce uint32, sequence uint64) (*vaa.VAA, error) {
-	if req.TargetChainId > math.MaxUint16 {
+	targetChainID, err := vaa.ChainIDFromNumber(req.TargetChainId)
+	if err != nil {
 		return nil, fmt.Errorf("invalid target chain id, must be <= %d", math.MaxUint16)
 	}
 	b, err := hex.DecodeString(req.NewImplementationAddress)
@@ -632,7 +642,7 @@ func circleIntegrationUpgradeContractImplementation(req *nodev1.CircleIntegratio
 	copy(newImplementationAddress[:], b)
 
 	body, err := vaa.BodyCircleIntegrationUpgradeContractImplementation{
-		TargetChainID:            vaa.ChainID(req.TargetChainId),
+		TargetChainID:            targetChainID,
 		NewImplementationAddress: newImplementationAddress,
 	}.Serialize()
 
@@ -652,11 +662,13 @@ func ibcUpdateChannelChain(
 	sequence uint64,
 ) (*vaa.VAA, error) {
 	// validate parameters
-	if req.TargetChainId > math.MaxUint16 {
+	targetChainID, err := vaa.ChainIDFromNumber(req.TargetChainId)
+	if err != nil {
 		return nil, fmt.Errorf("invalid target chain id, must be <= %d", math.MaxUint16)
 	}
 
-	if req.ChainId > math.MaxUint16 {
+	chainID, err := vaa.ChainIDFromNumber(req.ChainId)
+	if err != nil {
 		return nil, fmt.Errorf("invalid chain id, must be <= %d", math.MaxUint16)
 	}
 
@@ -678,9 +690,9 @@ func ibcUpdateChannelChain(
 	}
 
 	body, err := vaa.BodyIbcUpdateChannelChain{
-		TargetChainId: vaa.ChainID(req.TargetChainId),
+		TargetChainId: targetChainID,
 		ChannelId:     channelId,
-		ChainId:       vaa.ChainID(req.ChainId),
+		ChainId:       chainID,
 	}.Serialize(module)
 
 	if err != nil {
@@ -694,7 +706,8 @@ func ibcUpdateChannelChain(
 // wormholeRelayerSetDefaultDeliveryProvider converts a nodev1.WormholeRelayerSetDefaultDeliveryProvider message to its canonical VAA representation.
 // Returns an error if the data is invalid.
 func wormholeRelayerSetDefaultDeliveryProvider(req *nodev1.WormholeRelayerSetDefaultDeliveryProvider, timestamp time.Time, guardianSetIndex uint32, nonce uint32, sequence uint64) (*vaa.VAA, error) {
-	if req.ChainId > math.MaxUint16 {
+	chainID, err := vaa.ChainIDFromNumber(req.ChainId)
+	if err != nil {
 		return nil, errors.New("invalid target_chain_id")
 	}
 
@@ -711,7 +724,7 @@ func wormholeRelayerSetDefaultDeliveryProvider(req *nodev1.WormholeRelayerSetDef
 	copy(NewDefaultDeliveryProviderAddress[:], b)
 
 	body, err := vaa.BodyWormholeRelayerSetDefaultDeliveryProvider{
-		ChainID:                           vaa.ChainID(req.ChainId),
+		ChainID:                           chainID,
 		NewDefaultDeliveryProviderAddress: NewDefaultDeliveryProviderAddress,
 	}.Serialize()
 
@@ -845,7 +858,8 @@ func delegatedGuardiansConfigToVaa(req *nodev1.DelegatedGuardiansConfig, timesta
 // delegatedManagerSetUpdateToVaa converts a nodev1.DelegatedManagerSetUpdate message to its canonical VAA representation.
 // Returns an error if the data is invalid.
 func delegatedManagerSetUpdateToVaa(req *nodev1.DelegatedManagerSetUpdate, timestamp time.Time, guardianSetIndex uint32, nonce uint32, sequence uint64) (*vaa.VAA, error) {
-	if req.ManagerChainId > math.MaxUint16 {
+	managerChainID, err := vaa.ChainIDFromNumber(req.ManagerChainId)
+	if err != nil {
 		return nil, errors.New("invalid manager_chain_id")
 	}
 
@@ -855,7 +869,7 @@ func delegatedManagerSetUpdateToVaa(req *nodev1.DelegatedManagerSetUpdate, times
 	}
 
 	body, err := vaa.BodyManagerSetUpdate{
-		ManagerChainID:     vaa.ChainID(req.ManagerChainId),
+		ManagerChainID:     managerChainID,
 		NewManagerSetIndex: req.ManagerSetIndex,
 		NewManagerSet:      managerSetBytes,
 	}.Serialize()
@@ -868,6 +882,11 @@ func delegatedManagerSetUpdateToVaa(req *nodev1.DelegatedManagerSetUpdate, times
 }
 
 func evmCallToVaa(evmCall *nodev1.EvmCall, timestamp time.Time, guardianSetIndex, nonce uint32, sequence uint64) (*vaa.VAA, error) {
+	chainID, err := vaa.ChainIDFromNumber(evmCall.ChainId)
+	if err != nil {
+		return nil, fmt.Errorf("chain id exceeds max uint16: %v", evmCall.ChainId)
+	}
+
 	governanceContract := ethcommon.HexToAddress(evmCall.GovernanceContract)
 	targetContract := ethcommon.HexToAddress(evmCall.TargetContract)
 
@@ -875,12 +894,9 @@ func evmCallToVaa(evmCall *nodev1.EvmCall, timestamp time.Time, guardianSetIndex
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode ABI encoded call: %w", err)
 	}
-	if evmCall.ChainId > math.MaxUint16 {
-		return nil, fmt.Errorf("chain id exceeds max uint16: %v", evmCall.ChainId)
-	}
 
 	body, err := vaa.BodyGeneralPurposeGovernanceEvm{
-		ChainID:            vaa.ChainID(evmCall.ChainId),
+		ChainID:            chainID,
 		GovernanceContract: governanceContract,
 		TargetContract:     targetContract,
 		Payload:            payload,
@@ -895,6 +911,11 @@ func evmCallToVaa(evmCall *nodev1.EvmCall, timestamp time.Time, guardianSetIndex
 }
 
 func solanaCallToVaa(solanaCall *nodev1.SolanaCall, timestamp time.Time, guardianSetIndex, nonce uint32, sequence uint64) (*vaa.VAA, error) {
+	chainID, err := vaa.ChainIDFromNumber(solanaCall.ChainId)
+	if err != nil {
+		return nil, fmt.Errorf("chain id exceeds max uint16: %v", solanaCall.ChainId)
+	}
+
 	address, err := base58.Decode(solanaCall.GovernanceContract)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode base58 governance contract address: %w", err)
@@ -910,12 +931,9 @@ func solanaCallToVaa(solanaCall *nodev1.SolanaCall, timestamp time.Time, guardia
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode instruction: %w", err)
 	}
-	if solanaCall.ChainId > math.MaxUint16 {
-		return nil, fmt.Errorf("chain id exceeds max uint16: %v", solanaCall.ChainId)
-	}
 
 	body, err := vaa.BodyGeneralPurposeGovernanceSolana{
-		ChainID:            vaa.ChainID(solanaCall.ChainId),
+		ChainID:            chainID,
 		GovernanceContract: governanceContract,
 		Instruction:        instruction,
 	}.Serialize()
@@ -929,6 +947,11 @@ func solanaCallToVaa(solanaCall *nodev1.SolanaCall, timestamp time.Time, guardia
 }
 
 func suiCallToVaa(suiCall *nodev1.SuiCall, timestamp time.Time, guardianSetIndex, nonce uint32, sequence uint64) (*vaa.VAA, error) {
+	chainID, err := vaa.ChainIDFromNumber(suiCall.ChainId)
+	if err != nil {
+		return nil, fmt.Errorf("chain id exceeds max uint16: %v", suiCall.ChainId)
+	}
+
 	govContractStr := strings.TrimPrefix(suiCall.GovernanceContract, "0x")
 	address, err := hex.DecodeString(govContractStr)
 	if err != nil {
@@ -945,12 +968,9 @@ func suiCallToVaa(suiCall *nodev1.SuiCall, timestamp time.Time, guardianSetIndex
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode call data: %w", err)
 	}
-	if suiCall.ChainId > math.MaxUint16 {
-		return nil, fmt.Errorf("chain id exceeds max uint16: %v", suiCall.ChainId)
-	}
 
 	body, err := vaa.BodyGeneralPurposeGovernanceSui{
-		ChainID:            vaa.ChainID(suiCall.ChainId),
+		ChainID:            chainID,
 		GovernanceContract: governanceContract,
 		Payload:            callData,
 	}.Serialize()
@@ -1180,14 +1200,15 @@ func (s *nodePrivilegedService) FindMissingMessages(ctx context.Context, req *no
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid emitter address encoding: %v", err)
 	}
-	if req.EmitterChain > math.MaxUint16 {
+	emitterChain, err := vaa.ChainIDFromNumber(req.EmitterChain)
+	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "chain id exceeds max uint16: %v", req.EmitterChain)
 	}
 	emitterAddress := vaa.Address{}
 	copy(emitterAddress[:], b)
 
 	ids, first, last, err := s.db.FindEmitterSequenceGap(guardianDB.VAAID{
-		EmitterChain:   vaa.ChainID(req.EmitterChain),
+		EmitterChain:   emitterChain,
 		EmitterAddress: emitterAddress,
 	})
 	if err != nil {
@@ -1198,7 +1219,7 @@ func (s *nodePrivilegedService) FindMissingMessages(ctx context.Context, req *no
 		c := &http.Client{}
 		unfilled := make([]uint64, 0, len(ids))
 		for _, id := range ids {
-			if ok, err := s.fetchMissing(ctx, req.BackfillNodes, c, vaa.ChainID(req.EmitterChain), emitterAddress.String(), id); err != nil {
+			if ok, err := s.fetchMissing(ctx, req.BackfillNodes, c, emitterChain, emitterAddress.String(), id); err != nil {
 				return nil, status.Errorf(codes.Internal, "failed to backfill VAA: %v", err)
 			} else if ok {
 				continue
@@ -1210,7 +1231,11 @@ func (s *nodePrivilegedService) FindMissingMessages(ctx context.Context, req *no
 
 	resp := make([]string, len(ids))
 	for i, v := range ids {
-		resp[i] = fmt.Sprintf("%d/%s/%d", req.EmitterChain, emitterAddress, v)
+		resp[i] = vaa.VAAID{
+			EmitterChain:   emitterChain,
+			EmitterAddress: emitterAddress,
+			Sequence:       v,
+		}.String()
 	}
 	return &nodev1.FindMissingMessagesResponse{
 		MissingMessages: resp,
@@ -1229,16 +1254,17 @@ func (s *nodePrivilegedService) SendObservationRequest(ctx context.Context, req 
 }
 
 func (s *nodePrivilegedService) ReobserveWithEndpoint(ctx context.Context, req *nodev1.ReobserveWithEndpointRequest) (*nodev1.ReobserveWithEndpointResponse, error) {
-	if req.ChainId > math.MaxUint16 {
+	chainID, err := vaa.ChainIDFromNumber(req.ChainId)
+	if err != nil {
 		return nil, status.Errorf(codes.Internal, "chain %d is not a valid uint16", req.ChainId)
 	}
 
-	watcher := s.reobservers[vaa.ChainID(req.ChainId)]
+	watcher := s.reobservers[chainID]
 	if watcher == nil {
 		return nil, status.Errorf(codes.Internal, "chain %d does not support reobservation by endpoint", req.ChainId)
 	}
 
-	numObservations, err := watcher.Reobserve(ctx, vaa.ChainID(req.ChainId), req.TxHash, req.Url)
+	numObservations, err := watcher.Reobserve(ctx, chainID, req.TxHash, req.Url)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "reobservation failed: %v", err)
 	}
@@ -1723,25 +1749,12 @@ func (s *nodePrivilegedService) GetAndObserveMissingVAAs(ctx context.Context, re
 		missingVAA := missingVAAs[i]
 		// First check to see if this VAA has already been signed
 		// Convert vaaKey to VAAID
-		splits := strings.Split(missingVAA.VaaKey, "/")
-		chainID, err := strconv.Atoi(splits[0])
+		vaaKey, err := vaa.VAAIDFromString(missingVAA.VaaKey)
 		if err != nil {
-			errMsgs += fmt.Sprintf("\nerror converting chainID [%s] to int", missingVAA.VaaKey)
+			errMsgs += fmt.Sprintf("\nerror parsing VAA key [%s]: %v", missingVAA.VaaKey, err)
 			errCounter++
 			continue
 		}
-		if chainID > math.MaxUint16 {
-			errMsgs += fmt.Sprintf("\nchainID [%d] not a valid uint16", chainID)
-			errCounter++
-			continue
-		}
-		sequence, err := strconv.ParseUint(splits[2], 10, 64)
-		if err != nil {
-			errMsgs += fmt.Sprintf("\nerror converting sequence %s to uint64", splits[2])
-			errCounter++
-			continue
-		}
-		vaaKey := guardianDB.VAAID{EmitterChain: vaa.ChainID(chainID), EmitterAddress: vaa.Address([]byte(splits[1])), Sequence: sequence} // #nosec G115 -- This chainId conversion is verified above
 		hasVaa, err := s.db.HasVAA(vaaKey)
 		if err != nil || hasVaa {
 			errMsgs += fmt.Sprintf("\nerror checking for VAA %s", missingVAA.VaaKey)
@@ -1749,12 +1762,13 @@ func (s *nodePrivilegedService) GetAndObserveMissingVAAs(ctx context.Context, re
 			continue
 		}
 		var obsvReq gossipv1.ObservationRequest
-		if missingVAA.Chain > math.MaxUint16 {
+		missingVAAChainID, err := vaa.ChainIDFromNumber(missingVAA.Chain)
+		if err != nil {
 			errMsgs += fmt.Sprintf("\nmissing VAA chainID [%d] not a valid uint16", missingVAA.Chain)
 			errCounter++
 			continue
 		}
-		obsvReq.ChainId = uint32(missingVAA.Chain) // #nosec G115 -- This conversion is checked above
+		obsvReq.ChainId = uint32(missingVAAChainID)
 		obsvReq.TxHash, err = hex.DecodeString(strings.TrimPrefix(missingVAA.Txhash, "0x"))
 		if err != nil {
 			obsvReq.TxHash, err = base58.Decode(missingVAA.Txhash)

--- a/node/pkg/common/chainlock.go
+++ b/node/pkg/common/chainlock.go
@@ -234,7 +234,11 @@ func (msg *MessagePublication) MessageID() []byte {
 }
 
 func (msg *MessagePublication) MessageIDString() string {
-	return fmt.Sprintf("%v/%v/%v", uint16(msg.EmitterChain), msg.EmitterAddress, msg.Sequence)
+	return vaa.VAAID{
+		EmitterChain:   msg.EmitterChain,
+		EmitterAddress: msg.EmitterAddress,
+		Sequence:       msg.Sequence,
+	}.String()
 }
 
 func (msg *MessagePublication) VerificationState() VerificationState {

--- a/node/pkg/db/db.go
+++ b/node/pkg/db/db.go
@@ -3,8 +3,6 @@ package db
 import (
 	"errors"
 	"fmt"
-	"strconv"
-	"strings"
 
 	"github.com/dgraph-io/badger/v3"
 	"github.com/prometheus/client_golang/prometheus"
@@ -22,61 +20,18 @@ type Database struct {
 	db *badger.DB
 }
 
-type VAAID struct {
-	EmitterChain   vaa.ChainID
-	EmitterAddress vaa.Address
-	Sequence       uint64
-}
-
-// VaaIDFromString parses a <chain>/<address>/<sequence> string into a VAAID.
-func VaaIDFromString(s string) (*VAAID, error) {
-	parts := strings.Split(s, "/")
-	if len(parts) != 3 {
-		return nil, errors.New("invalid message id")
-	}
-
-	emitterChain, err := strconv.ParseUint(parts[0], 10, 16)
-	if err != nil {
-		return nil, fmt.Errorf("invalid emitter chain: %s", err)
-	}
-
-	emitterAddress, err := vaa.StringToAddress(parts[1])
-	if err != nil {
-		return nil, fmt.Errorf("invalid emitter address: %s", err)
-	}
-
-	sequence, err := strconv.ParseUint(parts[2], 10, 64)
-	if err != nil {
-		return nil, fmt.Errorf("invalid sequence: %s", err)
-	}
-
-	msgId := &VAAID{
-		EmitterChain:   vaa.ChainID(emitterChain),
-		EmitterAddress: emitterAddress,
-		Sequence:       sequence,
-	}
-
-	return msgId, nil
-}
-
-func VaaIDFromVAA(v *vaa.VAA) *VAAID {
-	return &VAAID{
-		EmitterChain:   v.EmitterChain,
-		EmitterAddress: v.EmitterAddress,
-		Sequence:       v.Sequence,
-	}
-}
+type VAAID = vaa.VAAID
 
 var (
 	ErrVAANotFound = errors.New("requested VAA not found in store")
 	nullAddr       = vaa.Address{}
 )
 
-func (i *VAAID) Bytes() []byte {
-	return []byte(fmt.Sprintf("signed/%d/%s/%d", i.EmitterChain, i.EmitterAddress, i.Sequence))
+func vaaKeyBytes(i vaa.VAAID) []byte {
+	return []byte("signed/" + i.String())
 }
 
-func (i *VAAID) EmitterPrefixBytes() []byte {
+func vaaEmitterPrefixBytes(i vaa.VAAID) []byte {
 	if i.EmitterAddress == nullAddr {
 		return []byte(fmt.Sprintf("signed/%d", i.EmitterChain))
 	}
@@ -102,7 +57,7 @@ func (d *Database) StoreSignedVAA(v *vaa.VAA) error {
 	// TODO: panic on non-identical signing digest?
 
 	err := d.db.Update(func(txn *badger.Txn) error {
-		if err := txn.Set(VaaIDFromVAA(v).Bytes(), b); err != nil {
+		if err := txn.Set(vaaKeyBytes(v.ID()), b); err != nil {
 			return err
 		}
 		return nil
@@ -134,7 +89,7 @@ func (d *Database) StoreSignedVAABatch(vaaBatch []*vaa.VAA) error {
 			panic("StoreSignedVAABatch failed to marshal VAA")
 		}
 
-		err = batchTx.Set(VaaIDFromVAA(v).Bytes(), b)
+		err = batchTx.Set(vaaKeyBytes(v.ID()), b)
 		if err != nil {
 			return err
 		}
@@ -148,7 +103,7 @@ func (d *Database) StoreSignedVAABatch(vaaBatch []*vaa.VAA) error {
 
 func (d *Database) HasVAA(id VAAID) (bool, error) {
 	err := d.db.View(func(txn *badger.Txn) error {
-		_, err := txn.Get(id.Bytes())
+		_, err := txn.Get(vaaKeyBytes(id))
 		return err
 	})
 	if err == nil {
@@ -162,7 +117,7 @@ func (d *Database) HasVAA(id VAAID) (bool, error) {
 
 func (d *Database) GetSignedVAABytes(id VAAID) (b []byte, err error) {
 	if err := d.db.View(func(txn *badger.Txn) error {
-		item, err := txn.Get(id.Bytes())
+		item, err := txn.Get(vaaKeyBytes(id))
 		if err != nil {
 			return err
 		}
@@ -186,7 +141,7 @@ func (d *Database) FindEmitterSequenceGap(prefix VAAID) (resp []uint64, firstSeq
 	if err = d.db.View(func(txn *badger.Txn) error {
 		it := txn.NewIterator(badger.DefaultIteratorOptions)
 		defer it.Close()
-		prefix := prefix.EmitterPrefixBytes()
+		prefix := vaaEmitterPrefixBytes(prefix)
 
 		// Find all sequence numbers (the message IDs are ordered lexicographically,
 		// rather than numerically, so we need to sort them in-memory).

--- a/node/pkg/db/db_test.go
+++ b/node/pkg/db/db_test.go
@@ -48,7 +48,7 @@ func getVAAWithSeqNum(seqNum uint64) vaa.VAA {
 // Testing the expected default behavior of a CreateGovernanceVAA
 func TestVaaIDFromString(t *testing.T) {
 	vaaIdString := "1/0000000000000000000000000000000000000000000000000000000000000004/1"
-	vaaID, _ := VaaIDFromString(vaaIdString)
+	vaaID, _ := vaa.VAAIDFromString(vaaIdString)
 	expectAddr := vaa.Address{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4}
 
 	assert.Equal(t, vaa.ChainIDSolana, vaaID.EmitterChain)
@@ -58,7 +58,7 @@ func TestVaaIDFromString(t *testing.T) {
 
 func TestVaaIDFromVAA(t *testing.T) {
 	testVaa := getVAA()
-	vaaID := VaaIDFromVAA(&testVaa)
+	vaaID := testVaa.ID()
 	expectAddr := vaa.Address{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4}
 
 	assert.Equal(t, vaa.ChainIDSolana, vaaID.EmitterChain)
@@ -68,23 +68,23 @@ func TestVaaIDFromVAA(t *testing.T) {
 
 func TestBytes(t *testing.T) {
 	vaaIdString := "1/0000000000000000000000000000000000000000000000000000000000000004/1"
-	vaaID, _ := VaaIDFromString(vaaIdString)
+	vaaID, _ := vaa.VAAIDFromString(vaaIdString)
 	expected := []byte{0x73, 0x69, 0x67, 0x6e, 0x65, 0x64, 0x2f, 0x31, 0x2f, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x34, 0x2f, 0x31}
 
-	assert.Equal(t, expected, vaaID.Bytes())
+	assert.Equal(t, expected, vaaKeyBytes(vaaID))
 }
 
 func TestEmitterPrefixBytesWithChainIDAndAddress(t *testing.T) {
 	vaaIdString := "1/0000000000000000000000000000000000000000000000000000000000000004/1"
-	vaaID, _ := VaaIDFromString(vaaIdString)
+	vaaID, _ := vaa.VAAIDFromString(vaaIdString)
 	expected := []byte{0x73, 0x69, 0x67, 0x6e, 0x65, 0x64, 0x2f, 0x31, 0x2f, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x34}
 
-	assert.Equal(t, expected, vaaID.EmitterPrefixBytes())
+	assert.Equal(t, expected, vaaEmitterPrefixBytes(vaaID))
 }
 
 func TestEmitterPrefixBytesWithOnlyChainID(t *testing.T) {
 	vaaID := VAAID{EmitterChain: vaa.ChainID(26)}
-	assert.Equal(t, []byte("signed/26"), vaaID.EmitterPrefixBytes())
+	assert.Equal(t, []byte("signed/26"), vaaEmitterPrefixBytes(vaaID))
 }
 
 func TestStoreSignedVAAUnsigned(t *testing.T) {
@@ -163,7 +163,7 @@ func TestStoreSignedVAABatch(t *testing.T) {
 
 	// Verify all the updated VAAs are in the database.
 	for _, v := range vaaBatch {
-		storedBytes, err := db.GetSignedVAABytes(*VaaIDFromVAA(v))
+		storedBytes, err := db.GetSignedVAABytes(v.ID())
 		require.NoError(t, err)
 
 		origBytes, err := v.Marshal()
@@ -181,7 +181,7 @@ func TestGetSignedVAABytes(t *testing.T) {
 
 	testVaa := getVAA()
 
-	vaaID := VaaIDFromVAA(&testVaa)
+	vaaID := testVaa.ID()
 
 	privKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	testVaa.AddSignature(privKey, 0)
@@ -191,7 +191,7 @@ func TestGetSignedVAABytes(t *testing.T) {
 	assert.NoError(t, err2)
 
 	// Retrieve it using vaaID
-	vaaBytes, err2 := db.GetSignedVAABytes(*vaaID)
+	vaaBytes, err2 := db.GetSignedVAABytes(vaaID)
 	assert.NoError(t, err2)
 
 	testVaaBytes, err3 := testVaa.Marshal()
@@ -208,7 +208,7 @@ func TestFindEmitterSequenceGap(t *testing.T) {
 
 	testVaa := getVAA()
 
-	vaaID := VaaIDFromVAA(&testVaa)
+	vaaID := testVaa.ID()
 
 	privKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	testVaa.AddSignature(privKey, 0)
@@ -217,7 +217,7 @@ func TestFindEmitterSequenceGap(t *testing.T) {
 	err2 := db.StoreSignedVAA(&testVaa)
 	assert.NoError(t, err2)
 
-	resp, firstSeq, lastSeq, err := db.FindEmitterSequenceGap(*vaaID)
+	resp, firstSeq, lastSeq, err := db.FindEmitterSequenceGap(vaaID)
 
 	assert.Equal(t, []uint64{0x0}, resp)
 	assert.Equal(t, uint64(0x0), firstSeq)
@@ -252,9 +252,15 @@ func BenchmarkVaaLookup(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		randId := math_rand.Intn(250000) //nolint
 		randId = 250000 - (i / 18)
+<<<<<<< HEAD
 		vaaId, idErr := VaaIDFromString(fmt.Sprintf("4/000000000000000000000000b6f6d86a8f9879a9c87f643768d9efc38c1da6e7/%d", randId))
 		assert.NoError(b, idErr)
 		vaaIds <- vaaId
+=======
+		vaaId, err := vaa.VAAIDFromString(fmt.Sprintf("4/000000000000000000000000b6f6d86a8f9879a9c87f643768d9efc38c1da6e7/%d", randId))
+		assert.NoError(b, err)
+		vaaIds <- &vaaId
+>>>>>>> 1e28030db (sdk: Add VAA ID validation and use it everywhere)
 	}
 
 	b.ResetTimer()

--- a/node/pkg/db/db_test.go
+++ b/node/pkg/db/db_test.go
@@ -143,7 +143,7 @@ func TestStoreSignedVAABatch(t *testing.T) {
 
 	// Verify all the VAAs are in the database.
 	for _, v := range vaaBatch {
-		storedBytes, getErr := db.GetSignedVAABytes(*VaaIDFromVAA(v))
+		storedBytes, getErr := db.GetSignedVAABytes(v.ID())
 		require.NoError(t, getErr)
 
 		origBytes, marshalErr := v.Marshal()
@@ -252,15 +252,9 @@ func BenchmarkVaaLookup(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		randId := math_rand.Intn(250000) //nolint
 		randId = 250000 - (i / 18)
-<<<<<<< HEAD
-		vaaId, idErr := VaaIDFromString(fmt.Sprintf("4/000000000000000000000000b6f6d86a8f9879a9c87f643768d9efc38c1da6e7/%d", randId))
+		vaaId, idErr := vaa.VAAIDFromString(fmt.Sprintf("4/000000000000000000000000b6f6d86a8f9879a9c87f643768d9efc38c1da6e7/%d", randId))
 		assert.NoError(b, idErr)
-		vaaIds <- vaaId
-=======
-		vaaId, err := vaa.VAAIDFromString(fmt.Sprintf("4/000000000000000000000000b6f6d86a8f9879a9c87f643768d9efc38c1da6e7/%d", randId))
-		assert.NoError(b, err)
 		vaaIds <- &vaaId
->>>>>>> 1e28030db (sdk: Add VAA ID validation and use it everywhere)
 	}
 
 	b.ResetTimer()

--- a/node/pkg/db/db_test.go
+++ b/node/pkg/db/db_test.go
@@ -50,7 +50,7 @@ func TestVaaIDFromString(t *testing.T) {
 	t.Parallel()
 
 	vaaIdString := "1/0000000000000000000000000000000000000000000000000000000000000004/1"
-	vaaID, _ := VaaIDFromString(vaaIdString)
+	vaaID, _ := vaa.VAAIDFromString(vaaIdString)
 	expectAddr := vaa.Address{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4}
 
 	assert.Equal(t, vaa.ChainIDSolana, vaaID.EmitterChain)
@@ -62,7 +62,7 @@ func TestVaaIDFromVAA(t *testing.T) {
 	t.Parallel()
 
 	testVaa := getVAA()
-	vaaID := VaaIDFromVAA(&testVaa)
+	vaaID := testVaa.ID()
 	expectAddr := vaa.Address{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4}
 
 	assert.Equal(t, vaa.ChainIDSolana, vaaID.EmitterChain)
@@ -74,27 +74,27 @@ func TestBytes(t *testing.T) {
 	t.Parallel()
 
 	vaaIdString := "1/0000000000000000000000000000000000000000000000000000000000000004/1"
-	vaaID, _ := VaaIDFromString(vaaIdString)
+	vaaID, _ := vaa.VAAIDFromString(vaaIdString)
 	expected := []byte{0x73, 0x69, 0x67, 0x6e, 0x65, 0x64, 0x2f, 0x31, 0x2f, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x34, 0x2f, 0x31}
 
-	assert.Equal(t, expected, vaaID.Bytes())
+	assert.Equal(t, expected, vaaKeyBytes(vaaID))
 }
 
 func TestEmitterPrefixBytesWithChainIDAndAddress(t *testing.T) {
 	t.Parallel()
 
 	vaaIdString := "1/0000000000000000000000000000000000000000000000000000000000000004/1"
-	vaaID, _ := VaaIDFromString(vaaIdString)
+	vaaID, _ := vaa.VAAIDFromString(vaaIdString)
 	expected := []byte{0x73, 0x69, 0x67, 0x6e, 0x65, 0x64, 0x2f, 0x31, 0x2f, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x34}
 
-	assert.Equal(t, expected, vaaID.EmitterPrefixBytes())
+	assert.Equal(t, expected, vaaEmitterPrefixBytes(vaaID))
 }
 
 func TestEmitterPrefixBytesWithOnlyChainID(t *testing.T) {
 	t.Parallel()
 
 	vaaID := VAAID{EmitterChain: vaa.ChainID(26)}
-	assert.Equal(t, []byte("signed/26"), vaaID.EmitterPrefixBytes())
+	assert.Equal(t, []byte("signed/26"), vaaEmitterPrefixBytes(vaaID))
 }
 
 func TestStoreSignedVAAUnsigned(t *testing.T) {
@@ -163,7 +163,7 @@ func TestStoreSignedVAABatch(t *testing.T) {
 
 	// Verify all the VAAs are in the database.
 	for _, v := range vaaBatch {
-		storedBytes, getErr := db.GetSignedVAABytes(*VaaIDFromVAA(v))
+		storedBytes, getErr := db.GetSignedVAABytes(v.ID())
 		require.NoError(t, getErr)
 
 		origBytes, marshalErr := v.Marshal()
@@ -183,7 +183,7 @@ func TestStoreSignedVAABatch(t *testing.T) {
 
 	// Verify all the updated VAAs are in the database.
 	for _, v := range vaaBatch {
-		storedBytes, err := db.GetSignedVAABytes(*VaaIDFromVAA(v))
+		storedBytes, err := db.GetSignedVAABytes(v.ID())
 		require.NoError(t, err)
 
 		origBytes, err := v.Marshal()
@@ -203,7 +203,7 @@ func TestGetSignedVAABytes(t *testing.T) {
 
 	testVaa := getVAA()
 
-	vaaID := VaaIDFromVAA(&testVaa)
+	vaaID := testVaa.ID()
 
 	privKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	testVaa.AddSignature(privKey, 0)
@@ -213,7 +213,7 @@ func TestGetSignedVAABytes(t *testing.T) {
 	assert.NoError(t, err2)
 
 	// Retrieve it using vaaID
-	vaaBytes, err2 := db.GetSignedVAABytes(*vaaID)
+	vaaBytes, err2 := db.GetSignedVAABytes(vaaID)
 	assert.NoError(t, err2)
 
 	testVaaBytes, err3 := testVaa.Marshal()
@@ -232,7 +232,7 @@ func TestFindEmitterSequenceGap(t *testing.T) {
 
 	testVaa := getVAA()
 
-	vaaID := VaaIDFromVAA(&testVaa)
+	vaaID := testVaa.ID()
 
 	privKey, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 	testVaa.AddSignature(privKey, 0)
@@ -241,7 +241,7 @@ func TestFindEmitterSequenceGap(t *testing.T) {
 	err2 := db.StoreSignedVAA(&testVaa)
 	assert.NoError(t, err2)
 
-	resp, firstSeq, lastSeq, err := db.FindEmitterSequenceGap(*vaaID)
+	resp, firstSeq, lastSeq, err := db.FindEmitterSequenceGap(vaaID)
 
 	assert.Equal(t, []uint64{0x0}, resp)
 	assert.Equal(t, uint64(0x0), firstSeq)
@@ -276,9 +276,9 @@ func BenchmarkVaaLookup(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		randId := math_rand.Intn(250000) //nolint
 		randId = 250000 - (i / 18)
-		vaaId, idErr := VaaIDFromString(fmt.Sprintf("4/000000000000000000000000b6f6d86a8f9879a9c87f643768d9efc38c1da6e7/%d", randId))
+		vaaId, idErr := vaa.VAAIDFromString(fmt.Sprintf("4/000000000000000000000000b6f6d86a8f9879a9c87f643768d9efc38c1da6e7/%d", randId))
 		assert.NoError(b, idErr)
-		vaaIds <- vaaId
+		vaaIds <- &vaaId
 	}
 
 	b.ResetTimer()

--- a/node/pkg/db/purge_vaas.go
+++ b/node/pkg/db/purge_vaas.go
@@ -24,7 +24,7 @@ func (d *Database) PurgeVaas(prefix VAAID, oldestTime time.Time, logOnly bool) (
 	if err := d.db.View(func(txn *badger.Txn) error {
 		it := txn.NewIterator(badger.DefaultIteratorOptions)
 		defer it.Close()
-		prefix := prefix.EmitterPrefixBytes()
+		prefix := vaaEmitterPrefixBytes(prefix)
 		for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
 			item := it.Item()
 			key := item.Key()

--- a/node/pkg/node/node_test.go
+++ b/node/pkg/node/node_test.go
@@ -371,6 +371,8 @@ type testCase struct {
 	// if true, assert that no VAA exists for this message at the end of the test.
 	// Note that it is not guaranteed that this message will never reach quorum because it may reach quorum some time after the test run finishes.
 	mustNotReachQuorum bool
+	// expected error for mustNotReachQuorum cases.
+	expectedErr string
 }
 
 func randomTime() time.Time {
@@ -601,27 +603,32 @@ func TestConsensus(t *testing.T) {
 			msg:                        someMessage(),
 			numGuardiansObserve:        1,
 			mustNotReachQuorum:         true,
+			expectedErr:                "rpc error: code = NotFound desc = requested VAA not found in store",
 			unavailableInReobservation: true,
 		},
 		{ // message with EmitterAddress == 0 should not reach quorum
 			msg:                 msgZeroEmitter,
 			numGuardiansObserve: numGuardians,
 			mustNotReachQuorum:  true,
+			expectedErr:         "rpc error: code = InvalidArgument desc = VAA ID emitter address is zero",
 		},
 		{ // message with Governance emitter should not reach quorum
 			msg:                 msgGovEmitter,
 			numGuardiansObserve: numGuardians,
 			mustNotReachQuorum:  true,
+			expectedErr:         "rpc error: code = NotFound desc = requested VAA not found in store",
 		},
 		{ // message with wrong EmitterChain should not reach quorum
 			msg:                 msgWrongEmitterChain,
 			numGuardiansObserve: numGuardians,
 			mustNotReachQuorum:  true,
+			expectedErr:         "rpc error: code = NotFound desc = requested VAA not found in store",
 		},
 		{ // Message covered by Governor that should be delayed 24h and hence not reach quorum within this test
 			msg:                 governedMsg(true),
 			numGuardiansObserve: numGuardians,
 			mustNotReachQuorum:  true,
+			expectedErr:         "rpc error: code = NotFound desc = requested VAA not found in store",
 		},
 		{ // vanilla case, where only a quorum of guardians gets the message
 			msg:                 someMessage(),
@@ -824,7 +831,7 @@ func runConsensusTests(t *testing.T, testCases []testCase, numGuardians int) {
 
 			assert.NotEqual(t, testCase.mustNotReachQuorum, testCase.mustReachQuorum) // either or
 			if testCase.mustNotReachQuorum {
-				assert.EqualError(t, err, "rpc error: code = NotFound desc = requested VAA not found in store")
+				assert.EqualError(t, err, testCase.expectedErr)
 			} else if testCase.mustReachQuorum {
 				require.NotNil(t, r)
 				returnedVaa, err := vaa.Unmarshal(r.VaaBytes)

--- a/node/pkg/node/node_test.go
+++ b/node/pkg/node/node_test.go
@@ -370,6 +370,8 @@ type testCase struct {
 	// if true, assert that no VAA exists for this message at the end of the test.
 	// Note that it is not guaranteed that this message will never reach quorum because it may reach quorum some time after the test run finishes.
 	mustNotReachQuorum bool
+	// expected error for mustNotReachQuorum cases.
+	expectedErr string
 }
 
 func randomTime() time.Time {
@@ -592,27 +594,32 @@ func TestConsensus(t *testing.T) {
 			msg:                        someMessage(),
 			numGuardiansObserve:        1,
 			mustNotReachQuorum:         true,
+			expectedErr:                "rpc error: code = NotFound desc = requested VAA not found in store",
 			unavailableInReobservation: true,
 		},
 		{ // message with EmitterAddress == 0 should not reach quorum
 			msg:                 msgZeroEmitter,
 			numGuardiansObserve: numGuardians,
 			mustNotReachQuorum:  true,
+			expectedErr:         "rpc error: code = InvalidArgument desc = VAA ID emitter address is zero",
 		},
 		{ // message with Governance emitter should not reach quorum
 			msg:                 msgGovEmitter,
 			numGuardiansObserve: numGuardians,
 			mustNotReachQuorum:  true,
+			expectedErr:         "rpc error: code = NotFound desc = requested VAA not found in store",
 		},
 		{ // message with wrong EmitterChain should not reach quorum
 			msg:                 msgWrongEmitterChain,
 			numGuardiansObserve: numGuardians,
 			mustNotReachQuorum:  true,
+			expectedErr:         "rpc error: code = NotFound desc = requested VAA not found in store",
 		},
 		{ // Message covered by Governor that should be delayed 24h and hence not reach quorum within this test
 			msg:                 governedMsg(true),
 			numGuardiansObserve: numGuardians,
 			mustNotReachQuorum:  true,
+			expectedErr:         "rpc error: code = NotFound desc = requested VAA not found in store",
 		},
 		{ // vanilla case, where only a quorum of guardians gets the message
 			msg:                 someMessage(),
@@ -815,7 +822,7 @@ func runConsensusTests(t *testing.T, testCases []testCase, numGuardians int) {
 
 			assert.NotEqual(t, testCase.mustNotReachQuorum, testCase.mustReachQuorum) // either or
 			if testCase.mustNotReachQuorum {
-				assert.EqualError(t, err, "rpc error: code = NotFound desc = requested VAA not found in store")
+				assert.EqualError(t, err, testCase.expectedErr)
 			} else if testCase.mustReachQuorum {
 				require.NotNil(t, r)
 				returnedVaa, err := vaa.Unmarshal(r.VaaBytes)

--- a/node/pkg/node/reobserve.go
+++ b/node/pkg/node/reobserve.go
@@ -3,7 +3,6 @@ package node
 import (
 	"context"
 	"encoding/hex"
-	"math"
 	"time"
 
 	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
@@ -63,7 +62,8 @@ func handleReobservationRequests(
 				}
 			}
 		case req := <-obsvReqC:
-			if req.ChainId > math.MaxUint16 {
+			chainID, err := vaa.ChainIDFromNumber(req.ChainId)
+			if err != nil {
 				logger.Error("chain id is larger than MaxUint16",
 					zap.Uint32("chain_id", req.ChainId),
 				)
@@ -71,7 +71,7 @@ func handleReobservationRequests(
 			}
 
 			r := cachedRequest{
-				chainId: vaa.ChainID(req.ChainId),
+				chainId: chainID,
 				txHash:  hex.EncodeToString(req.TxHash),
 			}
 

--- a/node/pkg/node/reobserve.go
+++ b/node/pkg/node/reobserve.go
@@ -62,7 +62,7 @@ func handleReobservationRequests(
 				}
 			}
 		case req := <-obsvReqC:
-			chainId, err := vaa.KnownChainIDFromNumber[uint32](req.ChainId)
+			chainID, err := vaa.KnownChainIDFromNumber[uint32](req.ChainId)
 			if err != nil {
 				logger.Error("invalid chain id in reobservation request",
 					zap.Uint32("chain_id", req.ChainId),
@@ -72,7 +72,7 @@ func handleReobservationRequests(
 			}
 
 			r := cachedRequest{
-				chainId: chainId,
+				chainId: chainID,
 				txHash:  hex.EncodeToString(req.TxHash),
 			}
 

--- a/node/pkg/processor/cleanup.go
+++ b/node/pkg/processor/cleanup.go
@@ -100,7 +100,7 @@ func (p *Processor) handleCleanup(ctx context.Context) {
 			// This occurs when we observed a message after the cluster has already reached
 			// consensus on it, causing us to never achieve quorum.
 			if ourVaa, ok := s.ourObservation.(*VAA); ok {
-				if p.haveSignedVAA(*db.VaaIDFromVAA(&ourVaa.VAA)) {
+				if p.haveSignedVAA(ourVaa.VAA.ID()) {
 					// If we have a stored quorum VAA, we can safely expire the state.
 					//
 					// This is a rare case, and we can safely expire the state, since we
@@ -338,7 +338,7 @@ func (p *Processor) signedVaaAlreadyInDB(hash string, s *state) (bool, error) {
 	}
 
 	msgId := s.ourObservation.MessageID()
-	vaaID, err := db.VaaIDFromString(msgId)
+	vaaID, err := vaa.VAAIDFromString(msgId)
 	if err != nil {
 		return false, fmt.Errorf(`failed to generate VAA ID from message id "%s": %w`, s.ourObservation.MessageID(), err)
 	}
@@ -346,7 +346,7 @@ func (p *Processor) signedVaaAlreadyInDB(hash string, s *state) (bool, error) {
 	// If the VAA is waiting to be written to the DB, use that version. Otherwise use the DB.
 	v := p.getVaaFromUpdateMap(msgId)
 	if v == nil {
-		vb, err := p.db.GetSignedVAABytes(*vaaID)
+		vb, err := p.db.GetSignedVAABytes(vaaID)
 		if err != nil {
 			if errors.Is(err, db.ErrVAANotFound) {
 				if p.logger.Level().Enabled(zapcore.DebugLevel) {

--- a/node/pkg/processor/observation.go
+++ b/node/pkg/processor/observation.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	node_common "github.com/certusone/wormhole/node/pkg/common"
-	"github.com/certusone/wormhole/node/pkg/db"
 	guardianNotary "github.com/certusone/wormhole/node/pkg/notary"
 	"github.com/mr-tron/base58"
 	"github.com/prometheus/client_golang/prometheus"
@@ -547,7 +546,7 @@ func (p *Processor) handleInboundSignedVAAWithQuorum(m *gossipv1.SignedVAAWithQu
 	}
 
 	// Check if we already store this VAA
-	if p.haveSignedVAA(*db.VaaIDFromVAA(v)) {
+	if p.haveSignedVAA(v.ID()) {
 		if p.logger.Level().Enabled(zapcore.DebugLevel) {
 			p.logger.Debug("ignored SignedVAAWithQuorum message for VAA we already stored",
 				zap.String("message_id", v.MessageID()),

--- a/node/pkg/processor/processor.go
+++ b/node/pkg/processor/processor.go
@@ -740,7 +740,7 @@ func (p *Processor) haveSignedVAA(id guardianDB.VAAID) bool {
 	ok, err := p.db.HasVAA(id)
 	if err != nil {
 		p.logger.Error("failed to look up VAA in database",
-			zap.String("vaaID", string(id.Bytes())),
+			zap.String("vaaID", id.String()),
 			zap.Error(err),
 		)
 		return false

--- a/node/pkg/publicrpc/publicrpcserver.go
+++ b/node/pkg/publicrpc/publicrpcserver.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"encoding/hex"
 	"errors"
-	"fmt"
-	"math"
 
 	"github.com/certusone/wormhole/node/pkg/common"
 	guardianDB "github.com/certusone/wormhole/node/pkg/db"
@@ -74,33 +72,17 @@ func (s *PublicrpcServer) GetSignedVAA(_ context.Context, req *publicrpcv1.GetSi
 		return nil, status.Error(codes.InvalidArgument, "no message ID specified")
 	}
 
-	if req.MessageId.GetEmitterChain() > math.MaxUint16 {
-		return nil, status.Error(codes.InvalidArgument, "emitter chain id must be no greater than 16 bits")
+	id, err := vaa.NewVAAID(req.MessageId.GetEmitterChain(), req.MessageId.EmitterAddress, req.MessageId.Sequence)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
-	chainID := vaa.ChainID(req.MessageId.GetEmitterChain()) // #nosec G115 -- This conversion is checked above
-
 	// This interface is not supported for PythNet messages because those VAAs are not stored in the database.
-	if chainID == vaa.ChainIDPythNet {
+	if id.EmitterChain == vaa.ChainIDPythNet {
 		return nil, status.Error(codes.InvalidArgument, "not supported for PythNet")
 	}
 
-	address, err := hex.DecodeString(req.MessageId.EmitterAddress)
-	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("failed to decode address: %v", err))
-	}
-	if len(address) != 32 {
-		return nil, status.Error(codes.InvalidArgument, "address must be 32 bytes")
-	}
-
-	addr := vaa.Address{}
-	copy(addr[:], address)
-
-	b, err := s.db.GetSignedVAABytes(guardianDB.VAAID{
-		EmitterChain:   chainID,
-		EmitterAddress: addr,
-		Sequence:       req.MessageId.Sequence,
-	})
+	b, err := s.db.GetSignedVAABytes(id)
 
 	if err != nil {
 		if errors.Is(err, guardianDB.ErrVAANotFound) {
@@ -203,27 +185,12 @@ func (s *PublicrpcServer) GetSignedManagerTransaction(_ context.Context, req *pu
 		return nil, status.Error(codes.InvalidArgument, "no message ID specified")
 	}
 
-	if req.MessageId.GetEmitterChain() > math.MaxUint16 {
-		return nil, status.Error(codes.InvalidArgument, "emitter chain id must be no greater than 16 bits")
-	}
-
-	chainID := vaa.ChainID(req.MessageId.GetEmitterChain()) // #nosec G115
-
-	address, err := hex.DecodeString(req.MessageId.EmitterAddress)
+	id, err := vaa.NewVAAID(req.MessageId.GetEmitterChain(), req.MessageId.EmitterAddress, req.MessageId.Sequence)
 	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("failed to decode address: %v", err))
-	}
-	if len(address) != 32 {
-		return nil, status.Error(codes.InvalidArgument, "address must be 32 bytes")
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
-	addr := vaa.Address{}
-	copy(addr[:], address)
-
-	// Build VAA ID
-	vaaID := fmt.Sprintf("%d/%s/%d", chainID, hex.EncodeToString(addr[:]), req.MessageId.Sequence)
-
-	aggTx := s.manager.GetPendingTransactionByID(vaaID)
+	aggTx := s.manager.GetPendingTransactionByID(id.String())
 	if aggTx == nil {
 		return nil, status.Error(codes.NotFound, "no manager transaction found for this VAA")
 	}

--- a/node/pkg/publicrpc/publicrpcserver_test.go
+++ b/node/pkg/publicrpc/publicrpcserver_test.go
@@ -5,9 +5,11 @@ import (
 	"testing"
 
 	"github.com/certusone/wormhole/node/pkg/common"
+	guardianDB "github.com/certusone/wormhole/node/pkg/db"
 	"github.com/certusone/wormhole/node/pkg/governor"
 	publicrpcv1 "github.com/certusone/wormhole/node/pkg/proto/publicrpc/v1"
 	"github.com/stretchr/testify/assert"
+	"github.com/wormhole-foundation/wormhole/sdk/vaa"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -80,4 +82,173 @@ func TestGovernorIsVAAEnqueuedNoMessage(t *testing.T) {
 		expected_err := status.Error(codes.InvalidArgument, "no message ID specified")
 		assert.Equal(t, expected_err, err)
 	})
+}
+
+func TestGetLastHeartbeatsNilGuardianSet(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := zap.NewProduction()
+	gst := common.NewGuardianSetState(nil)
+	server := &PublicrpcServer{logger: logger, gst: gst}
+
+	resp, err := server.GetLastHeartbeats(ctx, &publicrpcv1.GetLastHeartbeatsRequest{})
+	assert.Nil(t, resp)
+	expected_err := status.Error(codes.Unavailable, "guardian set not fetched from chain yet")
+	assert.Equal(t, expected_err, err)
+}
+
+func TestGetCurrentGuardianSetNilGuardianSet(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := zap.NewProduction()
+	gst := common.NewGuardianSetState(nil)
+	server := &PublicrpcServer{logger: logger, gst: gst}
+
+	resp, err := server.GetCurrentGuardianSet(ctx, &publicrpcv1.GetCurrentGuardianSetRequest{})
+	assert.Nil(t, resp)
+	expected_err := status.Error(codes.Unavailable, "guardian set not fetched from chain yet")
+	assert.Equal(t, expected_err, err)
+}
+
+func TestGovernorGetAvailableNotionalByChainNilGovernor(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := zap.NewProduction()
+	server := &PublicrpcServer{logger: logger, gov: nil}
+
+	resp, err := server.GovernorGetAvailableNotionalByChain(ctx, &publicrpcv1.GovernorGetAvailableNotionalByChainRequest{})
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Empty(t, resp.Entries)
+}
+
+func TestGovernorGetEnqueuedVAAsNilGovernor(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := zap.NewProduction()
+	server := &PublicrpcServer{logger: logger, gov: nil}
+
+	resp, err := server.GovernorGetEnqueuedVAAs(ctx, &publicrpcv1.GovernorGetEnqueuedVAAsRequest{})
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Empty(t, resp.Entries)
+}
+
+func TestGovernorGetTokenListNilGovernor(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := zap.NewProduction()
+	server := &PublicrpcServer{logger: logger, gov: nil}
+
+	resp, err := server.GovernorGetTokenList(ctx, &publicrpcv1.GovernorGetTokenListRequest{})
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Empty(t, resp.Entries)
+}
+
+func TestGetSignedManagerTransactionNilManager(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := zap.NewProduction()
+	server := &PublicrpcServer{logger: logger, manager: nil}
+
+	resp, err := server.GetSignedManagerTransaction(ctx, &publicrpcv1.GetSignedManagerTransactionRequest{})
+	assert.Nil(t, resp)
+	expected_err := status.Error(codes.Unavailable, "manager service not enabled")
+	assert.Equal(t, expected_err, err)
+}
+
+func TestGetSignedManagerTransactionByHashNilManager(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := zap.NewProduction()
+	server := &PublicrpcServer{logger: logger, manager: nil}
+
+	resp, err := server.GetSignedManagerTransactionByHash(ctx, &publicrpcv1.GetSignedManagerTransactionByHashRequest{})
+	assert.Nil(t, resp)
+	expected_err := status.Error(codes.Unavailable, "manager service not enabled")
+	assert.Equal(t, expected_err, err)
+}
+
+func TestAggregatedTxToResponse(t *testing.T) {
+	aggTx := &guardianDB.AggregatedTransaction{
+		VAAHash:          []byte{0x01, 0x02, 0x03},
+		VAAID:            "1/0000000000000000000000000000000000000000000000000000000000000001/42",
+		DestinationChain: vaa.ChainIDEthereum,
+		ManagerSetIndex:  5,
+		Required:         3,
+		Total:            5,
+		Signatures: map[uint8][][]byte{
+			0: {{0xAA, 0xBB}},
+			1: {{0xCC, 0xDD}},
+		},
+	}
+
+	resp := aggregatedTxToResponse(aggTx)
+	assert.Equal(t, "010203", resp.VaaHash)
+	assert.Equal(t, aggTx.VAAID, resp.VaaId)
+	assert.Equal(t, uint32(aggTx.DestinationChain), resp.DestinationChain)
+	assert.Equal(t, aggTx.ManagerSetIndex, resp.ManagerSetIndex)
+	assert.Equal(t, uint32(aggTx.Required), resp.Required)
+	assert.Equal(t, uint32(aggTx.Total), resp.Total)
+	assert.False(t, resp.IsComplete)
+	assert.Len(t, resp.Signatures, 2)
+}
+
+func TestAggregatedTxToByHashResponse(t *testing.T) {
+	aggTx := &guardianDB.AggregatedTransaction{
+		VAAHash:          []byte{0x04, 0x05, 0x06},
+		VAAID:            "2/0000000000000000000000000000000000000000000000000000000000000002/99",
+		DestinationChain: vaa.ChainIDBSC,
+		ManagerSetIndex:  10,
+		Required:         1,
+		Total:            3,
+		Signatures: map[uint8][][]byte{
+			0: {{0xEE, 0xFF}},
+		},
+	}
+
+	resp := aggregatedTxToByHashResponse(aggTx)
+	assert.Equal(t, "040506", resp.VaaHash)
+	assert.Equal(t, aggTx.VAAID, resp.VaaId)
+	assert.Equal(t, uint32(aggTx.DestinationChain), resp.DestinationChain)
+	assert.Equal(t, aggTx.ManagerSetIndex, resp.ManagerSetIndex)
+	assert.Equal(t, uint32(aggTx.Required), resp.Required)
+	assert.Equal(t, uint32(aggTx.Total), resp.Total)
+	assert.True(t, resp.IsComplete)
+	assert.Len(t, resp.Signatures, 1)
+}
+
+func TestGetSignedVAAPythNet(t *testing.T) {
+	chainID := uint32(vaa.ChainIDPythNet)
+	emitterAddr := "0000000000000000000000000000000000000000000000000000000000000001"
+	seq := uint64(1)
+
+	msg := publicrpcv1.GetSignedVAARequest{
+		MessageId: &publicrpcv1.MessageID{
+			EmitterChain:   publicrpcv1.ChainID(chainID),
+			EmitterAddress: emitterAddr,
+			Sequence:       seq,
+		},
+	}
+
+	ctx := context.Background()
+	logger, _ := zap.NewProduction()
+	server := &PublicrpcServer{logger: logger}
+
+	resp, err := server.GetSignedVAA(ctx, &msg)
+	assert.Nil(t, resp)
+	expected_err := status.Error(codes.InvalidArgument, "not supported for PythNet")
+	assert.Equal(t, expected_err, err)
+}
+
+func TestGovernorIsVAAEnqueuedNilGovernor(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := zap.NewProduction()
+	server := &PublicrpcServer{logger: logger, gov: nil}
+
+	msg := publicrpcv1.GovernorIsVAAEnqueuedRequest{
+		MessageId: &publicrpcv1.MessageID{
+			EmitterChain:   1,
+			EmitterAddress: "0000000000000000000000000000000000000000000000000000000000000001",
+			Sequence:       1,
+		},
+	}
+	resp, err := server.GovernorIsVAAEnqueued(ctx, &msg)
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.False(t, resp.IsEnqueued)
 }

--- a/node/pkg/publicrpc/publicrpcserver_test.go
+++ b/node/pkg/publicrpc/publicrpcserver_test.go
@@ -5,9 +5,11 @@ import (
 	"testing"
 
 	"github.com/certusone/wormhole/node/pkg/common"
+	guardianDB "github.com/certusone/wormhole/node/pkg/db"
 	"github.com/certusone/wormhole/node/pkg/governor"
 	publicrpcv1 "github.com/certusone/wormhole/node/pkg/proto/publicrpc/v1"
 	"github.com/stretchr/testify/assert"
+	"github.com/wormhole-foundation/wormhole/sdk/vaa"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -37,7 +39,7 @@ func TestGetSignedVAANoAddress(t *testing.T) {
 	resp, err := server.GetSignedVAA(ctx, &msg)
 	assert.Nil(t, resp)
 
-	expected_err := status.Error(codes.InvalidArgument, "address must be 32 bytes")
+	expected_err := status.Error(codes.InvalidArgument, "VAA ID emitter address must be 32 bytes")
 	assert.Equal(t, expected_err, err)
 }
 
@@ -62,7 +64,7 @@ func TestGetSignedVAABadAddress(t *testing.T) {
 	resp, err := server.GetSignedVAA(ctx, &msg)
 	assert.Nil(t, resp)
 
-	expected_err := status.Error(codes.InvalidArgument, "address must be 32 bytes")
+	expected_err := status.Error(codes.InvalidArgument, "VAA ID emitter address must be 32 bytes")
 	assert.Equal(t, expected_err, err)
 }
 
@@ -80,4 +82,173 @@ func TestGovernorIsVAAEnqueuedNoMessage(t *testing.T) {
 		expected_err := status.Error(codes.InvalidArgument, "no message ID specified")
 		assert.Equal(t, expected_err, err)
 	})
+}
+
+func TestGetLastHeartbeatsNilGuardianSet(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := zap.NewProduction()
+	gst := common.NewGuardianSetState(nil)
+	server := &PublicrpcServer{logger: logger, gst: gst}
+
+	resp, err := server.GetLastHeartbeats(ctx, &publicrpcv1.GetLastHeartbeatsRequest{})
+	assert.Nil(t, resp)
+	expected_err := status.Error(codes.Unavailable, "guardian set not fetched from chain yet")
+	assert.Equal(t, expected_err, err)
+}
+
+func TestGetCurrentGuardianSetNilGuardianSet(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := zap.NewProduction()
+	gst := common.NewGuardianSetState(nil)
+	server := &PublicrpcServer{logger: logger, gst: gst}
+
+	resp, err := server.GetCurrentGuardianSet(ctx, &publicrpcv1.GetCurrentGuardianSetRequest{})
+	assert.Nil(t, resp)
+	expected_err := status.Error(codes.Unavailable, "guardian set not fetched from chain yet")
+	assert.Equal(t, expected_err, err)
+}
+
+func TestGovernorGetAvailableNotionalByChainNilGovernor(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := zap.NewProduction()
+	server := &PublicrpcServer{logger: logger, gov: nil}
+
+	resp, err := server.GovernorGetAvailableNotionalByChain(ctx, &publicrpcv1.GovernorGetAvailableNotionalByChainRequest{})
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Empty(t, resp.Entries)
+}
+
+func TestGovernorGetEnqueuedVAAsNilGovernor(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := zap.NewProduction()
+	server := &PublicrpcServer{logger: logger, gov: nil}
+
+	resp, err := server.GovernorGetEnqueuedVAAs(ctx, &publicrpcv1.GovernorGetEnqueuedVAAsRequest{})
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Empty(t, resp.Entries)
+}
+
+func TestGovernorGetTokenListNilGovernor(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := zap.NewProduction()
+	server := &PublicrpcServer{logger: logger, gov: nil}
+
+	resp, err := server.GovernorGetTokenList(ctx, &publicrpcv1.GovernorGetTokenListRequest{})
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Empty(t, resp.Entries)
+}
+
+func TestGetSignedManagerTransactionNilManager(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := zap.NewProduction()
+	server := &PublicrpcServer{logger: logger, manager: nil}
+
+	resp, err := server.GetSignedManagerTransaction(ctx, &publicrpcv1.GetSignedManagerTransactionRequest{})
+	assert.Nil(t, resp)
+	expected_err := status.Error(codes.Unavailable, "manager service not enabled")
+	assert.Equal(t, expected_err, err)
+}
+
+func TestGetSignedManagerTransactionByHashNilManager(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := zap.NewProduction()
+	server := &PublicrpcServer{logger: logger, manager: nil}
+
+	resp, err := server.GetSignedManagerTransactionByHash(ctx, &publicrpcv1.GetSignedManagerTransactionByHashRequest{})
+	assert.Nil(t, resp)
+	expected_err := status.Error(codes.Unavailable, "manager service not enabled")
+	assert.Equal(t, expected_err, err)
+}
+
+func TestAggregatedTxToResponse(t *testing.T) {
+	aggTx := &guardianDB.AggregatedTransaction{
+		VAAHash:          []byte{0x01, 0x02, 0x03},
+		VAAID:            "1/0000000000000000000000000000000000000000000000000000000000000001/42",
+		DestinationChain: vaa.ChainIDEthereum,
+		ManagerSetIndex:  5,
+		Required:         3,
+		Total:            5,
+		Signatures: map[uint8][][]byte{
+			0: {{0xAA, 0xBB}},
+			1: {{0xCC, 0xDD}},
+		},
+	}
+
+	resp := aggregatedTxToResponse(aggTx)
+	assert.Equal(t, "010203", resp.VaaHash)
+	assert.Equal(t, aggTx.VAAID, resp.VaaId)
+	assert.Equal(t, uint32(aggTx.DestinationChain), resp.DestinationChain)
+	assert.Equal(t, aggTx.ManagerSetIndex, resp.ManagerSetIndex)
+	assert.Equal(t, uint32(aggTx.Required), resp.Required)
+	assert.Equal(t, uint32(aggTx.Total), resp.Total)
+	assert.False(t, resp.IsComplete)
+	assert.Len(t, resp.Signatures, 2)
+}
+
+func TestAggregatedTxToByHashResponse(t *testing.T) {
+	aggTx := &guardianDB.AggregatedTransaction{
+		VAAHash:          []byte{0x04, 0x05, 0x06},
+		VAAID:            "2/0000000000000000000000000000000000000000000000000000000000000002/99",
+		DestinationChain: vaa.ChainIDBSC,
+		ManagerSetIndex:  10,
+		Required:         1,
+		Total:            3,
+		Signatures: map[uint8][][]byte{
+			0: {{0xEE, 0xFF}},
+		},
+	}
+
+	resp := aggregatedTxToByHashResponse(aggTx)
+	assert.Equal(t, "040506", resp.VaaHash)
+	assert.Equal(t, aggTx.VAAID, resp.VaaId)
+	assert.Equal(t, uint32(aggTx.DestinationChain), resp.DestinationChain)
+	assert.Equal(t, aggTx.ManagerSetIndex, resp.ManagerSetIndex)
+	assert.Equal(t, uint32(aggTx.Required), resp.Required)
+	assert.Equal(t, uint32(aggTx.Total), resp.Total)
+	assert.True(t, resp.IsComplete)
+	assert.Len(t, resp.Signatures, 1)
+}
+
+func TestGetSignedVAAPythNet(t *testing.T) {
+	chainID := uint32(vaa.ChainIDPythNet)
+	emitterAddr := "0000000000000000000000000000000000000000000000000000000000000001"
+	seq := uint64(1)
+
+	msg := publicrpcv1.GetSignedVAARequest{
+		MessageId: &publicrpcv1.MessageID{
+			EmitterChain:   publicrpcv1.ChainID(chainID),
+			EmitterAddress: emitterAddr,
+			Sequence:       seq,
+		},
+	}
+
+	ctx := context.Background()
+	logger, _ := zap.NewProduction()
+	server := &PublicrpcServer{logger: logger}
+
+	resp, err := server.GetSignedVAA(ctx, &msg)
+	assert.Nil(t, resp)
+	expected_err := status.Error(codes.InvalidArgument, "not supported for PythNet")
+	assert.Equal(t, expected_err, err)
+}
+
+func TestGovernorIsVAAEnqueuedNilGovernor(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := zap.NewProduction()
+	server := &PublicrpcServer{logger: logger, gov: nil}
+
+	msg := publicrpcv1.GovernorIsVAAEnqueuedRequest{
+		MessageId: &publicrpcv1.MessageID{
+			EmitterChain:   1,
+			EmitterAddress: "0000000000000000000000000000000000000000000000000000000000000001",
+			Sequence:       1,
+		},
+	}
+	resp, err := server.GovernorIsVAAEnqueued(ctx, &msg)
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.False(t, resp.IsEnqueued)
 }

--- a/node/pkg/publicrpc/publicrpcserver_test.go
+++ b/node/pkg/publicrpc/publicrpcserver_test.go
@@ -37,7 +37,7 @@ func TestGetSignedVAANoAddress(t *testing.T) {
 	resp, err := server.GetSignedVAA(ctx, &msg)
 	assert.Nil(t, resp)
 
-	expected_err := status.Error(codes.InvalidArgument, "address must be 32 bytes")
+	expected_err := status.Error(codes.InvalidArgument, "VAA ID emitter address must be 32 bytes")
 	assert.Equal(t, expected_err, err)
 }
 
@@ -62,7 +62,7 @@ func TestGetSignedVAABadAddress(t *testing.T) {
 	resp, err := server.GetSignedVAA(ctx, &msg)
 	assert.Nil(t, resp)
 
-	expected_err := status.Error(codes.InvalidArgument, "address must be 32 bytes")
+	expected_err := status.Error(codes.InvalidArgument, "VAA ID emitter address must be 32 bytes")
 	assert.Equal(t, expected_err, err)
 }
 

--- a/node/pkg/query/query.go
+++ b/node/pkg/query/query.go
@@ -287,7 +287,13 @@ func handleQueryRequestsImpl(
 			receiveTime := time.Now()
 
 			for requestIdx, pcq := range queryRequest.PerChainQueries {
-				chainID := vaa.ChainID(pcq.ChainId)
+				chainID, err := vaa.ChainIDFromNumber(pcq.ChainId)
+				if err != nil {
+					qLogger.Debug("invalid chain ID for query request", zap.String("requestID", requestID), zap.Uint16("chain_id", uint16(pcq.ChainId)), zap.Error(err))
+					invalidQueryRequestReceived.WithLabelValues("invalid_chain_id").Inc()
+					errorFound = true
+					break
+				}
 				if _, exists := supportedChains[chainID]; !exists {
 					qLogger.Debug("chain does not support cross chain queries", zap.String("requestID", requestID), zap.Stringer("chainID", chainID))
 					invalidQueryRequestReceived.WithLabelValues("chain_does_not_support_ccq").Inc()

--- a/node/pkg/query/query.go
+++ b/node/pkg/query/query.go
@@ -289,7 +289,13 @@ func handleQueryRequestsImpl(
 			receiveTime := time.Now()
 
 			for requestIdx, pcq := range queryRequest.PerChainQueries {
-				chainID := vaa.ChainID(pcq.ChainId)
+				chainID, err := vaa.ChainIDFromNumber(pcq.ChainId)
+				if err != nil {
+					qLogger.Debug("invalid chain ID for query request", zap.String("requestID", requestID), zap.Uint16("chain_id", uint16(pcq.ChainId)), zap.Error(err))
+					invalidQueryRequestReceived.WithLabelValues("invalid_chain_id").Inc()
+					errorFound = true
+					break
+				}
 				if _, exists := supportedChains[chainID]; !exists {
 					qLogger.Debug("chain does not support cross chain queries", zap.String("requestID", requestID), zap.Stringer("chainID", chainID))
 					invalidQueryRequestReceived.WithLabelValues("chain_does_not_support_ccq").Inc()

--- a/node/pkg/txverifier/utils.go
+++ b/node/pkg/txverifier/utils.go
@@ -7,7 +7,6 @@ import (
 	"math"
 	"math/big"
 	"slices"
-	"strconv"
 	"strings"
 
 	"github.com/wormhole-foundation/wormhole/sdk/vaa"
@@ -35,64 +34,21 @@ const (
 // i.e.emitter_chain/emitter_address/sequence tuple. In this package, it is used
 // to identify a single LogMessagePublished event, which in turn maps onto a unique
 // MessagePublication elsewhere in the Guardian code.
-type msgID struct {
-	// Sequence of the VAA
-	Sequence uint64
-	// EmitterChain the VAA was emitted on
-	EmitterChain vaa.ChainID
-	// EmitterAddress of the contract that emitted the Message
-	EmitterAddress vaa.Address
-}
-
-// MessageID returns a human-readable emitter_chain/emitter_address/sequence tuple.
-func (m *msgID) String() string {
-	return fmt.Sprintf("%d/%s/%d", m.EmitterChain, m.EmitterAddress, m.Sequence)
-}
-
-func (m *msgID) Empty() bool {
-	return m.EmitterChain == 0 && m.EmitterAddress == ZERO_ADDRESS_VAA && m.Sequence == 0
-}
+type msgID = vaa.VAAID
 
 // NewMsgID creates a new msgID from a string in the format "chainID/emitterAddress/sequence".
 func NewMsgID(in string) (msgID, error) {
-	if len(in) == 0 {
-		return msgID{}, errors.New("msgIDStr is empty")
-	}
-	parts := strings.Split(in, "/")
-	if len(parts) != 3 {
-		return msgID{}, errors.New("invalid msgID: must be in the format chainID/emitterAddress/sequence")
-	}
-
-	chainID, err := vaa.StringToKnownChainID(parts[0])
+	id, err := vaa.VAAIDFromString(in)
 	if err != nil {
 		return msgID{}, err
 	}
 
-	supported := IsSupported(chainID)
+	supported := IsSupported(id.EmitterChain)
 	if !supported {
-		return msgID{}, fmt.Errorf("chainID %d (%s) is does not have a Transfer Verifier implementation or is not supported", chainID, chainID.String())
+		return msgID{}, fmt.Errorf("chainID %d (%s) is does not have a Transfer Verifier implementation or is not supported", id.EmitterChain, id.EmitterChain.String())
 	}
 
-	emitterAddress, err := vaa.StringToAddress(parts[1])
-	if err != nil {
-		return msgID{}, err
-	}
-
-	sequence, err := strconv.ParseUint(parts[2], 10, 64)
-	if err != nil {
-		return msgID{}, err
-	}
-
-	if chainID == vaa.ChainIDUnset || emitterAddress == ZERO_ADDRESS_VAA {
-		return msgID{}, errors.New("invalid msgID: chainID or emitterAddress is unset or zero")
-	}
-
-	return msgID{
-		EmitterChain:   chainID,
-		EmitterAddress: emitterAddress,
-		Sequence:       sequence,
-	}, nil
-
+	return id, nil
 }
 
 // Custom error type used to signal that a core invariant of the token bridge has been violated.

--- a/node/pkg/txverifier/utils.go
+++ b/node/pkg/txverifier/utils.go
@@ -7,7 +7,6 @@ import (
 	"math"
 	"math/big"
 	"slices"
-	"strconv"
 	"strings"
 
 	"github.com/wormhole-foundation/wormhole/sdk/vaa"
@@ -35,64 +34,23 @@ const (
 // i.e.emitter_chain/emitter_address/sequence tuple. In this package, it is used
 // to identify a single LogMessagePublished event, which in turn maps onto a unique
 // MessagePublication elsewhere in the Guardian code.
-type msgID struct {
-	// Sequence of the VAA
-	Sequence uint64
-	// EmitterChain the VAA was emitted on
-	EmitterChain vaa.ChainID
-	// EmitterAddress of the contract that emitted the Message
-	EmitterAddress vaa.Address
-}
-
-// MessageID returns a human-readable emitter_chain/emitter_address/sequence tuple.
-func (m *msgID) String() string {
-	return fmt.Sprintf("%d/%s/%d", m.EmitterChain, m.EmitterAddress, m.Sequence)
-}
-
-func (m *msgID) Empty() bool {
-	return m.EmitterChain == 0 && m.EmitterAddress == ZERO_ADDRESS_VAA && m.Sequence == 0
-}
+type msgID = vaa.VAAID
 
 // NewMsgID creates a new msgID from a string in the format "chainID/emitterAddress/sequence".
+// The Chain ID in the msg ID must be a chain that is supported by the Transfer Verifier
+// according to [IsSupported].
 func NewMsgID(in string) (msgID, error) {
-	if len(in) == 0 {
-		return msgID{}, errors.New("msgIDStr is empty")
-	}
-	parts := strings.Split(in, "/")
-	if len(parts) != 3 {
-		return msgID{}, errors.New("invalid msgID: must be in the format chainID/emitterAddress/sequence")
-	}
-
-	chainID, err := vaa.StringToKnownChainID(parts[0])
+	id, err := vaa.VAAIDFromString(in)
 	if err != nil {
 		return msgID{}, err
 	}
 
-	supported := IsSupported(chainID)
+	supported := IsSupported(id.EmitterChain)
 	if !supported {
-		return msgID{}, fmt.Errorf("chainID %d (%s) is does not have a Transfer Verifier implementation or is not supported", chainID, chainID.String())
+		return msgID{}, fmt.Errorf("chainID %d (%s) is does not have a Transfer Verifier implementation or is not supported", id.EmitterChain, id.EmitterChain.String())
 	}
 
-	emitterAddress, err := vaa.StringToAddress(parts[1])
-	if err != nil {
-		return msgID{}, err
-	}
-
-	sequence, err := strconv.ParseUint(parts[2], 10, 64)
-	if err != nil {
-		return msgID{}, err
-	}
-
-	if chainID == vaa.ChainIDUnset || emitterAddress == ZERO_ADDRESS_VAA {
-		return msgID{}, errors.New("invalid msgID: chainID or emitterAddress is unset or zero")
-	}
-
-	return msgID{
-		EmitterChain:   chainID,
-		EmitterAddress: emitterAddress,
-		Sequence:       sequence,
-	}, nil
-
+	return id, nil
 }
 
 // Custom error type used to signal that a core invariant of the token bridge has been violated.

--- a/node/pkg/txverifier/utils.go
+++ b/node/pkg/txverifier/utils.go
@@ -37,6 +37,8 @@ const (
 type msgID = vaa.VAAID
 
 // NewMsgID creates a new msgID from a string in the format "chainID/emitterAddress/sequence".
+// The Chain ID in the msg ID must be a chain that is supported by the Transfer Verifier
+// according to [IsSupported].
 func NewMsgID(in string) (msgID, error) {
 	id, err := vaa.VAAIDFromString(in)
 	if err != nil {

--- a/node/pkg/watchers/evm/watcher.go
+++ b/node/pkg/watchers/evm/watcher.go
@@ -422,8 +422,8 @@ func (w *Watcher) Run(parentCtx context.Context) error {
 			case <-ctx.Done():
 				return nil
 			case r := <-w.obsvReqC:
-				chainID, err := vaa.ChainIDFromNumber(r.ChainId)
-				if err != nil {
+				chainID, chainErr := vaa.ChainIDFromNumber(r.ChainId)
+				if chainErr != nil {
 					logger.Error("chain id for observation request is not a valid uint16",
 						zap.Uint32("chainID", r.ChainId),
 						zap.String("txID", hex.EncodeToString(r.TxHash)),

--- a/node/pkg/watchers/evm/watcher.go
+++ b/node/pkg/watchers/evm/watcher.go
@@ -422,7 +422,8 @@ func (w *Watcher) Run(parentCtx context.Context) error {
 			case <-ctx.Done():
 				return nil
 			case r := <-w.obsvReqC:
-				if r.ChainId > math.MaxUint16 {
+				chainID, err := vaa.ChainIDFromNumber(r.ChainId)
+				if err != nil {
 					logger.Error("chain id for observation request is not a valid uint16",
 						zap.Uint32("chainID", r.ChainId),
 						zap.String("txID", hex.EncodeToString(r.TxHash)),
@@ -431,7 +432,7 @@ func (w *Watcher) Run(parentCtx context.Context) error {
 				}
 				numObservations, handleErr := w.handleReobservationRequest(
 					ctx,
-					vaa.ChainID(r.ChainId),
+					chainID,
 					r.TxHash,
 					w.ethConn,
 					atomic.LoadUint64(&w.latestFinalizedBlockNumber),
@@ -1192,7 +1193,11 @@ func (w *Watcher) logVersion(ctx context.Context) {
 
 // msgIdFromLogEvent formats the message ID (chain/emitterAddress/seqNo) from a log event.
 func msgIdFromLogEvent(chainID vaa.ChainID, ev *ethabi.AbiLogMessagePublished) string {
-	return fmt.Sprintf("%v/%v/%v", uint16(chainID), PadAddress(ev.Sender), ev.Sequence)
+	return vaa.VAAID{
+		EmitterChain:   chainID,
+		EmitterAddress: PadAddress(ev.Sender),
+		Sequence:       ev.Sequence,
+	}.String()
 }
 
 // createConnector determines the type of connector needed for a chain and creates the appropriate one.

--- a/node/pkg/watchers/evm/watcher.go
+++ b/node/pkg/watchers/evm/watcher.go
@@ -427,7 +427,7 @@ func (w *Watcher) Run(parentCtx context.Context) error {
 			case <-ctx.Done():
 				return nil
 			case r := <-w.obsvReqC:
-				chainId, chainErr := vaa.KnownChainIDFromNumber[uint32](r.ChainId)
+				chainID, chainErr := vaa.KnownChainIDFromNumber[uint32](r.ChainId)
 				if chainErr != nil {
 					logger.Error("invalid chain id for observation request",
 						zap.Uint32("chainID", r.ChainId),
@@ -438,7 +438,7 @@ func (w *Watcher) Run(parentCtx context.Context) error {
 				}
 				numObservations, handleErr := w.handleReobservationRequest(
 					ctx,
-					chainId,
+					chainID,
 					r.TxHash,
 					w.ethConn,
 					atomic.LoadUint64(&w.latestFinalizedBlockNumber),
@@ -1201,7 +1201,11 @@ func (w *Watcher) logVersion(ctx context.Context) {
 
 // msgIdFromLogEvent formats the message ID (chain/emitterAddress/seqNo) from a log event.
 func msgIdFromLogEvent(chainID vaa.ChainID, ev *ethabi.AbiLogMessagePublished) string {
-	return fmt.Sprintf("%v/%v/%v", uint16(chainID), PadAddress(ev.Sender), ev.Sequence)
+	return vaa.VAAID{
+		EmitterChain:   chainID,
+		EmitterAddress: PadAddress(ev.Sender),
+		Sequence:       ev.Sequence,
+	}.String()
 }
 
 // createConnector determines the type of connector needed for a chain and creates the appropriate one.

--- a/node/pkg/watchers/solana/client.go
+++ b/node/pkg/watchers/solana/client.go
@@ -502,7 +502,7 @@ func (s *SolanaWatcher) Run(ctx context.Context) error {
 					return err
 				}
 			case m := <-s.obsvReqC:
-				chainId, err := vaa.KnownChainIDFromNumber[uint32](m.ChainId)
+				chainID, err := vaa.KnownChainIDFromNumber[uint32](m.ChainId)
 				if err != nil {
 					logger.Error("invalid chain id for observation request",
 						zap.Uint32("chainID", m.ChainId),
@@ -513,16 +513,16 @@ func (s *SolanaWatcher) Run(ctx context.Context) error {
 				}
 
 				//nolint:contextcheck // Passed via the 's' object instead of as a parameter.
-				numObservations, err := s.handleReobservationRequest(chainId, m.TxHash, s.rpcClient)
+				numObservations, err := s.handleReobservationRequest(chainID, m.TxHash, s.rpcClient)
 				if err != nil {
 					logger.Error("failed to process observation request",
-						zap.Uint32("chainID", m.ChainId),
+						zap.Uint16("chainID", uint16(chainID)),
 						zap.String("identifier", base58.Encode(m.TxHash)),
 						zap.Error(err),
 					)
 				} else {
 					logger.Info("reobserved transactions",
-						zap.Uint32("chainID", m.ChainId),
+						zap.Uint16("chainID", uint16(chainID)),
 						zap.String("identifier", base58.Encode(m.TxHash)),
 						zap.Uint32("numObservations", numObservations),
 					)

--- a/node/pkg/watchers/solana/client.go
+++ b/node/pkg/watchers/solana/client.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -426,8 +425,10 @@ func (s *SolanaWatcher) Run(ctx context.Context) error {
 					return err
 				}
 			case m := <-s.obsvReqC:
-				if m.ChainId > math.MaxUint16 {
-					logger.Error("chain id for observation request is not a valid uint16",
+
+				chainID, err := vaa.KnownChainIDFromNumber(m.ChainId)
+				if err != nil {
+					logger.Error("chain id for observation request is invalid",
 						zap.Uint32("chainID", m.ChainId),
 						zap.String("txID", hex.EncodeToString(m.TxHash)),
 					)
@@ -435,16 +436,16 @@ func (s *SolanaWatcher) Run(ctx context.Context) error {
 				}
 
 				//nolint:contextcheck // Passed via the 's' object instead of as a parameter.
-				numObservations, err := s.handleReobservationRequest(vaa.ChainID(m.ChainId), m.TxHash, s.rpcClient)
+				numObservations, err := s.handleReobservationRequest(chainID, m.TxHash, s.rpcClient)
 				if err != nil {
 					logger.Error("failed to process observation request",
-						zap.Uint32("chainID", m.ChainId),
+						zap.Uint16("chainID", uint16(chainID)),
 						zap.String("identifier", base58.Encode(m.TxHash)),
 						zap.Error(err),
 					)
 				} else {
 					logger.Info("reobserved transactions",
-						zap.Uint32("chainID", m.ChainId),
+						zap.Uint16("chainID", uint16(chainID)),
 						zap.String("identifier", base58.Encode(m.TxHash)),
 						zap.Uint32("numObservations", numObservations),
 					)

--- a/sdk/vaa/constants.go
+++ b/sdk/vaa/constants.go
@@ -1,0 +1,17 @@
+package vaa
+
+// Addresses
+const (
+	// AddressBytesLen is the size in bytes of the Wormhole normalized address format.
+	// It is the protocol-level 32-byte address representation, not the native address size of any particular chain.
+	AddressBytesLen = 32
+	// AddressHexLen is the canonical hex string length of the Wormhole normalized address format.
+	// It corresponds to the protocol-level 32-byte address representation, not the native address size of any particular chain.
+	AddressHexLen = AddressBytesLen * 2
+)
+
+// VAA format
+const (
+	// e.g. for `<chain-id>/<emitter-addr/<seq-num>`
+	VAAIDPartsLen = 3
+)

--- a/sdk/vaa/id.go
+++ b/sdk/vaa/id.go
@@ -1,0 +1,156 @@
+package vaa
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+var (
+	ErrEmptyVAAID         = errors.New("VAA ID is empty")
+	ErrInvalidVAAIDFormat = errors.New("VAA ID must be in the format chainId/emitterAddress/sequence")
+)
+
+// VAAID is the canonical Wormhole message identifier.
+// It is the tuple emitter_chain/emitter_address/sequence.
+type VAAID struct {
+	EmitterChain   ChainID
+	EmitterAddress Address
+	Sequence       uint64
+}
+
+// String returns the canonical chain/address/sequence representation.
+func (id VAAID) String() string {
+	return fmt.Sprintf("%d/%s/%d", uint16(id.EmitterChain), id.EmitterAddress, id.Sequence)
+}
+
+// Empty reports whether every field is its zero value.
+func (id VAAID) Empty() bool {
+	return id == (VAAID{})
+}
+
+// Validate returns an error if the ID is not usable as a full Wormhole message identifier.
+func (id VAAID) Validate() error {
+	if id.EmitterChain == ChainIDUnset {
+		return errors.New("VAA ID emitter chain is unset")
+	}
+	if id.EmitterAddress == (Address{}) {
+		return errors.New("VAA ID emitter address is zero")
+	}
+	return nil
+}
+
+// VAAIDFromVAA returns the canonical VAA ID for the supplied VAA.
+func VAAIDFromVAA(v *VAA) VAAID {
+	if v == nil {
+		return VAAID{}
+	}
+	return v.ID()
+}
+
+// ID returns the canonical VAA ID for the supplied VAA.
+func (v *VAA) ID() VAAID {
+	return VAAID{
+		EmitterChain:   v.EmitterChain,
+		EmitterAddress: v.EmitterAddress,
+		Sequence:       v.Sequence,
+	}
+}
+
+// NewVAAID constructs a VAA ID from validated numeric chain and string address fields.
+// This method does not validate that the ChainID is known to the SDK. It only converts the emitterChain parameter
+// to the correct type.
+func NewVAAID[N number](emitterChain N, emitterAddress string, sequence uint64) (VAAID, error) {
+	chainID, err := ChainIDFromNumber(emitterChain)
+	if err != nil {
+		return VAAID{}, err
+	}
+
+	address, err := parseVAAIDAddress(emitterAddress)
+	if err != nil {
+		return VAAID{}, err
+	}
+
+	id := VAAID{
+		EmitterChain:   chainID,
+		EmitterAddress: address,
+		Sequence:       sequence,
+	}
+
+	if err := id.Validate(); err != nil {
+		return VAAID{}, err
+	}
+
+	return id, nil
+}
+
+// VAAIDFromString parses a chain/address/sequence identifier into a validated VAA ID.
+// Numeric chain IDs do not need to correspond to a chain registered in the SDK.
+func VAAIDFromString(s string) (VAAID, error) {
+	return parseVAAIDString(s, false)
+}
+
+// VAAIDFromStringKnownChain parses a chain/address/sequence identifier into a validated VAA ID.
+// The chain component must correspond to a chain registered in the SDK.
+func VAAIDFromStringKnownChain(s string) (VAAID, error) {
+	return parseVAAIDString(s, true)
+}
+
+func parseVAAIDString(s string, knownChain bool) (VAAID, error) {
+	if s == "" {
+		return VAAID{}, ErrEmptyVAAID
+	}
+
+	parts := strings.Split(s, "/")
+	if len(parts) != VAAIDPartsLen {
+		return VAAID{}, ErrInvalidVAAIDFormat
+	}
+
+	chainID, err := parseVAAIDChain(parts[0], knownChain)
+	if err != nil {
+		return VAAID{}, err
+	}
+
+	address, err := parseVAAIDAddress(parts[1])
+	if err != nil {
+		return VAAID{}, err
+	}
+
+	sequence, err := strconv.ParseUint(parts[2], 10, 64)
+	if err != nil {
+		return VAAID{}, err
+	}
+
+	id := VAAID{
+		EmitterChain:   chainID,
+		EmitterAddress: address,
+		Sequence:       sequence,
+	}
+
+	if err := id.Validate(); err != nil {
+		return VAAID{}, err
+	}
+
+	return id, nil
+}
+
+func parseVAAIDChain(s string, knownChain bool) (ChainID, error) {
+	if s == "" {
+		return ChainIDUnset, errors.New("VAA ID emitter chain is empty")
+	}
+	if knownChain {
+		return StringToKnownChainID(s)
+	}
+
+	return StringToChainID(s)
+}
+
+func parseVAAIDAddress(s string) (Address, error) {
+	trimmed := strings.TrimPrefix(s, "0x")
+	if len(trimmed) != AddressHexLen {
+		return Address{}, errors.New("VAA ID emitter address must be 32 bytes")
+	}
+
+	return StringToAddress(trimmed)
+}

--- a/sdk/vaa/id.go
+++ b/sdk/vaa/id.go
@@ -1,0 +1,142 @@
+package vaa
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+var (
+	ErrEmptyVAAID         = errors.New("VAA ID is empty")
+	ErrInvalidVAAIDFormat = errors.New("VAA ID must be in the format chainId/emitterAddress/sequence")
+)
+
+// VAAID is the canonical Wormhole message identifier.
+// It is the tuple emitter_chain/emitter_address/sequence.
+type VAAID struct {
+	EmitterChain   ChainID
+	EmitterAddress Address
+	Sequence       uint64
+}
+
+// String returns the canonical chain/address/sequence representation.
+func (id VAAID) String() string {
+	return fmt.Sprintf("%d/%s/%d", uint16(id.EmitterChain), id.EmitterAddress, id.Sequence)
+}
+
+// Empty reports whether every field is its zero value.
+func (id VAAID) Empty() bool {
+	return id == (VAAID{})
+}
+
+// Validate returns an error if the ID is not usable as a full Wormhole message identifier.
+func (id VAAID) Validate() error {
+	if id.EmitterChain == ChainIDUnset {
+		return errors.New("VAA ID emitter chain is unset")
+	}
+	if id.EmitterAddress == (Address{}) {
+		return errors.New("VAA ID emitter address is zero")
+	}
+	return nil
+}
+
+// VAAIDFromVAA returns the canonical VAA ID for the supplied VAA.
+func VAAIDFromVAA(v *VAA) VAAID {
+	if v == nil {
+		return VAAID{}
+	}
+	return v.ID()
+}
+
+// ID returns the canonical VAA ID for the supplied VAA.
+func (v *VAA) ID() VAAID {
+	return VAAID{
+		EmitterChain:   v.EmitterChain,
+		EmitterAddress: v.EmitterAddress,
+		Sequence:       v.Sequence,
+	}
+}
+
+// NewVAAID constructs a VAA ID from validated numeric chain and string address fields.
+// This method does not validate that the ChainID is known to the SDK. It only converts the emitterChain parameter
+// to the correct type.
+func NewVAAID[N number](emitterChain N, emitterAddress string, sequence uint64) (VAAID, error) {
+	chainID, err := ChainIDFromNumber(emitterChain)
+	if err != nil {
+		return VAAID{}, err
+	}
+
+	address, err := parseVAAIDAddress(emitterAddress)
+	if err != nil {
+		return VAAID{}, err
+	}
+
+	id := VAAID{
+		EmitterChain:   chainID,
+		EmitterAddress: address,
+		Sequence:       sequence,
+	}
+
+	if err := id.Validate(); err != nil {
+		return VAAID{}, err
+	}
+
+	return id, nil
+}
+
+// VAAIDFromString parses a chain/address/sequence identifier into a validated VAA ID.
+func VAAIDFromString(s string) (VAAID, error) {
+	if s == "" {
+		return VAAID{}, ErrEmptyVAAID
+	}
+
+	parts := strings.Split(s, "/")
+	if len(parts) != 3 {
+		return VAAID{}, ErrInvalidVAAIDFormat
+	}
+
+	chainID, err := parseVAAIDChain(parts[0])
+	if err != nil {
+		return VAAID{}, err
+	}
+
+	address, err := parseVAAIDAddress(parts[1])
+	if err != nil {
+		return VAAID{}, err
+	}
+
+	sequence, err := strconv.ParseUint(parts[2], 10, 64)
+	if err != nil {
+		return VAAID{}, err
+	}
+
+	id := VAAID{
+		EmitterChain:   chainID,
+		EmitterAddress: address,
+		Sequence:       sequence,
+	}
+
+	if err := id.Validate(); err != nil {
+		return VAAID{}, err
+	}
+
+	return id, nil
+}
+
+func parseVAAIDChain(s string) (ChainID, error) {
+	if s == "" {
+		return ChainIDUnset, errors.New("VAA ID emitter chain is empty")
+	}
+
+	return StringToKnownChainID(s)
+}
+
+func parseVAAIDAddress(s string) (Address, error) {
+	trimmed := strings.TrimPrefix(s, "0x")
+	if len(trimmed) != 64 {
+		return Address{}, errors.New("VAA ID emitter address must be 32 bytes")
+	}
+
+	return StringToAddress(trimmed)
+}

--- a/sdk/vaa/id.go
+++ b/sdk/vaa/id.go
@@ -103,7 +103,7 @@ func parseVAAIDString(s string, knownChain bool) (VAAID, error) {
 	}
 
 	parts := strings.Split(s, "/")
-	if len(parts) != 3 {
+	if len(parts) != VAAIDPartsLen {
 		return VAAID{}, ErrInvalidVAAIDFormat
 	}
 
@@ -148,7 +148,7 @@ func parseVAAIDChain(s string, knownChain bool) (ChainID, error) {
 
 func parseVAAIDAddress(s string) (Address, error) {
 	trimmed := strings.TrimPrefix(s, "0x")
-	if len(trimmed) != 64 {
+	if len(trimmed) != AddressHexLen {
 		return Address{}, errors.New("VAA ID emitter address must be 32 bytes")
 	}
 

--- a/sdk/vaa/id.go
+++ b/sdk/vaa/id.go
@@ -86,7 +86,18 @@ func NewVAAID[N number](emitterChain N, emitterAddress string, sequence uint64) 
 }
 
 // VAAIDFromString parses a chain/address/sequence identifier into a validated VAA ID.
+// Numeric chain IDs do not need to correspond to a chain registered in the SDK.
 func VAAIDFromString(s string) (VAAID, error) {
+	return parseVAAIDString(s, false)
+}
+
+// VAAIDFromStringKnownChain parses a chain/address/sequence identifier into a validated VAA ID.
+// The chain component must correspond to a chain registered in the SDK.
+func VAAIDFromStringKnownChain(s string) (VAAID, error) {
+	return parseVAAIDString(s, true)
+}
+
+func parseVAAIDString(s string, knownChain bool) (VAAID, error) {
 	if s == "" {
 		return VAAID{}, ErrEmptyVAAID
 	}
@@ -96,7 +107,7 @@ func VAAIDFromString(s string) (VAAID, error) {
 		return VAAID{}, ErrInvalidVAAIDFormat
 	}
 
-	chainID, err := parseVAAIDChain(parts[0])
+	chainID, err := parseVAAIDChain(parts[0], knownChain)
 	if err != nil {
 		return VAAID{}, err
 	}
@@ -124,12 +135,15 @@ func VAAIDFromString(s string) (VAAID, error) {
 	return id, nil
 }
 
-func parseVAAIDChain(s string) (ChainID, error) {
+func parseVAAIDChain(s string, knownChain bool) (ChainID, error) {
 	if s == "" {
 		return ChainIDUnset, errors.New("VAA ID emitter chain is empty")
 	}
+	if knownChain {
+		return StringToKnownChainID(s)
+	}
 
-	return StringToKnownChainID(s)
+	return StringToChainID(s)
 }
 
 func parseVAAIDAddress(s string) (Address, error) {

--- a/sdk/vaa/id_test.go
+++ b/sdk/vaa/id_test.go
@@ -1,0 +1,50 @@
+package vaa
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVAAIDFromString(t *testing.T) {
+	t.Parallel()
+
+	id, err := VAAIDFromString("1/0000000000000000000000000000000000000000000000000000000000000004/1")
+	require.NoError(t, err)
+	require.Equal(t, ChainIDSolana, id.EmitterChain)
+	require.Equal(t, uint64(1), id.Sequence)
+	require.Equal(t, "1/0000000000000000000000000000000000000000000000000000000000000004/1", id.String())
+}
+
+func TestNewVAAID(t *testing.T) {
+	t.Parallel()
+
+	id, err := NewVAAID(uint32(2), "0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16", 7)
+	require.NoError(t, err)
+	require.Equal(t, ChainIDEthereum, id.EmitterChain)
+	require.Equal(t, uint64(7), id.Sequence)
+	require.Equal(t, "2/0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16/7", id.String())
+}
+
+func TestVAAIDFromVAAUsesMethod(t *testing.T) {
+	t.Parallel()
+
+	v := &VAA{
+		EmitterChain:   ChainIDSolana,
+		EmitterAddress: Address{31: 4},
+		Sequence:       9,
+	}
+
+	require.Equal(t, v.ID(), VAAIDFromVAA(v))
+	require.Equal(t, "1/0000000000000000000000000000000000000000000000000000000000000004/9", v.ID().String())
+}
+
+func TestVAAIDValidateRejectsZeroValues(t *testing.T) {
+	t.Parallel()
+
+	err := (VAAID{}).Validate()
+	require.EqualError(t, err, "VAA ID emitter chain is unset")
+
+	err = (VAAID{EmitterChain: ChainIDSolana}).Validate()
+	require.EqualError(t, err, "VAA ID emitter address is zero")
+}

--- a/sdk/vaa/id_test.go
+++ b/sdk/vaa/id_test.go
@@ -1,0 +1,66 @@
+package vaa
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVAAIDFromString(t *testing.T) {
+	t.Parallel()
+
+	id, err := VAAIDFromString("1/0000000000000000000000000000000000000000000000000000000000000004/1")
+	require.NoError(t, err)
+	require.Equal(t, ChainIDSolana, id.EmitterChain)
+	require.Equal(t, uint64(1), id.Sequence)
+	require.Equal(t, "1/0000000000000000000000000000000000000000000000000000000000000004/1", id.String())
+}
+
+func TestVAAIDFromStringAllowsUnknownNumericChain(t *testing.T) {
+	t.Parallel()
+
+	id, err := VAAIDFromString("65535/0000000000000000000000000000000000000000000000000000000000000004/1")
+	require.NoError(t, err)
+	require.Equal(t, ChainID(65535), id.EmitterChain)
+	require.Equal(t, "65535/0000000000000000000000000000000000000000000000000000000000000004/1", id.String())
+}
+
+func TestVAAIDFromStringKnownChainRejectsUnknownNumericChain(t *testing.T) {
+	t.Parallel()
+
+	_, err := VAAIDFromStringKnownChain("65535/0000000000000000000000000000000000000000000000000000000000000004/1")
+	require.EqualError(t, err, "no known ChainID for input 65535")
+}
+
+func TestNewVAAID(t *testing.T) {
+	t.Parallel()
+
+	id, err := NewVAAID(uint32(2), "0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16", 7)
+	require.NoError(t, err)
+	require.Equal(t, ChainIDEthereum, id.EmitterChain)
+	require.Equal(t, uint64(7), id.Sequence)
+	require.Equal(t, "2/0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16/7", id.String())
+}
+
+func TestVAAIDFromVAAUsesMethod(t *testing.T) {
+	t.Parallel()
+
+	v := &VAA{
+		EmitterChain:   ChainIDSolana,
+		EmitterAddress: Address{31: 4},
+		Sequence:       9,
+	}
+
+	require.Equal(t, v.ID(), VAAIDFromVAA(v))
+	require.Equal(t, "1/0000000000000000000000000000000000000000000000000000000000000004/9", v.ID().String())
+}
+
+func TestVAAIDValidateRejectsZeroValues(t *testing.T) {
+	t.Parallel()
+
+	err := (VAAID{}).Validate()
+	require.EqualError(t, err, "VAA ID emitter chain is unset")
+
+	err = (VAAID{EmitterChain: ChainIDSolana}).Validate()
+	require.EqualError(t, err, "VAA ID emitter address is zero")
+}

--- a/sdk/vaa/id_test.go
+++ b/sdk/vaa/id_test.go
@@ -16,6 +16,22 @@ func TestVAAIDFromString(t *testing.T) {
 	require.Equal(t, "1/0000000000000000000000000000000000000000000000000000000000000004/1", id.String())
 }
 
+func TestVAAIDFromStringAllowsUnknownNumericChain(t *testing.T) {
+	t.Parallel()
+
+	id, err := VAAIDFromString("65535/0000000000000000000000000000000000000000000000000000000000000004/1")
+	require.NoError(t, err)
+	require.Equal(t, ChainID(65535), id.EmitterChain)
+	require.Equal(t, "65535/0000000000000000000000000000000000000000000000000000000000000004/1", id.String())
+}
+
+func TestVAAIDFromStringKnownChainRejectsUnknownNumericChain(t *testing.T) {
+	t.Parallel()
+
+	_, err := VAAIDFromStringKnownChain("65535/0000000000000000000000000000000000000000000000000000000000000004/1")
+	require.EqualError(t, err, "no known ChainID for input 65535")
+}
+
 func TestNewVAAID(t *testing.T) {
 	t.Parallel()
 

--- a/sdk/vaa/structs.go
+++ b/sdk/vaa/structs.go
@@ -229,7 +229,7 @@ func TimeFromUnix[N number](n N) (time.Time, error) {
 // Inputs of unknown ChainIDs, including 0, will result in an error.
 func StringToKnownChainID(s string) (ChainID, error) {
 	// Try to convert from chain name first, and return early if it's found.
-	id, err := ChainIDFromString(s)
+	id, err := ChainNameToChainID(s)
 	if err == nil {
 		return id, nil
 	}
@@ -242,6 +242,29 @@ func StringToKnownChainID(s string) (ChainID, error) {
 	}
 
 	return KnownChainIDFromNumber(u16)
+}
+
+// ChainNameToChainID converts a chain's name, such as "solana", into its corresponding ChainID.
+func ChainNameToChainID(name string) (ChainID, error) {
+	return ChainIDFromString(name)
+}
+
+// StringToChainID converts from a string representation of a chain into a ChainID.
+// The argument can be either a numeric string representation of a uint16 or a known chain name such as "solana".
+// Unlike StringToKnownChainID, numeric inputs do not need to correspond to a chain registered in the SDK.
+func StringToChainID(s string) (ChainID, error) {
+	// Try to convert from chain name first, and return early if it's found.
+	id, err := ChainNameToChainID(s)
+	if err == nil {
+		return id, nil
+	}
+
+	u16, err := strconv.ParseUint(s, 10, 16)
+	if err != nil {
+		return ChainIDUnset, err
+	}
+
+	return ChainIDFromNumber(u16)
 }
 
 // NOTE: Please keep these in numerical order.
@@ -745,7 +768,7 @@ func (v *VAA) UnmarshalBinary(data []byte) error {
 
 // MessageID returns a human-readable emitter_chain/emitter_address/sequence tuple.
 func (v *VAA) MessageID() string {
-	return fmt.Sprintf("%d/%s/%d", v.EmitterChain, v.EmitterAddress, v.Sequence)
+	return v.ID().String()
 }
 
 // UniqueID normalizes the ID of the VAA (any type) for the Attestation interface

--- a/sdk/vaa/structs.go
+++ b/sdk/vaa/structs.go
@@ -194,7 +194,7 @@ func KnownChainIDFromNumber[N number](n N) (ChainID, error) {
 // Inputs of unknown ChainIDs, including 0, will result in an error.
 func StringToKnownChainID(s string) (ChainID, error) {
 	// Try to convert from chain name first, and return early if it's found.
-	id, err := ChainIDFromString(s)
+	id, err := ChainNameToChainID(s)
 	if err == nil {
 		return id, nil
 	}
@@ -207,6 +207,29 @@ func StringToKnownChainID(s string) (ChainID, error) {
 	}
 
 	return KnownChainIDFromNumber(u16)
+}
+
+// ChainNameToChainID converts a chain's name, such as "solana", into its corresponding ChainID.
+func ChainNameToChainID(name string) (ChainID, error) {
+	return ChainIDFromString(name)
+}
+
+// StringToChainID converts from a string representation of a chain into a ChainID.
+// The argument can be either a numeric string representation of a uint16 or a known chain name such as "solana".
+// Unlike StringToKnownChainID, numeric inputs do not need to correspond to a chain registered in the SDK.
+func StringToChainID(s string) (ChainID, error) {
+	// Try to convert from chain name first, and return early if it's found.
+	id, err := ChainNameToChainID(s)
+	if err == nil {
+		return id, nil
+	}
+
+	u16, err := strconv.ParseUint(s, 10, 16)
+	if err != nil {
+		return ChainIDUnset, err
+	}
+
+	return ChainIDFromNumber(u16)
 }
 
 // NOTE: Please keep these in numerical order.
@@ -708,7 +731,7 @@ func (v *VAA) UnmarshalBinary(data []byte) error {
 
 // MessageID returns a human-readable emitter_chain/emitter_address/sequence tuple.
 func (v *VAA) MessageID() string {
-	return fmt.Sprintf("%d/%s/%d", v.EmitterChain, v.EmitterAddress, v.Sequence)
+	return v.ID().String()
 }
 
 // UniqueID normalizes the ID of the VAA (any type) for the Attestation interface

--- a/sdk/vaa/structs_test.go
+++ b/sdk/vaa/structs_test.go
@@ -1064,3 +1064,12 @@ func TestStringToKnownChainID(t *testing.T) {
 		})
 	}
 }
+
+func TestChainNameToChainID(t *testing.T) {
+	actual, err := ChainNameToChainID("solana")
+	require.NoError(t, err)
+	require.Equal(t, ChainIDSolana, actual)
+
+	_, err = ChainNameToChainID("1")
+	require.Error(t, err)
+}

--- a/sdk/vaa/structs_test.go
+++ b/sdk/vaa/structs_test.go
@@ -1129,3 +1129,12 @@ func TestStringToKnownChainID(t *testing.T) {
 		})
 	}
 }
+
+func TestChainNameToChainID(t *testing.T) {
+	actual, err := ChainNameToChainID("solana")
+	require.NoError(t, err)
+	require.Equal(t, ChainIDSolana, actual)
+
+	_, err = ChainNameToChainID("1")
+	require.Error(t, err)
+}


### PR DESCRIPTION
# Before (example)

```go
// Before: a maintainer had to manually parse the string, perform type
// conversions, decode hex, validate lengths, and build the canonical ID.
parts := strings.Split(msgID, "/")
if len(parts) != 3 {
	log.Fatalf("invalid message ID")
}
chain, err := strconv.ParseUint(parts[0], 10, 16)
if err != nil {
	log.Fatalf("invalid chain ID: %v", err)
}
addrBytes, err := hex.DecodeString(parts[1])
if err != nil {
	log.Fatalf("invalid emitter address: %v", err)
}
if len(addrBytes) != 32 {
	log.Fatalf("address must be 32 bytes")
}
var addr vaa.Address
copy(addr[:], addrBytes)
seq, err := strconv.ParseUint(parts[2], 10, 64)
if err != nil {
	log.Fatalf("invalid sequence: %v", err)
}
id := guardianDB.VAAID{
	EmitterChain:   vaa.ChainID(chain),
	EmitterAddress: addr,
	Sequence:       seq,
}
key := []byte(fmt.Sprintf("signed/%d/%s/%d", id.EmitterChain, id.EmitterAddress, id.Sequence))
```

# After (example)

```go
// After: all they need to do is parse once and use the typed ID everywhere.
id, err := vaa.VAAIDFromString(msgID)
if err != nil {
	log.Fatalf("invalid message ID %q: %v", msgID, err)
}
key := []byte("signed/" + id.String())
```

# Description

VAA and chain ID validation is replicated in a ton of places all over the Guardian code. These validations are so important for Wormhole's security that they are necessary to do across various trust boundaries.

This PR makes use of the VAA type within the SDK to do as much validation in a standardized way as possible using focused, well-tested implementations.

The PR fixes at least one existing bug in the Guardian: `GetAndObserveMissingVAAs` was incorrectly parsing the emitter value for VAAs, causing the DB to always miss stored VAAs. This occurred because the emitter address was converted into a byte slice according to its (ASCII) string representation and not its hex representation. (So e.g. the character `0` was represented as `0x30` rather than `0x00`)
It should also address problems like https://github.com/wormhole-foundation/wormhole/pull/4717

The goals of this refactoring is:
- Make it easier for maintainers to validate these crucial data types
- Hide implementation details for downstream code (not every maintainer needs to check for uint16 overflows)
- Allow code reviewers to trust that VAA and ChainID validation is done properly rather than the current status quo which is to cross-reference across e.g. all of the watchers for compliance
- Remove duplicated ad-hoc validation and formatting logic that has subtle differences between implementations
- Reduce the burden needed to test the ad-hoc validations
- Absolutely no existing behaviour should be modified. The "loose" versions of the SDK methods were used in order to preserve current behaviour rather than make validation more strict during refactoring