### PR TITLE
fix(cosmwasm): update registration flow

### DIFF
--- a/cosmwasm/contracts/ntt-global-accountant/README.md
+++ b/cosmwasm/contracts/ntt-global-accountant/README.md
@@ -36,5 +36,6 @@ The guardians will have a new allow list of NTTs and will be expected to submit 
    1. Add the NTT transceivers' emitters to the Guardian's allow list.
    1. Cross-register the NTT transceivers on-chain, emitting the VAAs.
    1. Submit the locking mode initialization VAA to the NTT accountant contract.
-   1. Submit the burn transceivers' locking hub registration VAA to the NTT accountant contract.
-   1. Submit the remaining registration VAAs to the NTT accountant.
+   1. Submit the hub's peer registration VAAs to the NTT accountant contract (the hub must register each spoke before the spoke can inherit the hub).
+   1. Submit the burn transceivers' locking hub registration VAAs to the NTT accountant contract (each spoke registers the hub, inheriting it — requires the hub to have pre-registered the spoke in the previous step).
+   1. Submit the remaining cross-registration VAAs to the NTT accountant.

--- a/cosmwasm/contracts/ntt-global-accountant/src/contract.rs
+++ b/cosmwasm/contracts/ntt-global-accountant/src/contract.rs
@@ -499,6 +499,8 @@ fn handle_ntt_vaa(
     let prefix = &payload[..4];
 
     if prefix == WormholeTransceiver::PREFIX {
+        // This is a TransceiverMessage (transfer)
+        // https://github.com/wormhole-foundation/native-token-transfers/blob/a13746a430fbd4a033aef0ff8180d0d49fdbbab3/docs/Transceiver.md?plain=1#L27
         let source_chain = body.emitter_chain.into();
 
         let hub = TRANSCEIVER_TO_HUB
@@ -550,6 +552,9 @@ fn handle_ntt_vaa(
 
         Ok(evt)
     } else if prefix == WormholeTransceiver::INFO_PREFIX {
+        // This is an Initialize Transceiver message
+        // https://github.com/wormhole-foundation/native-token-transfers/blob/a13746a430fbd4a033aef0ff8180d0d49fdbbab3/docs/Transceiver.md?plain=1#L36
+        // STEP 4 of setup: Hub initialization
         // only process init messages for locking hubs, setting their hub mapping to themselves
         let message: WormholeTransceiverInfo =
             TypePrefixedPayload::read_payload(&mut payload.as_slice())
@@ -575,18 +580,13 @@ fn handle_ntt_vaa(
             bail!("ignoring non-locking NTT initialization")
         }
     } else if prefix == WormholeTransceiver::PEER_INFO_PREFIX {
+        // This is a Transceiver (Peer) Registration message
+        // https://github.com/wormhole-foundation/native-token-transfers/blob/a13746a430fbd4a033aef0ff8180d0d49fdbbab3/docs/Transceiver.md?plain=1#L53
         // for ease of code assurances, all transceivers should register their hub first, followed by other peers
         // this code will only add peers for which it can assure their hubs match so one less key can be loaded on transfers
         let message: WormholeTransceiverRegistration =
             TypePrefixedPayload::read_payload(&mut payload.as_slice())
                 .context("failed to parse NTT registration payload")?;
-
-        let peer_hub = TRANSCEIVER_TO_HUB
-            .load(
-                deps.storage,
-                (message.chain_id.id, message.transceiver_address.into()),
-            )
-            .map_err(|_| ContractError::MissingHubRegistration)?;
 
         let chain = body.emitter_chain.into();
         let peer_key = TRANSCEIVER_PEER.key((chain, sender, message.chain_id.id));
@@ -595,30 +595,59 @@ fn handle_ntt_vaa(
             bail!("peer entry for this chain already exists")
         }
 
-        let hub_key = TRANSCEIVER_TO_HUB.key((chain, sender));
+        let peer_hub = TRANSCEIVER_TO_HUB.may_load(
+            deps.storage,
+            (message.chain_id.id, message.transceiver_address.into()),
+        )?;
 
-        if let Some(transceiver_hub) = hub_key.may_load(deps.storage)? {
-            // hubs must match
-            if transceiver_hub != peer_hub {
-                bail!("peer hub does not match")
+        let sender_hub = TRANSCEIVER_TO_HUB.may_load(deps.storage, (chain, sender))?;
+
+        match (sender_hub, peer_hub) {
+            // Neither has a hub
+            (None, None) => {
+                bail!("no registered hub for sender or peer")
             }
-        } else {
-            // this transceiver does not have a known hub, check if this peer is a hub themselves
-            if peer_hub.0 == message.chain_id.id && peer_hub.1 == message.transceiver_address.into()
-            {
-                // this peer is a hub, so set it as this transceiver's hub
-                hub_key
-                    .save(deps.storage, &peer_hub.clone())
+            // STEP 5 of setup: Hub registers peers
+            // Sender is a hub, peer has no hub: hub pre-registering a spoke
+            (Some(s_hub), None) => {
+                // only actual hubs (self-referential mapping) can pre-register unknown peers
+                if s_hub.0 != chain || s_hub.1 != sender {
+                    bail!("only hubs can register peers without hub registration")
+                }
+            }
+            // STEP 6 of setup: Peer accepts hub registration
+            // Sender has no hub, peer is hub: hub inheritance path
+            (None, Some(p_hub)) => {
+                // the peer must be a hub itself (not just a spoke that inherited one)
+                if p_hub.0 != message.chain_id.id || p_hub.1 != message.transceiver_address.into() {
+                    bail!("ignoring attempt to register peer before hub")
+                }
+
+                // SECURITY: verify the hub has already registered this sender as a peer.
+                // This prevents rogue emitters from unilaterally inheriting a legitimate hub.
+                let hub_peer_for_sender =
+                    TRANSCEIVER_PEER.may_load(deps.storage, (p_hub.0, p_hub.1, chain))?;
+                if hub_peer_for_sender != Some(sender) {
+                    bail!("hub has not registered this transceiver as a peer")
+                }
+
+                // hub has acknowledged this sender — allow inheritance
+                TRANSCEIVER_TO_HUB
+                    .save(deps.storage, (chain, sender), &p_hub)
                     .context("failed to save hub")?;
-            } else {
-                // this peer is not a hub and we don't want to make indirect assumptions, so do nothing
-                bail!("ignoring attempt to register peer before hub")
+            }
+            // STEP 7 of setup: Other peers, cross-register
+            // Both have hubs: verify they match
+            (Some(s_hub), Some(p_hub)) => {
+                if s_hub != p_hub {
+                    bail!("peer hub does not match")
+                }
             }
         }
 
         peer_key
             .save(deps.storage, &(message.transceiver_address.into()))
-            .context("failed to save hub")?;
+            .context("failed to save peer")?;
         Ok(Event::new("RegisterPeer")
             .add_attribute("chain", chain.to_string())
             .add_attribute("emitter_address", hex::encode(sender))

--- a/cosmwasm/contracts/ntt-global-accountant/src/contract.rs
+++ b/cosmwasm/contracts/ntt-global-accountant/src/contract.rs
@@ -589,6 +589,9 @@ fn handle_ntt_vaa(
                 .context("failed to parse NTT registration payload")?;
 
         let chain = body.emitter_chain.into();
+        if chain == message.chain_id.id {
+            bail!("sender and peer cannot be on the same chain")
+        }
         let peer_key = TRANSCEIVER_PEER.key((chain, sender, message.chain_id.id));
 
         if peer_key.may_load(deps.storage)?.is_some() {

--- a/cosmwasm/contracts/ntt-global-accountant/tests/ntt_registration.rs
+++ b/cosmwasm/contracts/ntt-global-accountant/tests/ntt_registration.rs
@@ -719,7 +719,8 @@ fn rogue_on_hub_chain_blocked_at_inheritance() {
 
     let rogue_on_hub: [u8; 32] = [0xCC; 32];
 
-    // Rogue on hub chain tries to register hub → blocked because hub hasn't pre-registered it
+    // Rogue on hub chain tries to register hub → blocked because sender and peer
+    // cannot be on the same chain
     let vaa = build_signed_vaa(
         &wh,
         HUB_CHAIN,
@@ -733,7 +734,37 @@ fn rogue_on_hub_chain_blocked_at_inheritance() {
     assert!(
         err.root_cause()
             .to_string()
-            .contains("hub has not registered this transceiver as a peer"),
+            .contains("sender and peer cannot be on the same chain"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn same_chain_peer_registration_rejected() {
+    let (wh, mut contract) = proper_instantiate();
+    let mut seq = Seq::new();
+
+    // Init hub so the sender has a hub registration (exercises the check before
+    // any of the match arms on sender/peer hub state).
+    let vaa = build_signed_vaa(&wh, HUB_CHAIN, HUB_ADDR, seq.next(), &hub_init_payload(0));
+    contract.submit_vaas(vec![vaa]).unwrap();
+
+    // Hub tries to register a peer on its own chain
+    let same_chain_peer: [u8; 32] = [0x66; 32];
+    let vaa = build_signed_vaa(
+        &wh,
+        HUB_CHAIN,
+        HUB_ADDR,
+        seq.next(),
+        &registration_payload(HUB_CHAIN, same_chain_peer),
+    );
+    let err = contract
+        .submit_vaas(vec![vaa])
+        .expect_err("same-chain registration should be rejected");
+    assert!(
+        err.root_cause()
+            .to_string()
+            .contains("sender and peer cannot be on the same chain"),
         "unexpected error: {err}"
     );
 }

--- a/cosmwasm/contracts/ntt-global-accountant/tests/ntt_registration.rs
+++ b/cosmwasm/contracts/ntt-global-accountant/tests/ntt_registration.rs
@@ -737,3 +737,299 @@ fn rogue_on_hub_chain_blocked_at_inheritance() {
         "unexpected error: {err}"
     );
 }
+
+// ============================================================
+// 4. Error-path coverage for handle_ntt_vaa
+// ============================================================
+
+#[test]
+fn short_payload_rejected() {
+    let (wh, mut contract) = proper_instantiate();
+
+    // payload < 4 bytes cannot carry an NTT prefix
+    let vaa = build_signed_vaa(&wh, 42, [0x77; 32], 0, &[0x01, 0x02]);
+    let err = contract
+        .submit_vaas(vec![vaa])
+        .expect_err("short payload should be rejected");
+    assert!(
+        err.root_cause()
+            .to_string()
+            .contains("payload prefix missing"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn unknown_prefix_rejected() {
+    let (wh, mut contract) = proper_instantiate();
+
+    // 4-byte prefix that matches none of the known NTT prefixes
+    let vaa = build_signed_vaa(&wh, 42, [0x77; 32], 0, &[0xDE, 0xAD, 0xBE, 0xEF]);
+    let err = contract
+        .submit_vaas(vec![vaa])
+        .expect_err("unknown prefix should be rejected");
+    assert!(
+        err.root_cause()
+            .to_string()
+            .contains("unsupported NTT action"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn info_malformed_payload_rejected() {
+    let (wh, mut contract) = proper_instantiate();
+
+    // INFO_PREFIX with truncated body
+    let mut payload = vec![0x9c, 0x23, 0xbd, 0x3b];
+    payload.extend_from_slice(&[0x11; 10]);
+    let vaa = build_signed_vaa(&wh, HUB_CHAIN, HUB_ADDR, 0, &payload);
+    let err = contract
+        .submit_vaas(vec![vaa])
+        .expect_err("malformed info payload should be rejected");
+    assert_eq!(
+        "failed to fill whole buffer",
+        err.root_cause().to_string().to_lowercase()
+    );
+}
+
+#[test]
+fn peer_info_malformed_payload_rejected() {
+    let (wh, mut contract) = proper_instantiate();
+    let mut seq = Seq::new();
+
+    let vaa = build_signed_vaa(&wh, HUB_CHAIN, HUB_ADDR, seq.next(), &hub_init_payload(0));
+    contract.submit_vaas(vec![vaa]).unwrap();
+
+    // PEER_INFO_PREFIX with truncated body (expects 2 + 32 bytes after prefix)
+    let mut payload = vec![0x18, 0xfc, 0x67, 0xc2];
+    payload.extend_from_slice(&[0x22; 10]);
+    let vaa = build_signed_vaa(&wh, HUB_CHAIN, HUB_ADDR, seq.next(), &payload);
+    let err = contract
+        .submit_vaas(vec![vaa])
+        .expect_err("malformed peer_info payload should be rejected");
+    assert_eq!(
+        "failed to fill whole buffer",
+        err.root_cause().to_string().to_lowercase()
+    );
+}
+
+#[test]
+fn transfer_malformed_payload_rejected() {
+    let (wh, mut contract) = proper_instantiate();
+    let mut seq = Seq::new();
+    setup_legitimate_network(&wh, &mut contract, &mut seq);
+
+    // WH_PREFIX with truncated TransceiverMessage body
+    let mut payload = vec![0x99, 0x45, 0xFF, 0x10];
+    payload.extend_from_slice(&[0u8; 8]);
+    let vaa = build_signed_vaa(&wh, HUB_CHAIN, HUB_ADDR, seq.next(), &payload);
+    let err = contract
+        .submit_vaas(vec![vaa])
+        .expect_err("malformed transfer payload should be rejected");
+    assert_eq!(
+        "failed to fill whole buffer",
+        err.root_cause().to_string().to_lowercase()
+    );
+}
+
+#[test]
+fn spoke_cannot_pre_register_unknown_peer() {
+    let (wh, mut contract) = proper_instantiate();
+    let mut seq = Seq::new();
+
+    let vaa = build_signed_vaa(&wh, HUB_CHAIN, HUB_ADDR, seq.next(), &hub_init_payload(0));
+    contract.submit_vaas(vec![vaa]).unwrap();
+    let vaa = build_signed_vaa(
+        &wh,
+        HUB_CHAIN,
+        HUB_ADDR,
+        seq.next(),
+        &registration_payload(SPOKE_CHAIN_A, SPOKE_ADDR_A),
+    );
+    contract.submit_vaas(vec![vaa]).unwrap();
+    let vaa = build_signed_vaa(
+        &wh,
+        SPOKE_CHAIN_A,
+        SPOKE_ADDR_A,
+        seq.next(),
+        &registration_payload(HUB_CHAIN, HUB_ADDR),
+    );
+    contract.submit_vaas(vec![vaa]).unwrap();
+
+    // spoke A has inherited the hub but is not a self-referential hub itself,
+    // so it cannot pre-register a peer that has no hub entry
+    let unknown_chain: u16 = 99;
+    let unknown_addr: [u8; 32] = [0x55; 32];
+    let vaa = build_signed_vaa(
+        &wh,
+        SPOKE_CHAIN_A,
+        SPOKE_ADDR_A,
+        seq.next(),
+        &registration_payload(unknown_chain, unknown_addr),
+    );
+    let err = contract
+        .submit_vaas(vec![vaa])
+        .expect_err("spoke should not be able to pre-register unknown peer");
+    assert!(
+        err.root_cause()
+            .to_string()
+            .contains("only hubs can register peers without hub registration"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn transfer_missing_source_peer_registration() {
+    let (wh, mut contract) = proper_instantiate();
+    let mut seq = Seq::new();
+
+    // init hub only — no peers registered
+    let vaa = build_signed_vaa(&wh, HUB_CHAIN, HUB_ADDR, seq.next(), &hub_init_payload(0));
+    contract.submit_vaas(vec![vaa]).unwrap();
+
+    let vaa = build_signed_vaa(
+        &wh,
+        HUB_CHAIN,
+        HUB_ADDR,
+        seq.next(),
+        &transfer_payload(8, 1000, SPOKE_CHAIN_A),
+    );
+    let err = contract
+        .submit_vaas(vec![vaa])
+        .expect_err("missing source peer should be rejected");
+    assert!(
+        err.root_cause()
+            .to_string()
+            .contains("no registered source peer"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn transfer_missing_destination_peer_registration() {
+    let (wh, mut contract) = proper_instantiate();
+    let mut seq = Seq::new();
+
+    // init hub, pre-register spoke A, but spoke A never inherits back
+    let vaa = build_signed_vaa(&wh, HUB_CHAIN, HUB_ADDR, seq.next(), &hub_init_payload(0));
+    contract.submit_vaas(vec![vaa]).unwrap();
+    let vaa = build_signed_vaa(
+        &wh,
+        HUB_CHAIN,
+        HUB_ADDR,
+        seq.next(),
+        &registration_payload(SPOKE_CHAIN_A, SPOKE_ADDR_A),
+    );
+    contract.submit_vaas(vec![vaa]).unwrap();
+
+    // hub→spoke A transfer: source peer exists, dest peer doesn't (A never inherited)
+    let vaa = build_signed_vaa(
+        &wh,
+        HUB_CHAIN,
+        HUB_ADDR,
+        seq.next(),
+        &transfer_payload(8, 1000, SPOKE_CHAIN_A),
+    );
+    let err = contract
+        .submit_vaas(vec![vaa])
+        .expect_err("missing destination peer should be rejected");
+    assert!(
+        err.root_cause()
+            .to_string()
+            .contains("no registered destination peer"),
+        "unexpected error: {err}"
+    );
+}
+
+// The "peers are not cross-registered" branch at contract.rs:525 is a
+// defense-in-depth check. It is unreachable via legitimate VAAs: the emitter
+// authenticates the sender's own address, and the per-(chain, sender, peer-chain)
+// slot prevents a sender from registering two different peer addresses on the
+// same chain — so cross-registration is always symmetric when both sides exist.
+
+// --- DeliveryInstruction builder (relayer-wrapped payload) ---
+
+fn delivery_instruction_payload(sender: [u8; 32], inner_payload: &[u8]) -> Vec<u8> {
+    let mut p = Vec::new();
+    p.push(1); // DeliveryInstruction::PAYLOAD_ID
+    p.extend_from_slice(&0u16.to_be_bytes()); // target_chain
+    p.extend_from_slice(&[0u8; 32]); // target_address
+    p.extend_from_slice(&(inner_payload.len() as u32).to_be_bytes());
+    p.extend_from_slice(inner_payload);
+    p.extend_from_slice(&[0u8; 32]); // requested_reciever_value
+    p.extend_from_slice(&[0u8; 32]); // extra_reciever_value
+    p.extend_from_slice(&0u32.to_be_bytes()); // encoded_execution_info_len
+    p.extend_from_slice(&0u16.to_be_bytes()); // refund_chain_id
+    p.extend_from_slice(&[0u8; 32]); // refund_address
+    p.extend_from_slice(&[0u8; 32]); // refund_delivery_provider
+    p.extend_from_slice(&[0u8; 32]); // source_delivery_provider
+    p.extend_from_slice(&sender); // sender_address
+    p.push(0); // num_messages
+    p
+}
+
+fn register_relayer(wh: &WormholeKeeper, contract: &mut Contract, chain: u16, address: [u8; 32]) {
+    let body = Body {
+        timestamp: 0,
+        nonce: 0,
+        emitter_chain: Chain::Solana,
+        emitter_address: wormhole_sdk::GOVERNANCE_EMITTER,
+        sequence: 999_999,
+        consistency_level: 0,
+        payload: wormhole_sdk::relayer::GovernancePacket {
+            chain: Chain::Any,
+            action: wormhole_sdk::relayer::Action::RegisterChain {
+                chain: chain.into(),
+                emitter_address: Address(address),
+            },
+        },
+    };
+    let (_, data) = sign_vaa_body(wh, body);
+    contract.submit_vaas(vec![data]).unwrap();
+}
+
+#[test]
+fn relayer_wraps_hub_init() {
+    let (wh, mut contract) = proper_instantiate();
+    let mut seq = Seq::new();
+
+    // register a standard relayer for the hub chain
+    let relayer_addr: [u8; 32] = [0xEE; 32];
+    register_relayer(&wh, &mut contract, HUB_CHAIN, relayer_addr);
+
+    // VAA from the relayer whose DeliveryInstruction wraps a hub init message,
+    // with sender_address = HUB_ADDR. The hub should register successfully.
+    let inner = hub_init_payload(0);
+    let wrapped = delivery_instruction_payload(HUB_ADDR, &inner);
+    let vaa = build_signed_vaa(&wh, HUB_CHAIN, relayer_addr, seq.next(), &wrapped);
+    contract.submit_vaas(vec![vaa]).unwrap();
+
+    // submitting the same init directly from HUB_ADDR should now be a duplicate
+    let vaa = build_signed_vaa(&wh, HUB_CHAIN, HUB_ADDR, seq.next(), &hub_init_payload(0));
+    let err = contract
+        .submit_vaas(vec![vaa])
+        .expect_err("hub was already registered via the relayer path");
+    assert!(
+        err.root_cause()
+            .to_string()
+            .contains("hub entry already exists"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn relayer_malformed_delivery_instruction_rejected() {
+    let (wh, mut contract) = proper_instantiate();
+    let mut seq = Seq::new();
+
+    let relayer_addr: [u8; 32] = [0xEE; 32];
+    register_relayer(&wh, &mut contract, HUB_CHAIN, relayer_addr);
+
+    // valid PAYLOAD_ID but truncated
+    let payload = vec![1u8, 0, 0];
+    let vaa = build_signed_vaa(&wh, HUB_CHAIN, relayer_addr, seq.next(), &payload);
+    contract
+        .submit_vaas(vec![vaa])
+        .expect_err("malformed delivery instruction should be rejected");
+}

--- a/cosmwasm/contracts/ntt-global-accountant/tests/ntt_registration.rs
+++ b/cosmwasm/contracts/ntt-global-accountant/tests/ntt_registration.rs
@@ -1,0 +1,739 @@
+mod helpers;
+
+use cosmwasm_std::Binary;
+use helpers::*;
+
+use accountant::state::account;
+use serde_wormhole::RawMessage;
+use wormhole_bindings::fake::WormholeKeeper;
+use wormhole_sdk::{
+    vaa::{Body, Header},
+    Address, Chain,
+};
+
+// --- Constants ---
+
+const HUB_CHAIN: u16 = 2; // Ethereum
+const HUB_ADDR: [u8; 32] = [0x42; 32];
+
+const SPOKE_CHAIN_A: u16 = 23; // Arbitrum
+const SPOKE_ADDR_A: [u8; 32] = [0x43; 32];
+
+const SPOKE_CHAIN_B: u16 = 30; // Base
+const SPOKE_ADDR_B: [u8; 32] = [0x44; 32];
+
+const ROGUE_ADDR_X: [u8; 32] = [0xAA; 32]; // rogue on SPOKE_CHAIN_A
+
+const DUMMY_MANAGER: [u8; 32] = [0x11; 32];
+const DUMMY_TOKEN: [u8; 32] = [0x22; 32];
+
+// --- Payload builders ---
+
+fn hub_init_payload(mode: u8) -> Vec<u8> {
+    let mut p = Vec::new();
+    p.extend_from_slice(&[0x9c, 0x23, 0xbd, 0x3b]); // INFO_PREFIX
+    p.extend_from_slice(&DUMMY_MANAGER); // manager_address
+    p.push(mode); // 0 = Locking, 1 = Burning
+    p.extend_from_slice(&DUMMY_TOKEN); // token_address
+    p.push(8); // token_decimals
+    p
+}
+
+fn registration_payload(chain_id: u16, addr: [u8; 32]) -> Vec<u8> {
+    let mut p = Vec::new();
+    p.extend_from_slice(&[0x18, 0xfc, 0x67, 0xc2]); // PEER_INFO_PREFIX
+    p.extend_from_slice(&chain_id.to_be_bytes());
+    p.extend_from_slice(&addr);
+    p
+}
+
+fn transfer_payload(decimals: u8, amount: u64, to_chain: u16) -> Vec<u8> {
+    // NativeTokenTransfer
+    let mut ntt = Vec::new();
+    ntt.extend_from_slice(&[0x99, 0x4E, 0x54, 0x54]); // NTT_PREFIX
+    ntt.push(decimals);
+    ntt.extend_from_slice(&amount.to_be_bytes());
+    ntt.extend_from_slice(&[0u8; 32]); // source_token
+    ntt.extend_from_slice(&[0u8; 32]); // to (recipient)
+    ntt.extend_from_slice(&to_chain.to_be_bytes());
+
+    // NttManagerMessage
+    let mut mgr = Vec::new();
+    mgr.extend_from_slice(&[0u8; 32]); // id
+    mgr.extend_from_slice(&[0u8; 32]); // sender
+    let ntt_len = ntt.len() as u16;
+    mgr.extend_from_slice(&ntt_len.to_be_bytes()); // payload_len
+    mgr.extend_from_slice(&ntt);
+
+    // TransceiverMessage
+    let mut p = Vec::new();
+    p.extend_from_slice(&[0x99, 0x45, 0xFF, 0x10]); // WH_PREFIX
+    p.extend_from_slice(&[0u8; 32]); // source_ntt_manager
+    p.extend_from_slice(&[0u8; 32]); // recipient_ntt_manager
+    let mgr_len = mgr.len() as u16;
+    p.extend_from_slice(&mgr_len.to_be_bytes()); // ntt_manager_payload_len
+    p.extend_from_slice(&mgr);
+    p.extend_from_slice(&0u16.to_be_bytes()); // transceiver_payload_len = 0
+    p
+}
+
+// --- VAA builder ---
+
+fn build_signed_vaa(
+    wh: &WormholeKeeper,
+    emitter_chain: u16,
+    emitter_address: [u8; 32],
+    seq: u64,
+    payload: &[u8],
+) -> Binary {
+    let body = Body {
+        timestamp: 0,
+        nonce: 0,
+        emitter_chain: Chain::from(emitter_chain),
+        emitter_address: Address(emitter_address),
+        sequence: seq,
+        consistency_level: 0,
+        payload: RawMessage::new(payload),
+    };
+
+    let body_bytes = serde_wormhole::to_vec(&body).unwrap();
+    let signatures = wh.sign(&body_bytes);
+
+    let header = Header {
+        version: 1,
+        guardian_set_index: wh.guardian_set_index(),
+        signatures,
+    };
+
+    let vaa = wormhole_sdk::Vaa {
+        version: header.version,
+        guardian_set_index: header.guardian_set_index,
+        signatures: header.signatures,
+        timestamp: body.timestamp,
+        nonce: body.nonce,
+        emitter_chain: body.emitter_chain,
+        emitter_address: body.emitter_address,
+        sequence: body.sequence,
+        consistency_level: body.consistency_level,
+        payload: RawMessage::new(payload),
+    };
+
+    serde_wormhole::to_vec(&vaa).map(Binary::from).unwrap()
+}
+
+// --- Sequence counter ---
+
+struct Seq(u64);
+impl Seq {
+    fn new() -> Self {
+        Self(0)
+    }
+    fn next(&mut self) -> u64 {
+        let v = self.0;
+        self.0 += 1;
+        v
+    }
+}
+
+// --- Helper to set up the legitimate hub + two spokes ---
+
+fn setup_legitimate_network(wh: &WormholeKeeper, contract: &mut Contract, seq: &mut Seq) {
+    // 1. Hub init (locking mode)
+    let vaa = build_signed_vaa(wh, HUB_CHAIN, HUB_ADDR, seq.next(), &hub_init_payload(0));
+    contract.submit_vaas(vec![vaa]).unwrap();
+
+    // 2. Hub pre-registers spoke A (hub can register peers that don't have a hub yet)
+    let vaa = build_signed_vaa(
+        wh,
+        HUB_CHAIN,
+        HUB_ADDR,
+        seq.next(),
+        &registration_payload(SPOKE_CHAIN_A, SPOKE_ADDR_A),
+    );
+    contract.submit_vaas(vec![vaa]).unwrap();
+
+    // 3. Spoke A registers hub → inherits hub (hub has pre-registered spoke A)
+    let vaa = build_signed_vaa(
+        wh,
+        SPOKE_CHAIN_A,
+        SPOKE_ADDR_A,
+        seq.next(),
+        &registration_payload(HUB_CHAIN, HUB_ADDR),
+    );
+    contract.submit_vaas(vec![vaa]).unwrap();
+
+    // 4. Hub pre-registers spoke B
+    let vaa = build_signed_vaa(
+        wh,
+        HUB_CHAIN,
+        HUB_ADDR,
+        seq.next(),
+        &registration_payload(SPOKE_CHAIN_B, SPOKE_ADDR_B),
+    );
+    contract.submit_vaas(vec![vaa]).unwrap();
+
+    // 5. Spoke B registers hub → inherits hub (hub has pre-registered spoke B)
+    let vaa = build_signed_vaa(
+        wh,
+        SPOKE_CHAIN_B,
+        SPOKE_ADDR_B,
+        seq.next(),
+        &registration_payload(HUB_CHAIN, HUB_ADDR),
+    );
+    contract.submit_vaas(vec![vaa]).unwrap();
+
+    // 6. Cross-register spokes (both have hubs now, hubs match)
+    let vaa = build_signed_vaa(
+        wh,
+        SPOKE_CHAIN_A,
+        SPOKE_ADDR_A,
+        seq.next(),
+        &registration_payload(SPOKE_CHAIN_B, SPOKE_ADDR_B),
+    );
+    contract.submit_vaas(vec![vaa]).unwrap();
+
+    let vaa = build_signed_vaa(
+        wh,
+        SPOKE_CHAIN_B,
+        SPOKE_ADDR_B,
+        seq.next(),
+        &registration_payload(SPOKE_CHAIN_A, SPOKE_ADDR_A),
+    );
+    contract.submit_vaas(vec![vaa]).unwrap();
+}
+
+fn account_key(chain: u16) -> account::Key {
+    account::Key::new(
+        chain,
+        HUB_CHAIN,
+        accountant::state::TokenAddress::new(HUB_ADDR),
+    )
+}
+
+// ============================================================
+// 1. Legitimate registration & transfer tests
+// ============================================================
+
+#[test]
+fn legitimate_hub_init_locking() {
+    let (wh, mut contract) = proper_instantiate();
+    let mut seq = Seq::new();
+
+    let vaa = build_signed_vaa(&wh, HUB_CHAIN, HUB_ADDR, seq.next(), &hub_init_payload(0));
+    contract.submit_vaas(vec![vaa]).unwrap();
+}
+
+#[test]
+fn hub_init_burning_rejected() {
+    let (wh, mut contract) = proper_instantiate();
+    let mut seq = Seq::new();
+
+    let vaa = build_signed_vaa(&wh, HUB_CHAIN, HUB_ADDR, seq.next(), &hub_init_payload(1));
+    let err = contract
+        .submit_vaas(vec![vaa])
+        .expect_err("burning hub should be rejected");
+    assert!(
+        err.root_cause()
+            .to_string()
+            .contains("ignoring non-locking NTT initialization"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn duplicate_hub_init_rejected() {
+    let (wh, mut contract) = proper_instantiate();
+    let mut seq = Seq::new();
+
+    let vaa = build_signed_vaa(&wh, HUB_CHAIN, HUB_ADDR, seq.next(), &hub_init_payload(0));
+    contract.submit_vaas(vec![vaa]).unwrap();
+
+    let vaa = build_signed_vaa(&wh, HUB_CHAIN, HUB_ADDR, seq.next(), &hub_init_payload(0));
+    let err = contract
+        .submit_vaas(vec![vaa])
+        .expect_err("duplicate hub init should fail");
+    assert!(
+        err.root_cause()
+            .to_string()
+            .contains("hub entry already exists"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn spoke_registers_hub_and_inherits() {
+    let (wh, mut contract) = proper_instantiate();
+    let mut seq = Seq::new();
+
+    // Init hub
+    let vaa = build_signed_vaa(&wh, HUB_CHAIN, HUB_ADDR, seq.next(), &hub_init_payload(0));
+    contract.submit_vaas(vec![vaa]).unwrap();
+
+    // Hub pre-registers spoke
+    let vaa = build_signed_vaa(
+        &wh,
+        HUB_CHAIN,
+        HUB_ADDR,
+        seq.next(),
+        &registration_payload(SPOKE_CHAIN_A, SPOKE_ADDR_A),
+    );
+    contract.submit_vaas(vec![vaa]).unwrap();
+
+    // Spoke registers hub → should inherit
+    let vaa = build_signed_vaa(
+        &wh,
+        SPOKE_CHAIN_A,
+        SPOKE_ADDR_A,
+        seq.next(),
+        &registration_payload(HUB_CHAIN, HUB_ADDR),
+    );
+    contract.submit_vaas(vec![vaa]).unwrap();
+}
+
+#[test]
+fn spoke_registers_hub_without_preregistration_rejected() {
+    let (wh, mut contract) = proper_instantiate();
+    let mut seq = Seq::new();
+
+    // Init hub
+    let vaa = build_signed_vaa(&wh, HUB_CHAIN, HUB_ADDR, seq.next(), &hub_init_payload(0));
+    contract.submit_vaas(vec![vaa]).unwrap();
+
+    // Spoke tries to register hub WITHOUT hub pre-registering the spoke first
+    let vaa = build_signed_vaa(
+        &wh,
+        SPOKE_CHAIN_A,
+        SPOKE_ADDR_A,
+        seq.next(),
+        &registration_payload(HUB_CHAIN, HUB_ADDR),
+    );
+    let err = contract
+        .submit_vaas(vec![vaa])
+        .expect_err("should require hub pre-registration");
+    assert!(
+        err.root_cause()
+            .to_string()
+            .contains("hub has not registered this transceiver as a peer"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn registration_to_peer_without_hub_rejected() {
+    let (wh, mut contract) = proper_instantiate();
+    let mut seq = Seq::new();
+
+    // Try to register a peer when neither sender nor peer has a hub entry
+    let vaa = build_signed_vaa(
+        &wh,
+        SPOKE_CHAIN_A,
+        SPOKE_ADDR_A,
+        seq.next(),
+        &registration_payload(SPOKE_CHAIN_B, SPOKE_ADDR_B),
+    );
+    let err = contract
+        .submit_vaas(vec![vaa])
+        .expect_err("should fail without hub");
+    assert!(
+        err.root_cause().to_string().contains("no registered hub"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn registration_to_non_hub_without_own_hub_rejected() {
+    let (wh, mut contract) = proper_instantiate();
+    let mut seq = Seq::new();
+
+    // Init hub, pre-register spoke A, then spoke A registers hub
+    let vaa = build_signed_vaa(&wh, HUB_CHAIN, HUB_ADDR, seq.next(), &hub_init_payload(0));
+    contract.submit_vaas(vec![vaa]).unwrap();
+
+    let vaa = build_signed_vaa(
+        &wh,
+        HUB_CHAIN,
+        HUB_ADDR,
+        seq.next(),
+        &registration_payload(SPOKE_CHAIN_A, SPOKE_ADDR_A),
+    );
+    contract.submit_vaas(vec![vaa]).unwrap();
+
+    let vaa = build_signed_vaa(
+        &wh,
+        SPOKE_CHAIN_A,
+        SPOKE_ADDR_A,
+        seq.next(),
+        &registration_payload(HUB_CHAIN, HUB_ADDR),
+    );
+    contract.submit_vaas(vec![vaa]).unwrap();
+
+    // Spoke B (no hub yet) tries to register spoke A (not a hub) → rejected
+    let vaa = build_signed_vaa(
+        &wh,
+        SPOKE_CHAIN_B,
+        SPOKE_ADDR_B,
+        seq.next(),
+        &registration_payload(SPOKE_CHAIN_A, SPOKE_ADDR_A),
+    );
+    let err = contract
+        .submit_vaas(vec![vaa])
+        .expect_err("non-hub registration should fail");
+    assert!(
+        err.root_cause()
+            .to_string()
+            .contains("ignoring attempt to register peer before hub"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn hub_mismatch_rejected() {
+    let (wh, mut contract) = proper_instantiate();
+    let mut seq = Seq::new();
+
+    // Init two different hubs
+    let vaa = build_signed_vaa(&wh, HUB_CHAIN, HUB_ADDR, seq.next(), &hub_init_payload(0));
+    contract.submit_vaas(vec![vaa]).unwrap();
+
+    let other_hub: [u8; 32] = [0xFF; 32];
+    let vaa = build_signed_vaa(&wh, 420, other_hub, seq.next(), &hub_init_payload(0));
+    contract.submit_vaas(vec![vaa]).unwrap();
+
+    // Hub pre-registers spoke A, then spoke A inherits first hub
+    let vaa = build_signed_vaa(
+        &wh,
+        HUB_CHAIN,
+        HUB_ADDR,
+        seq.next(),
+        &registration_payload(SPOKE_CHAIN_A, SPOKE_ADDR_A),
+    );
+    contract.submit_vaas(vec![vaa]).unwrap();
+
+    let vaa = build_signed_vaa(
+        &wh,
+        SPOKE_CHAIN_A,
+        SPOKE_ADDR_A,
+        seq.next(),
+        &registration_payload(HUB_CHAIN, HUB_ADDR),
+    );
+    contract.submit_vaas(vec![vaa]).unwrap();
+
+    // Spoke A tries to register peer from different hub → mismatch
+    let vaa = build_signed_vaa(
+        &wh,
+        SPOKE_CHAIN_A,
+        SPOKE_ADDR_A,
+        seq.next(),
+        &registration_payload(420, other_hub),
+    );
+    let err = contract
+        .submit_vaas(vec![vaa])
+        .expect_err("hub mismatch should fail");
+    assert!(
+        err.root_cause()
+            .to_string()
+            .contains("peer hub does not match"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn duplicate_peer_registration_rejected() {
+    let (wh, mut contract) = proper_instantiate();
+    let mut seq = Seq::new();
+
+    let vaa = build_signed_vaa(&wh, HUB_CHAIN, HUB_ADDR, seq.next(), &hub_init_payload(0));
+    contract.submit_vaas(vec![vaa]).unwrap();
+
+    // Hub pre-registers spoke A
+    let vaa = build_signed_vaa(
+        &wh,
+        HUB_CHAIN,
+        HUB_ADDR,
+        seq.next(),
+        &registration_payload(SPOKE_CHAIN_A, SPOKE_ADDR_A),
+    );
+    contract.submit_vaas(vec![vaa]).unwrap();
+
+    // Spoke A registers hub → inherits
+    let vaa = build_signed_vaa(
+        &wh,
+        SPOKE_CHAIN_A,
+        SPOKE_ADDR_A,
+        seq.next(),
+        &registration_payload(HUB_CHAIN, HUB_ADDR),
+    );
+    contract.submit_vaas(vec![vaa]).unwrap();
+
+    // Try same registration again (different VAA sequence, but same peer slot)
+    let vaa = build_signed_vaa(
+        &wh,
+        SPOKE_CHAIN_A,
+        SPOKE_ADDR_A,
+        seq.next(),
+        &registration_payload(HUB_CHAIN, HUB_ADDR),
+    );
+    let err = contract
+        .submit_vaas(vec![vaa])
+        .expect_err("duplicate should fail");
+    assert!(
+        err.root_cause()
+            .to_string()
+            .contains("peer entry for this chain already exists"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn legitimate_hub_to_spoke_transfer() {
+    let (wh, mut contract) = proper_instantiate();
+    let mut seq = Seq::new();
+    setup_legitimate_network(&wh, &mut contract, &mut seq);
+
+    // Transfer 1000 from hub to spoke A
+    let vaa = build_signed_vaa(
+        &wh,
+        HUB_CHAIN,
+        HUB_ADDR,
+        seq.next(),
+        &transfer_payload(8, 1000, SPOKE_CHAIN_A),
+    );
+    contract.submit_vaas(vec![vaa]).unwrap();
+
+    // Hub balance should be 1000 (locked)
+    let bal = contract.query_balance(account_key(HUB_CHAIN)).unwrap();
+    assert_eq!(*bal, cosmwasm_std::Uint256::from(1000u128));
+
+    // Spoke A balance should be 1000 (minted)
+    let bal = contract.query_balance(account_key(SPOKE_CHAIN_A)).unwrap();
+    assert_eq!(*bal, cosmwasm_std::Uint256::from(1000u128));
+}
+
+#[test]
+fn legitimate_spoke_to_hub_transfer() {
+    let (wh, mut contract) = proper_instantiate();
+    let mut seq = Seq::new();
+    setup_legitimate_network(&wh, &mut contract, &mut seq);
+
+    // Seed: hub → spoke A (1000)
+    let vaa = build_signed_vaa(
+        &wh,
+        HUB_CHAIN,
+        HUB_ADDR,
+        seq.next(),
+        &transfer_payload(8, 1000, SPOKE_CHAIN_A),
+    );
+    contract.submit_vaas(vec![vaa]).unwrap();
+
+    // Spoke A → hub (400)
+    let vaa = build_signed_vaa(
+        &wh,
+        SPOKE_CHAIN_A,
+        SPOKE_ADDR_A,
+        seq.next(),
+        &transfer_payload(8, 400, HUB_CHAIN),
+    );
+    contract.submit_vaas(vec![vaa]).unwrap();
+
+    // Hub: 1000 - 400 = 600
+    let bal = contract.query_balance(account_key(HUB_CHAIN)).unwrap();
+    assert_eq!(*bal, cosmwasm_std::Uint256::from(600u128));
+
+    // Spoke A: 1000 - 400 = 600
+    let bal = contract.query_balance(account_key(SPOKE_CHAIN_A)).unwrap();
+    assert_eq!(*bal, cosmwasm_std::Uint256::from(600u128));
+}
+
+#[test]
+fn legitimate_spoke_to_spoke_transfer() {
+    let (wh, mut contract) = proper_instantiate();
+    let mut seq = Seq::new();
+    setup_legitimate_network(&wh, &mut contract, &mut seq);
+
+    // Seed: hub → spoke A (1000)
+    let vaa = build_signed_vaa(
+        &wh,
+        HUB_CHAIN,
+        HUB_ADDR,
+        seq.next(),
+        &transfer_payload(8, 1000, SPOKE_CHAIN_A),
+    );
+    contract.submit_vaas(vec![vaa]).unwrap();
+
+    // Spoke A → spoke B (300)
+    let vaa = build_signed_vaa(
+        &wh,
+        SPOKE_CHAIN_A,
+        SPOKE_ADDR_A,
+        seq.next(),
+        &transfer_payload(8, 300, SPOKE_CHAIN_B),
+    );
+    contract.submit_vaas(vec![vaa]).unwrap();
+
+    // Spoke A: 1000 - 300 = 700
+    let bal = contract.query_balance(account_key(SPOKE_CHAIN_A)).unwrap();
+    assert_eq!(*bal, cosmwasm_std::Uint256::from(700u128));
+
+    // Spoke B: 0 + 300 = 300
+    let bal = contract.query_balance(account_key(SPOKE_CHAIN_B)).unwrap();
+    assert_eq!(*bal, cosmwasm_std::Uint256::from(300u128));
+}
+
+#[test]
+fn single_rogue_blocked_at_hub_inheritance() {
+    let (wh, mut contract) = proper_instantiate();
+    let mut seq = Seq::new();
+    setup_legitimate_network(&wh, &mut contract, &mut seq);
+
+    // Seed: hub → spoke A (1000)
+    let vaa = build_signed_vaa(
+        &wh,
+        HUB_CHAIN,
+        HUB_ADDR,
+        seq.next(),
+        &transfer_payload(8, 1000, SPOKE_CHAIN_A),
+    );
+    contract.submit_vaas(vec![vaa]).unwrap();
+
+    // Rogue on spoke A's chain tries to register the hub → blocked at inheritance
+    let vaa = build_signed_vaa(
+        &wh,
+        SPOKE_CHAIN_A,
+        ROGUE_ADDR_X,
+        seq.next(),
+        &registration_payload(HUB_CHAIN, HUB_ADDR),
+    );
+    let err = contract
+        .submit_vaas(vec![vaa])
+        .expect_err("rogue should be blocked at inheritance");
+    assert!(
+        err.root_cause()
+            .to_string()
+            .contains("hub has not registered this transceiver as a peer"),
+        "unexpected error: {err}"
+    );
+}
+
+// ============================================================
+// 2. Rogue emitter attack (Scenario A)
+// ============================================================
+
+#[test]
+fn rogue_hub_inheritance_blocked_without_preregistration() {
+    let (wh, mut contract) = proper_instantiate();
+    let mut seq = Seq::new();
+    setup_legitimate_network(&wh, &mut contract, &mut seq);
+
+    // Rogue X (on spoke chain A) tries to register hub → blocked because hub
+    // has not pre-registered the rogue
+    let vaa = build_signed_vaa(
+        &wh,
+        SPOKE_CHAIN_A,
+        ROGUE_ADDR_X,
+        seq.next(),
+        &registration_payload(HUB_CHAIN, HUB_ADDR),
+    );
+    let err = contract
+        .submit_vaas(vec![vaa])
+        .expect_err("rogue should not inherit hub");
+    assert!(
+        err.root_cause()
+            .to_string()
+            .contains("hub has not registered this transceiver as a peer"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn rogue_pair_transfer_blocked() {
+    let (wh, mut contract) = proper_instantiate();
+    let mut seq = Seq::new();
+    setup_legitimate_network(&wh, &mut contract, &mut seq);
+
+    // Seed legitimate balance: hub → spoke A (1000)
+    let vaa = build_signed_vaa(
+        &wh,
+        HUB_CHAIN,
+        HUB_ADDR,
+        seq.next(),
+        &transfer_payload(8, 1000, SPOKE_CHAIN_A),
+    );
+    contract.submit_vaas(vec![vaa]).unwrap();
+
+    // Verify initial state
+    let bal = contract.query_balance(account_key(SPOKE_CHAIN_A)).unwrap();
+    assert_eq!(*bal, cosmwasm_std::Uint256::from(1000u128));
+
+    // Rogue X tries to inherit hub → blocked
+    let vaa = build_signed_vaa(
+        &wh,
+        SPOKE_CHAIN_A,
+        ROGUE_ADDR_X,
+        seq.next(),
+        &registration_payload(HUB_CHAIN, HUB_ADDR),
+    );
+    let err = contract
+        .submit_vaas(vec![vaa])
+        .expect_err("rogue should not inherit hub");
+    assert!(
+        err.root_cause()
+            .to_string()
+            .contains("hub has not registered this transceiver as a peer"),
+        "unexpected error: {err}"
+    );
+
+    // Without hub inheritance, the rogue can't even attempt a transfer
+    // (it has no hub registration, so the transfer would fail at hub load)
+    let vaa = build_signed_vaa(
+        &wh,
+        SPOKE_CHAIN_A,
+        ROGUE_ADDR_X,
+        seq.next(),
+        &transfer_payload(8, 400, SPOKE_CHAIN_B),
+    );
+    let err = contract
+        .submit_vaas(vec![vaa])
+        .expect_err("rogue transfer should fail");
+    assert!(
+        err.root_cause().to_string().contains("no registered hub"),
+        "unexpected error: {err}"
+    );
+
+    // Legitimate balance is untouched
+    let bal = contract.query_balance(account_key(SPOKE_CHAIN_A)).unwrap();
+    assert_eq!(*bal, cosmwasm_std::Uint256::from(1000u128));
+}
+
+// ============================================================
+// 3. Scenario B is impossible (rogue on hub chain)
+// ============================================================
+
+#[test]
+fn rogue_on_hub_chain_blocked_at_inheritance() {
+    let (wh, mut contract) = proper_instantiate();
+    let mut seq = Seq::new();
+
+    // Init hub
+    let vaa = build_signed_vaa(&wh, HUB_CHAIN, HUB_ADDR, seq.next(), &hub_init_payload(0));
+    contract.submit_vaas(vec![vaa]).unwrap();
+
+    let rogue_on_hub: [u8; 32] = [0xCC; 32];
+
+    // Rogue on hub chain tries to register hub → blocked because hub hasn't pre-registered it
+    let vaa = build_signed_vaa(
+        &wh,
+        HUB_CHAIN,
+        rogue_on_hub,
+        seq.next(),
+        &registration_payload(HUB_CHAIN, HUB_ADDR),
+    );
+    let err = contract
+        .submit_vaas(vec![vaa])
+        .expect_err("rogue should not inherit hub");
+    assert!(
+        err.root_cause()
+            .to_string()
+            .contains("hub has not registered this transceiver as a peer"),
+        "unexpected error: {err}"
+    );
+}

--- a/cosmwasm/contracts/ntt-global-accountant/tests/ntt_registration.rs
+++ b/cosmwasm/contracts/ntt-global-accountant/tests/ntt_registration.rs
@@ -645,6 +645,60 @@ fn rogue_hub_inheritance_blocked_without_preregistration() {
 }
 
 #[test]
+fn inheritance_blocked_known_chain_unknown_address() {
+    let (wh, mut contract) = proper_instantiate();
+    let mut seq = Seq::new();
+    setup_legitimate_network(&wh, &mut contract, &mut seq);
+
+    // Hub pre-registered (SPOKE_CHAIN_A, SPOKE_ADDR_A); a different address on
+    // that same chain must still be blocked at inheritance.
+    let vaa = build_signed_vaa(
+        &wh,
+        SPOKE_CHAIN_A,
+        ROGUE_ADDR_X,
+        seq.next(),
+        &registration_payload(HUB_CHAIN, HUB_ADDR),
+    );
+    let err = contract
+        .submit_vaas(vec![vaa])
+        .expect_err("known chain + unknown address should fail");
+    assert!(
+        err.root_cause()
+            .to_string()
+            .contains("hub has not registered this transceiver as a peer"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn inheritance_blocked_unknown_chain_known_address() {
+    let (wh, mut contract) = proper_instantiate();
+    let mut seq = Seq::new();
+    setup_legitimate_network(&wh, &mut contract, &mut seq);
+
+    // SPOKE_ADDR_A is the registered transceiver address on SPOKE_CHAIN_A; a
+    // VAA carrying that address from a chain the hub has not pre-registered
+    // must produce the same error as the known-chain/unknown-address case.
+    let unregistered_chain: u16 = 99;
+    let vaa = build_signed_vaa(
+        &wh,
+        unregistered_chain,
+        SPOKE_ADDR_A,
+        seq.next(),
+        &registration_payload(HUB_CHAIN, HUB_ADDR),
+    );
+    let err = contract
+        .submit_vaas(vec![vaa])
+        .expect_err("unknown chain + known address should fail");
+    assert!(
+        err.root_cause()
+            .to_string()
+            .contains("hub has not registered this transceiver as a peer"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
 fn rogue_pair_transfer_blocked() {
     let (wh, mut contract) = proper_instantiate();
     let mut seq = Seq::new();

--- a/wormchain/contracts/tools/__tests__/test_ntt_accountant.ts
+++ b/wormchain/contracts/tools/__tests__/test_ntt_accountant.ts
@@ -123,6 +123,8 @@ const FAUX_SPOKE_TRANSCEIVER_A = FAUX_HUB_TRANSCEIVER;
 const UNKNOWN_SPOKE_CHAIN = 404;
 const UNKNOWN_SPOKE_TRANSCEIVER =
   "beeffacebeeffacebeeffacebeeffacebeeffacebeeffacebeeffacebeefface";
+const DEST_ONLY_SPOKE_CHAIN = 6;
+const DEST_ONLY_SPOKE_TRANSCEIVER = `0000000000000000000000000000000000000000000000000000000000000046`;
 const RELAYER_ADDRESS = ci
   ? "0xb98F46E96cb1F519C333FdFB5CCe0B13E0300ED4"
   : "0xcC680D088586c09c3E0E099a676FA4b6e42467b4";
@@ -378,17 +380,39 @@ describe("NTT Global Accountant Tests", () => {
     });
   });
   describe("2. Registrations", () => {
-    test("a. Ensure a hub registration to an transceiver without a known hub is rejected", async () => {
+    test("a. Ensure a hub can pre-register a transceiver", async () => {
       const vaa = makeVAA(
         HUB_CHAIN,
         HUB_TRANSCEIVER,
         `18fc67c2${chainToHex(SPOKE_CHAIN_A)}${SPOKE_TRANSCEIVER_A}`
       );
       const result = await submitVAA(vaa);
-      expect(result.code).toEqual(5);
-      expect(result.rawLog).toMatch("no registered hub");
+      expect(result.code).toEqual(0);
+      const response = await cosmWasmClient.queryContractSmart(NTT_GA_ADDRESS, {
+        all_transceiver_peers: {},
+      });
+      const peer = response.peers.find(
+        (entry) =>
+          entry.key[0] === HUB_CHAIN &&
+          entry.key[1] === HUB_TRANSCEIVER &&
+          entry.key[2] === SPOKE_CHAIN_A
+      );
+      expect(peer).toBeDefined();
+      expect(peer.data).toStrictEqual(SPOKE_TRANSCEIVER_A);
     });
-    test("b. Ensure an transceiver registration to a hub is saved", async () => {
+    test("b. Ensure a transceiver registration to a hub without pre-registration is rejected", async () => {
+      const vaa = makeVAA(
+        SPOKE_CHAIN_B,
+        SPOKE_TRANSCEIVER_B,
+        `18fc67c2${chainToHex(HUB_CHAIN)}${HUB_TRANSCEIVER}`
+      );
+      const result = await submitVAA(vaa);
+      expect(result.code).toEqual(5);
+      expect(result.rawLog).toMatch(
+        "hub has not registered this transceiver as a peer"
+      );
+    });
+    test("c. Ensure a transceiver registration to a hub with pre-registration is saved", async () => {
       const vaa = makeVAA(
         SPOKE_CHAIN_A,
         SPOKE_TRANSCEIVER_A,
@@ -414,27 +438,7 @@ describe("NTT Global Accountant Tests", () => {
         expect(result.rawLog).toMatch("message already processed");
       }
     });
-    test("c. Ensure a hub registration to an transceiver with a known hub is saved", async () => {
-      const vaa = makeVAA(
-        HUB_CHAIN,
-        HUB_TRANSCEIVER,
-        `18fc67c2${chainToHex(SPOKE_CHAIN_A)}${SPOKE_TRANSCEIVER_A}`
-      );
-      const result = await submitVAA(vaa);
-      expect(result.code).toEqual(0);
-      const response = await cosmWasmClient.queryContractSmart(NTT_GA_ADDRESS, {
-        all_transceiver_peers: {},
-      });
-      const peer = response.peers.find(
-        (entry) =>
-          entry.key[0] === HUB_CHAIN &&
-          entry.key[1] === HUB_TRANSCEIVER &&
-          entry.key[2] === SPOKE_CHAIN_A
-      );
-      expect(peer).toBeDefined();
-      expect(peer.data).toStrictEqual(SPOKE_TRANSCEIVER_A);
-    });
-    test("d. Ensure an transceiver registration to another transceiver without a known hub is rejected", async () => {
+    test("d. Ensure a non-hub transceiver cannot pre-register an unknown peer", async () => {
       const vaa = makeVAA(
         SPOKE_CHAIN_A,
         SPOKE_TRANSCEIVER_A,
@@ -442,7 +446,9 @@ describe("NTT Global Accountant Tests", () => {
       );
       const result = await submitVAA(vaa);
       expect(result.code).toEqual(5);
-      expect(result.rawLog).toMatch("no registered hub");
+      expect(result.rawLog).toMatch(
+        "only hubs can register peers without hub registration"
+      );
     });
     test("e. Ensure an transceiver registration from an transceiver without a known hub to a non-hub is rejected", async () => {
       const vaa = makeVAA(
@@ -458,6 +464,17 @@ describe("NTT Global Accountant Tests", () => {
     });
     test("f. Ensure an transceiver registration to another transceiver with a known hub is saved", async () => {
       {
+        // hub pre-registers spoke B
+        const vaa = makeVAA(
+          HUB_CHAIN,
+          HUB_TRANSCEIVER,
+          `18fc67c2${chainToHex(SPOKE_CHAIN_B)}${SPOKE_TRANSCEIVER_B}`
+        );
+        const result = await submitVAA(vaa);
+        expect(result.code).toEqual(0);
+      }
+      {
+        // spoke B registers hub → inherits
         const vaa = makeVAA(
           SPOKE_CHAIN_B,
           SPOKE_TRANSCEIVER_B,
@@ -481,6 +498,7 @@ describe("NTT Global Accountant Tests", () => {
         expect(peer.data).toStrictEqual(HUB_TRANSCEIVER);
       }
       {
+        // spoke A registers spoke B (hubs match)
         const vaa = makeVAA(
           SPOKE_CHAIN_A,
           SPOKE_TRANSCEIVER_A,
@@ -619,28 +637,26 @@ describe("NTT Global Accountant Tests", () => {
         "no registered source peer for chain Ethereum"
       );
     });
-    test("g. Ensure a token sent from a source chain without a matching transceiver is rejected", async () => {
+    test("g. Ensure a token sent to a pre-registered peer that never inherited is rejected", async () => {
       {
-        // set faux spoke registration to hub but not vice-versa
-        {
-          const vaa = makeVAA(
-            FAUX_SPOKE_CHAIN_A,
-            FAUX_SPOKE_TRANSCEIVER_A,
-            `18fc67c2${chainToHex(FAUX_HUB_CHAIN)}${FAUX_HUB_TRANSCEIVER}`
-          );
-          const result = await submitVAA(vaa);
-          expect(result.code).toEqual(0);
-        }
+        // hub pre-registers a spoke that never inherits
+        const vaa = makeVAA(
+          HUB_CHAIN,
+          HUB_TRANSCEIVER,
+          `18fc67c2${chainToHex(DEST_ONLY_SPOKE_CHAIN)}${DEST_ONLY_SPOKE_TRANSCEIVER}`
+        );
+        const result = await submitVAA(vaa);
+        expect(result.code).toEqual(0);
       }
       const vaa = makeVAA(
-        FAUX_SPOKE_CHAIN_A,
-        FAUX_SPOKE_TRANSCEIVER_A,
-        mockTransferPayload(8, 1, FAUX_HUB_CHAIN)
+        HUB_CHAIN,
+        HUB_TRANSCEIVER,
+        mockTransferPayload(8, 1, DEST_ONLY_SPOKE_CHAIN)
       );
       const result = await submitVAA(vaa);
       expect(result.code).toEqual(5);
       expect(result.rawLog).toMatch(
-        "no registered destination peer for chain Bsc"
+        "no registered destination peer for chain Ethereum"
       );
     });
     test("h. Ensure a token sent to a destination chain without a known transceiver is rejected", async () => {
@@ -677,27 +693,18 @@ describe("NTT Global Accountant Tests", () => {
         "insufficient balance in source account: Overflow: Cannot Sub"
       );
     });
-    test("k. Ensure a rogue endpoint cannot complete a transfer", async () => {
-      {
-        // set faux spoke registration to legit hub but not vice-versa
-        {
-          const vaa = makeVAA(
-            SPOKE_CHAIN_A,
-            ROGUE_TRANSCEIVER_A,
-            `18fc67c2${chainToHex(HUB_CHAIN)}${HUB_TRANSCEIVER}`
-          );
-          const result = await submitVAA(vaa);
-          expect(result.code).toEqual(0);
-        }
-      }
+    test("k. Ensure a rogue endpoint cannot inherit a hub without pre-registration", async () => {
+      // rogue attempts to register the legit hub, but the hub never pre-registered it
       const vaa = makeVAA(
         SPOKE_CHAIN_A,
         ROGUE_TRANSCEIVER_A,
-        mockTransferPayload(8, 1, HUB_CHAIN)
+        `18fc67c2${chainToHex(HUB_CHAIN)}${HUB_TRANSCEIVER}`
       );
       const result = await submitVAA(vaa);
       expect(result.code).toEqual(5);
-      expect(result.rawLog).toMatch("peers are not cross-registered");
+      expect(result.rawLog).toMatch(
+        "hub has not registered this transceiver as a peer"
+      );
     });
   });
   describe("4. Relayers", () => {
@@ -834,56 +841,7 @@ describe("NTT Global Accountant Tests", () => {
         expect(hub.data).toStrictEqual([HUB_CHAIN, ETH_WALLET_EMITTER]);
       }
       {
-        // register the spokes with the hub
-        {
-          const vaa = makeVAA(
-            SPOKE_CHAIN_A,
-            BSC_WALLET_EMITTER,
-            `18fc67c2${chainToHex(HUB_CHAIN)}${ETH_WALLET_EMITTER}`
-          );
-          const result = await submitVAA(vaa);
-          expect(result.code).toEqual(0);
-          const response = await cosmWasmClient.queryContractSmart(
-            NTT_GA_ADDRESS,
-            {
-              all_transceiver_peers: {},
-            }
-          );
-          const peer = response.peers.find(
-            (entry) =>
-              entry.key[0] === SPOKE_CHAIN_A &&
-              entry.key[1] === BSC_WALLET_EMITTER &&
-              entry.key[2] === HUB_CHAIN
-          );
-          expect(peer).toBeDefined();
-          expect(peer.data).toStrictEqual(ETH_WALLET_EMITTER);
-        }
-        {
-          const vaa = makeVAA(
-            SPOKE_CHAIN_B,
-            ETH_WALLET_EMITTER,
-            `18fc67c2${chainToHex(HUB_CHAIN)}${ETH_WALLET_EMITTER}`
-          );
-          const result = await submitVAA(vaa);
-          expect(result.code).toEqual(0);
-          const response = await cosmWasmClient.queryContractSmart(
-            NTT_GA_ADDRESS,
-            {
-              all_transceiver_peers: {},
-            }
-          );
-          const peer = response.peers.find(
-            (entry) =>
-              entry.key[0] === SPOKE_CHAIN_B &&
-              entry.key[1] === ETH_WALLET_EMITTER &&
-              entry.key[2] === HUB_CHAIN
-          );
-          expect(peer).toBeDefined();
-          expect(peer.data).toStrictEqual(ETH_WALLET_EMITTER);
-        }
-      }
-      {
-        // register the hub with the spoke
+        // hub pre-registers the spokes
         {
           const vaa = makeVAA(
             HUB_CHAIN,
@@ -926,6 +884,55 @@ describe("NTT Global Accountant Tests", () => {
               entry.key[0] === HUB_CHAIN &&
               entry.key[1] === ETH_WALLET_EMITTER &&
               entry.key[2] === SPOKE_CHAIN_B
+          );
+          expect(peer).toBeDefined();
+          expect(peer.data).toStrictEqual(ETH_WALLET_EMITTER);
+        }
+      }
+      {
+        // spokes register the hub (inherit)
+        {
+          const vaa = makeVAA(
+            SPOKE_CHAIN_A,
+            BSC_WALLET_EMITTER,
+            `18fc67c2${chainToHex(HUB_CHAIN)}${ETH_WALLET_EMITTER}`
+          );
+          const result = await submitVAA(vaa);
+          expect(result.code).toEqual(0);
+          const response = await cosmWasmClient.queryContractSmart(
+            NTT_GA_ADDRESS,
+            {
+              all_transceiver_peers: {},
+            }
+          );
+          const peer = response.peers.find(
+            (entry) =>
+              entry.key[0] === SPOKE_CHAIN_A &&
+              entry.key[1] === BSC_WALLET_EMITTER &&
+              entry.key[2] === HUB_CHAIN
+          );
+          expect(peer).toBeDefined();
+          expect(peer.data).toStrictEqual(ETH_WALLET_EMITTER);
+        }
+        {
+          const vaa = makeVAA(
+            SPOKE_CHAIN_B,
+            ETH_WALLET_EMITTER,
+            `18fc67c2${chainToHex(HUB_CHAIN)}${ETH_WALLET_EMITTER}`
+          );
+          const result = await submitVAA(vaa);
+          expect(result.code).toEqual(0);
+          const response = await cosmWasmClient.queryContractSmart(
+            NTT_GA_ADDRESS,
+            {
+              all_transceiver_peers: {},
+            }
+          );
+          const peer = response.peers.find(
+            (entry) =>
+              entry.key[0] === SPOKE_CHAIN_B &&
+              entry.key[1] === ETH_WALLET_EMITTER &&
+              entry.key[2] === HUB_CHAIN
           );
           expect(peer).toBeDefined();
           expect(peer.data).toStrictEqual(ETH_WALLET_EMITTER);
@@ -1354,16 +1361,8 @@ describe("NTT Global Accountant Tests", () => {
       ).rejects.toThrow();
     });
     test("g. Ensure a token sent from a source chain without a matching transceiver is rejected", async () => {
-      {
-        // set faux spoke registration to hub but not vice-versa
-        const vaa = makeVAA(
-          FAUX_SPOKE_CHAIN_A,
-          ETH_WALLET_EMITTER,
-          `18fc67c2${chainToHex(HUB_CHAIN)}${BSC_WALLET_EMITTER}`
-        );
-        const result = await submitVAA(vaa);
-        expect(result.code).toEqual(0);
-      }
+      // in the new flow one-way registrations are impossible, so we skip the
+      // setup and rely on the rogue emitter having no hub at all
       const beforeMetrics = await fetchGlobalAccountantMetrics();
       const core = ethers_contracts.Implementation__factory.connect(
         CONTRACTS.DEVNET.bsc.core,


### PR DESCRIPTION
This PR updates the NTT accountant registration flow to be more clear and robust. I also generated some more test coverage.

---

## Coverage Report for `handle_ntt_vaa`

Ran `cargo llvm-cov` against `ntt-global-accountant` after the added tests.                     

### Uncovered lines in `handle_ntt_vaa` (contract.rs:471–662)

Only two lines remain uncovered:
- **Line 525** — `bail!("peers are not cross-registered")` — defense-in-depth branch; unreachable via legitimate VAAs because the emitter authenticates the sender's own address and the per-`(chain, sender, peer-chain)` slot prevents asymmetric cross-registration.
- **Line 601** — `?` on `TRANSCEIVER_TO_HUB.may_load(...)` — storage-error propagation; only triggers on a `cw-multi-test` storage failure, which can't happen in tests.

Every other branch in `handle_ntt_vaa` is covered.

### File-wide coverage

| File | Lines | Covered |
|---|---|---|
| `contract.rs` | 763 | 52.82% |
| `structs/relayer.rs` | 183 | 89.07% |
| `state.rs` | 68 | 57.35% |
| `error.rs` | 12 | 0% |
| `msg.rs` | 13 | 0% |
| **TOTAL** | **1039** | **58.23%** |

The overall `contract.rs` percentage is dragged down by other unrelated top-level functions (queries, migrate, admin paths ~lines 670–954) that aren't exercised by this test suite. `handle_ntt_vaa` itself is effectively fully covered.

### Reproduce

Prerequisites

```bash
rustup component add llvm-tools-preview
cargo install cargo-llvm-cov --locked
```

```bash
cd cosmwasm
cargo llvm-cov --package ntt-global-accountant --html
# open target/llvm-cov/html/index.html
```