### PR TITLE
node(processor): Remove double VAA broadcast

### DIFF
--- a/node/pkg/processor/broadcast.go
+++ b/node/pkg/processor/broadcast.go
@@ -80,7 +80,6 @@ func (p *Processor) broadcastSignedVAA(v *vaa.VAA) {
 	}
 
 	// Broadcast the signed VAA. The channel is buffered. If it overflows, just drop it and rely on a reobservation if necessary.
-	common.WriteToChannelWithoutBlocking(p.gossipVaaSendC, msg, "vaa_broadcast")
 	select {
 	case p.gossipVaaSendC <- msg:
 		signedVAAsBroadcast.Inc()


### PR DESCRIPTION
The code in `broadcast.go` sent the VAA twice each time: once in `WriteToChannelWithoutBlocking` and again in-line.

This removes the first instance, which means that the 'channel drop' metric will not be pinged. However, we will still get the metric for VAA publish overflow. I chose to preserve this metric because it's more specific and actionable than the general one used in the channel library.

Fixes: https://github.com/asymmetric-research/wormhole-llm-issues/issues/189