### PR TITLE
ci: fix Rust 1.95.0 lints

### DIFF
--- a/cosmwasm/contracts/wormchain-ibc-receiver/src/tests/integration_tests.rs
+++ b/cosmwasm/contracts/wormchain-ibc-receiver/src/tests/integration_tests.rs
@@ -151,7 +151,7 @@ pub fn add_channel_chain_happy_path_multiple() -> anyhow::Result<(), Error> {
         channels_chains: mut channels,
     }: AllChannelChainsResponse = from_binary(&channel_binary)?;
 
-    channels.sort_by(|(_, a_chain_id), (_, b_chain_id)| a_chain_id.cmp(b_chain_id));
+    channels.sort_by_key(|(_, chain_id)| *chain_id);
 
     assert_eq!(channels.len(), 2);
 


### PR DESCRIPTION
```
Checking wormhole-ibc v0.1.0 (/home/runner/work/wormhole/wormhole/cosmwasm/contracts/wormhole-ibc)
error: consider using `sort_by_key`
   --> contracts/wormchain-ibc-receiver/src/tests/integration_tests.rs:154:5
    |
154 |     channels.sort_by(|(_, a_chain_id), (_, b_chain_id)| a_chain_id.cmp(b_chain_id));
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#unnecessary_sort_by
    = note: `-D clippy::unnecessary-sort-by` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::unnecessary_sort_by)]`
help: try
    |
154 -     channels.sort_by(|(_, a_chain_id), (_, b_chain_id)| a_chain_id.cmp(b_chain_id));
154 +     channels.sort_by_key(|(_, a_chain_id)| *a_chain_id);
    |
error: could not compile `wormchain-ibc-receiver` (lib test) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
Error: Process completed with exit code 101.  (cosmwasm dir)
```

example CI failure: https://github.com/wormhole-foundation/wormhole/actions/runs/24513660429/job/71651419018?pr=4654