### PR TITLE
node(svm-watcher): Remove unused code referring to Anchor version of core bridge

### DIFF
--- a/node/pkg/watchers/solana/client.go
+++ b/node/pkg/watchers/solana/client.go
@@ -129,21 +129,38 @@ type (
 		} `json:"params"`
 	}
 
+	// The two types below represent Go equivalent of the on-chain Solana structs corresponding
+	// to message publication accounts and the account data within those accounts.
+
 	// MessagePublicationAccount is the data structure used to deserialize Solana PostedMessage account data for
 	// both the reliable and unreliable message types.
 	// It corresponds to the `data` field of the Wormhole PostedMessage account.
+	// Keep this layout in sync with the Solana core bridge MessageData struct in
+	// solana/bridge/program/src/accounts/posted_message.rs.
 	MessagePublicationAccount struct {
-		VaaVersion       uint8
+		// VaaVersion corresponds to MessageData::vaa_version (u8).
+		VaaVersion uint8
+		// ConsistencyLevel corresponds to MessageData::consistency_level (u8).
 		ConsistencyLevel uint8
-		EmitterAuthority vaa.Address
-		MessageStatus    uint8
-		Gap              [3]byte
-		SubmissionTime   uint32
-		Nonce            uint32
-		Sequence         uint64
-		EmitterChain     uint16
-		EmitterAddress   vaa.Address
-		// Payload is the message payload. It is a variable-length byte array with no minimum length.
+		// VaaTime corresponds to MessageData::vaa_time (u32). The SVM core bridge's
+		// post_message and post_message_unreliable paths leave this field at zero for
+		// msg/msu accounts; post_vaa sets non-zero values on vaa-prefixed accounts.
+		// See https://github.com/wormhole-foundation/wormhole/blob/main/solana/bridge/program/src/api/post_message.rs
+		// and https://github.com/wormhole-foundation/wormhole/blob/main/solana/bridge/program/src/api/post_vaa.rs.
+		VaaTime uint32
+		// VaaSignatureAccount corresponds to MessageData::vaa_signature_account (Pubkey).
+		VaaSignatureAccount solana.PublicKey
+		// SubmissionTime corresponds to MessageData::submission_time (u32).
+		SubmissionTime uint32
+		// Nonce corresponds to MessageData::nonce (u32).
+		Nonce uint32
+		// Sequence corresponds to MessageData::sequence (u64).
+		Sequence uint64
+		// EmitterChain corresponds to MessageData::emitter_chain (u16).
+		EmitterChain uint16
+		// EmitterAddress corresponds to MessageData::emitter_address ([u8; 32]).
+		EmitterAddress vaa.Address
+		// Payload corresponds to MessageData::payload (Vec<u8>). It is a variable-length byte array with no minimum length.
 		// Messages using the Shim contract will have a payload of length 0.
 		Payload []byte
 	}
@@ -196,13 +213,8 @@ const (
 )
 
 var (
-	emptyAddressBytes = vaa.Address{}.Bytes()
-	emptyGapBytes     = []byte{0, 0, 0}
-
 	addressLookupTableProgramID = solana.MustPublicKeyFromBase58("AddressLookupTab1e1111111111111111111111111")
-)
 
-var (
 	solanaConnectionErrors = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "wormhole_solana_connection_errors_total",
@@ -1194,20 +1206,6 @@ func (s *SolanaWatcher) processMessageAccount(logger *zap.Logger, messageAccount
 			)
 		}
 		return
-	}
-
-	// As of 2023-11-09, Pythnet has a bug which is not zeroing out these fields appropriately. This carve out should be removed after a fix is deployed.
-	if s.chainID != vaa.ChainIDPythNet {
-		// SECURITY: ensure these fields are zeroed out. in the legacy solana program they were always zero, and in the 2023 rewrite they are zeroed once the account is finalized
-		if !bytes.Equal(proposal.EmitterAuthority.Bytes(), emptyAddressBytes) || proposal.MessageStatus != 0 || !bytes.Equal(proposal.Gap[:], emptyGapBytes) {
-			solanaAccountSkips.WithLabelValues(s.networkName, "unfinalized_account").Inc()
-			logger.Error(
-				"account is not finalized",
-				zap.Stringer("account", acc),
-				zap.String("data", messageAccountData.String()),
-			)
-			return
-		}
 	}
 
 	var txID []byte

--- a/node/pkg/watchers/solana/client_test.go
+++ b/node/pkg/watchers/solana/client_test.go
@@ -196,7 +196,9 @@ func Test_validateTransactionMeta(t *testing.T) {
 
 func TestParseMessagePublicationAccount(t *testing.T) {
 
-	// Define well-formed Solana mainnet PostedMessage account data for reliable and unreliable messages
+	// Define well-formed Solana mainnet PostedMessage account data for reliable and unreliable messages.
+	// The SVM core bridge leaves vaa_time at zero for msg/msu accounts; post_vaa writes
+	// non-zero vaa_time to vaa-prefixed accounts instead.
 	var (
 		// Solana mainnet PostedMessage account: `GU76rcJ4rgw5sZQ2efVRC4yUZyhwrVM6pTGs2kFhckYy`
 		validMessageAccountDataReliable, _ = hex.DecodeString("6d73670020000000000000000000000000000000000000000000000000000000000000000000000000404d836900000000f5de1400000000000100ec7372995d5cc8732397fb0ad35c0121e0eaa90d26f828a534cab54391b3a4f5850000000100000000000000000000000000000000000000000000000000009ed268a30dd700000000000000000000000089f4e8011c35831130c4c3ab95e53de9411d2fcc00040000000000000000000000006722b2c28d7d299b56a5febedbbe865a84ee0d7d00040000000000000000000000000000000000000000000000000000000000000000")
@@ -237,17 +239,16 @@ func TestParseMessagePublicationAccount(t *testing.T) {
 				return mustNewMessageAccountData(t, validMessageAccountDataReliable)
 			},
 			want: &MessagePublicationAccount{
-				VaaVersion:       0,
-				ConsistencyLevel: 32,
-				EmitterAuthority: vaa.Address{},
-				MessageStatus:    0,
-				Gap:              [3]byte{0, 0, 0},
-				SubmissionTime:   1770212672,
-				Nonce:            0,
-				Sequence:         1367797,
-				EmitterChain:     1,
-				EmitterAddress:   emitterAddrReliable,
-				Payload:          payload,
+				VaaVersion:          0,
+				ConsistencyLevel:    32,
+				VaaTime:             0,
+				VaaSignatureAccount: solana.PublicKey{},
+				SubmissionTime:      1770212672,
+				Nonce:               0,
+				Sequence:            1367797,
+				EmitterChain:        1,
+				EmitterAddress:      emitterAddrReliable,
+				Payload:             payload,
 			},
 			errStr: "",
 		},
@@ -257,18 +258,45 @@ func TestParseMessagePublicationAccount(t *testing.T) {
 				return mustNewMessageAccountData(t, validMessageAccountDataUnreliable)
 			},
 			want: &MessagePublicationAccount{
-				VaaVersion:       0,
-				ConsistencyLevel: 1,
-				EmitterAuthority: vaa.Address{},
-				MessageStatus:    0,
-				Gap:              [3]byte{},
-				SubmissionTime:   1770216312,
-				Nonce:            0,
-				Sequence:         3458072,
-				EmitterChain:     1,
-				EmitterAddress:   emitterAddrUnreliable,
-				Payload:          nil, // borsh deserialization results in this being nil rather than an empty slice
+				VaaVersion:          0,
+				ConsistencyLevel:    1,
+				VaaTime:             0,
+				VaaSignatureAccount: solana.PublicKey{},
+				SubmissionTime:      1770216312,
+				Nonce:               0,
+				Sequence:            3458072,
+				EmitterChain:        1,
+				EmitterAddress:      emitterAddrUnreliable,
+				Payload:             nil, // borsh deserialization results in this being nil rather than an empty slice
 			},
+			errStr: "",
+		},
+		{
+			name: "success -- reliable message with non-zero vaa time",
+			messageAccountData: func(t *testing.T) MessageAccountData {
+				acct := testMessagePublicationAccount(payload, 32)
+				acct.VaaTime = 1_700_000_000
+				return mustNewMessageAccountData(t, encodeMessagePublicationAccount(t, accountPrefixReliable, acct))
+			},
+			want: func() *MessagePublicationAccount {
+				acct := testMessagePublicationAccount(payload, 32)
+				acct.VaaTime = 1_700_000_000
+				return &acct
+			}(),
+			errStr: "",
+		},
+		{
+			name: "success -- unreliable message with non-zero vaa time",
+			messageAccountData: func(t *testing.T) MessageAccountData {
+				acct := testMessagePublicationAccount(nil, 1)
+				acct.VaaTime = 1_700_000_001
+				return mustNewMessageAccountData(t, encodeMessagePublicationAccount(t, accountPrefixUnreliable, acct))
+			},
+			want: func() *MessagePublicationAccount {
+				acct := testMessagePublicationAccount(nil, 1)
+				acct.VaaTime = 1_700_000_001
+				return &acct
+			}(),
 			errStr: "",
 		},
 		{
@@ -426,30 +454,6 @@ func TestProcessMessageAccount(t *testing.T) {
 			payload:          []byte("hello"),
 			consistencyLevel: 32,
 			wantCount:        1,
-		},
-		{
-			name:             "skips_unfinalized",
-			chainID:          vaa.ChainIDSolana,
-			commitment:       rpc.CommitmentFinalized,
-			prefix:           accountPrefixReliable,
-			payload:          []byte("hello"),
-			consistencyLevel: 32,
-			tweakProposal: func(p *MessagePublicationAccount) {
-				copy(p.EmitterAuthority[:], bytes.Repeat([]byte{0x01}, len(p.EmitterAuthority)))
-			},
-		},
-		{
-			name:             "pythnet_bypasses_finalization_check",
-			chainID:          vaa.ChainIDPythNet,
-			commitment:       rpc.CommitmentFinalized,
-			prefix:           accountPrefixReliable,
-			payload:          []byte("hello"),
-			consistencyLevel: 32,
-			tweakProposal: func(p *MessagePublicationAccount) {
-				copy(p.EmitterAuthority[:], bytes.Repeat([]byte{0x01}, len(p.EmitterAuthority)))
-				p.MessageStatus = 1
-			},
-			wantCount: 1,
 		},
 		{
 			name:             "commitment_mismatch",
@@ -1450,7 +1454,6 @@ func testMessagePublicationAccount(payload []byte, consistencyLevel uint8) Messa
 	return MessagePublicationAccount{
 		VaaVersion:       1,
 		ConsistencyLevel: consistencyLevel,
-		MessageStatus:    0,
 		SubmissionTime:   123,
 		Nonce:            7,
 		Sequence:         99,
@@ -1472,9 +1475,8 @@ func encodeMessagePublicationAccount(t *testing.T, prefix string, proposal Messa
 	buf.WriteString(prefix)
 	buf.WriteByte(proposal.VaaVersion)
 	buf.WriteByte(proposal.ConsistencyLevel)
-	buf.Write(proposal.EmitterAuthority[:])
-	buf.WriteByte(proposal.MessageStatus)
-	buf.Write(proposal.Gap[:])
+	writeLE(t, buf, proposal.VaaTime)
+	buf.Write(proposal.VaaSignatureAccount[:])
 	writeLE(t, buf, proposal.SubmissionTime)
 	writeLE(t, buf, proposal.Nonce)
 	writeLE(t, buf, proposal.Sequence)


### PR DESCRIPTION
## Summary
- Remove the Solana watcher finalization check for the abandoned 2023 core bridge rewrite layout.
- Restore the parsed message account field names to the current legacy layout (`VaaTime`, `VaaSignatureAccount`).
- Remove tests that only covered the unused rewrite-specific `EmitterAuthority` / `MessageStatus` / `Gap` behavior.
## Context
The watcher check was introduced directly on `main` in 85e785a13 (`node/watchers/solana: additional safety check`) and later given a Pythnet carve-out in 4bfcb89d4 (`node/watchers/solana: pythnet safety carve out`). GitHub does not report an associated PR for either commit, and 4bfcb89d4 is the v2.23.16 tag, which is why this shows up as release history rather than a PR merge.
The check appears to have been intended to support the 2023 Anchor-based Solana core bridge rewrite message account layout. That rewrite work was developed under the `wen/solana-rewrite` branch family. The original scaffolding PR was #3253 (`Solana: add legacy directory for old programs and fix CI`), which merged into `wen/solana-rewrite`, not `main`.
The rewrite never landed on `main`; the current Solana core bridge still uses the legacy message account layout.

## Layout Difference
Current `main` core bridge message layout is:
https://github.com/wormhole-foundation/wormhole/blob/main/solana/bridge/program/src/accounts/posted_message.rs#L45-L76
```rust
pub struct MessageData {
    pub vaa_version: u8,
    pub consistency_level: u8,
    pub vaa_time: u32,
    pub vaa_signature_account: Pubkey,
    pub submission_time: u32,
    pub nonce: u32,
    pub sequence: u64,
    pub emitter_chain: u16,
    pub emitter_address: [u8; 32],
    pub payload: Vec<u8>,
}
```

The abandoned wen/solana-rewrite layout instead used:
https://github.com/wormhole-foundation/wormhole/blob/wen/solana-rewrite/solana/programs/core-bridge/src/legacy/state/posted_message_v1/mod.rs#L36-L69

```rust
pub struct PostedMessageV1Info {
    pub consistency_level: u8,
    pub emitter_authority: Pubkey,
    pub status: MessageStatus,
    pub _gap_0: [u8; 3],
    pub posted_timestamp: Timestamp,
    pub nonce: u32,
    pub sequence: u64,
    pub solana_chain_id: ChainIdSolanaOnly,
    pub emitter: Pubkey,
}
```

The removed watcher check interpreted the current legacy vaa_time / vaa_signature_account byte range as rewrite-only emitter_authority / status / gap state. That state machine does not exist in the current core bridge code on main.