### PR TITLE
ci: Bump forge-std version

### DIFF
--- a/ethereum/Makefile
+++ b/ethereum/Makefile
@@ -36,7 +36,7 @@ forge_dependencies: lib/forge-std lib/openzeppelin-contracts
 
 lib/forge-std:
 	forge --version
-	forge install foundry-rs/forge-std@v1.5.5 --no-git
+	forge install foundry-rs/forge-std@v1.13.0 --no-git
 
 lib/openzeppelin-contracts:
 	forge --version


### PR DESCRIPTION
From what I understand with Claude's assistance is we are getting CI issues in the `ethereum` and `ethereum-upgrade` jobs because `ds-test` is a submodule of `forge-std` in version v1.5.5 and new git versions are stricter about validating submodule indexes during checkout.

I update the `forge-std` version to v1.13.0 which is the last version that supports the solc versions we use in the smart contracts and it also has `ds-test` inlined, so no more submodule checkout. 