### PR TITLE
feat(node): switch sei to cosmwasm watcher

### DIFF
--- a/cosmwasm/deployment/terra2/tools/deploy.js
+++ b/cosmwasm/deployment/terra2/tools/deploy.js
@@ -10,10 +10,13 @@ import { Bech32, toHex } from "@cosmjs/encoding";
 import { zeroPad } from "ethers/lib/utils.js";
 
 // Generated using
-// `guardiand template ibc-receiver-update-channel-chain --channel-id channel-0 --chain-id 3104 --target-chain-id 32 > terra2.prototxt`
-// `guardiand admin governance-vaa-verify terra2.prototxt`
+// `kubectl exec -it -n wormhole guardian-0 -- sh`
+// `/guardiand template ibc-receiver-update-channel-chain --channel-id channel-0 --chain-id 3104 --target-chain-id 4002 --idx 0 > terra2.prototxt`
+// `/guardiand admin governance-vaa-verify terra2.prototxt`
+// `/guardiand admin governance-vaa-inject --socket /tmp/admin.sock terra2.prototxt`
+// http://localhost:7071/v1/signed_vaa/1/0000000000000000000000000000000000000000000000000000000000000004/sequence
 const WORMHOLE_IBC_WHITELIST_VAA =
-  "0100000000010025e55ab23c8d0a7fddd4686f41801792cdce1ff7335a2b9436192bd552fa0f9b5c18016057b0d4b3f24c759eafe3e5fedd7fce76fe6f21cec815ffbaf4ec3ad801000000009b9a6b2d0001000000000000000000000000000000000000000000000000000000000000000460efd4405060ac0c200000000000000000000000000000000000000000004962635265636569766572010020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000006368616e6e656c2d300c20";
+  "010000000001003d89310a91636a17c3a82c8bd4903681d1892d1a01df269d5dd39fe45bec3f83778485ec7f51791789f6a3a20496a26bd29ac44a47b45684e92baf197a9bffe10100000000c96dd8240001000000000000000000000000000000000000000000000000000000000000000423880251f492b5df200000000000000000000000000000000000000000004962635265636569766572010fa2000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000006368616e6e656c2d300c20";
 
 /*
   NOTE: Only append to this array: keeping the ordering is crucial, as the
@@ -213,7 +216,7 @@ addresses["wormhole_ibc.wasm"] = await instantiate(
       ],
       expiration_time: 0,
     },
-    chain_id: 32,
+    chain_id: 4002,
     fee_denom: "uluna",
   },
   "wormholeIbc"

--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -103,6 +103,10 @@ var (
 	injectiveLCD      *string
 	injectiveContract *string
 
+	seiWS       *string
+	seiLCD      *string
+	seiContract *string
+
 	gatewayWS       *string
 	gatewayLCD      *string
 	gatewayContract *string
@@ -357,6 +361,10 @@ func init() {
 	injectiveWS = node.RegisterFlagWithValidationOrFail(NodeCmd, "injectiveWS", "Path to root for Injective websocket connection", "ws://injective:26657/websocket", []string{"ws", "wss"})
 	injectiveLCD = node.RegisterFlagWithValidationOrFail(NodeCmd, "injectiveLCD", "Path to LCD service root for Injective http calls", "http://injective:1317", []string{"http", "https"})
 	injectiveContract = NodeCmd.Flags().String("injectiveContract", "", "Wormhole contract address on Injective blockchain")
+
+	seiWS = node.RegisterFlagWithValidationOrFail(NodeCmd, "seiWS", "Path to root for Sei websocket connection", "ws://sei:26657/websocket", []string{"ws", "wss"})
+	seiLCD = node.RegisterFlagWithValidationOrFail(NodeCmd, "seiLCD", "Path to LCD service root for Sei http calls", "http://sei:1317", []string{"http", "https"})
+	seiContract = NodeCmd.Flags().String("seiContract", "", "Wormhole contract address on Sei blockchain")
 
 	gatewayWS = node.RegisterFlagWithValidationOrFail(NodeCmd, "gatewayWS", "Path to root for Gateway watcher websocket connection", "ws://wormchain:26657/websocket", []string{"ws", "wss"})
 	gatewayLCD = node.RegisterFlagWithValidationOrFail(NodeCmd, "gatewayLCD", "Path to LCD service root for Gateway watcher http calls", "http://wormchain:1317", []string{"http", "https"})
@@ -924,6 +932,10 @@ func runNode(cmd *cobra.Command, args []string) {
 		logger.Fatal("Either --injectiveContract, --injectiveWS and --injectiveLCD must all be set or all unset")
 	}
 
+	if !argsConsistent([]string{*seiContract, *seiWS, *seiLCD}) {
+		logger.Fatal("Either --seiContract, --seiWS and --seiLCD must all be set or all unset")
+	}
+
 	if !argsConsistent([]string{*algorandIndexerRPC, *algorandAlgodRPC, *algorandAlgodToken}) {
 		logger.Fatal("Either --algorandIndexerRPC, --algorandAlgodRPC and --algorandAlgodToken must all be set or all unset")
 	}
@@ -1040,7 +1052,8 @@ func runNode(cmd *cobra.Command, args []string) {
 	rpcMap["pythnetWS"] = *pythnetWS
 	// ChainIDBtc is not supported in the guardian.
 	rpcMap["baseRPC"] = *baseRPC
-	// ChainIDSei is supported over IBC, so it's not listed here.
+	rpcMap["seiWS"] = *seiWS
+	rpcMap["seiLCD"] = *seiLCD
 	// ChainIDRootstock is not supported in the guardian.
 	rpcMap["lineaRPC"] = *lineaRPC
 	rpcMap["berachainRPC"] = *berachainRPC
@@ -1626,6 +1639,18 @@ func runNode(cmd *cobra.Command, args []string) {
 			Websocket: *injectiveWS,
 			Lcd:       *injectiveLCD,
 			Contract:  *injectiveContract,
+		}
+
+		watcherConfigs = append(watcherConfigs, wc)
+	}
+
+	if shouldStart(seiWS) {
+		wc := &cosmwasm.WatcherConfig{
+			NetworkID: "sei",
+			ChainID:   vaa.ChainIDSei,
+			Websocket: *seiWS,
+			Lcd:       *seiLCD,
+			Contract:  *seiContract,
 		}
 
 		watcherConfigs = append(watcherConfigs, wc)

--- a/node/pkg/watchers/cosmwasm/sei_mainnet_integration_test.go
+++ b/node/pkg/watchers/cosmwasm/sei_mainnet_integration_test.go
@@ -1,0 +1,272 @@
+//go:build integration
+
+package cosmwasm
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/certusone/wormhole/node/pkg/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+	"github.com/wormhole-foundation/wormhole/sdk/vaa"
+	"go.uber.org/zap/zaptest"
+)
+
+const (
+	seiCoreContract = "sei1gjrrme22cyha4ht2xapn3f08zzw6z3d4uxx6fyy9zd5dyr3yxgzqqncdqn"
+	// SEI_LCD must be set to a Sei mainnet LCD endpoint that has the test
+	// transactions in its history (most public endpoints prune old txs and
+	// return 404 / panic). Tests are skipped when unset.
+	seiLCDEnvVar = "SEI_LCD"
+)
+
+// fetchSeiTxEvents performs the same LCD query that Watcher.Run does in its
+// reobservation handler and returns the parsed events array.
+func fetchSeiTxEvents(t *testing.T, lcd, txHash string) []gjson.Result {
+	t.Helper()
+	client := &http.Client{Timeout: 20 * time.Second}
+	resp, err := client.Get(strings.TrimRight(lcd, "/") + "/cosmos/tx/v1beta1/txs/" + txHash)
+	require.NoError(t, err, "failed to fetch tx from sei mainnet LCD")
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "non-200 from sei LCD: %s", string(body))
+
+	txJSON := string(body)
+	gotHash := gjson.Get(txJSON, "tx_response.txhash").String()
+	require.True(t, strings.EqualFold(gotHash, txHash), "tx hash mismatch in response: got %q want %q", gotHash, txHash)
+
+	events := gjson.Get(txJSON, "tx_response.events")
+	require.True(t, events.Exists(), "tx response has no events")
+	return events.Array()
+}
+
+func requireSeiLCD(t *testing.T) string {
+	t.Helper()
+	lcd := os.Getenv(seiLCDEnvVar)
+	if lcd == "" {
+		t.Skipf("%s not set; skipping Sei mainnet integration test", seiLCDEnvVar)
+	}
+	return lcd
+}
+
+// newSeiMainnetWatcher builds a Watcher with the same settings the guardian
+// uses on Sei mainnet, so the test exercises the constructor's chain-specific
+// derivations (notably b64Encoded) instead of hardcoding them.
+func newSeiMainnetWatcher(t *testing.T, lcd string) *Watcher {
+	t.Helper()
+	w := NewWatcher(
+		"", // urlWS unused; we only call EventsToMessagePublications
+		strings.TrimRight(lcd, "/"),
+		seiCoreContract,
+		nil, // msgC unused in this path
+		nil, // obsvReqC unused in this path
+		vaa.ChainIDSei,
+		common.MainNet,
+	)
+	// Sei must be base64-encoded (it is not Injective or Terra2). Catches
+	// regressions in the b64Encoded selection in NewWatcher.
+	require.True(t, w.b64Encoded, "Sei mainnet watcher must have b64Encoded=true")
+	require.Equal(t, "_contract_address", w.contractAddressLogKey, "Sei mainnet watcher must use cosmwasm 1.0 contract address log key")
+	return w
+}
+
+// TestSeiMainnetMessageParsing confirms the cosmwasm watcher correctly
+// observes a real Sei mainnet wormhole core bridge "hello world" tx.
+//
+// Tx: A0E841E95ECEF63B50D033E03F7B66723F49891CA645B1E0F2B12B74D612E012
+//
+// Run with:
+//
+//	SEI_LCD=https://your-sei-lcd \
+//	  go test -tags=integration -run TestSeiMainnetMessageParsing ./pkg/watchers/cosmwasm/
+func TestSeiMainnetMessageParsing(t *testing.T) {
+	lcd := requireSeiLCD(t)
+
+	const (
+		txHash          = "A0E841E95ECEF63B50D033E03F7B66723F49891CA645B1E0F2B12B74D612E012"
+		expectedSender  = "0000000000000000000000006576f9c768da087790efca8d09a0c4ad81e3729d"
+		expectedPayload = "68656c6c6f20776f726c64" // "hello world"
+		expectedNonce   = uint32(2604184548)
+		expectedSeq     = uint64(3)
+		expectedTime    = int64(1778085335)
+	)
+
+	logger := zaptest.NewLogger(t)
+	w := newSeiMainnetWatcher(t, lcd)
+	events := fetchSeiTxEvents(t, lcd, txHash)
+
+	msgs := EventsToMessagePublications(
+		w.contract,
+		txHash,
+		events,
+		logger,
+		w.chainID,
+		w.contractAddressLogKey,
+		w.b64Encoded,
+	)
+	require.Len(t, msgs, 1, "expected exactly one wormhole message publication")
+	msg := msgs[0]
+
+	expectedSenderBytes, err := hex.DecodeString(expectedSender)
+	require.NoError(t, err)
+	var expectedEmitter vaa.Address
+	copy(expectedEmitter[:], expectedSenderBytes)
+
+	expectedPayloadBytes, err := hex.DecodeString(expectedPayload)
+	require.NoError(t, err)
+
+	expectedTxID, err := hex.DecodeString(txHash)
+	require.NoError(t, err)
+
+	assert.Equal(t, vaa.ChainIDSei, msg.EmitterChain, "emitter chain")
+	assert.Equal(t, expectedEmitter, msg.EmitterAddress, "emitter address")
+	assert.Equal(t, expectedSeq, msg.Sequence, "sequence")
+	assert.Equal(t, expectedNonce, msg.Nonce, "nonce")
+	assert.Equal(t, expectedPayloadBytes, msg.Payload, "payload")
+	assert.Equal(t, "hello world", string(msg.Payload), "payload as string")
+	assert.Equal(t, time.Unix(expectedTime, 0), msg.Timestamp, "timestamp")
+	assert.Equal(t, uint8(0), msg.ConsistencyLevel, "consistency level (instant finality)")
+	assert.False(t, msg.Unreliable, "Unreliable should be false")
+	assert.Equal(t, expectedTxID, msg.TxID, "TxID should be the Sei tx hash bytes")
+
+	t.Logf("Successfully parsed Sei mainnet tx %s", txHash)
+	t.Logf("  emitter: %s", hex.EncodeToString(msg.EmitterAddress[:]))
+	t.Logf("  sequence: %d, nonce: %d", msg.Sequence, msg.Nonce)
+	t.Logf("  payload: %q", string(msg.Payload))
+}
+
+// TestSeiMainnetReobservationMatchesVAA_B32EFC48 confirms that a reobservation
+// of Sei mainnet tx B32EFC48D6E1D2CD0B2F744F3EEAC3D62EFDEBBB1BDFB97B972A2B213E34BE6C
+// produces a MessagePublication whose VAA body matches the canonical signed
+// VAA from wormholescan:
+//
+//	https://api.wormholescan.io/v1/signed_vaa/32/86c5fd957e2db8389553e1728f9c27964b22a8154091ccba54d75f4b10c61f5e/29310
+//
+// Run with:
+//
+//	SEI_LCD=https://your-sei-lcd \
+//	  go test -tags=integration -run TestSeiMainnetReobservationMatchesVAA_B32EFC48 ./pkg/watchers/cosmwasm/
+func TestSeiMainnetReobservationMatchesVAA_B32EFC48(t *testing.T) {
+	lcd := requireSeiLCD(t)
+
+	const txHash = "B32EFC48D6E1D2CD0B2F744F3EEAC3D62EFDEBBB1BDFB97B972A2B213E34BE6C"
+
+	// Canonical signed VAA for chain=32 emitter=86c5...1f5e sequence=29310.
+	const canonicalVAAB64 = "AQAAAAQNABK6V94bpyu7TLLWzhIyZtTngH4KEAgDRhYgmocGcnDsGh5/IYnoIELygJQQ6CnUqll/WoG9b2aQiCz7+2UeHXkBAUx50zirgozrnoWqDnHQmVwU7l0sPevJBfstDE5Wdu0eMB2Kjayg4gkucvdHX4AXJve8+5+cUP4IPkpHG50xJRYAAg4+McGhS+Lg5ITE7G3qlY9xZ1u3itjzsrR06YuZhlKLObPoo9vH4qum8xFE3xj2ij79Wmoze1iWRtU/CbF3U+MABPn6f8DWMeB/Tv7qKqBv0f5ETQMvoU/rSpb2UQDtR6k4P0UlibSGnz+CMfMV/aOKLuWO1ugmIWlZMBhsWta2cC4ABtLze0YLh9Zro6uxKEpSsUi7p+mGJOUNtW5MrfQME4ZGT8OGHbrYVJ0dN2Iwh7h51Rhol8TmlYds34BLmPvXtToBB9PT9iGXW7UW4coICAseSV5fos6vvdGFvpl+9BDsiyBCFiZ/GLzb0KX2kDF1n5HKZ8BzM09cQS6MiAcgE9sej84ACOeDDYF89UP0l6hCqIJbcNnnnZK0tgmPL2IfTSlAixXBP8o9H6bH6IegmE5Oa2b9sZVho8wslqgWKwPAVWh0jlgACtWPokIZ5u5DhbB+yV6acPXLNjcAU4kI9nMqHyeDrMjtEXMx2LO1UCKPXORcKufV51op0PALfdM177/ucP2VvdgADHJEOgkw++gqyg8VXzLmEEzGl+uL+ocq2EjLrXDEmYTRUHmueHaxyO0xJKBOExWr59wU9ihvnglshGnzP3JjrmsADlVKTUZzQ8w/oo+kCM3ZzN8TkbtzPNeTzfRpD3lX0mUDAmBIe8uaFcNDRZN/yhgfE/M5B8Du3SGu3xjGNjuR82QAD+SPtxwCUY9Fw2Xt9q4PtoT+JNzBt+IP3wZLeeFBcFVbCkNpbOPlqBIWIkKPJlXUtm6uEDCXtoLJ+tAcv7PTwKsBEWtiU7x4EzbFaYPRkgIn6w8wyFUSnhFZxSuqZKnn9sqXUAx20ksw8mx/76Skoxkq1lUepqfQHBLF79hvtAMa5kQBEu9AhQ3Z69xIJBM+HNjBw6dIkVb58iJovp9E5n6v3qd3TXhsUyh9gTp8+J0G+3yoXhZPo8txQmm1O22nRpqTLfAAaZdivgAAAAAAIIbF/ZV+Lbg4lVPhco+cJ5ZLIqgVQJHMulTXX0sQxh9eAAAAAAAAcn4AAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAokpAAAAAAAAAAAAAAAAImD6xeVUKnc6pE+8/t98GTvCxZkAApCeO2rE6WlWtVgAQp6i0hT/lNafzi/hUgqQP8luK0p5ABUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
+	canonicalVAA, err := base64.StdEncoding.DecodeString(canonicalVAAB64)
+	require.NoError(t, err)
+
+	parsedCanonical, err := vaa.Unmarshal(canonicalVAA)
+	require.NoError(t, err, "failed to unmarshal canonical VAA")
+
+	logger := zaptest.NewLogger(t)
+	w := newSeiMainnetWatcher(t, lcd)
+	events := fetchSeiTxEvents(t, lcd, txHash)
+	msgs := EventsToMessagePublications(
+		w.contract,
+		txHash,
+		events,
+		logger,
+		w.chainID,
+		w.contractAddressLogKey,
+		w.b64Encoded,
+	)
+	require.Len(t, msgs, 1, "expected exactly one wormhole message publication")
+	msg := msgs[0]
+
+	// Build a VAA from the reobservation using guardian-set-index=0 (matches
+	// what Watcher.Run produces). We compare body fields, not signatures —
+	// signatures are added later by guardian signing, not by parsing.
+	observedVAA := msg.CreateVAA(parsedCanonical.GuardianSetIndex)
+
+	// Field-by-field equality with the canonical VAA's body.
+	assert.Equal(t, parsedCanonical.Timestamp.Unix(), observedVAA.Timestamp.Unix(), "timestamp")
+	assert.Equal(t, parsedCanonical.Nonce, observedVAA.Nonce, "nonce")
+	assert.Equal(t, parsedCanonical.EmitterChain, observedVAA.EmitterChain, "emitter chain")
+	assert.Equal(t, parsedCanonical.EmitterAddress, observedVAA.EmitterAddress, "emitter address")
+	assert.Equal(t, parsedCanonical.Sequence, observedVAA.Sequence, "sequence")
+	assert.Equal(t, parsedCanonical.ConsistencyLevel, observedVAA.ConsistencyLevel, "consistency level")
+	assert.Equal(t, parsedCanonical.Payload, observedVAA.Payload, "payload")
+
+	// Byte-level body equality is the strongest check: identical body bytes
+	// produce identical signing digests, so any guardian quorum signing the
+	// reobservation produces the same VAA body as the canonical one.
+	canonicalBodyDigest := parsedCanonical.SigningDigest()
+	observedBodyDigest := observedVAA.SigningDigest()
+	assert.Equal(t,
+		hex.EncodeToString(canonicalBodyDigest.Bytes()),
+		hex.EncodeToString(observedBodyDigest.Bytes()),
+		"signing digest must match canonical VAA",
+	)
+
+	// Sanity: chain id, emitter, sequence match the wormholescan URL.
+	assert.Equal(t, vaa.ChainIDSei, msg.EmitterChain)
+	assert.Equal(t, "86c5fd957e2db8389553e1728f9c27964b22a8154091ccba54d75f4b10c61f5e", hex.EncodeToString(msg.EmitterAddress[:]))
+	assert.Equal(t, uint64(29310), msg.Sequence)
+
+	t.Logf("Reobservation of %s matches canonical VAA digest %s", txHash, hex.EncodeToString(observedBodyDigest.Bytes()))
+}
+
+// TestSeiMainnetReobservation_8803D593 confirms that Sei mainnet tx
+// 8803D593F90F6013BF09946008525E61D8FC7A6B4F3625E91D18969E9A056454 emits a
+// well-formed wormhole message that the cosmwasm watcher will publish.
+//
+// Run with:
+//
+//	SEI_LCD=https://your-sei-lcd \
+//	  go test -tags=integration -run TestSeiMainnetReobservation_8803D593 ./pkg/watchers/cosmwasm/
+func TestSeiMainnetReobservation_8803D593(t *testing.T) {
+	lcd := requireSeiLCD(t)
+
+	const txHash = "8803D593F90F6013BF09946008525E61D8FC7A6B4F3625E91D18969E9A056454"
+
+	logger := zaptest.NewLogger(t)
+	w := newSeiMainnetWatcher(t, lcd)
+	events := fetchSeiTxEvents(t, lcd, txHash)
+	msgs := EventsToMessagePublications(
+		w.contract,
+		txHash,
+		events,
+		logger,
+		w.chainID,
+		w.contractAddressLogKey,
+		w.b64Encoded,
+	)
+	require.NotEmpty(t, msgs, "expected at least one wormhole message publication")
+
+	expectedTxID, err := hex.DecodeString(txHash)
+	require.NoError(t, err)
+
+	for i, msg := range msgs {
+		assert.Equal(t, vaa.ChainIDSei, msg.EmitterChain, "msg[%d] emitter chain", i)
+		assert.Equal(t, expectedTxID, msg.TxID, "msg[%d] TxID should be the Sei tx hash bytes", i)
+		assert.NotZero(t, msg.Timestamp.Unix(), "msg[%d] timestamp", i)
+		assert.NotEmpty(t, msg.Payload, "msg[%d] payload", i)
+		assert.NotEqual(t, vaa.Address{}, msg.EmitterAddress, "msg[%d] emitter address", i)
+
+		// CreateVAA must succeed and round-trip — confirms the publication is
+		// shaped correctly for guardian signing.
+		v := msg.CreateVAA(0)
+		require.NotNil(t, v)
+		raw, err := v.Marshal()
+		require.NoError(t, err, "msg[%d] VAA must marshal", i)
+		require.NotEmpty(t, raw, "msg[%d] marshalled VAA bytes", i)
+
+		t.Logf("msg[%d]: emitter=%s sequence=%d nonce=%d payload_len=%d",
+			i,
+			hex.EncodeToString(msg.EmitterAddress[:]),
+			msg.Sequence,
+			msg.Nonce,
+			len(msg.Payload),
+		)
+	}
+}

--- a/node/pkg/watchers/cosmwasm/watcher_test.go
+++ b/node/pkg/watchers/cosmwasm/watcher_test.go
@@ -1,0 +1,40 @@
+package cosmwasm
+
+import (
+	"testing"
+
+	"github.com/certusone/wormhole/node/pkg/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/wormhole-foundation/wormhole/sdk/vaa"
+)
+
+// TestNewWatcher_B64EncodedByChain locks in the per-chain b64Encoded selection
+// in NewWatcher (watcher.go:125). Sei mainnet must be base64-encoded; flipping
+// it to false would silently break event parsing in production, since the
+// watcher's reobservation path uses this flag to decode event keys/values.
+func TestNewWatcher_B64EncodedByChain(t *testing.T) {
+	cases := []struct {
+		name       string
+		chainID    vaa.ChainID
+		env        common.Environment
+		wantB64    bool
+		wantLogKey string
+	}{
+		{"Sei mainnet", vaa.ChainIDSei, common.MainNet, true, "_contract_address"},
+		{"Sei testnet", vaa.ChainIDSei, common.TestNet, true, "_contract_address"},
+		{"Sei devnet always base64", vaa.ChainIDSei, common.UnsafeDevNet, true, "_contract_address"},
+		{"Injective mainnet not base64", vaa.ChainIDInjective, common.MainNet, false, "_contract_address"},
+		{"Injective devnet base64", vaa.ChainIDInjective, common.UnsafeDevNet, true, "_contract_address"},
+		{"Terra2 mainnet not base64", vaa.ChainIDTerra2, common.MainNet, false, "_contract_address"},
+		{"Terra2 devnet base64", vaa.ChainIDTerra2, common.UnsafeDevNet, true, "_contract_address"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := NewWatcher("ws://unused", "http://unused", "contract", nil, nil, tc.chainID, tc.env)
+			assert.Equal(t, tc.wantB64, w.b64Encoded, "b64Encoded mismatch")
+			assert.Equal(t, tc.wantLogKey, w.contractAddressLogKey, "contractAddressLogKey mismatch")
+			assert.Equal(t, tc.chainID, w.chainID)
+		})
+	}
+}

--- a/node/pkg/watchers/ibc/watcher.go
+++ b/node/pkg/watchers/ibc/watcher.go
@@ -66,7 +66,6 @@ var (
 	// Chains defines the list of chains to be monitored by IBC. Add new chains here as necessary.
 	Chains = []vaa.ChainID{
 		vaa.ChainIDOsmosis,
-		vaa.ChainIDSei,
 		vaa.ChainIDCosmoshub,
 		vaa.ChainIDEvmos,
 		vaa.ChainIDKujira,

--- a/sdk/js/src/bridge/__tests__/wormhole_ibc_e2e.ts
+++ b/sdk/js/src/bridge/__tests__/wormhole_ibc_e2e.ts
@@ -16,7 +16,7 @@ import {
   getSignedVAABySequence,
   waitForTerraExecution,
 } from "../../token_bridge/__tests__/utils/helpers";
-import { CHAIN_ID_SEI } from "../../utils/consts";
+import { CHAIN_ID_KUJIRA } from "../../utils/consts";
 
 const TERRA2_PRIVATE_KEY_4 =
   "bounce success option birth apple portion aunt rural episode solution hockey pencil lend session cause hedgehog slender journey system canvas decorate razor catch empty";
@@ -58,11 +58,11 @@ const terraBroadcastTxAndGetSignedVaa = async (
   if (!txSequence) {
     throw new Error("tx sequence not found");
   }
-  return await getSignedVAABySequence(CHAIN_ID_SEI, txSequence, emitter);
+  return await getSignedVAABySequence(CHAIN_ID_KUJIRA, txSequence, emitter);
 };
 
 describe("IBC Watcher Integration Tests", () => {
-  test('Send a message from "Sei" (Terra2) via IBC', async () => {
+  test('Send a message from "Kujira" (Terra2) via IBC', async () => {
     const postMsg = new MsgExecuteContract(
       terraWalletAddress,
       "terra1436kxs0w2es6xlqpp9rd35e3d0cjnw4sv8j3a7483sgks29jqwgsnyey7t",

--- a/wormchain/contracts/tools/deploy_wormchain.ts
+++ b/wormchain/contracts/tools/deploy_wormchain.ts
@@ -295,8 +295,9 @@ async function main() {
   );
 
   // Generated VAA using
-  // `guardiand template ibc-receiver-update-channel-chain --channel-id channel-0 --chain-id 32 --target-chain-id 3104 > wormchain.prototxt`
-  // `guardiand admin governance-vaa-verify wormchain.prototxt`
+  // `kubectl exec -it -n wormhole guardian-0 -- sh`
+  // `/guardiand template ibc-receiver-update-channel-chain --channel-id channel-0 --chain-id 4002 --target-chain-id 3104 > wormchain.prototxt`
+  // `/guardiand admin governance-vaa-verify wormchain.prototxt`
   let wormchainIbcReceiverWhitelistVaa: VAA<Other> = {
     version: 1,
     guardianSetIndex: 0,
@@ -309,7 +310,7 @@ async function main() {
     consistencyLevel: 0,
     payload: {
       type: "Other",
-      hex: `0000000000000000000000000000000000000000004962635265636569766572010c20000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000006368616e6e656c2d300020`,
+      hex: `0000000000000000000000000000000000000000004962635265636569766572010c20000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000006368616e6e656c2d300fa2`,
     },
   };
   wormchainIbcReceiverWhitelistVaa.signatures = sign(


### PR DESCRIPTION
This PR switches Sei from the IBC Wormchain watcher to a direct CosmWasm watcher. New flags are
```bash
--seiWS ws://sei:26657/websocket
--seiLCD http://sei:1317
--seiContract sei1gjrrme22cyha4ht2xapn3f08zzw6z3d4uxx6fyy9zd5dyr3yxgzqqncdqn
```

To run the integration test, you'll need an archive node (I tested against a quicknode endpoint)
```bash
SEI_LCD=https://your-sei-lcd-endpoint go test -tags=integration -run TestSeiMainnet -v ./pkg/watchers/cosmwasm/
```