### PR TITLE
feat(evm): wtt pauser role

### DIFF
--- a/ethereum/contracts/bridge/Bridge.sol
+++ b/ethereum/contracts/bridge/Bridge.sol
@@ -52,7 +52,7 @@ contract Bridge is BridgeGovernance, ReentrancyGuard {
     ///         so that an all-zero `unpauser` is never treated as an authorized caller.
     error NotUnpauser();
     /// @notice Reverts when `msg.value` does not cover the wormhole message fee.
-    error WormholeFeeTooLarge();
+    error InsufficientFee();
     /// @notice Reverts when an arbiter / relayer fee exceeds the transfer amount.
     error FeeExceedsAmount();
     /// @notice Reverts when a transfer VAA is not from a registered token-bridge emitter.
@@ -99,6 +99,10 @@ contract Bridge is BridgeGovernance, ReentrancyGuard {
     ///         via the `SetPauserAddresses` (action 4) governance VAA and may be left unassigned;
     ///         when unassigned this entry point reverts before comparing `msg.sender`, so an
     ///         all-zero `pauser` is never authorized.
+    /// @dev Intentionally does not check `isFork()`. On a forked chain the pre-fork pauser can
+    ///      still pause the bridge without first waiting for a `submitRecoverChainId` governance
+    ///      VAA — letting whoever holds the pauser key shut the bridge down on the fork
+    ///      immediately, before chain-id recovery completes.
     function pause() external {
         address p = pauser();
         if (p == address(0)) revert NotPauser();
@@ -112,6 +116,7 @@ contract Bridge is BridgeGovernance, ReentrancyGuard {
     ///         unassigned; when unassigned this entry point reverts before comparing `msg.sender`,
     ///         so an all-zero `unpauser` is never authorized. Note that `unpause` is intentionally
     ///         exempt from the `notPaused` modifier so it remains callable while paused.
+    /// @dev Intentionally does not check `isFork()`; see the matching note on `pause()`.
     function unpause() external {
         address u = unpauser();
         if (u == address(0)) revert NotUnpauser();
@@ -216,7 +221,7 @@ contract Bridge is BridgeGovernance, ReentrancyGuard {
     function _wrapAndTransferETH(uint256 arbiterFee) internal returns (BridgeStructs.TransferResult memory transferResult) {
         uint wormholeFee = wormhole().messageFee();
 
-        if (wormholeFee >= msg.value) revert WormholeFeeTooLarge();
+        if (wormholeFee >= msg.value) revert InsufficientFee();
 
         uint amount = msg.value - wormholeFee;
 

--- a/ethereum/contracts/bridge/Bridge.sol
+++ b/ethereum/contracts/bridge/Bridge.sol
@@ -38,16 +38,63 @@ contract Bridge is BridgeGovernance, ReentrancyGuard {
     /// @notice Emitted when the bridge is unpaused.
     event Unpaused(address indexed by);
 
+    /// @dev Custom errors are used in place of revert strings to keep `BridgeImplementation` under
+    ///      the 24,576-byte EIP-170 limit.
+
+    /// @notice Reverts when a `notPaused`-guarded entry point is called while the bridge is paused.
+    error BridgePaused();
+    /// @notice Reverts when `pause()` is called by anyone other than the configured pauser.
+    error NotPauser();
+    /// @notice Reverts when `unpause()` is called by anyone other than the configured unpauser.
+    error NotUnpauser();
+    /// @notice Reverts when `msg.value` does not cover the wormhole message fee.
+    error WormholeFeeTooLarge();
+    /// @notice Reverts when an arbiter / relayer fee exceeds the transfer amount.
+    error FeeExceedsAmount();
+    /// @notice Reverts when a transfer VAA is not from a registered token-bridge emitter.
+    error InvalidEmitter();
+    /// @notice Reverts when no wrapped asset is registered for a given (chain, token) pair.
+    error WrappedAssetNotFound();
+    /// @notice Reverts when `createWrapped` is called for a token native to this chain.
+    error OnlyForeignTokens();
+    /// @notice Reverts when `createWrapped` is called for a (chain, token) that already has a wrapper.
+    error WrappedAssetAlreadyExists();
+    /// @notice Reverts when truncating a 32-byte value to an EVM address loses non-zero high bytes.
+    error InvalidEVMAddress();
+    /// @notice Reverts when a payload-3 transfer is redeemed by anyone other than the recipient.
+    error InvalidSender();
+    /// @notice Reverts when a transfer VAA has already been redeemed.
+    error TransferAlreadyCompleted();
+    /// @notice Reverts when redeeming a transfer whose target chain is not this chain.
+    error InvalidTargetChain();
+    /// @notice Reverts when an unwrap-ETH path is taken with a token other than WETH.
+    error OnlyWETH();
+    /// @notice Reverts when an outbound transfer would exceed the per-token outstanding bridged cap.
+    error OutstandingExceedsMax();
+    /// @notice Reverts when an AssetMeta payload is malformed.
+    error InvalidAssetMeta();
+    /// @notice Reverts when a Transfer payload is malformed.
+    error InvalidTransferPayload();
+    /// @notice Reverts when an unknown payload id is encountered.
+    error InvalidPayloadId();
+
     /// @dev Reverts if the bridge is paused. See whitepapers/0018_pauser.md.
+    /// @dev Implemented as a shared internal function (rather than inlining the check in the
+    ///      modifier body) so the bytecode is emitted once and JUMPed to from every callsite,
+    ///      keeping `BridgeImplementation` under the 24,576-byte EIP-170 limit.
+    function _requireNotPaused() internal view {
+        if (paused()) revert BridgePaused();
+    }
+
     modifier notPaused() {
-        require(!paused(), "paused");
+        _requireNotPaused();
         _;
     }
 
     /// @notice Pause the bridge. Only callable by the configured pauser. Configured via the
     ///         SetPauserAddressesEvm (action 4) governance VAA.
     function pause() external {
-        require(msg.sender == pauser(), "not pauser");
+        if (msg.sender != pauser()) revert NotPauser();
         setPaused(true);
         emit Paused(msg.sender);
     }
@@ -56,7 +103,7 @@ contract Bridge is BridgeGovernance, ReentrancyGuard {
     ///         SetPauserAddressesEvm (action 4) governance VAA. Note that `unpause` is intentionally
     ///         exempt from the `notPaused` modifier.
     function unpause() external {
-        require(msg.sender == unpauser(), "not unpauser");
+        if (msg.sender != unpauser()) revert NotUnpauser();
         setPaused(false);
         emit Unpaused(msg.sender);
     }
@@ -157,11 +204,11 @@ contract Bridge is BridgeGovernance, ReentrancyGuard {
     function _wrapAndTransferETH(uint256 arbiterFee) internal returns (BridgeStructs.TransferResult memory transferResult) {
         uint wormholeFee = wormhole().messageFee();
 
-        require(wormholeFee < msg.value, "value is smaller than wormhole fee");
+        if (wormholeFee >= msg.value) revert WormholeFeeTooLarge();
 
         uint amount = msg.value - wormholeFee;
 
-        require(arbiterFee <= amount, "fee is bigger than amount minus wormhole fee");
+        if (arbiterFee > amount) revert FeeExceedsAmount();
 
         uint normalizedAmount = normalizeAmount(amount, 18);
         uint normalizedArbiterFee = normalizeAmount(arbiterFee, 18);
@@ -338,7 +385,7 @@ contract Bridge is BridgeGovernance, ReentrancyGuard {
         uint256 callValue,
         uint32 nonce
     ) internal returns (uint64 sequence) {
-        require(fee <= amount, "fee exceeds amount");
+        if (fee > amount) revert FeeExceedsAmount();
 
         BridgeStructs.Transfer memory transfer = BridgeStructs.Transfer({
             payloadID: 1,
@@ -395,7 +442,7 @@ contract Bridge is BridgeGovernance, ReentrancyGuard {
         (IWormhole.VM memory vm, bool valid, string memory reason) = wormhole().parseAndVerifyVM(encodedVm);
 
         require(valid, reason);
-        require(verifyBridgeVM(vm), "invalid emitter");
+        if (!verifyBridgeVM(vm)) revert InvalidEmitter();
 
         BridgeStructs.AssetMeta memory meta = parseAssetMeta(vm.payload);
         return _updateWrapped(meta, vm.sequence);
@@ -403,7 +450,7 @@ contract Bridge is BridgeGovernance, ReentrancyGuard {
 
     function _updateWrapped(BridgeStructs.AssetMeta memory meta, uint64 sequence) internal returns (address token) {
         address wrapped = wrappedAsset(meta.tokenChain, meta.tokenAddress);
-        require(wrapped != address(0), "wrapped asset does not exists");
+        if (wrapped == address(0)) revert WrappedAssetNotFound();
 
         // Update metadata
         TokenImplementation(wrapped).updateDetails(bytes32ToString(meta.name), bytes32ToString(meta.symbol), sequence);
@@ -415,7 +462,7 @@ contract Bridge is BridgeGovernance, ReentrancyGuard {
         (IWormhole.VM memory vm, bool valid, string memory reason) = wormhole().parseAndVerifyVM(encodedVm);
 
         require(valid, reason);
-        require(verifyBridgeVM(vm), "invalid emitter");
+        if (!verifyBridgeVM(vm)) revert InvalidEmitter();
 
         BridgeStructs.AssetMeta memory meta = parseAssetMeta(vm.payload);
         return _createWrapped(meta, vm.sequence);
@@ -423,8 +470,8 @@ contract Bridge is BridgeGovernance, ReentrancyGuard {
 
     // Creates a wrapped asset using AssetMeta
     function _createWrapped(BridgeStructs.AssetMeta memory meta, uint64 sequence) internal returns (address token) {
-        require(meta.tokenChain != chainId(), "can only wrap tokens from foreign chains");
-        require(wrappedAsset(meta.tokenChain, meta.tokenAddress) == address(0), "wrapped asset already exists");
+        if (meta.tokenChain == chainId()) revert OnlyForeignTokens();
+        if (wrappedAsset(meta.tokenChain, meta.tokenAddress) != address(0)) revert WrappedAssetAlreadyExists();
 
         // initialize the TokenImplementation
         bytes memory initialisationArgs = abi.encodeWithSelector(
@@ -516,7 +563,7 @@ contract Bridge is BridgeGovernance, ReentrancyGuard {
      * @param bytes32 bytes The 32 byte array to be converted.
      */
     function _truncateAddress(bytes32 b) internal pure returns (address) {
-        require(bytes12(b) == 0, "invalid EVM address");
+        if (bytes12(b) != 0) revert InvalidEVMAddress();
         return address(uint160(uint256(b)));
     }
 
@@ -525,23 +572,23 @@ contract Bridge is BridgeGovernance, ReentrancyGuard {
         (IWormhole.VM memory vm, bool valid, string memory reason) = wormhole().parseAndVerifyVM(encodedVm);
 
         require(valid, reason);
-        require(verifyBridgeVM(vm), "invalid emitter");
+        if (!verifyBridgeVM(vm)) revert InvalidEmitter();
 
         BridgeStructs.Transfer memory transfer = _parseTransferCommon(vm.payload);
 
         // payload 3 must be redeemed by the designated proxy contract
         address transferRecipient = _truncateAddress(transfer.to);
         if (transfer.payloadID == 3) {
-            require(msg.sender == transferRecipient, "invalid sender");
+            if (msg.sender != transferRecipient) revert InvalidSender();
         }
 
-        require(!isTransferCompleted(vm.hash), "transfer already completed");
+        if (isTransferCompleted(vm.hash)) revert TransferAlreadyCompleted();
         setTransferCompleted(vm.hash);
 
         // emit `TransferRedeemed` event
         emit TransferRedeemed(vm.emitterChainId, vm.emitterAddress, vm.sequence);
 
-        require(transfer.toChain == chainId(), "invalid target chain");
+        if (transfer.toChain != chainId()) revert InvalidTargetChain();
 
         IERC20 transferToken;
         if (transfer.tokenChain == chainId()) {
@@ -551,12 +598,12 @@ contract Bridge is BridgeGovernance, ReentrancyGuard {
             bridgedIn(address(transferToken), transfer.amount);
         } else {
             address wrapped = wrappedAsset(transfer.tokenChain, transfer.tokenAddress);
-            require(wrapped != address(0), "no wrapper for this token created yet");
+            if (wrapped == address(0)) revert WrappedAssetNotFound();
 
             transferToken = IERC20(wrapped);
         }
 
-        require(unwrapWETH == false || address(transferToken) == address(WETH()), "invalid token, can only unwrap WETH");
+        if (unwrapWETH && address(transferToken) != address(WETH())) revert OnlyWETH();
 
         // query decimals
         (,bytes memory queriedDecimals) = address(transferToken).staticcall(abi.encodeWithSignature("decimals()"));
@@ -568,7 +615,7 @@ contract Bridge is BridgeGovernance, ReentrancyGuard {
 
         // transfer fee to arbiter
         if (nativeFee > 0 && transferRecipient != msg.sender) {
-            require(nativeFee <= nativeAmount, "fee higher than transferred amount");
+            if (nativeFee > nativeAmount) revert FeeExceedsAmount();
 
             if (unwrapWETH) {
                 WETH().withdraw(nativeFee);
@@ -608,7 +655,7 @@ contract Bridge is BridgeGovernance, ReentrancyGuard {
 
     function bridgeOut(address token, uint normalizedAmount) internal {
         uint outstanding = outstandingBridged(token);
-        require(outstanding + normalizedAmount <= type(uint64).max, "transfer exceeds max outstanding bridged token amount");
+        if (outstanding + normalizedAmount > type(uint64).max) revert OutstandingExceedsMax();
         setOutstandingBridged(token, outstanding + normalizedAmount);
     }
 
@@ -617,7 +664,7 @@ contract Bridge is BridgeGovernance, ReentrancyGuard {
     }
 
     function verifyBridgeVM(IWormhole.VM memory vm) internal view returns (bool){
-        require(!isFork(), "invalid fork");
+        if (isFork()) revert InvalidFork();
         return bridgeContracts(vm.emitterChainId) == vm.emitterAddress;
     }
 
@@ -670,7 +717,7 @@ contract Bridge is BridgeGovernance, ReentrancyGuard {
         meta.payloadID = encoded.toUint8(index);
         index += 1;
 
-        require(meta.payloadID == 2, "invalid AssetMeta");
+        if (meta.payloadID != 2) revert InvalidAssetMeta();
 
         meta.tokenAddress = encoded.toBytes32(index);
         index += 32;
@@ -687,7 +734,7 @@ contract Bridge is BridgeGovernance, ReentrancyGuard {
         meta.name = encoded.toBytes32(index);
         index += 32;
 
-        require(encoded.length == index, "invalid AssetMeta");
+        if (encoded.length != index) revert InvalidAssetMeta();
     }
 
     /*
@@ -702,7 +749,7 @@ contract Bridge is BridgeGovernance, ReentrancyGuard {
         transfer.payloadID = encoded.toUint8(index);
         index += 1;
 
-        require(transfer.payloadID == 1, "invalid Transfer");
+        if (transfer.payloadID != 1) revert InvalidTransferPayload();
 
         transfer.amount = encoded.toUint256(index);
         index += 32;
@@ -722,7 +769,7 @@ contract Bridge is BridgeGovernance, ReentrancyGuard {
         transfer.fee = encoded.toUint256(index);
         index += 32;
 
-        require(encoded.length == index, "invalid Transfer");
+        if (encoded.length != index) revert InvalidTransferPayload();
     }
 
     /*
@@ -737,7 +784,7 @@ contract Bridge is BridgeGovernance, ReentrancyGuard {
         transfer.payloadID = encoded.toUint8(index);
         index += 1;
 
-        require(transfer.payloadID == 3, "invalid Transfer");
+        if (transfer.payloadID != 3) revert InvalidTransferPayload();
 
         transfer.amount = encoded.toUint256(index);
         index += 32;
@@ -784,7 +831,7 @@ contract Bridge is BridgeGovernance, ReentrancyGuard {
             // Type 3 payloads don't have fees.
             transfer.fee = 0;
         } else {
-            revert("Invalid payload id");
+            revert InvalidPayloadId();
         }
     }
 

--- a/ethereum/contracts/bridge/Bridge.sol
+++ b/ethereum/contracts/bridge/Bridge.sol
@@ -43,9 +43,13 @@ contract Bridge is BridgeGovernance, ReentrancyGuard {
 
     /// @notice Reverts when a `notPaused`-guarded entry point is called while the bridge is paused.
     error BridgePaused();
-    /// @notice Reverts when `pause()` is called by anyone other than the configured pauser.
+    /// @notice Reverts when `pause()` is called while the pauser role is unassigned, or by anyone
+    ///         other than the configured pauser. The "unassigned" branch is checked first so that
+    ///         an all-zero `pauser` is never treated as an authorized caller.
     error NotPauser();
-    /// @notice Reverts when `unpause()` is called by anyone other than the configured unpauser.
+    /// @notice Reverts when `unpause()` is called while the unpauser role is unassigned, or by
+    ///         anyone other than the configured unpauser. The "unassigned" branch is checked first
+    ///         so that an all-zero `unpauser` is never treated as an authorized caller.
     error NotUnpauser();
     /// @notice Reverts when `msg.value` does not cover the wormhole message fee.
     error WormholeFeeTooLarge();
@@ -78,7 +82,7 @@ contract Bridge is BridgeGovernance, ReentrancyGuard {
     /// @notice Reverts when an unknown payload id is encountered.
     error InvalidPayloadId();
 
-    /// @dev Reverts if the bridge is paused. See whitepapers/0018_pauser.md.
+    /// @dev Reverts if the bridge is paused. See the "Pausing" section of whitepapers/0003_token_bridge.md.
     /// @dev Implemented as a shared internal function (rather than inlining the check in the
     ///      modifier body) so the bytecode is emitted once and JUMPed to from every callsite,
     ///      keeping `BridgeImplementation` under the 24,576-byte EIP-170 limit.
@@ -91,19 +95,27 @@ contract Bridge is BridgeGovernance, ReentrancyGuard {
         _;
     }
 
-    /// @notice Pause the bridge. Only callable by the configured pauser. Configured via the
-    ///         SetPauserAddressesEvm (action 4) governance VAA.
+    /// @notice Pause the bridge. Only callable by the configured pauser. The pauser is configured
+    ///         via the `SetPauserAddresses` (action 4) governance VAA and may be left unassigned;
+    ///         when unassigned this entry point reverts before comparing `msg.sender`, so an
+    ///         all-zero `pauser` is never authorized.
     function pause() external {
-        if (msg.sender != pauser()) revert NotPauser();
+        address p = pauser();
+        if (p == address(0)) revert NotPauser();
+        if (msg.sender != p) revert NotPauser();
         setPaused(true);
         emit Paused(msg.sender);
     }
 
-    /// @notice Unpause the bridge. Only callable by the configured unpauser. Configured via the
-    ///         SetPauserAddressesEvm (action 4) governance VAA. Note that `unpause` is intentionally
-    ///         exempt from the `notPaused` modifier.
+    /// @notice Unpause the bridge. Only callable by the configured unpauser. The unpauser is
+    ///         configured via the `SetPauserAddresses` (action 4) governance VAA and may be left
+    ///         unassigned; when unassigned this entry point reverts before comparing `msg.sender`,
+    ///         so an all-zero `unpauser` is never authorized. Note that `unpause` is intentionally
+    ///         exempt from the `notPaused` modifier so it remains callable while paused.
     function unpause() external {
-        if (msg.sender != unpauser()) revert NotUnpauser();
+        address u = unpauser();
+        if (u == address(0)) revert NotUnpauser();
+        if (msg.sender != u) revert NotUnpauser();
         setPaused(false);
         emit Unpaused(msg.sender);
     }

--- a/ethereum/contracts/bridge/Bridge.sol
+++ b/ethereum/contracts/bridge/Bridge.sol
@@ -32,10 +32,39 @@ contract Bridge is BridgeGovernance, ReentrancyGuard {
         uint64 indexed sequence
     );
 
+    /// @notice Emitted when the bridge is paused.
+    event Paused(address indexed by);
+
+    /// @notice Emitted when the bridge is unpaused.
+    event Unpaused(address indexed by);
+
+    /// @dev Reverts if the bridge is paused. See whitepapers/0018_pauser.md.
+    modifier notPaused() {
+        require(!paused(), "paused");
+        _;
+    }
+
+    /// @notice Pause the bridge. Only callable by the configured pauser. Configured via the
+    ///         SetPauserAddressesEvm (action 4) governance VAA.
+    function pause() external {
+        require(msg.sender == pauser(), "not pauser");
+        setPaused(true);
+        emit Paused(msg.sender);
+    }
+
+    /// @notice Unpause the bridge. Only callable by the configured unpauser. Configured via the
+    ///         SetPauserAddressesEvm (action 4) governance VAA. Note that `unpause` is intentionally
+    ///         exempt from the `notPaused` modifier.
+    function unpause() external {
+        require(msg.sender == unpauser(), "not unpauser");
+        setPaused(false);
+        emit Unpaused(msg.sender);
+    }
+
     /*
      *  @dev Produce a AssetMeta message for a given token
      */
-    function attestToken(address tokenAddress, uint32 nonce) public payable returns (uint64 sequence) {
+    function attestToken(address tokenAddress, uint32 nonce) public payable notPaused returns (uint64 sequence) {
         // decimals, symbol & token are not part of the core ERC20 token standard, so we need to support contracts that dont implement them
         (,bytes memory queriedDecimals) = tokenAddress.staticcall(abi.encodeWithSignature("decimals()"));
         (,bytes memory queriedSymbol) = tokenAddress.staticcall(abi.encodeWithSignature("symbol()"));
@@ -78,7 +107,7 @@ contract Bridge is BridgeGovernance, ReentrancyGuard {
         bytes32 recipient,
         uint256 arbiterFee,
         uint32 nonce
-    ) public payable returns (uint64 sequence) {
+    ) public payable notPaused returns (uint64 sequence) {
         BridgeStructs.TransferResult
             memory transferResult = _wrapAndTransferETH(arbiterFee);
         sequence = logTransfer(
@@ -110,7 +139,7 @@ contract Bridge is BridgeGovernance, ReentrancyGuard {
         bytes32 recipient,
         uint32 nonce,
         bytes memory payload
-    ) public payable returns (uint64 sequence) {
+    ) public payable notPaused returns (uint64 sequence) {
         BridgeStructs.TransferResult
             memory transferResult = _wrapAndTransferETH(0);
         sequence = logTransferWithPayload(
@@ -170,7 +199,7 @@ contract Bridge is BridgeGovernance, ReentrancyGuard {
         bytes32 recipient,
         uint256 arbiterFee,
         uint32 nonce
-    ) public payable nonReentrant returns (uint64 sequence) {
+    ) public payable nonReentrant notPaused returns (uint64 sequence) {
         BridgeStructs.TransferResult memory transferResult = _transferTokens(
             token,
             amount,
@@ -207,7 +236,7 @@ contract Bridge is BridgeGovernance, ReentrancyGuard {
         bytes32 recipient,
         uint32 nonce,
         bytes memory payload
-    ) public payable nonReentrant returns (uint64 sequence) {
+    ) public payable nonReentrant notPaused returns (uint64 sequence) {
         BridgeStructs.TransferResult memory transferResult = _transferTokens(
             token,
             amount,
@@ -362,7 +391,7 @@ contract Bridge is BridgeGovernance, ReentrancyGuard {
         );
     }
 
-    function updateWrapped(bytes memory encodedVm) external returns (address token) {
+    function updateWrapped(bytes memory encodedVm) external notPaused returns (address token) {
         (IWormhole.VM memory vm, bool valid, string memory reason) = wormhole().parseAndVerifyVM(encodedVm);
 
         require(valid, reason);
@@ -382,7 +411,7 @@ contract Bridge is BridgeGovernance, ReentrancyGuard {
         return wrapped;
     }
 
-    function createWrapped(bytes memory encodedVm) external returns (address token) {
+    function createWrapped(bytes memory encodedVm) external notPaused returns (address token) {
         (IWormhole.VM memory vm, bool valid, string memory reason) = wormhole().parseAndVerifyVM(encodedVm);
 
         require(valid, reason);
@@ -440,7 +469,7 @@ contract Bridge is BridgeGovernance, ReentrancyGuard {
      *
      * @return The byte array representing a BridgeStructs.TransferWithPayload.
      */
-    function completeTransferWithPayload(bytes memory encodedVm) public returns (bytes memory) {
+    function completeTransferWithPayload(bytes memory encodedVm) public notPaused returns (bytes memory) {
         return _completeTransfer(encodedVm, false);
     }
 
@@ -454,7 +483,7 @@ contract Bridge is BridgeGovernance, ReentrancyGuard {
      *
      * @return The byte array representing a BridgeStructs.TransferWithPayload.
      */
-    function completeTransferAndUnwrapETHWithPayload(bytes memory encodedVm) public returns (bytes memory) {
+    function completeTransferAndUnwrapETHWithPayload(bytes memory encodedVm) public notPaused returns (bytes memory) {
         return _completeTransfer(encodedVm, true);
     }
 
@@ -465,7 +494,7 @@ contract Bridge is BridgeGovernance, ReentrancyGuard {
      *
      * @param encodedVm A byte array containing a VAA signed by the guardians.
      */
-    function completeTransfer(bytes memory encodedVm) public {
+    function completeTransfer(bytes memory encodedVm) public notPaused {
         _completeTransfer(encodedVm, false);
     }
 
@@ -476,7 +505,7 @@ contract Bridge is BridgeGovernance, ReentrancyGuard {
      *
      * @param encodedVm A byte array containing a VAA signed by the guardians.
      */
-    function completeTransferAndUnwrapETH(bytes memory encodedVm) public {
+    function completeTransferAndUnwrapETH(bytes memory encodedVm) public notPaused {
         _completeTransfer(encodedVm, true);
     }
 

--- a/ethereum/contracts/bridge/BridgeGetters.sol
+++ b/ethereum/contracts/bridge/BridgeGetters.sol
@@ -74,4 +74,16 @@ contract BridgeGetters is BridgeState {
     function finality() public view returns (uint8) {
         return _state.provider.finality;
     }
+
+    function pauser() public view returns (address) {
+        return _state.pauser;
+    }
+
+    function unpauser() public view returns (address) {
+        return _state.unpauser;
+    }
+
+    function paused() public view returns (bool) {
+        return _state.paused;
+    }
 }

--- a/ethereum/contracts/bridge/BridgeGetters.sol
+++ b/ethereum/contracts/bridge/BridgeGetters.sol
@@ -9,6 +9,7 @@ import "../interfaces/IWormhole.sol";
 import "./interfaces/IWETH.sol";
 
 import "./BridgeState.sol";
+import "./BridgePauserStorage.sol";
 
 contract BridgeGetters is BridgeState {
     function governanceActionIsConsumed(bytes32 hash) public view returns (bool) {
@@ -76,14 +77,14 @@ contract BridgeGetters is BridgeState {
     }
 
     function pauser() public view returns (address) {
-        return _state.pauser;
+        return BridgePauserStorage.data().pauser;
     }
 
     function unpauser() public view returns (address) {
-        return _state.unpauser;
+        return BridgePauserStorage.data().unpauser;
     }
 
     function paused() public view returns (bool) {
-        return _state.paused;
+        return _state.provider.paused;
     }
 }

--- a/ethereum/contracts/bridge/BridgeGovernance.sol
+++ b/ethereum/contracts/bridge/BridgeGovernance.sol
@@ -39,6 +39,9 @@ contract BridgeGovernance is BridgeGetters, BridgeSetters, ERC1967Upgrade {
     error WrongGovernanceContract();
     error GovernanceActionConsumed();
     error InitializeFailed(bytes reason);
+    /// @notice Reverts when a `SetPauserAddresses` payload encodes a pauser/unpauser length that is
+    ///         neither 0 (unassigned) nor 20 (the EVM native address size).
+    error InvalidAddressLength();
 
     // Execute a RegisterChain governance message
     function registerChain(bytes memory encodedVM) public {
@@ -74,23 +77,50 @@ contract BridgeGovernance is BridgeGetters, BridgeSetters, ERC1967Upgrade {
     /// @param unpauser The address authorized to call unpause().
     event PauserAddressesSet(address indexed pauser, address indexed unpauser);
 
-    /// @notice Set the pauser and unpauser addresses via a SetPauserAddressesEvm (action 4) governance VAA.
-    /// @dev Payload layout: module(32) | action(1)=4 | chainId(2) | pauser(20) | unpauser(20). Parsed
-    ///      inline (no separate `parseSetPauserAddresses` / struct) to keep `BridgeImplementation` under
-    ///      the 24,576-byte EIP-170 limit. See whitepapers/0018_pauser.md.
+    /// @notice Set the pauser and unpauser addresses via a `SetPauserAddresses` (action 4) governance VAA.
+    /// @dev Payload layout:
+    ///        module(32) | action(1)=4 | chainId(2)
+    ///      | pauserLen(1) | pauser[pauserLen]
+    ///      | unpauserLen(1) | unpauser[unpauserLen]
+    ///
+    ///      Each length must be either 20 (the EVM native address size) or 0 (role left
+    ///      unassigned); any other length is rejected. An all-zero 20-byte address is treated as
+    ///      equivalent to a zero-length address (also unassigned). Parsed inline (no separate
+    ///      `parseSetPauserAddresses` / struct) to keep `BridgeImplementation` under the
+    ///      24,576-byte EIP-170 limit. See the "Pausing" section of whitepapers/0003_token_bridge.md.
     function submitSetPauserAddresses(bytes memory encodedVM) public {
         IWormhole.VM memory vm = verifyGovernanceVM(encodedVM);
 
         setGovernanceActionConsumed(vm.hash);
 
         bytes memory payload = vm.payload;
-        if (payload.length != 75) revert WrongLength();
         if (payload.toBytes32(0) != module) revert WrongModule();
         if (payload.toUint8(32) != 4) revert WrongAction();
         if (payload.toUint16(33) != chainId()) revert WrongChainId();
 
-        address newPauser = payload.toAddress(35);
-        address newUnpauser = payload.toAddress(55);
+        uint index = 35;
+
+        uint8 pauserLen = payload.toUint8(index);
+        index += 1;
+        address newPauser;
+        if (pauserLen == 20) {
+            newPauser = payload.toAddress(index);
+            index += 20;
+        } else if (pauserLen != 0) {
+            revert InvalidAddressLength();
+        }
+
+        uint8 unpauserLen = payload.toUint8(index);
+        index += 1;
+        address newUnpauser;
+        if (unpauserLen == 20) {
+            newUnpauser = payload.toAddress(index);
+            index += 20;
+        } else if (unpauserLen != 0) {
+            revert InvalidAddressLength();
+        }
+
+        if (payload.length != index) revert WrongLength();
 
         setPauser(newPauser);
         setUnpauser(newUnpauser);

--- a/ethereum/contracts/bridge/BridgeGovernance.sol
+++ b/ethereum/contracts/bridge/BridgeGovernance.sol
@@ -55,6 +55,29 @@ contract BridgeGovernance is BridgeGetters, BridgeSetters, ERC1967Upgrade {
         upgradeImplementation(address(uint160(uint256(implementation.newContract))));
     }
 
+    /// @notice Emitted when the pauser/unpauser addresses are updated via governance.
+    /// @param pauser The address authorized to call pause().
+    /// @param unpauser The address authorized to call unpause().
+    event PauserAddressesSet(address indexed pauser, address indexed unpauser);
+
+    /// @notice Set the pauser and unpauser addresses via a SetPauserAddressesEvm (action 4) governance VAA.
+    /// @dev See whitepapers/0018_pauser.md.
+    function submitSetPauserAddresses(bytes memory encodedVM) public {
+        (IWormhole.VM memory vm, bool valid, string memory reason) = verifyGovernanceVM(encodedVM);
+        require(valid, reason);
+
+        setGovernanceActionConsumed(vm.hash);
+
+        BridgeStructs.SetPauserAddresses memory spa = parseSetPauserAddresses(vm.payload);
+
+        require(spa.chainId == chainId(), "wrong chain id");
+
+        setPauser(spa.pauser);
+        setUnpauser(spa.unpauser);
+
+        emit PauserAddressesSet(spa.pauser, spa.unpauser);
+    }
+
     /**
     * @dev Updates the `chainId` and `evmChainId` on a forked chain via Governance VAA/VM
     */
@@ -159,6 +182,35 @@ contract BridgeGovernance is BridgeGetters, BridgeSetters, ERC1967Upgrade {
 
         chain.newContract = encoded.toBytes32(index);
         index += 32;
+
+        require(encoded.length == index, "wrong length");
+    }
+
+    /// @dev Parse a SetPauserAddresses governance message. Action 4 = SetPauserAddressesEvm; action 5
+    ///      (SetPauserAddressesSolana) is rejected on EVM.
+    function parseSetPauserAddresses(bytes memory encoded) public pure returns (BridgeStructs.SetPauserAddresses memory spa) {
+        uint index = 0;
+
+        // governance header
+
+        spa.module = encoded.toBytes32(index);
+        index += 32;
+        require(spa.module == module, "wrong module");
+
+        spa.action = encoded.toUint8(index);
+        index += 1;
+        require(spa.action == 4, "wrong action");
+
+        spa.chainId = encoded.toUint16(index);
+        index += 2;
+
+        // payload: pauser (20) + unpauser (20)
+
+        spa.pauser = encoded.toAddress(index);
+        index += 20;
+
+        spa.unpauser = encoded.toAddress(index);
+        index += 20;
 
         require(encoded.length == index, "wrong length");
     }

--- a/ethereum/contracts/bridge/BridgeGovernance.sol
+++ b/ethereum/contracts/bridge/BridgeGovernance.sol
@@ -148,8 +148,7 @@ contract BridgeGovernance is BridgeGetters, BridgeSetters, ERC1967Upgrade {
         setChainId(rci.newChainId);
     }
 
-    /// @dev Reverts directly on any failure path. Returns the parsed VM on success. Callers no longer
-    ///      need to unpack a `(vm, valid, reason)` tuple — saves bytecode at every call site.
+    /// @dev Verify a governance VM. Reverts on any failure path; returns the parsed VM on success.
     function verifyGovernanceVM(bytes memory encodedVM) internal view returns (IWormhole.VM memory) {
         (IWormhole.VM memory vm, bool valid, string memory reason) = wormhole().parseAndVerifyVM(encodedVM);
         // Forwards the dynamic Wormhole core reason; cheaper than encoding a parameterized error.
@@ -228,7 +227,7 @@ contract BridgeGovernance is BridgeGetters, BridgeSetters, ERC1967Upgrade {
         if (encoded.length != index) revert WrongLength();
     }
 
-/// @dev Parse a recoverChainId (action 3) with minimal validation
+    /// @dev Parse a recoverChainId (action 3) with minimal validation
     function parseRecoverChainId(bytes memory encodedRecoverChainId) public pure returns (BridgeStructs.RecoverChainId memory rci) {
         uint index = 0;
 

--- a/ethereum/contracts/bridge/BridgeGovernance.sol
+++ b/ethereum/contracts/bridge/BridgeGovernance.sol
@@ -24,33 +24,47 @@ contract BridgeGovernance is BridgeGetters, BridgeSetters, ERC1967Upgrade {
     // "TokenBridge" (left padded)
     bytes32 constant module = 0x000000000000000000000000000000000000000000546f6b656e427269646765;
 
+    /// @dev Custom errors are used in place of revert strings to keep `BridgeImplementation` under
+    ///      the 24,576-byte EIP-170 limit.
+    error InvalidChainId();
+    error ChainAlreadyRegistered();
+    error WrongChainId();
+    error WrongLength();
+    error WrongModule();
+    error WrongAction();
+    error InvalidFork();
+    error NotAFork();
+    error InvalidEVMChain();
+    error WrongGovernanceChain();
+    error WrongGovernanceContract();
+    error GovernanceActionConsumed();
+    error InitializeFailed(bytes reason);
+
     // Execute a RegisterChain governance message
     function registerChain(bytes memory encodedVM) public {
-        (IWormhole.VM memory vm, bool valid, string memory reason) = verifyGovernanceVM(encodedVM);
-        require(valid, reason);
+        IWormhole.VM memory vm = verifyGovernanceVM(encodedVM);
 
         setGovernanceActionConsumed(vm.hash);
 
         BridgeStructs.RegisterChain memory chain = parseRegisterChain(vm.payload);
 
-        require((chain.chainId == chainId() && !isFork()) || chain.chainId == 0, "invalid chain id");
-        require(bridgeContracts(chain.emitterChainID) == bytes32(0), "chain already registered");
+        if (!((chain.chainId == chainId() && !isFork()) || chain.chainId == 0)) revert InvalidChainId();
+        if (bridgeContracts(chain.emitterChainID) != bytes32(0)) revert ChainAlreadyRegistered();
 
         setBridgeImplementation(chain.emitterChainID, chain.emitterAddress);
     }
 
     // Execute a UpgradeContract governance message
     function upgrade(bytes memory encodedVM) public {
-        require(!isFork(), "invalid fork");
+        if (isFork()) revert InvalidFork();
 
-        (IWormhole.VM memory vm, bool valid, string memory reason) = verifyGovernanceVM(encodedVM);
-        require(valid, reason);
+        IWormhole.VM memory vm = verifyGovernanceVM(encodedVM);
 
         setGovernanceActionConsumed(vm.hash);
 
         BridgeStructs.UpgradeContract memory implementation = parseUpgrade(vm.payload);
 
-        require(implementation.chainId == chainId(), "wrong chain id");
+        if (implementation.chainId != chainId()) revert WrongChainId();
 
         upgradeImplementation(address(uint160(uint256(implementation.newContract))));
     }
@@ -61,63 +75,61 @@ contract BridgeGovernance is BridgeGetters, BridgeSetters, ERC1967Upgrade {
     event PauserAddressesSet(address indexed pauser, address indexed unpauser);
 
     /// @notice Set the pauser and unpauser addresses via a SetPauserAddressesEvm (action 4) governance VAA.
-    /// @dev See whitepapers/0018_pauser.md.
+    /// @dev Payload layout: module(32) | action(1)=4 | chainId(2) | pauser(20) | unpauser(20). Parsed
+    ///      inline (no separate `parseSetPauserAddresses` / struct) to keep `BridgeImplementation` under
+    ///      the 24,576-byte EIP-170 limit. See whitepapers/0018_pauser.md.
     function submitSetPauserAddresses(bytes memory encodedVM) public {
-        (IWormhole.VM memory vm, bool valid, string memory reason) = verifyGovernanceVM(encodedVM);
-        require(valid, reason);
+        IWormhole.VM memory vm = verifyGovernanceVM(encodedVM);
 
         setGovernanceActionConsumed(vm.hash);
 
-        BridgeStructs.SetPauserAddresses memory spa = parseSetPauserAddresses(vm.payload);
+        bytes memory payload = vm.payload;
+        if (payload.length != 75) revert WrongLength();
+        if (payload.toBytes32(0) != module) revert WrongModule();
+        if (payload.toUint8(32) != 4) revert WrongAction();
+        if (payload.toUint16(33) != chainId()) revert WrongChainId();
 
-        require(spa.chainId == chainId(), "wrong chain id");
+        address newPauser = payload.toAddress(35);
+        address newUnpauser = payload.toAddress(55);
 
-        setPauser(spa.pauser);
-        setUnpauser(spa.unpauser);
+        setPauser(newPauser);
+        setUnpauser(newUnpauser);
 
-        emit PauserAddressesSet(spa.pauser, spa.unpauser);
+        emit PauserAddressesSet(newPauser, newUnpauser);
     }
 
     /**
     * @dev Updates the `chainId` and `evmChainId` on a forked chain via Governance VAA/VM
     */
     function submitRecoverChainId(bytes memory encodedVM) public {
-        require(isFork(), "not a fork");
+        if (!isFork()) revert NotAFork();
 
-        (IWormhole.VM memory vm, bool valid, string memory reason) = verifyGovernanceVM(encodedVM);
-        require(valid, reason);
+        IWormhole.VM memory vm = verifyGovernanceVM(encodedVM);
 
         setGovernanceActionConsumed(vm.hash);
 
         BridgeStructs.RecoverChainId memory rci = parseRecoverChainId(vm.payload);
 
         // Verify the VAA is for this chain
-        require(rci.evmChainId == block.chainid, "invalid EVM Chain");
+        if (rci.evmChainId != block.chainid) revert InvalidEVMChain();
 
         // Update the chainIds
         setEvmChainId(rci.evmChainId);
         setChainId(rci.newChainId);
     }
 
-    function verifyGovernanceVM(bytes memory encodedVM) internal view returns (IWormhole.VM memory parsedVM, bool isValid, string memory invalidReason){
+    /// @dev Reverts directly on any failure path. Returns the parsed VM on success. Callers no longer
+    ///      need to unpack a `(vm, valid, reason)` tuple — saves bytecode at every call site.
+    function verifyGovernanceVM(bytes memory encodedVM) internal view returns (IWormhole.VM memory) {
         (IWormhole.VM memory vm, bool valid, string memory reason) = wormhole().parseAndVerifyVM(encodedVM);
+        // Forwards the dynamic Wormhole core reason; cheaper than encoding a parameterized error.
+        require(valid, reason);
 
-        if (!valid) {
-            return (vm, valid, reason);
-        }
+        if (vm.emitterChainId != governanceChainId()) revert WrongGovernanceChain();
+        if (vm.emitterAddress != governanceContract()) revert WrongGovernanceContract();
+        if (governanceActionIsConsumed(vm.hash)) revert GovernanceActionConsumed();
 
-        if (vm.emitterChainId != governanceChainId()) {
-            return (vm, false, "wrong governance chain");
-        }
-        if (vm.emitterAddress != governanceContract()) {
-            return (vm, false, "wrong governance contract");
-        }
-
-        if (governanceActionIsConsumed(vm.hash)) {
-            return (vm, false, "governance action already consumed");
-        }
-
-        return (vm, true, "");
+        return vm;
     }
 
     event ContractUpgraded(address indexed oldContract, address indexed newContract);
@@ -130,7 +142,7 @@ contract BridgeGovernance is BridgeGetters, BridgeSetters, ERC1967Upgrade {
         // Call initialize function of the new implementation
         (bool success, bytes memory reason) = newImplementation.delegatecall(abi.encodeWithSignature("initialize()"));
 
-        require(success, string(reason));
+        if (!success) revert InitializeFailed(reason);
 
         emit ContractUpgraded(currentImplementation, newImplementation);
     }
@@ -142,11 +154,11 @@ contract BridgeGovernance is BridgeGetters, BridgeSetters, ERC1967Upgrade {
 
         chain.module = encoded.toBytes32(index);
         index += 32;
-        require(chain.module == module, "wrong module");
+        if (chain.module != module) revert WrongModule();
 
         chain.action = encoded.toUint8(index);
         index += 1;
-        require(chain.action == 1, "wrong action");
+        if (chain.action != 1) revert WrongAction();
 
         chain.chainId = encoded.toUint16(index);
         index += 2;
@@ -159,7 +171,7 @@ contract BridgeGovernance is BridgeGetters, BridgeSetters, ERC1967Upgrade {
         chain.emitterAddress = encoded.toBytes32(index);
         index += 32;
 
-        require(encoded.length == index, "wrong length");
+        if (encoded.length != index) revert WrongLength();
     }
 
     function parseUpgrade(bytes memory encoded) public pure returns (BridgeStructs.UpgradeContract memory chain) {
@@ -169,11 +181,11 @@ contract BridgeGovernance is BridgeGetters, BridgeSetters, ERC1967Upgrade {
 
         chain.module = encoded.toBytes32(index);
         index += 32;
-        require(chain.module == module, "wrong module");
+        if (chain.module != module) revert WrongModule();
 
         chain.action = encoded.toUint8(index);
         index += 1;
-        require(chain.action == 2, "wrong action");
+        if (chain.action != 2) revert WrongAction();
 
         chain.chainId = encoded.toUint16(index);
         index += 2;
@@ -183,49 +195,20 @@ contract BridgeGovernance is BridgeGetters, BridgeSetters, ERC1967Upgrade {
         chain.newContract = encoded.toBytes32(index);
         index += 32;
 
-        require(encoded.length == index, "wrong length");
+        if (encoded.length != index) revert WrongLength();
     }
 
-    /// @dev Parse a SetPauserAddresses governance message. Action 4 = SetPauserAddressesEvm; action 5
-    ///      (SetPauserAddressesSolana) is rejected on EVM.
-    function parseSetPauserAddresses(bytes memory encoded) public pure returns (BridgeStructs.SetPauserAddresses memory spa) {
-        uint index = 0;
-
-        // governance header
-
-        spa.module = encoded.toBytes32(index);
-        index += 32;
-        require(spa.module == module, "wrong module");
-
-        spa.action = encoded.toUint8(index);
-        index += 1;
-        require(spa.action == 4, "wrong action");
-
-        spa.chainId = encoded.toUint16(index);
-        index += 2;
-
-        // payload: pauser (20) + unpauser (20)
-
-        spa.pauser = encoded.toAddress(index);
-        index += 20;
-
-        spa.unpauser = encoded.toAddress(index);
-        index += 20;
-
-        require(encoded.length == index, "wrong length");
-    }
-
-    /// @dev Parse a recoverChainId (action 3) with minimal validation
+/// @dev Parse a recoverChainId (action 3) with minimal validation
     function parseRecoverChainId(bytes memory encodedRecoverChainId) public pure returns (BridgeStructs.RecoverChainId memory rci) {
         uint index = 0;
 
         rci.module = encodedRecoverChainId.toBytes32(index);
         index += 32;
-        require(rci.module == module, "wrong module");
+        if (rci.module != module) revert WrongModule();
 
         rci.action = encodedRecoverChainId.toUint8(index);
         index += 1;
-        require(rci.action == 3, "wrong action");
+        if (rci.action != 3) revert WrongAction();
 
         rci.evmChainId = encodedRecoverChainId.toUint256(index);
         index += 32;
@@ -233,6 +216,6 @@ contract BridgeGovernance is BridgeGetters, BridgeSetters, ERC1967Upgrade {
         rci.newChainId = encodedRecoverChainId.toUint16(index);
         index += 2;
 
-        require(encodedRecoverChainId.length == index, "wrong length");
+        if (encodedRecoverChainId.length != index) revert WrongLength();
     }
 }

--- a/ethereum/contracts/bridge/BridgeImplementation.sol
+++ b/ethereum/contracts/bridge/BridgeImplementation.sol
@@ -10,6 +10,8 @@ import "./Bridge.sol";
 
 
 contract BridgeImplementation is Bridge {
+    error AlreadyInitialized();
+
     // Beacon getter for the token contracts
     function implementation() public view returns (address) {
         return tokenImplementation();
@@ -26,10 +28,7 @@ contract BridgeImplementation is Bridge {
     modifier initializer() {
         address impl = ERC1967Upgrade._getImplementation();
 
-        require(
-            !isInitialized(impl),
-            "already initialized"
-        );
+        if (isInitialized(impl)) revert AlreadyInitialized();
 
         setInitialized(impl);
 

--- a/ethereum/contracts/bridge/BridgePauserStorage.sol
+++ b/ethereum/contracts/bridge/BridgePauserStorage.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache 2
+pragma solidity ^0.8.0;
+
+/// @notice ERC-7201 namespaced storage for the token bridge `pauser` / `unpauser` roles.
+/// @dev Decoupling these roles from `BridgeStorage.State` means adding pauser support does not
+///      shift any pre-existing storage slot (notably `_status` from `ReentrancyGuard` at slot 13)
+///      on an in-place proxy upgrade. The `paused` flag itself lives in `BridgeStorage.Provider`
+///      so the hot-path `notPaused` check piggybacks on the SLOAD that already loads `chainId`.
+///      Namespace: "wormhole.tokenbridge.pauser.storage".
+library BridgePauserStorage {
+    struct Layout {
+        // Address authorized to call pause(). May be address(0), in which case pause() reverts
+        // before comparing msg.sender. See the "Pausing" section of whitepapers/0003_token_bridge.md.
+        address pauser;
+        // Address authorized to call unpause(). May be address(0), in which case unpause() reverts
+        // before comparing msg.sender; recovery then requires governance to first assign a non-zero
+        // unpauser via SetPauserAddresses.
+        address unpauser;
+    }
+
+    /// @dev `keccak256(abi.encode(uint256(keccak256("wormhole.tokenbridge.pauser.storage")) - 1))
+    ///       & ~bytes32(uint256(0xff))` — precomputed per ERC-7201.
+    bytes32 internal constant LAYOUT_SLOT =
+        0x685f7dd8ace9c4fb94a4997fcd733e0d769273ee87b95731641e14d0cc4a6700;
+
+    function data() internal pure returns (Layout storage l) {
+        bytes32 slot = LAYOUT_SLOT;
+        assembly {
+            l.slot := slot
+        }
+    }
+}

--- a/ethereum/contracts/bridge/BridgeSetters.sol
+++ b/ethereum/contracts/bridge/BridgeSetters.sol
@@ -64,4 +64,16 @@ contract BridgeSetters is BridgeState {
         require(evmChainId == block.chainid, "invalid evmChainId");
         _state.evmChainId = evmChainId;
     }
+
+    function setPauser(address pauser) internal {
+        _state.pauser = pauser;
+    }
+
+    function setUnpauser(address unpauser) internal {
+        _state.unpauser = unpauser;
+    }
+
+    function setPaused(bool paused) internal {
+        _state.paused = paused;
+    }
 }

--- a/ethereum/contracts/bridge/BridgeSetters.sol
+++ b/ethereum/contracts/bridge/BridgeSetters.sol
@@ -4,6 +4,7 @@
 pragma solidity ^0.8.0;
 
 import "./BridgeState.sol";
+import "./BridgePauserStorage.sol";
 
 contract BridgeSetters is BridgeState {
     error InvalidImplementationAddress();
@@ -69,14 +70,14 @@ contract BridgeSetters is BridgeState {
     }
 
     function setPauser(address pauser) internal {
-        _state.pauser = pauser;
+        BridgePauserStorage.data().pauser = pauser;
     }
 
     function setUnpauser(address unpauser) internal {
-        _state.unpauser = unpauser;
+        BridgePauserStorage.data().unpauser = unpauser;
     }
 
     function setPaused(bool paused) internal {
-        _state.paused = paused;
+        _state.provider.paused = paused;
     }
 }

--- a/ethereum/contracts/bridge/BridgeSetters.sol
+++ b/ethereum/contracts/bridge/BridgeSetters.sol
@@ -6,6 +6,9 @@ pragma solidity ^0.8.0;
 import "./BridgeState.sol";
 
 contract BridgeSetters is BridgeState {
+    error InvalidImplementationAddress();
+    error InvalidEvmChainId();
+
     function setInitialized(address implementatiom) internal {
         _state.initializedImplementations[implementatiom] = true;
     }
@@ -35,7 +38,7 @@ contract BridgeSetters is BridgeState {
     }
 
     function setTokenImplementation(address impl) internal {
-        require(impl != address(0), "invalid implementation address");
+        if (impl == address(0)) revert InvalidImplementationAddress();
         _state.tokenImplementation = impl;
     }
 
@@ -61,7 +64,7 @@ contract BridgeSetters is BridgeState {
     }
 
     function setEvmChainId(uint256 evmChainId) internal {
-        require(evmChainId == block.chainid, "invalid evmChainId");
+        if (evmChainId != block.chainid) revert InvalidEvmChainId();
         _state.evmChainId = evmChainId;
     }
 

--- a/ethereum/contracts/bridge/BridgeState.sol
+++ b/ethereum/contracts/bridge/BridgeState.sol
@@ -49,6 +49,19 @@ contract BridgeStorage {
 
         // EIP-155 Chain ID
         uint256 evmChainId;
+
+        // Address authorized to call pause(). Configured via the SetPauserAddresses governance action.
+        // Typically the WormholePauser contract.
+        // See whitepapers/0018_pauser.md.
+        address pauser;
+
+        // Address authorized to call unpause(). Configured via the SetPauserAddresses governance action.
+        // Typically the guardian governance contract for a higher-trust unpause path.
+        address unpauser;
+
+        // Whether the Token Bridge is currently paused. When true, all entry points except governance
+        // and unpause revert.
+        bool paused;
     }
 }
 

--- a/ethereum/contracts/bridge/BridgeState.sol
+++ b/ethereum/contracts/bridge/BridgeState.sol
@@ -11,6 +11,11 @@ contract BridgeStorage {
         uint16 governanceChainId;
         // Required number of block confirmations to assume finality
         uint8 finality;
+        // Whether the Token Bridge is currently paused. When true, all entry points except
+        // governance and unpause revert. Packed into this slot (after `finality`) so that the
+        // `notPaused` check piggybacks on the SLOAD that already loads `chainId` on every entry
+        // point. See the "Pausing" section of whitepapers/0003_token_bridge.md.
+        bool paused;
         bytes32 governanceContract;
         address WETH;
     }
@@ -49,20 +54,6 @@ contract BridgeStorage {
 
         // EIP-155 Chain ID
         uint256 evmChainId;
-
-        // Address authorized to call pause(). Configured via the SetPauserAddresses governance action.
-        // May be address(0) (unassigned), in which case pause() reverts before comparing msg.sender.
-        // See the "Pausing" section of whitepapers/0003_token_bridge.md.
-        address pauser;
-
-        // Address authorized to call unpause(). Configured via the SetPauserAddresses governance action.
-        // May be address(0) (unassigned), in which case unpause() reverts before comparing msg.sender;
-        // recovery then requires governance to first assign a non-zero unpauser.
-        address unpauser;
-
-        // Whether the Token Bridge is currently paused. When true, all entry points except governance
-        // and unpause revert.
-        bool paused;
     }
 }
 

--- a/ethereum/contracts/bridge/BridgeState.sol
+++ b/ethereum/contracts/bridge/BridgeState.sol
@@ -51,12 +51,13 @@ contract BridgeStorage {
         uint256 evmChainId;
 
         // Address authorized to call pause(). Configured via the SetPauserAddresses governance action.
-        // Typically the WormholePauser contract.
-        // See whitepapers/0018_pauser.md.
+        // May be address(0) (unassigned), in which case pause() reverts before comparing msg.sender.
+        // See the "Pausing" section of whitepapers/0003_token_bridge.md.
         address pauser;
 
         // Address authorized to call unpause(). Configured via the SetPauserAddresses governance action.
-        // Typically the guardian governance contract for a higher-trust unpause path.
+        // May be address(0) (unassigned), in which case unpause() reverts before comparing msg.sender;
+        // recovery then requires governance to first assign a non-zero unpauser.
         address unpauser;
 
         // Whether the Token Bridge is currently paused. When true, all entry points except governance

--- a/ethereum/contracts/bridge/BridgeStructs.sol
+++ b/ethereum/contracts/bridge/BridgeStructs.sol
@@ -109,18 +109,4 @@ contract BridgeStructs {
         uint16 newChainId;
     }
 
-    struct SetPauserAddresses {
-        // Governance Header
-        // module: "TokenBridge" left-padded
-        bytes32 module;
-        // governance action: 4 (SetPauserAddressesEvm) on EVM
-        uint8 action;
-        // governance packet chain id: this or 0
-        uint16 chainId;
-
-        // Address authorized to call pause(). Typically the WormholePauser contract.
-        address pauser;
-        // Address authorized to call unpause(). Typically the guardian governance contract.
-        address unpauser;
-    }
 }

--- a/ethereum/contracts/bridge/BridgeStructs.sol
+++ b/ethereum/contracts/bridge/BridgeStructs.sol
@@ -108,4 +108,19 @@ contract BridgeStructs {
         // Chain ID
         uint16 newChainId;
     }
+
+    struct SetPauserAddresses {
+        // Governance Header
+        // module: "TokenBridge" left-padded
+        bytes32 module;
+        // governance action: 4 (SetPauserAddressesEvm) on EVM
+        uint8 action;
+        // governance packet chain id: this or 0
+        uint16 chainId;
+
+        // Address authorized to call pause(). Typically the WormholePauser contract.
+        address pauser;
+        // Address authorized to call unpause(). Typically the guardian governance contract.
+        address unpauser;
+    }
 }

--- a/ethereum/contracts/bridge/interfaces/ITokenBridge.sol
+++ b/ethereum/contracts/bridge/interfaces/ITokenBridge.sol
@@ -62,9 +62,24 @@ interface ITokenBridge {
         uint16 newChainId;
     }
 
+    struct SetPauserAddresses {
+        bytes32 module;
+        uint8 action;
+        uint16 chainId;
+
+        address pauser;
+        address unpauser;
+    }
+
     event ContractUpgraded(address indexed oldContract, address indexed newContract);
 
     event TransferRedeemed(uint16 indexed emitterChainId, bytes32 indexed emitterAddress, uint64 indexed sequence);
+
+    event PauserAddressesSet(address indexed pauser, address indexed unpauser);
+
+    event Paused(address indexed by);
+
+    event Unpaused(address indexed by);
 
     function _parseTransferCommon(bytes memory encoded) external pure returns (Transfer memory transfer);
 
@@ -136,6 +151,12 @@ interface ITokenBridge {
 
     function finality() external view returns (uint8);
 
+    function pauser() external view returns (address);
+
+    function unpauser() external view returns (address);
+
+    function paused() external view returns (bool);
+
     function implementation() external view returns (address);
 
     function initialize() external;
@@ -146,9 +167,17 @@ interface ITokenBridge {
 
     function submitRecoverChainId(bytes memory encodedVM) external;
 
+    function submitSetPauserAddresses(bytes memory encodedVM) external;
+
+    function pause() external;
+
+    function unpause() external;
+
     function parseRegisterChain(bytes memory encoded) external pure returns (RegisterChain memory chain);
 
     function parseUpgrade(bytes memory encoded) external pure returns (UpgradeContract memory chain);
 
     function parseRecoverChainId(bytes memory encodedRecoverChainId) external pure returns (RecoverChainId memory rci);
+
+    function parseSetPauserAddresses(bytes memory encoded) external pure returns (SetPauserAddresses memory spa);
 }

--- a/ethereum/contracts/bridge/interfaces/ITokenBridge.sol
+++ b/ethereum/contracts/bridge/interfaces/ITokenBridge.sol
@@ -108,6 +108,7 @@ interface ITokenBridge {
     error WrongGovernanceContract();
     error GovernanceActionConsumed();
     error InitializeFailed(bytes reason);
+    error InvalidAddressLength();
 
     // Setter / initializer (declared in BridgeSetters / BridgeImplementation).
     error InvalidImplementationAddress();

--- a/ethereum/contracts/bridge/interfaces/ITokenBridge.sol
+++ b/ethereum/contracts/bridge/interfaces/ITokenBridge.sol
@@ -62,15 +62,6 @@ interface ITokenBridge {
         uint16 newChainId;
     }
 
-    struct SetPauserAddresses {
-        bytes32 module;
-        uint8 action;
-        uint16 chainId;
-
-        address pauser;
-        address unpauser;
-    }
-
     event ContractUpgraded(address indexed oldContract, address indexed newContract);
 
     event TransferRedeemed(uint16 indexed emitterChainId, bytes32 indexed emitterAddress, uint64 indexed sequence);
@@ -80,6 +71,48 @@ interface ITokenBridge {
     event Paused(address indexed by);
 
     event Unpaused(address indexed by);
+
+    // Pauser-related (declared in Bridge contract).
+    error BridgePaused();
+    error NotPauser();
+    error NotUnpauser();
+
+    // Transfer/wrap-related (declared in Bridge contract).
+    error WormholeFeeTooLarge();
+    error FeeExceedsAmount();
+    error InvalidEmitter();
+    error WrappedAssetNotFound();
+    error OnlyForeignTokens();
+    error WrappedAssetAlreadyExists();
+    error InvalidEVMAddress();
+    error InvalidSender();
+    error TransferAlreadyCompleted();
+    error InvalidTargetChain();
+    error OnlyWETH();
+    error OutstandingExceedsMax();
+    error InvalidAssetMeta();
+    error InvalidTransferPayload();
+    error InvalidPayloadId();
+
+    // Governance-related (declared in BridgeGovernance contract).
+    error InvalidChainId();
+    error ChainAlreadyRegistered();
+    error WrongChainId();
+    error WrongLength();
+    error WrongModule();
+    error WrongAction();
+    error InvalidFork();
+    error NotAFork();
+    error InvalidEVMChain();
+    error WrongGovernanceChain();
+    error WrongGovernanceContract();
+    error GovernanceActionConsumed();
+    error InitializeFailed(bytes reason);
+
+    // Setter / initializer (declared in BridgeSetters / BridgeImplementation).
+    error InvalidImplementationAddress();
+    error InvalidEvmChainId();
+    error AlreadyInitialized();
 
     function _parseTransferCommon(bytes memory encoded) external pure returns (Transfer memory transfer);
 
@@ -178,6 +211,4 @@ interface ITokenBridge {
     function parseUpgrade(bytes memory encoded) external pure returns (UpgradeContract memory chain);
 
     function parseRecoverChainId(bytes memory encodedRecoverChainId) external pure returns (RecoverChainId memory rci);
-
-    function parseSetPauserAddresses(bytes memory encoded) external pure returns (SetPauserAddresses memory spa);
 }

--- a/ethereum/contracts/bridge/interfaces/ITokenBridge.sol
+++ b/ethereum/contracts/bridge/interfaces/ITokenBridge.sol
@@ -78,7 +78,7 @@ interface ITokenBridge {
     error NotUnpauser();
 
     // Transfer/wrap-related (declared in Bridge contract).
-    error WormholeFeeTooLarge();
+    error InsufficientFee();
     error FeeExceedsAmount();
     error InvalidEmitter();
     error WrappedAssetNotFound();

--- a/ethereum/forge-test/Bridge.t.sol
+++ b/ethereum/forge-test/Bridge.t.sol
@@ -118,7 +118,7 @@ contract TestBridge is Test {
     function testTruncate(bytes32 b) public {
         bool invalidAddress = bytes12(b) != 0;
         if (invalidAddress) {
-            vm.expectRevert("invalid EVM address");
+            vm.expectRevert(ITokenBridge.InvalidEVMAddress.selector);
         }
         bytes32 converted = bytes32(
             uint256(uint160(bytes20(bridge._truncateAddressPub(b))))
@@ -144,7 +144,7 @@ contract TestBridge is Test {
         assertEq(bridge.evmChainId(), 10001);
 
         // evmChainId must equal block.chainid
-        vm.expectRevert("invalid evmChainId");
+        vm.expectRevert(ITokenBridge.InvalidEvmChainId.selector);
         bridge.setEvmChainIdPub(1337);
     }
 
@@ -756,7 +756,7 @@ contract TestBridge is Test {
 
         address sender = address(0x1);
 
-        vm.expectRevert("invalid sender");
+        vm.expectRevert(ITokenBridge.InvalidSender.selector);
         vm.prank(sender);
         bridge.completeTransferWithPayload(vaa);
     }
@@ -1065,9 +1065,7 @@ contract TestBridge is Test {
             234
         );
 
-        vm.expectRevert(
-            "transfer exceeds max outstanding bridged token amount"
-        );
+        vm.expectRevert(ITokenBridge.OutstandingExceedsMax.selector);
         bridge.transferTokens(
             address(tokenImpl),
             amount - firstTransfer,
@@ -1212,7 +1210,7 @@ contract TestBridge is Test {
             2
         );
 
-        vm.expectRevert("invalid fork");
+        vm.expectRevert(ITokenBridge.InvalidFork.selector);
         bridge.upgrade(vaa);
     }
 

--- a/ethereum/forge-test/BridgePauser.t.sol
+++ b/ethereum/forge-test/BridgePauser.t.sol
@@ -117,7 +117,7 @@ contract TestBridgePauser is Test {
 
     function testSubmitSetPauserAddresses_Revert_WrongChain() public {
         bytes memory payload = _setPauserAddressesPayload(uint16(99), PAUSER, UNPAUSER);
-        vm.expectRevert("wrong chain id");
+        vm.expectRevert(ITokenBridge.WrongChainId.selector);
         bridge.submitSetPauserAddresses(_signAndEncodeVM(payload, 0));
     }
 
@@ -130,7 +130,7 @@ contract TestBridgePauser is Test {
             PAUSER,
             UNPAUSER
         );
-        vm.expectRevert("wrong action");
+        vm.expectRevert(ITokenBridge.WrongAction.selector);
         bridge.submitSetPauserAddresses(_signAndEncodeVM(payload, 0));
     }
 
@@ -142,7 +142,7 @@ contract TestBridgePauser is Test {
             PAUSER,
             UNPAUSER
         );
-        vm.expectRevert("wrong module");
+        vm.expectRevert(ITokenBridge.WrongModule.selector);
         bridge.submitSetPauserAddresses(_signAndEncodeVM(payload, 0));
     }
 
@@ -150,7 +150,7 @@ contract TestBridgePauser is Test {
         bytes memory payload = _setPauserAddressesPayload(testChainId, PAUSER, UNPAUSER);
         bytes memory vaa = _signAndEncodeVM(payload, 0);
         bridge.submitSetPauserAddresses(vaa);
-        vm.expectRevert("governance action already consumed");
+        vm.expectRevert(ITokenBridge.GovernanceActionConsumed.selector);
         bridge.submitSetPauserAddresses(vaa);
     }
 
@@ -183,7 +183,7 @@ contract TestBridgePauser is Test {
 
     function testPause_Revert_NotPauser() public {
         _configurePauser();
-        vm.expectRevert("not pauser");
+        vm.expectRevert(ITokenBridge.NotPauser.selector);
         bridge.pause();
     }
 
@@ -203,7 +203,7 @@ contract TestBridgePauser is Test {
         _configurePauser();
         vm.prank(PAUSER);
         bridge.pause();
-        vm.expectRevert("not unpauser");
+        vm.expectRevert(ITokenBridge.NotUnpauser.selector);
         bridge.unpause();
     }
 
@@ -222,7 +222,7 @@ contract TestBridgePauser is Test {
         vm.prank(PAUSER);
         bridge.pause();
 
-        vm.expectRevert("paused");
+        vm.expectRevert(ITokenBridge.BridgePaused.selector);
         bridge.attestToken(address(weth), 0);
     }
 
@@ -231,7 +231,7 @@ contract TestBridgePauser is Test {
         vm.prank(PAUSER);
         bridge.pause();
 
-        vm.expectRevert("paused");
+        vm.expectRevert(ITokenBridge.BridgePaused.selector);
         bridge.transferTokens(address(weth), 1, 2, bytes32(0), 0, 0);
     }
 
@@ -239,7 +239,7 @@ contract TestBridgePauser is Test {
         _configurePauser();
         vm.prank(PAUSER);
         bridge.pause();
-        vm.expectRevert("paused");
+        vm.expectRevert(ITokenBridge.BridgePaused.selector);
         bridge.transferTokensWithPayload(address(weth), 1, 2, bytes32(0), 0, hex"");
     }
 
@@ -247,7 +247,7 @@ contract TestBridgePauser is Test {
         _configurePauser();
         vm.prank(PAUSER);
         bridge.pause();
-        vm.expectRevert("paused");
+        vm.expectRevert(ITokenBridge.BridgePaused.selector);
         bridge.wrapAndTransferETH(2, bytes32(0), 0, 0);
     }
 
@@ -255,7 +255,7 @@ contract TestBridgePauser is Test {
         _configurePauser();
         vm.prank(PAUSER);
         bridge.pause();
-        vm.expectRevert("paused");
+        vm.expectRevert(ITokenBridge.BridgePaused.selector);
         bridge.wrapAndTransferETHWithPayload(2, bytes32(0), 0, hex"");
     }
 
@@ -263,7 +263,7 @@ contract TestBridgePauser is Test {
         _configurePauser();
         vm.prank(PAUSER);
         bridge.pause();
-        vm.expectRevert("paused");
+        vm.expectRevert(ITokenBridge.BridgePaused.selector);
         bridge.completeTransfer(hex"");
     }
 
@@ -271,7 +271,7 @@ contract TestBridgePauser is Test {
         _configurePauser();
         vm.prank(PAUSER);
         bridge.pause();
-        vm.expectRevert("paused");
+        vm.expectRevert(ITokenBridge.BridgePaused.selector);
         bridge.completeTransferAndUnwrapETH(hex"");
     }
 
@@ -279,7 +279,7 @@ contract TestBridgePauser is Test {
         _configurePauser();
         vm.prank(PAUSER);
         bridge.pause();
-        vm.expectRevert("paused");
+        vm.expectRevert(ITokenBridge.BridgePaused.selector);
         bridge.completeTransferWithPayload(hex"");
     }
 
@@ -287,7 +287,7 @@ contract TestBridgePauser is Test {
         _configurePauser();
         vm.prank(PAUSER);
         bridge.pause();
-        vm.expectRevert("paused");
+        vm.expectRevert(ITokenBridge.BridgePaused.selector);
         bridge.completeTransferAndUnwrapETHWithPayload(hex"");
     }
 
@@ -295,7 +295,7 @@ contract TestBridgePauser is Test {
         _configurePauser();
         vm.prank(PAUSER);
         bridge.pause();
-        vm.expectRevert("paused");
+        vm.expectRevert(ITokenBridge.BridgePaused.selector);
         bridge.createWrapped(hex"");
     }
 
@@ -303,7 +303,7 @@ contract TestBridgePauser is Test {
         _configurePauser();
         vm.prank(PAUSER);
         bridge.pause();
-        vm.expectRevert("paused");
+        vm.expectRevert(ITokenBridge.BridgePaused.selector);
         bridge.updateWrapped(hex"");
     }
 
@@ -318,22 +318,10 @@ contract TestBridgePauser is Test {
         assertEq(bridge.pauser(), address(0xFEED));
     }
 
-    // ============================ parseSetPauserAddresses ============================
-
-    function testParseSetPauserAddresses() public {
-        bytes memory payload = _setPauserAddressesPayload(testChainId, PAUSER, UNPAUSER);
-        ITokenBridge.SetPauserAddresses memory spa = bridge.parseSetPauserAddresses(payload);
-        assertEq(spa.module, tokenBridgeModule);
-        assertEq(spa.action, ACTION_SET_PAUSER_ADDRESSES_EVM);
-        assertEq(spa.chainId, testChainId);
-        assertEq(spa.pauser, PAUSER);
-        assertEq(spa.unpauser, UNPAUSER);
-    }
-
-    function testParseSetPauserAddresses_Revert_WrongLength() public {
+    function testSubmitSetPauserAddresses_Revert_WrongLength() public {
         bytes memory payload = abi.encodePacked(_setPauserAddressesPayload(testChainId, PAUSER, UNPAUSER), hex"ff");
-        vm.expectRevert("wrong length");
-        bridge.parseSetPauserAddresses(payload);
+        vm.expectRevert(ITokenBridge.WrongLength.selector);
+        bridge.submitSetPauserAddresses(_signAndEncodeVM(payload, 0));
     }
 
     // ============================ Internal ============================

--- a/ethereum/forge-test/BridgePauser.t.sol
+++ b/ethereum/forge-test/BridgePauser.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.0;
 
 import "../contracts/bridge/BridgeSetup.sol";
 import "../contracts/bridge/BridgeImplementation.sol";
+import "../contracts/bridge/BridgePauserStorage.sol";
 import "../contracts/bridge/TokenBridge.sol";
 import "../contracts/bridge/interfaces/ITokenBridge.sol";
 import "../contracts/bridge/token/TokenImplementation.sol";
@@ -77,8 +78,19 @@ contract TestBridgePauser is Test {
     // ============================ Helpers ============================
 
     function _signAndEncodeVM(bytes memory data, uint64 sequence) internal pure returns (bytes memory) {
+        return _signAndEncodeVMFrom(data, sequence, uint16(1), bytes32(uint256(0x4)));
+    }
+
+    /// @dev Variant that lets a test override the emitter chain id and emitter address — used to
+    ///      exercise the `WrongGovernanceChain` and `WrongGovernanceContract` revert paths.
+    function _signAndEncodeVMFrom(
+        bytes memory data,
+        uint64 sequence,
+        uint16 emitterChainId,
+        bytes32 emitterAddress
+    ) internal pure returns (bytes memory) {
         bytes memory body = abi.encodePacked(
-            uint32(0), uint32(0), uint16(1), bytes32(uint256(0x4)), sequence, uint8(0), data
+            uint32(0), uint32(0), emitterChainId, emitterAddress, sequence, uint8(0), data
         );
         bytes32 bodyHash = keccak256(abi.encodePacked(keccak256(body)));
         (uint8 v, bytes32 r, bytes32 s) = Vm(address(uint160(uint256(keccak256("hevm cheat code"))))).sign(testGuardian, bodyHash);
@@ -445,16 +457,296 @@ contract TestBridgePauser is Test {
         vm.prank(PAUSER);
         bridge.pause();
 
-        // submitSetPauserAddresses is governance and must remain callable when paused.
-        bytes memory payload = _setPauserAddressesPayload(testChainId, address(0xFEED), UNPAUSER);
+        // submitSetPauserAddresses is governance and must remain callable when paused. Both
+        // fields update atomically — assert each independently.
+        address newPauser = address(0xFEED);
+        address newUnpauser = address(0xCEED);
+        bytes memory payload = _setPauserAddressesPayload(testChainId, newPauser, newUnpauser);
         bridge.submitSetPauserAddresses(_signAndEncodeVM(payload, 7));
-        assertEq(bridge.pauser(), address(0xFEED));
+        assertEq(bridge.pauser(), newPauser);
+        assertEq(bridge.unpauser(), newUnpauser);
+        assertTrue(bridge.paused());
     }
 
     function testSubmitSetPauserAddresses_Revert_WrongLength() public {
         bytes memory payload = abi.encodePacked(_setPauserAddressesPayload(testChainId, PAUSER, UNPAUSER), hex"ff");
         vm.expectRevert(ITokenBridge.WrongLength.selector);
         bridge.submitSetPauserAddresses(_signAndEncodeVM(payload, 0));
+    }
+
+    function testSubmitSetPauserAddresses_Revert_WrongGovernanceChain() public {
+        bytes memory payload = _setPauserAddressesPayload(testChainId, PAUSER, UNPAUSER);
+        bytes memory vaa = _signAndEncodeVMFrom(payload, 0, uint16(99), bytes32(uint256(0x4)));
+        vm.expectRevert(ITokenBridge.WrongGovernanceChain.selector);
+        bridge.submitSetPauserAddresses(vaa);
+    }
+
+    function testSubmitSetPauserAddresses_Revert_WrongGovernanceContract() public {
+        bytes memory payload = _setPauserAddressesPayload(testChainId, PAUSER, UNPAUSER);
+        bytes memory vaa = _signAndEncodeVMFrom(payload, 0, uint16(1), bytes32(uint256(0xDEADBEEF)));
+        vm.expectRevert(ITokenBridge.WrongGovernanceContract.selector);
+        bridge.submitSetPauserAddresses(vaa);
+    }
+
+    // ============================ Other governance handlers while paused ============================
+    //
+    // The whitepaper specifies that every governance handler must remain callable while the bridge
+    // is paused (only user-facing entry points are gated by `notPaused`). For each handler we
+    // either drive a successful execution or assert it reverts on a handler-specific check rather
+    // than `BridgePaused` — proving the `notPaused` modifier is not applied.
+
+    function testNotPaused_RegisterChain_WorksWhenPaused() public {
+        _configurePauser();
+        vm.prank(PAUSER);
+        bridge.pause();
+
+        uint16 foreignChain = 42;
+        bytes32 foreignEmitter = bytes32(uint256(0xDEAD));
+        bytes memory payload = abi.encodePacked(
+            tokenBridgeModule,
+            uint8(1),         // action: RegisterChain
+            uint16(0),        // chainId 0 = any
+            foreignChain,
+            foreignEmitter
+        );
+        bridge.registerChain(_signAndEncodeVM(payload, 100));
+        assertEq(bridge.bridgeContracts(foreignChain), foreignEmitter);
+    }
+
+    function testNotPaused_Upgrade_NotBlockedByPause() public {
+        _configurePauser();
+        vm.prank(PAUSER);
+        bridge.pause();
+
+        // Send an UpgradeContract VAA targeted at the wrong chain so the handler reverts at the
+        // chainId check rather than executing an upgrade. The point is to demonstrate the revert
+        // is `WrongChainId`, NOT `BridgePaused` — i.e. the handler runs past the (absent)
+        // notPaused gate.
+        bytes memory payload = abi.encodePacked(
+            tokenBridgeModule,
+            uint8(2),                                // action: Upgrade
+            uint16(testChainId + 1),                 // wrong chain
+            bytes32(uint256(uint160(address(0xBEEF))))
+        );
+        vm.expectRevert(ITokenBridge.WrongChainId.selector);
+        bridge.upgrade(_signAndEncodeVM(payload, 101));
+    }
+
+    function testNotPaused_SubmitRecoverChainId_WorksWhenPaused() public {
+        _configurePauser();
+        vm.prank(PAUSER);
+        bridge.pause();
+
+        // Simulate a fork: bump block.chainid so `isFork()` returns true, then send a matching
+        // RecoverChainId VAA. The handler must run to completion despite the bridge being paused.
+        uint256 forkChainId = testEvmChainId + 1;
+        vm.chainId(forkChainId);
+
+        uint16 newWormholeChainId = 999;
+        bytes memory payload = abi.encodePacked(
+            tokenBridgeModule,
+            uint8(3),                  // action: RecoverChainId
+            uint256(forkChainId),      // evmChainId — must match block.chainid
+            newWormholeChainId
+        );
+        bridge.submitRecoverChainId(_signAndEncodeVM(payload, 102));
+        assertEq(bridge.chainId(), newWormholeChainId);
+        assertEq(bridge.evmChainId(), forkChainId);
+    }
+
+    // ============================ Idempotency ============================
+
+    function testPause_Idempotent() public {
+        _configurePauser();
+        vm.prank(PAUSER);
+        bridge.pause();
+        assertTrue(bridge.paused());
+
+        // A second pause() must not toggle the state and must not revert. State stays `true`.
+        vm.prank(PAUSER);
+        bridge.pause();
+        assertTrue(bridge.paused());
+    }
+
+    function testUnpause_Idempotent() public {
+        _configurePauser();
+        // Bridge starts unpaused. Calling unpause() should keep it unpaused, not toggle to paused.
+        vm.prank(UNPAUSER);
+        bridge.unpause();
+        assertFalse(bridge.paused());
+
+        // Pause, unpause, then unpause again — the second unpause must not re-pause the bridge.
+        vm.prank(PAUSER);
+        bridge.pause();
+        vm.prank(UNPAUSER);
+        bridge.unpause();
+        assertFalse(bridge.paused());
+
+        vm.prank(UNPAUSER);
+        bridge.unpause();
+        assertFalse(bridge.paused());
+    }
+
+    // ============================ Rotation while paused ============================
+
+    function testSubmitSetPauserAddresses_CanRotateWhilePaused() public {
+        _configurePauser();
+        vm.prank(PAUSER);
+        bridge.pause();
+        assertTrue(bridge.paused());
+
+        // Rotate to a fresh pauser / unpauser pair while paused; the new addresses must take
+        // effect immediately and the bridge must stay paused (rotation does not unpause).
+        address newPauser = address(0xAAAA);
+        address newUnpauser = address(0xBBBB);
+        bytes memory payload = _setPauserAddressesPayload(testChainId, newPauser, newUnpauser);
+        bridge.submitSetPauserAddresses(_signAndEncodeVM(payload, 200));
+
+        assertEq(bridge.pauser(), newPauser);
+        assertEq(bridge.unpauser(), newUnpauser);
+        assertTrue(bridge.paused());
+
+        // Old pauser/unpauser can no longer act on the bridge.
+        vm.expectRevert(ITokenBridge.NotUnpauser.selector);
+        vm.prank(UNPAUSER);
+        bridge.unpause();
+
+        // New unpauser unpauses successfully.
+        vm.prank(newUnpauser);
+        bridge.unpause();
+        assertFalse(bridge.paused());
+
+        // And the new pauser can re-pause.
+        vm.prank(newPauser);
+        bridge.pause();
+        assertTrue(bridge.paused());
+    }
+
+    // ============================ Storage layout ============================
+    //
+    // These tests pin the ERC-7201 namespaced storage decision: `pauser` and `unpauser` live in a
+    // namespaced slot disjoint from `BridgeStorage.State`, so adding/removing pauser support never
+    // shifts slot 13 (the `_status` slot inherited from OpenZeppelin's `ReentrancyGuard`).
+
+    /// @dev Matches `BridgePauserStorage.LAYOUT_SLOT`.
+    bytes32 constant PAUSER_NAMESPACE_SLOT =
+        0x685f7dd8ace9c4fb94a4997fcd733e0d769273ee87b95731641e14d0cc4a6700;
+
+    function testStorageLayout_NamespacedSlotMatchesERC7201() public {
+        // Recompute the slot per ERC-7201 and assert it matches the constant baked into
+        // `BridgePauserStorage`. Guards against silent drift: any rename of the namespace string,
+        // or any miscopied constant, fails here rather than corrupting storage on a live deploy.
+        bytes32 expected =
+            keccak256(abi.encode(uint256(keccak256("wormhole.tokenbridge.pauser.storage")) - 1))
+            & ~bytes32(uint256(0xff));
+        assertEq(BridgePauserStorage.LAYOUT_SLOT, expected);
+        assertEq(BridgePauserStorage.LAYOUT_SLOT, PAUSER_NAMESPACE_SLOT);
+    }
+
+    function testStorageLayout_FreshDeploy_RolesAreZero() public {
+        assertEq(bridge.pauser(), address(0));
+        assertEq(bridge.unpauser(), address(0));
+        assertFalse(bridge.paused());
+    }
+
+    function testStorageLayout_PauserLivesAtNamespacedSlot() public {
+        bytes memory payload = _setPauserAddressesPayload(testChainId, PAUSER, UNPAUSER);
+        bridge.submitSetPauserAddresses(_signAndEncodeVM(payload, 0));
+
+        // `pauser` is at the namespaced slot, `unpauser` packs into the next slot.
+        bytes32 pauserSlotValue = vm.load(address(bridge), PAUSER_NAMESPACE_SLOT);
+        bytes32 unpauserSlotValue =
+            vm.load(address(bridge), bytes32(uint256(PAUSER_NAMESPACE_SLOT) + 1));
+        assertEq(address(uint160(uint256(pauserSlotValue))), PAUSER);
+        assertEq(address(uint160(uint256(unpauserSlotValue))), UNPAUSER);
+    }
+
+    function testStorageLayout_StateSlotsUnchangedByPauser() public {
+        // Slot 13 is the ReentrancyGuard `_status` slot. A previous version of this PR placed
+        // `pauser` directly in `BridgeStorage.State`, which would have pushed `_status` to slot 15
+        // and made the freshly-upgraded proxy read `pauser` from the old `_status` slot. The
+        // ERC-7201 split prevents that: slot 13 must NOT hold the pauser address.
+        bytes memory payload = _setPauserAddressesPayload(testChainId, PAUSER, UNPAUSER);
+        bridge.submitSetPauserAddresses(_signAndEncodeVM(payload, 0));
+
+        bytes32 slot13 = vm.load(address(bridge), bytes32(uint256(13)));
+        assertTrue(slot13 != bytes32(uint256(uint160(PAUSER))));
+        // `_status` on a fresh proxy is `0` until the first `nonReentrant` call lazily initializes
+        // it; either way it stays a small reentrancy sentinel, never an address.
+        assertLt(uint256(slot13), uint256(3));
+    }
+
+    function testStorageLayout_PausedPacksIntoProviderSlot() public {
+        // `paused` is packed into the first slot of `BridgeStorage.Provider` after
+        // `chainId(2) | governanceChainId(2) | finality(1)`. That slot starts at offset 2 within
+        // `_state` (after `wormhole` and `tokenImplementation`), i.e. slot 2 of the contract.
+        bytes32 providerSlotBefore = vm.load(address(bridge), bytes32(uint256(2)));
+        // `paused` byte sits at offset 5 within the slot (after chainId + governanceChainId +
+        // finality). Note that storage is right-aligned: byte offset N in the slot corresponds to
+        // byte index (31 - N) from the left in the bytes32 representation.
+        uint256 pausedByteIndex = 31 - 5;
+        assertEq(uint8(providerSlotBefore[pausedByteIndex]), 0);
+
+        _configurePauser();
+        vm.prank(PAUSER);
+        bridge.pause();
+
+        bytes32 providerSlotAfter = vm.load(address(bridge), bytes32(uint256(2)));
+        assertEq(uint8(providerSlotAfter[pausedByteIndex]), 1);
+        // The lower bytes (chainId, governanceChainId, finality) must be untouched by the pause.
+        assertEq(
+            providerSlotBefore & bytes32(uint256(0x000000000000000000000000000000000000000000000000000000ffffffffff)),
+            providerSlotAfter & bytes32(uint256(0x000000000000000000000000000000000000000000000000000000ffffffffff))
+        );
+    }
+
+    // ============================ Real wire vector ============================
+    //
+    // Pin compatibility with the off-chain encoder in `sdk/vaa/payloads.go`. The hex vector below
+    // is copied from the `TestBodyTokenBridgeSetPauserAddressesSerialize` "evm both set" case
+    // (PR #4810): module(32) || action(04) || chain(0002) || pauserLen(14) || pauser(20 × 0xaa)
+    // || unpauserLen(14) || unpauser(20 × 0xbb). If the guardian encoder format ever diverges
+    // from what this contract parses, this test fails.
+
+    function testSubmitSetPauserAddresses_RealVector_EvmBothSet() public {
+        bytes memory payload =
+            hex"000000000000000000000000000000000000000000546f6b656e427269646765"
+            hex"04"
+            hex"0002"
+            hex"14" hex"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            hex"14" hex"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+        bridge.submitSetPauserAddresses(_signAndEncodeVM(payload, 0));
+        assertEq(bridge.pauser(), address(0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa));
+        assertEq(bridge.unpauser(), address(0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB));
+    }
+
+    function testSubmitSetPauserAddresses_RealVector_PauserUnassigned() public {
+        // "pauser unassigned, unpauser set" vector from PR #4810.
+        bytes memory payload =
+            hex"000000000000000000000000000000000000000000546f6b656e427269646765"
+            hex"04"
+            hex"0002"
+            hex"00"
+            hex"14" hex"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+        bridge.submitSetPauserAddresses(_signAndEncodeVM(payload, 0));
+        assertEq(bridge.pauser(), address(0));
+        assertEq(bridge.unpauser(), address(0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB));
+    }
+
+    function testSubmitSetPauserAddresses_RealVector_BothUnassigned() public {
+        // "both unassigned" vector from PR #4810.
+        bytes memory payload =
+            hex"000000000000000000000000000000000000000000546f6b656e427269646765"
+            hex"04"
+            hex"0002"
+            hex"00"
+            hex"00";
+
+        bridge.submitSetPauserAddresses(_signAndEncodeVM(payload, 0));
+        assertEq(bridge.pauser(), address(0));
+        assertEq(bridge.unpauser(), address(0));
     }
 
     // ============================ Internal ============================

--- a/ethereum/forge-test/BridgePauser.t.sol
+++ b/ethereum/forge-test/BridgePauser.t.sol
@@ -29,8 +29,8 @@ contract TestBridgePauser is Test {
     // "TokenBridge" left-padded
     bytes32 constant tokenBridgeModule =
         0x000000000000000000000000000000000000000000546f6b656e427269646765;
-    uint8 constant ACTION_SET_PAUSER_ADDRESSES_EVM = 4;
-    uint8 constant ACTION_SET_PAUSER_ADDRESSES_SOLANA = 5;
+    uint8 constant ACTION_SET_PAUSER_ADDRESSES = 4;
+    uint8 constant EVM_ADDR_LEN = 20;
 
     address constant PAUSER = address(0xCAFE);
     address constant UNPAUSER = address(0xBEEF);
@@ -86,6 +86,9 @@ contract TestBridgePauser is Test {
         return abi.encodePacked(header, body);
     }
 
+    /// @dev Encode a SetPauserAddresses payload using the length-prefixed wire format described in
+    ///      whitepapers/0003_token_bridge.md. Each address is preceded by its length (20 on EVM, or
+    ///      0 to leave the role unassigned).
     function _setPauserAddressesPayload(uint16 chain_, address pauser_, address unpauser_)
         internal
         pure
@@ -93,10 +96,36 @@ contract TestBridgePauser is Test {
     {
         return abi.encodePacked(
             tokenBridgeModule,
-            ACTION_SET_PAUSER_ADDRESSES_EVM,
+            ACTION_SET_PAUSER_ADDRESSES,
             chain_,
+            EVM_ADDR_LEN,
             pauser_,
+            EVM_ADDR_LEN,
             unpauser_
+        );
+    }
+
+    /// @dev Encode a SetPauserAddresses payload where each role may independently be marked as
+    ///      unassigned (length 0, zero-byte body).
+    function _setPauserAddressesPayloadOptional(
+        uint16 chain_,
+        bool hasPauser,
+        address pauser_,
+        bool hasUnpauser,
+        address unpauser_
+    ) internal pure returns (bytes memory) {
+        bytes memory pauserField = hasPauser
+            ? abi.encodePacked(EVM_ADDR_LEN, pauser_)
+            : abi.encodePacked(uint8(0));
+        bytes memory unpauserField = hasUnpauser
+            ? abi.encodePacked(EVM_ADDR_LEN, unpauser_)
+            : abi.encodePacked(uint8(0));
+        return abi.encodePacked(
+            tokenBridgeModule,
+            ACTION_SET_PAUSER_ADDRESSES,
+            chain_,
+            pauserField,
+            unpauserField
         );
     }
 
@@ -121,13 +150,16 @@ contract TestBridgePauser is Test {
         bridge.submitSetPauserAddresses(_signAndEncodeVM(payload, 0));
     }
 
-    function testSubmitSetPauserAddresses_Revert_SolanaActionRejected() public {
-        // Build a payload with action 5 (SetPauserAddressesSolana) — must be rejected on EVM.
+    function testSubmitSetPauserAddresses_Revert_UnknownAction() public {
+        // Action 5 is not defined for `SetPauserAddresses`; the single action 4 is length-prefixed
+        // and covers every runtime. Any other action must be rejected.
         bytes memory payload = abi.encodePacked(
             tokenBridgeModule,
-            ACTION_SET_PAUSER_ADDRESSES_SOLANA,
+            uint8(5),
             testChainId,
+            EVM_ADDR_LEN,
             PAUSER,
+            EVM_ADDR_LEN,
             UNPAUSER
         );
         vm.expectRevert(ITokenBridge.WrongAction.selector);
@@ -137,13 +169,114 @@ contract TestBridgePauser is Test {
     function testSubmitSetPauserAddresses_Revert_WrongModule() public {
         bytes memory payload = abi.encodePacked(
             bytes32(uint256(0xdeadbeef)),
-            ACTION_SET_PAUSER_ADDRESSES_EVM,
+            ACTION_SET_PAUSER_ADDRESSES,
             testChainId,
+            EVM_ADDR_LEN,
             PAUSER,
+            EVM_ADDR_LEN,
             UNPAUSER
         );
         vm.expectRevert(ITokenBridge.WrongModule.selector);
         bridge.submitSetPauserAddresses(_signAndEncodeVM(payload, 0));
+    }
+
+    function testSubmitSetPauserAddresses_Revert_InvalidPauserLength() public {
+        // 32 is the Solana native size but must be rejected on EVM (native size = 20).
+        bytes memory payload = abi.encodePacked(
+            tokenBridgeModule,
+            ACTION_SET_PAUSER_ADDRESSES,
+            testChainId,
+            uint8(32),
+            bytes32(uint256(uint160(PAUSER))),
+            EVM_ADDR_LEN,
+            UNPAUSER
+        );
+        vm.expectRevert(ITokenBridge.InvalidAddressLength.selector);
+        bridge.submitSetPauserAddresses(_signAndEncodeVM(payload, 0));
+    }
+
+    function testSubmitSetPauserAddresses_Revert_InvalidUnpauserLength() public {
+        bytes memory payload = abi.encodePacked(
+            tokenBridgeModule,
+            ACTION_SET_PAUSER_ADDRESSES,
+            testChainId,
+            EVM_ADDR_LEN,
+            PAUSER,
+            uint8(21),
+            UNPAUSER,
+            uint8(0xff)
+        );
+        vm.expectRevert(ITokenBridge.InvalidAddressLength.selector);
+        bridge.submitSetPauserAddresses(_signAndEncodeVM(payload, 0));
+    }
+
+    function testSubmitSetPauserAddresses_BothUnassigned_ZeroLength() public {
+        // Length 0 on both roles is the canonical "unassigned" encoding.
+        bytes memory payload = _setPauserAddressesPayloadOptional(
+            testChainId, false, address(0), false, address(0)
+        );
+        vm.expectEmit(true, true, true, true);
+        emit PauserAddressesSet(address(0), address(0));
+        bridge.submitSetPauserAddresses(_signAndEncodeVM(payload, 0));
+        assertEq(bridge.pauser(), address(0));
+        assertEq(bridge.unpauser(), address(0));
+    }
+
+    function testSubmitSetPauserAddresses_PauserUnassigned_OnlyUnpauserSet() public {
+        bytes memory payload = _setPauserAddressesPayloadOptional(
+            testChainId, false, address(0), true, UNPAUSER
+        );
+        bridge.submitSetPauserAddresses(_signAndEncodeVM(payload, 0));
+        assertEq(bridge.pauser(), address(0));
+        assertEq(bridge.unpauser(), UNPAUSER);
+    }
+
+    function testSubmitSetPauserAddresses_AllZero20ByteAddress_IsUnassigned() public {
+        // An all-zero 20-byte address must be treated as equivalent to a zero-length field —
+        // i.e., the role ends up unassigned and the entry point reverts before comparing msg.sender.
+        bytes memory payload = _setPauserAddressesPayload(testChainId, address(0), address(0));
+        bridge.submitSetPauserAddresses(_signAndEncodeVM(payload, 0));
+        assertEq(bridge.pauser(), address(0));
+        assertEq(bridge.unpauser(), address(0));
+
+        vm.expectRevert(ITokenBridge.NotPauser.selector);
+        vm.prank(address(0));
+        bridge.pause();
+
+        vm.expectRevert(ITokenBridge.NotUnpauser.selector);
+        vm.prank(address(0));
+        bridge.unpause();
+    }
+
+    function testPause_Revert_PauserUnassigned() public {
+        // No prior governance message → pauser defaults to address(0) → pause() must revert before
+        // comparing msg.sender.
+        vm.expectRevert(ITokenBridge.NotPauser.selector);
+        vm.prank(PAUSER);
+        bridge.pause();
+    }
+
+    function testUnpause_Revert_UnpauserUnassigned() public {
+        // Configure only pauser, then pause; unpause must remain stuck because unpauser is unassigned.
+        bytes memory payload = _setPauserAddressesPayloadOptional(
+            testChainId, true, PAUSER, false, address(0)
+        );
+        bridge.submitSetPauserAddresses(_signAndEncodeVM(payload, 0));
+
+        vm.prank(PAUSER);
+        bridge.pause();
+        assertTrue(bridge.paused());
+
+        vm.expectRevert(ITokenBridge.NotUnpauser.selector);
+        vm.prank(UNPAUSER);
+        bridge.unpause();
+
+        // Recovery path: governance assigns an unpauser, then unpause succeeds.
+        bytes memory recovery = _setPauserAddressesPayload(testChainId, PAUSER, UNPAUSER);
+        bridge.submitSetPauserAddresses(_signAndEncodeVM(recovery, 1));
+        vm.prank(UNPAUSER);
+        bridge.unpause();
+        assertFalse(bridge.paused());
     }
 
     function testSubmitSetPauserAddresses_Revert_AlreadyConsumed() public {

--- a/ethereum/forge-test/BridgePauser.t.sol
+++ b/ethereum/forge-test/BridgePauser.t.sol
@@ -1,0 +1,345 @@
+// SPDX-License-Identifier: Apache 2
+pragma solidity ^0.8.0;
+
+import "../contracts/bridge/BridgeSetup.sol";
+import "../contracts/bridge/BridgeImplementation.sol";
+import "../contracts/bridge/TokenBridge.sol";
+import "../contracts/bridge/interfaces/ITokenBridge.sol";
+import "../contracts/bridge/token/TokenImplementation.sol";
+import "../contracts/bridge/mock/MockWETH9.sol";
+import "../contracts/interfaces/IWormhole.sol";
+import "forge-std/Test.sol";
+import "./Implementation.t.sol";
+
+contract TestBridgePauser is Test {
+    BridgeSetup bridgeSetup;
+    BridgeImplementation bridgeImpl;
+    ITokenBridge bridge;
+    IWormhole wormhole;
+    TestImplementation implementationTest;
+    TokenImplementation tokenImpl;
+    IERC20 weth;
+
+    uint16 testChainId;
+    uint256 testEvmChainId;
+    uint16 governanceChainId;
+    bytes32 governanceContract;
+    uint8 constant finality = 15;
+
+    // "TokenBridge" left-padded
+    bytes32 constant tokenBridgeModule =
+        0x000000000000000000000000000000000000000000546f6b656e427269646765;
+    uint8 constant ACTION_SET_PAUSER_ADDRESSES_EVM = 4;
+    uint8 constant ACTION_SET_PAUSER_ADDRESSES_SOLANA = 5;
+
+    address constant PAUSER = address(0xCAFE);
+    address constant UNPAUSER = address(0xBEEF);
+
+    // Re-declared so vm.expectEmit can match (Solidity 0.8.4 doesn't allow IName.Event references).
+    event PauserAddressesSet(address indexed pauser, address indexed unpauser);
+    event Paused(address indexed by);
+    event Unpaused(address indexed by);
+
+    uint256 constant testGuardian =
+        93941733246223705020089879371323733820373732307041878556247502674739205313440;
+
+    function setUp() public {
+        implementationTest = new TestImplementation();
+        implementationTest.setUp();
+        wormhole = IWormhole(address(implementationTest.proxied()));
+
+        bridgeSetup = new BridgeSetup();
+        bridgeImpl = new BridgeImplementation();
+        tokenImpl = new TokenImplementation();
+        weth = IERC20(address(new MockWETH9()));
+
+        testChainId = implementationTest.testChainId();
+        testEvmChainId = implementationTest.testEvmChainId();
+        vm.chainId(testEvmChainId);
+        governanceChainId = implementationTest.governanceChainId();
+        governanceContract = implementationTest.governanceContract();
+
+        bytes memory setupAbi = abi.encodeWithSelector(
+            BridgeSetup.setup.selector,
+            address(bridgeImpl),
+            testChainId,
+            address(wormhole),
+            governanceChainId,
+            governanceContract,
+            address(tokenImpl),
+            address(weth),
+            finality,
+            testEvmChainId
+        );
+        bridge = ITokenBridge(address(new TokenBridge(address(bridgeSetup), setupAbi)));
+    }
+
+    // ============================ Helpers ============================
+
+    function _signAndEncodeVM(bytes memory data, uint64 sequence) internal pure returns (bytes memory) {
+        bytes memory body = abi.encodePacked(
+            uint32(0), uint32(0), uint16(1), bytes32(uint256(0x4)), sequence, uint8(0), data
+        );
+        bytes32 bodyHash = keccak256(abi.encodePacked(keccak256(body)));
+        (uint8 v, bytes32 r, bytes32 s) = Vm(address(uint160(uint256(keccak256("hevm cheat code"))))).sign(testGuardian, bodyHash);
+        bytes memory header = abi.encodePacked(uint8(1), uint32(0), uint8(1), uint8(0), r, s, v - 27);
+        return abi.encodePacked(header, body);
+    }
+
+    function _setPauserAddressesPayload(uint16 chain_, address pauser_, address unpauser_)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return abi.encodePacked(
+            tokenBridgeModule,
+            ACTION_SET_PAUSER_ADDRESSES_EVM,
+            chain_,
+            pauser_,
+            unpauser_
+        );
+    }
+
+    // ============================ submitSetPauserAddresses ============================
+
+    function testSubmitSetPauserAddresses_Success() public {
+        bytes memory payload = _setPauserAddressesPayload(testChainId, PAUSER, UNPAUSER);
+        bytes memory vaa = _signAndEncodeVM(payload, 0);
+
+        vm.expectEmit(true, true, true, true);
+        emit PauserAddressesSet(PAUSER, UNPAUSER);
+        bridge.submitSetPauserAddresses(vaa);
+
+        assertEq(bridge.pauser(), PAUSER);
+        assertEq(bridge.unpauser(), UNPAUSER);
+        assertFalse(bridge.paused());
+    }
+
+    function testSubmitSetPauserAddresses_Revert_WrongChain() public {
+        bytes memory payload = _setPauserAddressesPayload(uint16(99), PAUSER, UNPAUSER);
+        vm.expectRevert("wrong chain id");
+        bridge.submitSetPauserAddresses(_signAndEncodeVM(payload, 0));
+    }
+
+    function testSubmitSetPauserAddresses_Revert_SolanaActionRejected() public {
+        // Build a payload with action 5 (SetPauserAddressesSolana) — must be rejected on EVM.
+        bytes memory payload = abi.encodePacked(
+            tokenBridgeModule,
+            ACTION_SET_PAUSER_ADDRESSES_SOLANA,
+            testChainId,
+            PAUSER,
+            UNPAUSER
+        );
+        vm.expectRevert("wrong action");
+        bridge.submitSetPauserAddresses(_signAndEncodeVM(payload, 0));
+    }
+
+    function testSubmitSetPauserAddresses_Revert_WrongModule() public {
+        bytes memory payload = abi.encodePacked(
+            bytes32(uint256(0xdeadbeef)),
+            ACTION_SET_PAUSER_ADDRESSES_EVM,
+            testChainId,
+            PAUSER,
+            UNPAUSER
+        );
+        vm.expectRevert("wrong module");
+        bridge.submitSetPauserAddresses(_signAndEncodeVM(payload, 0));
+    }
+
+    function testSubmitSetPauserAddresses_Revert_AlreadyConsumed() public {
+        bytes memory payload = _setPauserAddressesPayload(testChainId, PAUSER, UNPAUSER);
+        bytes memory vaa = _signAndEncodeVM(payload, 0);
+        bridge.submitSetPauserAddresses(vaa);
+        vm.expectRevert("governance action already consumed");
+        bridge.submitSetPauserAddresses(vaa);
+    }
+
+    function testSubmitSetPauserAddresses_CanRotate() public {
+        bytes memory v1 = _signAndEncodeVM(_setPauserAddressesPayload(testChainId, PAUSER, UNPAUSER), 0);
+        bridge.submitSetPauserAddresses(v1);
+
+        address newPauser = address(0xAAAA);
+        address newUnpauser = address(0xBBBB);
+        bytes memory v2 = _signAndEncodeVM(
+            _setPauserAddressesPayload(testChainId, newPauser, newUnpauser),
+            1
+        );
+        bridge.submitSetPauserAddresses(v2);
+        assertEq(bridge.pauser(), newPauser);
+        assertEq(bridge.unpauser(), newUnpauser);
+    }
+
+    // ============================ pause / unpause ============================
+
+    function testPause_Success() public {
+        _configurePauser();
+
+        vm.expectEmit(true, true, true, true);
+        emit Paused(PAUSER);
+        vm.prank(PAUSER);
+        bridge.pause();
+        assertTrue(bridge.paused());
+    }
+
+    function testPause_Revert_NotPauser() public {
+        _configurePauser();
+        vm.expectRevert("not pauser");
+        bridge.pause();
+    }
+
+    function testUnpause_Success() public {
+        _configurePauser();
+        vm.prank(PAUSER);
+        bridge.pause();
+
+        vm.expectEmit(true, true, true, true);
+        emit Unpaused(UNPAUSER);
+        vm.prank(UNPAUSER);
+        bridge.unpause();
+        assertFalse(bridge.paused());
+    }
+
+    function testUnpause_Revert_NotUnpauser() public {
+        _configurePauser();
+        vm.prank(PAUSER);
+        bridge.pause();
+        vm.expectRevert("not unpauser");
+        bridge.unpause();
+    }
+
+    function testUnpause_NotGuardedByNotPaused() public {
+        _configurePauser();
+        // unpause is callable even when not paused; idempotent.
+        vm.prank(UNPAUSER);
+        bridge.unpause();
+        assertFalse(bridge.paused());
+    }
+
+    // ============================ notPaused on entry points ============================
+
+    function testNotPaused_AttestToken_RevertsWhenPaused() public {
+        _configurePauser();
+        vm.prank(PAUSER);
+        bridge.pause();
+
+        vm.expectRevert("paused");
+        bridge.attestToken(address(weth), 0);
+    }
+
+    function testNotPaused_TransferTokens_RevertsWhenPaused() public {
+        _configurePauser();
+        vm.prank(PAUSER);
+        bridge.pause();
+
+        vm.expectRevert("paused");
+        bridge.transferTokens(address(weth), 1, 2, bytes32(0), 0, 0);
+    }
+
+    function testNotPaused_TransferTokensWithPayload_RevertsWhenPaused() public {
+        _configurePauser();
+        vm.prank(PAUSER);
+        bridge.pause();
+        vm.expectRevert("paused");
+        bridge.transferTokensWithPayload(address(weth), 1, 2, bytes32(0), 0, hex"");
+    }
+
+    function testNotPaused_WrapAndTransferETH_RevertsWhenPaused() public {
+        _configurePauser();
+        vm.prank(PAUSER);
+        bridge.pause();
+        vm.expectRevert("paused");
+        bridge.wrapAndTransferETH(2, bytes32(0), 0, 0);
+    }
+
+    function testNotPaused_WrapAndTransferETHWithPayload_RevertsWhenPaused() public {
+        _configurePauser();
+        vm.prank(PAUSER);
+        bridge.pause();
+        vm.expectRevert("paused");
+        bridge.wrapAndTransferETHWithPayload(2, bytes32(0), 0, hex"");
+    }
+
+    function testNotPaused_CompleteTransfer_RevertsWhenPaused() public {
+        _configurePauser();
+        vm.prank(PAUSER);
+        bridge.pause();
+        vm.expectRevert("paused");
+        bridge.completeTransfer(hex"");
+    }
+
+    function testNotPaused_CompleteTransferAndUnwrapETH_RevertsWhenPaused() public {
+        _configurePauser();
+        vm.prank(PAUSER);
+        bridge.pause();
+        vm.expectRevert("paused");
+        bridge.completeTransferAndUnwrapETH(hex"");
+    }
+
+    function testNotPaused_CompleteTransferWithPayload_RevertsWhenPaused() public {
+        _configurePauser();
+        vm.prank(PAUSER);
+        bridge.pause();
+        vm.expectRevert("paused");
+        bridge.completeTransferWithPayload(hex"");
+    }
+
+    function testNotPaused_CompleteTransferAndUnwrapETHWithPayload_RevertsWhenPaused() public {
+        _configurePauser();
+        vm.prank(PAUSER);
+        bridge.pause();
+        vm.expectRevert("paused");
+        bridge.completeTransferAndUnwrapETHWithPayload(hex"");
+    }
+
+    function testNotPaused_CreateWrapped_RevertsWhenPaused() public {
+        _configurePauser();
+        vm.prank(PAUSER);
+        bridge.pause();
+        vm.expectRevert("paused");
+        bridge.createWrapped(hex"");
+    }
+
+    function testNotPaused_UpdateWrapped_RevertsWhenPaused() public {
+        _configurePauser();
+        vm.prank(PAUSER);
+        bridge.pause();
+        vm.expectRevert("paused");
+        bridge.updateWrapped(hex"");
+    }
+
+    function testNotPaused_GovernanceStillWorksWhenPaused() public {
+        _configurePauser();
+        vm.prank(PAUSER);
+        bridge.pause();
+
+        // submitSetPauserAddresses is governance and must remain callable when paused.
+        bytes memory payload = _setPauserAddressesPayload(testChainId, address(0xFEED), UNPAUSER);
+        bridge.submitSetPauserAddresses(_signAndEncodeVM(payload, 7));
+        assertEq(bridge.pauser(), address(0xFEED));
+    }
+
+    // ============================ parseSetPauserAddresses ============================
+
+    function testParseSetPauserAddresses() public {
+        bytes memory payload = _setPauserAddressesPayload(testChainId, PAUSER, UNPAUSER);
+        ITokenBridge.SetPauserAddresses memory spa = bridge.parseSetPauserAddresses(payload);
+        assertEq(spa.module, tokenBridgeModule);
+        assertEq(spa.action, ACTION_SET_PAUSER_ADDRESSES_EVM);
+        assertEq(spa.chainId, testChainId);
+        assertEq(spa.pauser, PAUSER);
+        assertEq(spa.unpauser, UNPAUSER);
+    }
+
+    function testParseSetPauserAddresses_Revert_WrongLength() public {
+        bytes memory payload = abi.encodePacked(_setPauserAddressesPayload(testChainId, PAUSER, UNPAUSER), hex"ff");
+        vm.expectRevert("wrong length");
+        bridge.parseSetPauserAddresses(payload);
+    }
+
+    // ============================ Internal ============================
+
+    function _configurePauser() internal {
+        bytes memory payload = _setPauserAddressesPayload(testChainId, PAUSER, UNPAUSER);
+        bridge.submitSetPauserAddresses(_signAndEncodeVM(payload, 0));
+    }
+}


### PR DESCRIPTION
This PR implements pauser functionality for the EVM Token Bridge.

- Design #4809
- Guardian #4810
- EVM WTT Pauser Role #4801
- SVM WTT Pauser Role #4802

Unfortunately, the pauser change alone put the contract over the 24,576-byte EIP-170 limit. e.g.

```
Error: `BridgeImplementation` is above the contract size limit (25714 > 24576).
```

So, this proposal also modernizes the contract by switching all of the reverts to custom errors leaving over 1,000 bytes of headroom. 