### PR TITLE
ci: Allow Claude to check out fork PRs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Run Claude Code
         id: claude
         if: steps.auth.outputs.authorized == 'true'
-        uses: anthropics/claude-code-action@ade221fd1c400376a4799977d683a4eda09f9d7c # v1.0.60
+        uses: anthropics/claude-code-action@11a9dadd198803a0cea6bd53da3e0e8a762fc6ea # v1.0.108
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }} # zizmor: ignore[secrets-outside-env] -- secret gated via prior auth checks
           # Use the workflow token directly so the action does not need OIDC.


### PR DESCRIPTION
This was a Anthropic issue which was fixed in https://github.com/anthropics/claude-code-action/issues/962. Bumping the action version should fix this.

The action is still checking out the old pinned hash, so I can't verify it works here, but it should be a low risk change.