### PR TITLE
feat(node): solana core close event handling

### DIFF
--- a/node/pkg/watchers/solana/client.go
+++ b/node/pkg/watchers/solana/client.go
@@ -22,7 +22,6 @@ import (
 	"github.com/certusone/wormhole/node/pkg/readiness"
 	"github.com/certusone/wormhole/node/pkg/supervisor"
 	"github.com/certusone/wormhole/node/pkg/watchers"
-	eth_common "github.com/ethereum/go-ethereum/common"
 	"github.com/gagliardetto/solana-go"
 	lookup "github.com/gagliardetto/solana-go/programs/address-lookup-table"
 	"github.com/gagliardetto/solana-go/rpc"
@@ -730,6 +729,30 @@ func (s *SolanaWatcher) processTransaction(ctx context.Context, rpcClient *rpc.C
 					)
 				}
 			}
+		} else if isReobservation && inst.ProgramIDIndex == programIndex && len(inst.Data) > 0 && inst.Data[0] == closePostedMessageInstructionID {
+			// Rent reclamation: close_posted_message emits a CPI event containing
+			// the full message data before the account is zeroed. We only process
+			// these during reobservation — the normal transaction stream must NOT
+			// generate new observations as message accounts are garbage-collected,
+			// because the original message was already observed when it was posted.
+			found, err := s.processClosePostedMessageEvent(s.logger, programIndex, tx, meta.InnerInstructions, i, inst, alreadyProcessed, signature)
+			if err != nil {
+				s.logger.Error("malformed close_posted_message event",
+					zap.Error(err),
+					zap.Int("idx", i),
+					zap.Stringer("signature", signature),
+					zap.Uint64("slot", slot),
+				)
+			} else if found {
+				numObservations++
+				if s.logger.Level().Enabled(zapcore.DebugLevel) {
+					s.logger.Debug("found a close_posted_message event (reobservation)",
+						zap.Int("idx", i),
+						zap.Stringer("signature", signature),
+						zap.Uint64("slot", slot),
+					)
+				}
+			}
 		} else {
 			found, err := s.processInstruction(ctx, rpcClient, slot, inst, programIndex, tx, signature, i, isReobservation)
 			if err != nil {
@@ -769,6 +792,31 @@ func (s *SolanaWatcher) processTransaction(ctx context.Context, rpcClient *rpc.C
 						numObservations++
 						if s.logger.Level().Enabled(zapcore.DebugLevel) {
 							s.logger.Debug("found an inner wormhole shim instruction",
+								zap.Int("outerIdx", outerIdx),
+								zap.Int("innerIdx", innerIdx),
+								zap.Stringer("signature", signature),
+								zap.Uint64("slot", slot),
+							)
+						}
+					}
+				} else if isReobservation && inst.ProgramIDIndex == programIndex && len(inst.Data) > 0 && inst.Data[0] == closePostedMessageInstructionID {
+					// Handle close_posted_message called via CPI from another
+					// program. Same reobservation-only policy as the top-level
+					// path: we never generate observations from the normal
+					// transaction stream for close events.
+					found, err := s.processInnerClosePostedMessageEvent(s.logger, programIndex, tx, inner.Instructions, outerIdx, innerIdx, inst, alreadyProcessed, signature)
+					if err != nil {
+						s.logger.Error("malformed inner close_posted_message event",
+							zap.Error(err),
+							zap.Int("outerIdx", outerIdx),
+							zap.Int("innerIdx", innerIdx),
+							zap.Stringer("signature", signature),
+							zap.Uint64("slot", slot),
+						)
+					} else if found {
+						numObservations++
+						if s.logger.Level().Enabled(zapcore.DebugLevel) {
+							s.logger.Debug("found an inner close_posted_message event (reobservation)",
 								zap.Int("outerIdx", outerIdx),
 								zap.Int("innerIdx", innerIdx),
 								zap.Stringer("signature", signature),
@@ -948,7 +996,7 @@ func (s *SolanaWatcher) fetchMessageAccount(ctx context.Context, rpcClient *rpc.
 			zap.Binary("data", data))
 	}
 
-	return s.processMessageAccount(s.logger, data, acc, isReobservation, signature), false
+	return s.processMessageAccount(s.logger, data, acc, isReobservation, signature, false), false
 }
 
 func (s *SolanaWatcher) processAccountSubscriptionData(_ context.Context, logger *zap.Logger, data []byte, isReobservation bool) error {
@@ -1002,7 +1050,7 @@ func (s *SolanaWatcher) processAccountSubscriptionData(_ context.Context, logger
 	switch string(data[:3]) {
 	case accountPrefixReliable, accountPrefixUnreliable:
 		acc := solana.PublicKeyFromBytes([]byte(value.Pubkey))
-		s.processMessageAccount(logger, data, acc, isReobservation, solana.Signature{})
+		s.processMessageAccount(logger, data, acc, isReobservation, solana.Signature{}, false)
 	default:
 		break
 	}
@@ -1011,7 +1059,7 @@ func (s *SolanaWatcher) processAccountSubscriptionData(_ context.Context, logger
 }
 
 // SECURITY: Ownership check on account key must be done BEFORE this function is called.
-func (s *SolanaWatcher) processMessageAccount(logger *zap.Logger, data []byte, acc solana.PublicKey, isReobservation bool, signature solana.Signature) (numObservations uint32) {
+func (s *SolanaWatcher) processMessageAccount(logger *zap.Logger, data []byte, acc solana.PublicKey, isReobservation bool, signature solana.Signature, useSignatureAsTxID bool) (numObservations uint32) {
 	proposal, err := ParseMessagePublicationAccount(data)
 	if err != nil {
 		solanaAccountSkips.WithLabelValues(s.networkName, "parse_transfer_out").Inc()
@@ -1057,8 +1105,15 @@ func (s *SolanaWatcher) processMessageAccount(logger *zap.Logger, data []byte, a
 		}
 	}
 
-	var txHash eth_common.Hash
-	copy(txHash[:], acc[:])
+	var txID []byte
+	if useSignatureAsTxID && !signature.IsZero() {
+		// Close event path: use the Solana transaction signature as TxID,
+		// matching the shim convention.
+		txID = signature[:]
+	} else {
+		// Account-based path: use the message account pubkey as TxID.
+		txID = acc[:]
+	}
 
 	var reliable bool
 	switch string(data[:3]) {
@@ -1071,7 +1126,7 @@ func (s *SolanaWatcher) processMessageAccount(logger *zap.Logger, data []byte, a
 	}
 
 	observation := &common.MessagePublication{
-		TxID:             txHash.Bytes(),
+		TxID:             txID,
 		Timestamp:        time.Unix(int64(proposal.SubmissionTime), 0),
 		Nonce:            proposal.Nonce,
 		Sequence:         proposal.Sequence,

--- a/node/pkg/watchers/solana/client_test.go
+++ b/node/pkg/watchers/solana/client_test.go
@@ -412,7 +412,7 @@ func TestProcessMessageAccount(t *testing.T) {
 			data := encodeMessagePublicationAccount(t, tc.prefix, proposal)
 
 			acc := solana.PublicKeyFromBytes(bytes.Repeat([]byte{0x11}, solana.PublicKeyLength))
-			num := s.processMessageAccount(s.logger, data, acc, tc.isReobservation, solana.Signature{})
+			num := s.processMessageAccount(s.logger, data, acc, tc.isReobservation, solana.Signature{}, false)
 			assert.Equal(t, tc.wantCount, num)
 
 			if tc.wantCount == 0 {

--- a/node/pkg/watchers/solana/close_event.go
+++ b/node/pkg/watchers/solana/close_event.go
@@ -87,11 +87,11 @@ func (s *SolanaWatcher) processClosePostedMessageEvent(
 		}
 		for innerIdx, inst := range innerSet.Instructions {
 			if isCloseEventInstruction(programIndex, inst) {
-				alreadyProcessed.add(outerIdx, innerIdx)
 				messageAccount, accountData, err := resolveCloseEventMessageAccount(tx, topLevelInst, inst.Data)
 				if err != nil {
 					return false, err
 				}
+				alreadyProcessed.add(outerIdx, innerIdx)
 				return s.processMessageAccount(logger, accountData, messageAccount, true, signature, true) > 0, nil
 			}
 		}
@@ -121,11 +121,11 @@ func (s *SolanaWatcher) processInnerClosePostedMessageEvent(
 	for i := closeIdx + 1; i < len(innerInstructions); i++ {
 		inst := innerInstructions[i]
 		if isCloseEventInstruction(programIndex, inst) {
-			alreadyProcessed.add(outerIdx, i)
 			messageAccount, accountData, err := resolveCloseEventMessageAccount(tx, closeInst, inst.Data)
 			if err != nil {
 				return false, err
 			}
+			alreadyProcessed.add(outerIdx, i)
 			return s.processMessageAccount(logger, accountData, messageAccount, true, signature, true) > 0, nil
 		}
 	}

--- a/node/pkg/watchers/solana/close_event.go
+++ b/node/pkg/watchers/solana/close_event.go
@@ -1,0 +1,133 @@
+package solana
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/rpc"
+	"go.uber.org/zap"
+)
+
+const (
+	closePostedMessageInstructionID     = 0x09
+	closePostedMessageMinNumAccounts    = 6
+	closePostedMessageMessageAccountIdx = 1
+	closeEventTagStr                    = "e445a52e51cb9a1d" // EVENT_IX_TAG_LE: SHA256("anchor:event")[0..8] as LE u64
+	closeEventDiscriminatorStr          = "9ef61bc2241428b9" // SHA256("event:MessageAccountClosed")[0..8]
+	closeEventMinDataLen                = 16 + 3             // 16-byte event header + 3-byte account prefix
+)
+
+// closeEventTag is the Anchor event CPI selector (8 bytes).
+var closeEventTag []byte
+
+// closeEventDiscriminator identifies the MessageAccountClosed event (8 bytes).
+var closeEventDiscriminator []byte
+
+func init() {
+	var err error
+	closeEventTag, err = hex.DecodeString(closeEventTagStr)
+	if err != nil {
+		panic("invalid closeEventTag: " + err.Error())
+	}
+	closeEventDiscriminator, err = hex.DecodeString(closeEventDiscriminatorStr)
+	if err != nil {
+		panic("invalid closeEventDiscriminator: " + err.Error())
+	}
+}
+
+// isCloseEventInstruction returns true if the instruction data starts with the
+// close event tag and discriminator.
+func isCloseEventInstruction(programIndex uint16, inst solana.CompiledInstruction) bool {
+	return inst.ProgramIDIndex == programIndex &&
+		len(inst.Data) >= 16 &&
+		bytes.Equal(inst.Data[:8], closeEventTag) &&
+		bytes.Equal(inst.Data[8:16], closeEventDiscriminator)
+}
+
+// resolveCloseEventMessageAccount extracts the message account pubkey from the
+// close instruction and returns the account data portion of the CPI event
+// (everything after the 16-byte event header, i.e. the full account data
+// including the 3-byte prefix).
+func resolveCloseEventMessageAccount(
+	tx *solana.Transaction,
+	closeInst solana.CompiledInstruction,
+	eventData []byte,
+) (solana.PublicKey, []byte, error) {
+	if len(eventData) < closeEventMinDataLen {
+		return solana.PublicKey{}, nil, fmt.Errorf("close event data too short: %d bytes", len(eventData))
+	}
+	if len(closeInst.Accounts) < closePostedMessageMinNumAccounts {
+		return solana.PublicKey{}, nil, fmt.Errorf("close instruction has insufficient accounts: %d", len(closeInst.Accounts))
+	}
+	messageAccountIdx := closeInst.Accounts[closePostedMessageMessageAccountIdx]
+	if int(messageAccountIdx) >= len(tx.Message.AccountKeys) {
+		return solana.PublicKey{}, nil, fmt.Errorf("message account index %d out of bounds (account keys len %d)", messageAccountIdx, len(tx.Message.AccountKeys))
+	}
+	return tx.Message.AccountKeys[messageAccountIdx], eventData[16:], nil
+}
+
+// processClosePostedMessageEvent handles a top-level close_posted_message
+// instruction by scanning its inner instructions for the CPI event.
+func (s *SolanaWatcher) processClosePostedMessageEvent(
+	logger *zap.Logger,
+	programIndex uint16,
+	tx *solana.Transaction,
+	innerInstructions []rpc.InnerInstruction,
+	topLevelIndex int,
+	topLevelInst solana.CompiledInstruction,
+	alreadyProcessed ShimAlreadyProcessed,
+	signature solana.Signature,
+) (bool, error) {
+	topLevelIdx := uint16(topLevelIndex) // #nosec G115 -- Solana max tx size (1232 bytes) bounds instruction count well within uint16.
+	for outerIdx, innerSet := range innerInstructions {
+		if innerSet.Index != topLevelIdx {
+			continue
+		}
+		for innerIdx, inst := range innerSet.Instructions {
+			if isCloseEventInstruction(programIndex, inst) {
+				alreadyProcessed.add(outerIdx, innerIdx)
+				messageAccount, accountData, err := resolveCloseEventMessageAccount(tx, topLevelInst, inst.Data)
+				if err != nil {
+					return false, err
+				}
+				return s.processMessageAccount(logger, accountData, messageAccount, true, signature, true) > 0, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+// processInnerClosePostedMessageEvent handles a close_posted_message that
+// appears as an inner instruction (called via CPI from another program). The
+// close instruction and its CPI event are sibling inner instructions within
+// the same inner instruction set. Both are marked in alreadyProcessed so the
+// outer loop does not re-process them (same pattern as the shim).
+func (s *SolanaWatcher) processInnerClosePostedMessageEvent(
+	logger *zap.Logger,
+	programIndex uint16,
+	tx *solana.Transaction,
+	innerInstructions []solana.CompiledInstruction,
+	outerIdx int,
+	closeIdx int,
+	closeInst solana.CompiledInstruction,
+	alreadyProcessed ShimAlreadyProcessed,
+	signature solana.Signature,
+) (bool, error) {
+	alreadyProcessed.add(outerIdx, closeIdx)
+
+	// The CPI event follows the close instruction in the same inner set.
+	for i := closeIdx + 1; i < len(innerInstructions); i++ {
+		inst := innerInstructions[i]
+		if isCloseEventInstruction(programIndex, inst) {
+			alreadyProcessed.add(outerIdx, i)
+			messageAccount, accountData, err := resolveCloseEventMessageAccount(tx, closeInst, inst.Data)
+			if err != nil {
+				return false, err
+			}
+			return s.processMessageAccount(logger, accountData, messageAccount, true, signature, true) > 0, nil
+		}
+	}
+	return false, nil
+}

--- a/node/pkg/watchers/solana/close_event_integration_test.go
+++ b/node/pkg/watchers/solana/close_event_integration_test.go
@@ -98,6 +98,9 @@ func TestCloseEventReobservation(t *testing.T) {
 		assert.Equal(t, expectedConsistencyLevel, msg.ConsistencyLevel, "consistency level mismatch")
 		assert.Equal(t, expectedPayload, msg.Payload, "payload mismatch")
 		assert.True(t, msg.IsReobservation, "expected IsReobservation to be true")
+		assert.Equal(t, signature[:], msg.TxID, "TxID should be the Solana transaction signature")
+		assert.False(t, msg.Unreliable, "expected Unreliable to be false for reliable message prefix")
+		assert.Equal(t, common.NotVerified, msg.VerificationState(), "expected VerificationState to be NotVerified")
 
 		// Verify both hash formats
 		v := msg.CreateVAA(0)

--- a/node/pkg/watchers/solana/close_event_integration_test.go
+++ b/node/pkg/watchers/solana/close_event_integration_test.go
@@ -1,0 +1,124 @@
+//go:build integration
+
+package solana
+
+import (
+	"context"
+	"encoding/hex"
+	"testing"
+	"time"
+
+	"github.com/certusone/wormhole/node/pkg/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/rpc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wormhole-foundation/wormhole/sdk/vaa"
+	"go.uber.org/zap"
+)
+
+// TestCloseEventReobservation tests reobservation of a close_posted_message event on Solana devnet.
+// The close_posted_message instruction closes an old message account and emits its data as a CPI event,
+// allowing guardians to reobserve messages even after the original account has been closed.
+// Run with: go test -tags=integration -run TestCloseEventReobservation ./pkg/watchers/solana/
+func TestCloseEventReobservation(t *testing.T) {
+	// Devnet RPC URL
+	const devnetRPC = "https://api.devnet.solana.com"
+
+	// Devnet Wormhole Core Bridge address
+	const rawContract = "3u8hJUVTA4jH1wYAyUur7FFZVQ8H635K3tSHHF4ssjQ5"
+	contractAddress, err := solana.PublicKeyFromBase58(rawContract)
+	require.NoError(t, err)
+
+	// Transaction signature to reobserve
+	// https://explorer.solana.com/tx/29zzwD7aRvyMhUBDLtqJUJR6PcFcFciRmhRwFzSqoXdPXMork1AG9wVdgYGUa7BVr2svNWC65fMp9Uia4Cy4zMXU?cluster=devnet
+	const txSignature = "29zzwD7aRvyMhUBDLtqJUJR6PcFcFciRmhRwFzSqoXdPXMork1AG9wVdgYGUa7BVr2svNWC65fMp9Uia4Cy4zMXU"
+	signature, err := solana.SignatureFromBase58(txSignature)
+	require.NoError(t, err)
+
+	// Expected message values
+	expectedTimestamp := time.Unix(1776161416, 0)
+	expectedNonce := uint32(24)
+	expectedSequence := uint64(23)
+	expectedConsistencyLevel := uint8(32)
+	expectedPayload, err := hex.DecodeString("0100000000000000000000000000000000000000000000000000000000000186a0000000000000000000000000742bf979105179e44aed27baf37d66ef73cc3d88")
+	require.NoError(t, err)
+	// Single keccak256 hash of the VAA body (what Wormhole Explorer shows)
+	expectedBodyHash := "ee897440b3aed4de69068689e2b385d25793f9658ba179bc680363af4db78ba2"
+	// Double keccak256 hash (signing digest used for guardian signatures)
+	// This can be confirmed by calling parseAndVerifyVM on the Ethereum Core Bridge
+	// https://etherscan.io/address/0x98f3c9e6E3fAce36bAAd05FE09d375Ef1464288B#readProxyContract
+	// with the VAA hex: 0x01000000000100b7e9e4a3336afbffee50e2b6cf3eea2b0ac110a01d083c35d5e5d4d8ee53ed36073017c80c4174c14fad263d9c84a3a5edd9b73360fcc48b90ed698626be1be30069de128800000018000176752c408f4314dafbafc0766d39847940292e7cbb0c57d60c8ddd929183757b0000000000000017200100000000000000000000000000000000000000000000000000000000000186a0000000000000000000000000742bf979105179e44aed27baf37d66ef73cc3d88
+	expectedSigningDigest := "d6458c37243d2cd1463a113174af01077f885b1a43bb31daea14b9cbc5b57eec"
+
+	// Convert base58 emitter address to vaa.Address
+	emitterPubkey, err := solana.PublicKeyFromBase58("8yQjiwvWM6BYeQ2wrYZgqtrPPDYr3bJVAqC23NSpacev")
+	require.NoError(t, err)
+	var expectedEmitterAddress vaa.Address
+	copy(expectedEmitterAddress[:], emitterPubkey[:])
+
+	// Create a message channel to receive observations
+	msgC := make(chan *common.MessagePublication, 10)
+
+	// Create logger
+	logger, err := zap.NewDevelopment()
+	require.NoError(t, err)
+
+	// Create the watcher with devnet configuration
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	s := &SolanaWatcher{
+		ctx:         ctx,
+		logger:      logger,
+		contract:    contractAddress,
+		rawContract: rawContract,
+		rpcUrl:      devnetRPC,
+		rpcClient:   rpc.New(devnetRPC),
+		commitment:  rpc.CommitmentFinalized,
+		chainID:     vaa.ChainIDSolana,
+		msgC:        msgC,
+	}
+
+	// Perform reobservation using the Reobserve method
+	numObservations, err := s.Reobserve(ctx, vaa.ChainIDSolana, signature[:], devnetRPC)
+	require.NoError(t, err)
+	assert.Equal(t, uint32(1), numObservations, "expected exactly one observation")
+
+	// Receive the message from the channel
+	select {
+	case msg := <-msgC:
+		// Verify all message fields
+		assert.Equal(t, expectedTimestamp, msg.Timestamp, "timestamp mismatch")
+		assert.Equal(t, expectedNonce, msg.Nonce, "nonce mismatch")
+		assert.Equal(t, vaa.ChainIDSolana, msg.EmitterChain, "emitter chain mismatch")
+		assert.Equal(t, expectedEmitterAddress, msg.EmitterAddress, "emitter address mismatch")
+		assert.Equal(t, expectedSequence, msg.Sequence, "sequence mismatch")
+		assert.Equal(t, expectedConsistencyLevel, msg.ConsistencyLevel, "consistency level mismatch")
+		assert.Equal(t, expectedPayload, msg.Payload, "payload mismatch")
+		assert.True(t, msg.IsReobservation, "expected IsReobservation to be true")
+
+		// Verify both hash formats
+		v := msg.CreateVAA(0)
+		vaaBytes, err := v.Marshal()
+		require.NoError(t, err)
+		// Body starts after header: 1 byte version + 4 bytes guardian set index + 1 byte sig count = 6 bytes
+		body := vaaBytes[6:]
+		actualBodyHash := hex.EncodeToString(crypto.Keccak256(body))
+		actualSigningDigest := v.HexDigest()
+
+		assert.Equal(t, expectedBodyHash, actualBodyHash, "VAA body hash (single keccak) mismatch")
+		assert.Equal(t, expectedSigningDigest, actualSigningDigest, "signing digest (double keccak) mismatch")
+
+		// Log success details
+		t.Logf("Successfully reobserved transaction %s", txSignature)
+		t.Logf("EmitterAddress: %s", hex.EncodeToString(msg.EmitterAddress[:]))
+		t.Logf("Sequence: %d", msg.Sequence)
+		t.Logf("Body Hash (single keccak): %s", actualBodyHash)
+		t.Logf("Signing Digest (double keccak): %s", actualSigningDigest)
+
+	case <-ctx.Done():
+		t.Fatal("timeout waiting for message publication")
+	}
+}

--- a/node/pkg/watchers/solana/close_event_test.go
+++ b/node/pkg/watchers/solana/close_event_test.go
@@ -1,0 +1,282 @@
+package solana
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/certusone/wormhole/node/pkg/common"
+	"github.com/mr-tron/base58"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wormhole-foundation/wormhole/sdk/vaa"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/rpc"
+)
+
+// Captured from: cargo test test_close_posted_message_capture_fixture -- --nocapture
+// See solana/bridge/program/tests/integration.rs
+const (
+	// The CPI event inner instruction data emitted by close_posted_message.
+	// Layout: EVENT_IX_TAG_LE (8) + DISCRIMINATOR (8) + account prefix "msg" (3) + borsh(MessageData).
+	capturedCPIEventHex = "e445a52e51cb9a1d9ef61bc2241428b96d736700010000000000000000000000000000000000000000000000000000000000000000000000008782b469a98487e200000000000000000100e4af35976c379d3028ca489e977e4efaf0ca40fc7f5e19909d673f15a5a42370200000000202020202020202020202020202020202020202020202020202020202020202"
+
+	// Real account keys from the captured transaction.
+	capturedPayer          = "5TSpbYV3ZfuHciTgLqZJu5Sm77vbym6yoUkUPi1Hq5MZ"
+	capturedMessage        = "o6XiTkG4cBwKxKDTA3cxmP5kXRFWNrJ82XCG5CFf8Y7"
+	capturedBridge         = "FKoMTctsC7vJbEqyRiiPskPnuQx2tX1kurmvWByq5uZP"
+	capturedFeeCollector   = "GXBsgBD3LDn3vkRZF6TfY5RqgajVZ4W5bMAdiAaaUARs"
+	capturedProgram        = "Bridge1p5gheXUvJ6jGWGeCsgPKgnE3YgdGKRVCMY9o"
+	capturedClock          = "SysvarC1ock11111111111111111111111111111111"
+	capturedEventAuthority = "GvMcVyV5xsijxCayHJXJyNvbcbqKnLTJF1LJ7BR5Phvw"
+	capturedSignature      = "26YFK4phBtW3daXKfF3gjBJok2bBUY9mzrZuY5YovTxK5CnTmAkBQh5kZA9YtUTdLi3HNTCpddMtJGDwzpcwYJQR"
+	capturedBlockhash      = "9cfBkPsoQ2NPHYPi7b69bcQG8FKfNc33k2UfRxiPFyd9"
+)
+
+func closeEventNewWatcherForTest(t *testing.T, msgC chan<- *common.MessagePublication) *SolanaWatcher {
+	t.Helper()
+
+	contractAddress, err := solana.PublicKeyFromBase58(capturedProgram)
+	require.NoError(t, err)
+
+	return &SolanaWatcher{
+		contract:            contractAddress,
+		rawContract:         capturedProgram,
+		chainID:             vaa.ChainIDSolana,
+		commitment:          rpc.CommitmentFinalized,
+		msgC:                msgC,
+		networkName:         "solana-test",
+		msgObservedLogLevel: zapcore.InfoLevel,
+		logger:              zap.NewNop(),
+	}
+}
+
+func TestParseCloseEventAccountData(t *testing.T) {
+	eventData, err := hex.DecodeString(capturedCPIEventHex)
+	require.NoError(t, err)
+
+	// Validate header.
+	require.True(t, bytes.Equal(eventData[:8], closeEventTag))
+	require.True(t, bytes.Equal(eventData[8:16], closeEventDiscriminator))
+
+	// After the 16-byte header, the payload is full account data (prefix + borsh)
+	// which ParseMessagePublicationAccount knows how to parse.
+	msg, err := ParseMessagePublicationAccount(eventData[16:])
+	require.NoError(t, err)
+	require.NotNil(t, msg)
+
+	assert.Equal(t, uint8(0), msg.VaaVersion)
+	assert.Equal(t, uint8(1), msg.ConsistencyLevel)
+	assert.Equal(t, uint16(1), msg.EmitterChain) // Solana
+	assert.Equal(t, uint64(0), msg.Sequence)
+
+	// Payload is [2u8; 32] from the Rust test.
+	expectedPayload := bytes.Repeat([]byte{0x02}, 32)
+	assert.True(t, bytes.Equal(expectedPayload, msg.Payload))
+
+	// Emitter address from the captured test run.
+	expectedEmitter, err := hex.DecodeString("e4af35976c379d3028ca489e977e4efaf0ca40fc7f5e19909d673f15a5a42370")
+	require.NoError(t, err)
+	assert.True(t, bytes.Equal(expectedEmitter, msg.EmitterAddress[:]))
+
+	assert.True(t, msg.SubmissionTime > 0)
+	assert.True(t, msg.Nonce > 0)
+}
+
+// buildCloseEventTransactionJSON builds a Solana RPC getTransaction-style JSON
+// fixture from data captured by the Rust test:
+//
+//	cargo test-sbf ... test_close_posted_message_capture_fixture -- --nocapture
+func buildCloseEventTransactionJSON(t *testing.T) string {
+	t.Helper()
+
+	eventData, err := hex.DecodeString(capturedCPIEventHex)
+	require.NoError(t, err)
+	eventDataB58 := base58.Encode(eventData)
+	closeIxDataB58 := base58.Encode([]byte{closePostedMessageInstructionID})
+
+	// Account layout and instruction accounts from the real transaction:
+	//   0: payer (writable signer)
+	//   1: message (writable non-signer)
+	//   2: bridge (writable non-signer)
+	//   3: fee_collector (writable non-signer)
+	//   4: program (readonly non-signer)
+	//   5: clock (readonly non-signer)
+	//   6: event_authority (readonly non-signer)
+	//
+	// instruction accounts=[2, 1, 3, 5, 6, 4]  program_id_index=4
+	// inner CPI: accounts=[6]  program_id_index=4
+	return fmt.Sprintf(`{
+		"blockTime": 1736530812,
+		"meta": {
+			"computeUnitsConsumed": 50000,
+			"err": null,
+			"fee": 5000,
+			"innerInstructions": [
+				{
+					"index": 0,
+					"instructions": [
+						{
+							"accounts": [6],
+							"data": "%s",
+							"programIdIndex": 4,
+							"stackHeight": 2
+						}
+					]
+				}
+			],
+			"loadedAddresses": { "readonly": [], "writable": [] },
+			"logMessages": [],
+			"postBalances": [1000000000, 1000000, 1000000, 1000000, 1000000, 1000000, 1000000],
+			"postTokenBalances": [],
+			"preBalances": [1000000000, 1000000, 1000000, 1000000, 1000000, 1000000, 1000000],
+			"preTokenBalances": [],
+			"rewards": [],
+			"status": { "Ok": null }
+		},
+		"slot": 100,
+		"transaction": {
+			"message": {
+				"header": {
+					"numReadonlySignedAccounts": 0,
+					"numReadonlyUnsignedAccounts": 3,
+					"numRequiredSignatures": 1
+				},
+				"accountKeys": [
+					"%s",
+					"%s",
+					"%s",
+					"%s",
+					"%s",
+					"%s",
+					"%s"
+				],
+				"recentBlockhash": "%s",
+				"instructions": [
+					{
+						"accounts": [2, 1, 3, 5, 6, 4],
+						"data": "%s",
+						"programIdIndex": 4,
+						"stackHeight": null
+					}
+				],
+				"indexToProgramIds": {}
+			},
+			"signatures": [
+				"%s"
+			]
+		},
+		"version": "legacy"
+	}`,
+		eventDataB58,
+		capturedPayer, capturedMessage, capturedBridge, capturedFeeCollector,
+		capturedProgram, capturedClock, capturedEventAuthority,
+		capturedBlockhash,
+		closeIxDataB58,
+		capturedSignature,
+	)
+}
+
+func TestClosePostedMessageDirect(t *testing.T) {
+	msgC := make(chan *common.MessagePublication, 10)
+	s := closeEventNewWatcherForTest(t, msgC)
+
+	eventJson := buildCloseEventTransactionJSON(t)
+
+	var txRpc rpc.TransactionWithMeta
+	err := json.Unmarshal([]byte(eventJson), &txRpc)
+	require.NoError(t, err)
+
+	tx, err := txRpc.GetParsedTransaction()
+	require.NoError(t, err)
+
+	require.Equal(t, 1, len(tx.Message.Instructions))
+	require.Equal(t, 1, len(txRpc.Meta.InnerInstructions))
+
+	// Find program index.
+	var programIndex uint16
+	for n, key := range tx.Message.AccountKeys {
+		if key.Equals(s.contract) {
+			programIndex = uint16(n) // #nosec G115 -- test code, bounded by account keys length
+		}
+	}
+	require.Equal(t, uint16(4), programIndex)
+
+	// Call processClosePostedMessageEvent directly.
+	logger := zap.NewNop()
+	alreadyProcessed := ShimAlreadyProcessed{}
+	found, err := s.processClosePostedMessageEvent(
+		logger,
+		programIndex,
+		tx,
+		txRpc.Meta.InnerInstructions,
+		0,
+		tx.Message.Instructions[0],
+		alreadyProcessed,
+		tx.Signatures[0],
+	)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, 1, len(msgC))
+
+	msg := <-msgC
+	require.NotNil(t, msg)
+
+	// TxID should be the Solana transaction signature.
+	expectedSignature := solana.MustSignatureFromBase58(capturedSignature)
+	assert.True(t, bytes.Equal(expectedSignature[:], msg.TxID))
+
+	assert.Equal(t, vaa.ChainIDSolana, msg.EmitterChain)
+	assert.Equal(t, uint64(0), msg.Sequence)
+	assert.Equal(t, uint8(1), msg.ConsistencyLevel)
+	assert.True(t, msg.IsReobservation)
+	assert.False(t, msg.Unreliable)
+
+	// Payload is [2u8; 32] from the Rust test.
+	expectedPayload := bytes.Repeat([]byte{0x02}, 32)
+	assert.True(t, bytes.Equal(expectedPayload, msg.Payload))
+
+	// Emitter address from the captured test run.
+	expectedEmitterAddress, err := vaa.StringToAddress("e4af35976c379d3028ca489e977e4efaf0ca40fc7f5e19909d673f15a5a42370")
+	require.NoError(t, err)
+	assert.Equal(t, expectedEmitterAddress, msg.EmitterAddress)
+
+	assert.True(t, msg.Timestamp.After(time.Unix(0, 0)))
+	assert.True(t, msg.Nonce > 0)
+}
+
+func TestClosePostedMessageSkippedDuringNormalProcessing(t *testing.T) {
+	msgC := make(chan *common.MessagePublication, 10)
+	s := closeEventNewWatcherForTest(t, msgC)
+
+	eventJson := buildCloseEventTransactionJSON(t)
+
+	var txRpc rpc.TransactionWithMeta
+	err := json.Unmarshal([]byte(eventJson), &txRpc)
+	require.NoError(t, err)
+
+	tx, err := txRpc.GetParsedTransaction()
+	require.NoError(t, err)
+
+	// Process as normal (non-reobservation) — should produce NO observation.
+	numObs := s.processTransaction(context.Background(), nil, tx, txRpc.Meta, 100, false)
+	assert.Equal(t, uint32(0), numObs)
+	assert.Equal(t, 0, len(msgC), "normal processing must not generate observation for close events")
+
+	// Process as reobservation — should produce an observation.
+	numObs = s.processTransaction(context.Background(), nil, tx, txRpc.Meta, 100, true)
+	assert.Equal(t, uint32(1), numObs)
+	assert.Equal(t, 1, len(msgC), "reobservation should generate observation for close events")
+
+	msg := <-msgC
+	assert.Equal(t, uint64(0), msg.Sequence)
+	assert.Equal(t, vaa.ChainIDSolana, msg.EmitterChain)
+	assert.True(t, msg.IsReobservation)
+}

--- a/node/pkg/watchers/solana/close_event_test.go
+++ b/node/pkg/watchers/solana/close_event_test.go
@@ -226,6 +226,11 @@ func TestClosePostedMessageDirect(t *testing.T) {
 	require.True(t, found)
 	require.Equal(t, 1, len(msgC))
 
+	// The CPI event inner instruction (outerIdx=0, innerIdx=0) should be
+	// recorded so the outer transaction loop does not re-process it.
+	require.Equal(t, 1, len(alreadyProcessed))
+	assert.True(t, alreadyProcessed.exists(0, 0))
+
 	msg := <-msgC
 	require.NotNil(t, msg)
 

--- a/solana/bridge/program/tests/common.rs
+++ b/solana/bridge/program/tests/common.rs
@@ -69,6 +69,26 @@ pub async fn execute<T: Signers>(
         .await
 }
 
+/// Like [`execute`], but returns the signed transaction after processing.
+/// Useful for capturing real account keys, indices, and signatures for test fixtures.
+pub async fn execute_and_return_tx<T: Signers>(
+    client: &mut BanksClient,
+    payer: &Keypair,
+    signers: &T,
+    instructions: &[Instruction],
+    commitment_level: CommitmentLevel,
+) -> Result<Transaction, BanksClientError> {
+    let mut transaction = Transaction::new_with_payer(instructions, Some(&payer.pubkey()));
+    let recent_blockhash = client.get_latest_blockhash().await?;
+    transaction.sign(signers, recent_blockhash);
+
+    let tx_copy = transaction.clone();
+    client
+        .process_transaction_with_commitment(transaction, commitment_level)
+        .await?;
+    Ok(tx_copy)
+}
+
 mod helpers {
     use super::*;
     use solana_program_test::processor;
@@ -472,6 +492,22 @@ mod helpers {
         message: Pubkey,
     ) -> Result<(), BanksClientError> {
         execute(
+            client,
+            payer,
+            &[payer],
+            &[instructions::close_posted_message(*program, message)],
+            CommitmentLevel::Processed,
+        )
+        .await
+    }
+
+    pub async fn close_posted_message_and_return_tx(
+        client: &mut BanksClient,
+        program: &Pubkey,
+        payer: &Keypair,
+        message: Pubkey,
+    ) -> Result<Transaction, BanksClientError> {
+        execute_and_return_tx(
             client,
             payer,
             &[payer],

--- a/solana/bridge/program/tests/integration.rs
+++ b/solana/bridge/program/tests/integration.rs
@@ -2322,3 +2322,84 @@ async fn test_fee_enforcement_after_close() {
         "Should still be able to post messages after close"
     );
 }
+
+/// Captures the real signed close_posted_message transaction and the CPI event
+/// data that the program would emit, then prints both for building guardian
+/// watcher Go test fixtures.
+///
+/// Run with: cargo test test_close_posted_message_capture_fixture -- --nocapture
+#[tokio::test]
+async fn test_close_posted_message_capture_fixture() {
+    let (ref mut _context, ref mut test_ctx, ref program) = initialize().await;
+
+    let emitter = Keypair::new();
+    let nonce = rand::thread_rng().gen();
+    let message = [2u8; 32].to_vec();
+
+    let message_key = common::post_message(
+        &mut test_ctx.banks_client,
+        program,
+        &test_ctx.payer,
+        &emitter,
+        None,
+        nonce,
+        message,
+        10_000,
+    )
+    .await
+    .unwrap();
+
+    let test_submission_time = old_submission_time();
+    common::set_submission_time(test_ctx, message_key, test_submission_time).await;
+
+    // Read the message account before close — the CPI event payload is the
+    // account data with the 3-byte prefix ("msg"/"msu") stripped.
+    let pre_close_data = common::get_account_data_raw(&mut test_ctx.banks_client, message_key)
+        .await
+        .unwrap();
+    // Close the message, capturing the real signed transaction.
+    let tx = common::close_posted_message_and_return_tx(
+        &mut test_ctx.banks_client,
+        program,
+        &test_ctx.payer,
+        message_key,
+    )
+    .await
+    .unwrap();
+
+    // CPI event data = EVENT_IX_TAG_LE (8) + DISCRIMINATOR (8) + full account data.
+    // The program emits the entire account (prefix + MessageData borsh).
+    // BanksClient 1.10 doesn't return inner instructions, so this is the one
+    // piece we construct from the pre-close account state.
+    let mut cpi_event_data = Vec::new();
+    cpi_event_data.extend_from_slice(&solitaire::EVENT_IX_TAG_LE);
+    cpi_event_data.extend_from_slice(&bridge::MESSAGE_ACCOUNT_CLOSED_DISCRIMINATOR);
+    cpi_event_data.extend_from_slice(&pre_close_data);
+
+    // Print the real transaction and constructed CPI event data.
+    println!("--- close_posted_message fixture data ---");
+    println!(
+        "header: num_required_signatures={} num_readonly_signed={} num_readonly_unsigned={}",
+        tx.message.header.num_required_signatures,
+        tx.message.header.num_readonly_signed_accounts,
+        tx.message.header.num_readonly_unsigned_accounts,
+    );
+    for (i, key) in tx.message.account_keys.iter().enumerate() {
+        println!("account_key[{}]: {}", i, key);
+    }
+    println!("recent_blockhash: {}", tx.message.recent_blockhash);
+    for (i, ix) in tx.message.instructions.iter().enumerate() {
+        println!(
+            "instruction[{}]: program_id_index={} accounts={:?} data={}",
+            i,
+            ix.program_id_index,
+            ix.accounts,
+            hex::encode(&ix.data)
+        );
+    }
+    for (i, sig) in tx.signatures.iter().enumerate() {
+        println!("signature[{}]: {}", i, sig);
+    }
+    println!("cpi_event_data: {}", hex::encode(&cpi_event_data));
+    println!("--- end fixture data ---");
+}


### PR DESCRIPTION
This PR adds support for re-observing a Solana message based on message closure CPI event data. It follows a similar pattern as the shim and reuses the same account parsing / publication logic.

This is the guardian portion of https://github.com/wormhole-foundation/wormhole/pull/4746.

I ran the additional Solana test with the following command in order to get the instruction data.
```bash
cd solana
docker run --rm -it -v "$(pwd):/usr/src/bridge" -w /usr/src/bridge "ghcr.io/wormhole-foundation/solana:1.10.31@sha256:d31e8db926a1d3fbaa9d9211d9979023692614b7b64912651aba0383e8c01bad" bash -c 'CHAIN_ID=1 EMITTER_ADDRESS="11111111111111111111111111111115" cargo test-bpf --manifest-path bridge/program/Cargo.toml --features instructions -- test_close_posted_message_capture_fixture --nocapture'
```

The integration test for the close event message generation can be run with 
```bash
cd node
go test -tags=integration -run TestReobservationDevnet -v ./pkg/watchers/solana/
```