### PR TITLE
ci: Relax delta for unit test coverage

### DIFF
--- a/scripts/coverage-check/README.md
+++ b/scripts/coverage-check/README.md
@@ -6,7 +6,7 @@ A minimal Go tool to enforce incremental test coverage improvements without bloc
 
 This tool enforces two simple rules:
 
-1. **No regression**: Packages in the baseline file must maintain their current coverage (within 0.2% tolerance)
+1. **No regression**: Packages in the baseline file must maintain their current coverage (within a configurable tolerance, see `coverageTolerance` in `main.go`)
 2. **New packages need tests**: Any new package in `pkg/` must have at least 10% test coverage
 
 ## How It Works
@@ -158,16 +158,12 @@ github.com/certusone/wormhole/node/pkg/supervisor 25.0  # Was 0.0
 
 ## Configuration
 
-Edit constants in `scripts/coverage-check/main.go`:
+Constants are defined at the top of `scripts/coverage-check/main.go` — those are the source of truth.
 
-```go
-const (
-    baselineFile       = ".coverage-baseline"        // Baseline file location (repo root)
-    coverageOutputFile = "coverage.txt"              // Where to read test coverage from (repo root)
-    minNewPkgCoverage  = 10.0                        // Minimum for new packages
-    coverageTolerance  = 0.2                         // Floating point tolerance for fresh-run variance
-)
-```
+| Constant | Purpose |
+|---|---|
+| `minNewPkgCoverage` | Minimum coverage % for new packages |
+| `coverageTolerance` | Allowed delta % before a regression or improvement is flagged |
 
 ### Command-line Flags
 

--- a/scripts/coverage-check/main.go
+++ b/scripts/coverage-check/main.go
@@ -15,7 +15,9 @@ const (
 	baselineFile       = ".coverage-baseline"
 	coverageOutputFile = "coverage.txt"
 	minNewPkgCoverage  = 10.0
-	coverageTolerance  = 0.2 // Allow 0.2% tolerance for fresh-run coverage variance
+	// Allow a 1.0% delta in test coverage. This is a trade-off for CI runs such that small formatting changes
+	// don't block a PR.
+	coverageTolerance  = 1.0 
 )
 
 // Colors for terminal output


### PR DESCRIPTION
The current code coverage skew is very tight, causing CI to fail even for small diffs that don't meaningfully reduce test coverage.

This bumps the skew up a bit so that there's less noise in the PR process.

e.g. https://github.com/wormhole-foundation/wormhole/actions/runs/25067571362/job/73439828216?pr=4711