### PR TITLE
feat(solana): wtt pauser role

### DIFF
--- a/solana/modules/token_bridge/program/src/api.rs
+++ b/solana/modules/token_bridge/program/src/api.rs
@@ -4,6 +4,7 @@ pub mod complete_transfer_payload;
 pub mod create_wrapped;
 pub mod governance;
 pub mod initialize;
+pub mod pause;
 pub mod transfer;
 pub mod transfer_payload;
 
@@ -13,5 +14,6 @@ pub use complete_transfer_payload::*;
 pub use create_wrapped::*;
 pub use governance::*;
 pub use initialize::*;
+pub use pause::*;
 pub use transfer::*;
 pub use transfer_payload::*;

--- a/solana/modules/token_bridge/program/src/api/attest.rs
+++ b/solana/modules/token_bridge/program/src/api/attest.rs
@@ -92,6 +92,8 @@ pub fn attest_token(
     accs: &mut AttestToken,
     data: AttestTokenData,
 ) -> Result<()> {
+    require_not_paused(accs.config.info())?;
+
     // Pay fee
     let transfer_ix = solana_program::system_instruction::transfer(
         accs.payer.key,

--- a/solana/modules/token_bridge/program/src/api/complete_transfer.rs
+++ b/solana/modules/token_bridge/program/src/api/complete_transfer.rs
@@ -76,6 +76,8 @@ pub fn complete_native(
     accs: &mut CompleteNative,
     _data: CompleteNativeData,
 ) -> Result<()> {
+    require_not_paused(accs.config.info())?;
+
     // Verify the chain registration
     let derivation_data: EndpointDerivationData = (&*accs).into();
     accs.chain_registration
@@ -207,6 +209,8 @@ pub fn complete_wrapped(
     accs: &mut CompleteWrapped,
     _data: CompleteWrappedData,
 ) -> Result<()> {
+    require_not_paused(accs.config.info())?;
+
     // Verify the chain registration
     let derivation_data: EndpointDerivationData = (&*accs).into();
     accs.chain_registration

--- a/solana/modules/token_bridge/program/src/api/complete_transfer_payload.rs
+++ b/solana/modules/token_bridge/program/src/api/complete_transfer_payload.rs
@@ -138,6 +138,8 @@ pub fn complete_native_with_payload(
     accs: &mut CompleteNativeWithPayload,
     _data: CompleteNativeWithPayloadData,
 ) -> Result<()> {
+    require_not_paused(accs.config.info())?;
+
     // Verify the chain registration
     let derivation_data: EndpointDerivationData = (&*accs).into();
     accs.chain_registration
@@ -257,6 +259,8 @@ pub fn complete_wrapped_with_payload(
     accs: &mut CompleteWrappedWithPayload,
     _data: CompleteWrappedWithPayloadData,
 ) -> Result<()> {
+    require_not_paused(accs.config.info())?;
+
     // Verify the chain registration
     let derivation_data: EndpointDerivationData = (&*accs).into();
     accs.chain_registration

--- a/solana/modules/token_bridge/program/src/api/create_wrapped.rs
+++ b/solana/modules/token_bridge/program/src/api/create_wrapped.rs
@@ -13,6 +13,7 @@ use crate::{
         WrappedTokenMeta,
     },
     messages::PayloadAssetMeta,
+    types::require_not_paused,
     TokenBridgeError::{
         InvalidChain,
         InvalidVAA,
@@ -96,6 +97,8 @@ pub fn create_wrapped(
     accs: &mut CreateWrapped,
     data: CreateWrappedData,
 ) -> Result<()> {
+    require_not_paused(accs.config.info())?;
+
     // Do not process attestations sourced from the current chain.
     if accs.vaa.token_chain == OUR_CHAIN_ID {
         return Err(InvalidChain.into());

--- a/solana/modules/token_bridge/program/src/api/governance.rs
+++ b/solana/modules/token_bridge/program/src/api/governance.rs
@@ -15,7 +15,7 @@ use crate::{
     },
     TokenBridgeError::{
         InvalidGovernanceKey,
-        InvalidProgramOwner,
+        InvalidSelfProgram,
         InvalidVAA,
     },
     INVALID_VAAS,
@@ -254,7 +254,7 @@ pub fn set_pauser_addresses(
     }
 
     if accs.self_program.key != ctx.program_id {
-        return Err(InvalidProgramOwner.into());
+        return Err(InvalidSelfProgram.into());
     }
     let mut payload = [0u8; 64];
     payload[..32].copy_from_slice(&accs.vaa.pauser.to_bytes());

--- a/solana/modules/token_bridge/program/src/api/governance.rs
+++ b/solana/modules/token_bridge/program/src/api/governance.rs
@@ -11,7 +11,7 @@ use crate::{
     },
     types::{
         write_pauser_addresses,
-        CONFIG_FULL_LEN,
+        CONFIG_WITH_PAUSER_LEN,
     },
     TokenBridgeError::{
         InvalidGovernanceKey,
@@ -182,7 +182,7 @@ pub const PAUSER_ADDRESSES_SET_EVENT_DISCRIMINATOR: [u8; 8] =
 pub struct SetPauserAddresses<'b> {
     pub payer: Mut<Signer<AccountInfo<'b>>>,
 
-    /// Existing token bridge `Config` PDA. Realloc'd from 32 → `CONFIG_FULL_LEN` bytes the first
+    /// Existing token bridge `Config` PDA. Realloc'd from 32 → `CONFIG_WITH_PAUSER_LEN` bytes the first
     /// time this governance VAA is processed; subsequent VAAs only update the tail.
     pub config: Mut<ConfigAccount<'b, { AccountState::Initialized }>>,
 
@@ -227,13 +227,13 @@ pub fn set_pauser_addresses(
     // pauser state must use the `paused()` / `pauser()` / `unpauser()` helpers in `types.rs`,
     // or similar, which check the account length and treat un-migrated accounts as unassigned.
     let config_info = accs.config.info();
-    if config_info.data_len() < CONFIG_FULL_LEN {
+    if config_info.data_len() < CONFIG_WITH_PAUSER_LEN {
         // Top up the lamport balance so the account remains rent-exempt at the new size, then
         // realloc. `zero_init = true` zeroes the new tail bytes — that's the desired
         // initial state for `paused = false`.
         use solana_program::sysvar::Sysvar;
         let rent = solana_program::sysvar::rent::Rent::get()?;
-        let required = rent.minimum_balance(CONFIG_FULL_LEN);
+        let required = rent.minimum_balance(CONFIG_WITH_PAUSER_LEN);
         let current = config_info.lamports();
         if current < required {
             let topup = required - current;
@@ -244,7 +244,7 @@ pub fn set_pauser_addresses(
             );
             invoke_signed(&topup_ix, ctx.accounts, &[])?;
         }
-        config_info.realloc(CONFIG_FULL_LEN, true)?;
+        config_info.realloc(CONFIG_WITH_PAUSER_LEN, true)?;
     }
 
     {

--- a/solana/modules/token_bridge/program/src/api/governance.rs
+++ b/solana/modules/token_bridge/program/src/api/governance.rs
@@ -7,6 +7,11 @@ use crate::{
     messages::{
         GovernancePayloadUpgrade,
         PayloadGovernanceRegisterChain,
+        PayloadSetPauserAddresses,
+    },
+    types::{
+        write_pauser_addresses,
+        CONFIG_FULL_LEN,
     },
     TokenBridgeError::{
         InvalidGovernanceKey,
@@ -162,6 +167,67 @@ pub fn register_chain(
 
     accs.endpoint.chain = accs.vaa.chain;
     accs.endpoint.contract = accs.vaa.endpoint_address;
+
+    Ok(())
+}
+
+#[derive(FromAccounts)]
+pub struct SetPauserAddresses<'b> {
+    pub payer: Mut<Signer<AccountInfo<'b>>>,
+
+    /// Existing token bridge `Config` PDA. Realloc'd from 32 → `CONFIG_FULL_LEN` bytes the first
+    /// time this governance VAA is processed; subsequent VAAs only update the tail.
+    pub config: Mut<ConfigAccount<'b, { AccountState::Initialized }>>,
+
+    /// Governance VAA carrying a `PayloadSetPauserAddresses` (action 5).
+    pub vaa: PayloadMessage<'b, PayloadSetPauserAddresses>,
+
+    /// VAA replay-protection claim, consistent with the rest of the token bridge governance.
+    pub claim: Mut<Claim<'b>>,
+}
+
+#[derive(BorshDeserialize, BorshSerialize, Default)]
+pub struct SetPauserAddressesData {}
+
+pub fn set_pauser_addresses(
+    ctx: &ExecutionContext,
+    accs: &mut SetPauserAddresses,
+    _data: SetPauserAddressesData,
+) -> Result<()> {
+    if INVALID_VAAS.contains(&&*accs.vaa.info().key.to_string()) {
+        return Err(InvalidVAA.into());
+    }
+
+    verify_governance(&accs.vaa)?;
+    claim::consume(ctx, accs.payer.key, &mut accs.claim, &accs.vaa)?;
+
+    // One-time migration: legacy 32-byte Config accounts grow to 97 bytes the first time this
+    // VAA is processed. Subsequent VAAs reuse the already-extended layout. The `paused` flag
+    // is preserved across updates — rotating the pauser/unpauser keys does not implicitly
+    // unpause the bridge.
+    let config_info = accs.config.info();
+    if config_info.data_len() < CONFIG_FULL_LEN {
+        // Top up the lamport balance so the account remains rent-exempt at the new size, then
+        // realloc. `zero_init = true` zeroes the new tail bytes — that's the desired
+        // initial state for `paused = false`.
+        use solana_program::sysvar::Sysvar;
+        let rent = solana_program::sysvar::rent::Rent::get()?;
+        let required = rent.minimum_balance(CONFIG_FULL_LEN);
+        let current = config_info.lamports();
+        if current < required {
+            let topup = required - current;
+            let topup_ix = solana_program::system_instruction::transfer(
+                accs.payer.key,
+                config_info.key,
+                topup,
+            );
+            invoke_signed(&topup_ix, ctx.accounts, &[])?;
+        }
+        config_info.realloc(CONFIG_FULL_LEN, true)?;
+    }
+
+    let mut data = config_info.data.borrow_mut();
+    write_pauser_addresses(&mut data, &accs.vaa.pauser, &accs.vaa.unpauser);
 
     Ok(())
 }

--- a/solana/modules/token_bridge/program/src/api/governance.rs
+++ b/solana/modules/token_bridge/program/src/api/governance.rs
@@ -15,6 +15,7 @@ use crate::{
     },
     TokenBridgeError::{
         InvalidGovernanceKey,
+        InvalidProgramOwner,
         InvalidVAA,
     },
     INVALID_VAAS,
@@ -171,6 +172,12 @@ pub fn register_chain(
     Ok(())
 }
 
+/// Event discriminator: `SHA256("event:PauserAddressesSet")[0..8]`. Emitted via Anchor-style
+/// self-CPI when `set_pauser_addresses` succeeds. Payload: 32-byte pauser pubkey followed by the
+/// 32-byte unpauser pubkey, in that order.
+pub const PAUSER_ADDRESSES_SET_EVENT_DISCRIMINATOR: [u8; 8] =
+    [0xb9, 0xcf, 0x4f, 0x8f, 0x6c, 0x76, 0xdf, 0x6d];
+
 #[derive(FromAccounts)]
 pub struct SetPauserAddresses<'b> {
     pub payer: Mut<Signer<AccountInfo<'b>>>,
@@ -179,11 +186,17 @@ pub struct SetPauserAddresses<'b> {
     /// time this governance VAA is processed; subsequent VAAs only update the tail.
     pub config: Mut<ConfigAccount<'b, { AccountState::Initialized }>>,
 
-    /// Governance VAA carrying a `PayloadSetPauserAddresses` (action 5).
+    /// Governance VAA carrying a `PayloadSetPauserAddresses` (action 4 per whitepaper 0003).
     pub vaa: PayloadMessage<'b, PayloadSetPauserAddresses>,
 
     /// VAA replay-protection claim, consistent with the rest of the token bridge governance.
     pub claim: Mut<Claim<'b>>,
+
+    /// Event authority PDA for Anchor CPI event signing.
+    pub event_authority: Info<'b>,
+
+    /// This program (for self-CPI).
+    pub self_program: Info<'b>,
 }
 
 #[derive(BorshDeserialize, BorshSerialize, Default)]
@@ -205,6 +218,14 @@ pub fn set_pauser_addresses(
     // VAA is processed. Subsequent VAAs reuse the already-extended layout. The `paused` flag
     // is preserved across updates — rotating the pauser/unpauser keys does not implicitly
     // unpause the bridge.
+    //
+    // Borsh back-compat: the first 32 bytes of the account (the original `Config` struct) are
+    // never moved or rewritten, and the `Config::BorshDeserialize` impl in `types.rs` is
+    // hand-rolled to tolerate the trailing tail (instead of the derived impl that would reject
+    // any unread bytes). Off-chain clients that deserialize Config via Borsh against the raw
+    // account data continue to round-trip both before and after this migration. SDKs that read
+    // pauser state must use the `paused()` / `pauser()` / `unpauser()` helpers in `types.rs`,
+    // or similar, which check the account length and treat un-migrated accounts as unassigned.
     let config_info = accs.config.info();
     if config_info.data_len() < CONFIG_FULL_LEN {
         // Top up the lamport balance so the account remains rent-exempt at the new size, then
@@ -226,8 +247,22 @@ pub fn set_pauser_addresses(
         config_info.realloc(CONFIG_FULL_LEN, true)?;
     }
 
-    let mut data = config_info.data.borrow_mut();
-    write_pauser_addresses(&mut data, &accs.vaa.pauser, &accs.vaa.unpauser);
+    {
+        let mut data = config_info.data.borrow_mut();
+        write_pauser_addresses(&mut data, &accs.vaa.pauser, &accs.vaa.unpauser);
+        // `data` borrow dropped here so the self-CPI below can re-borrow the account.
+    }
 
-    Ok(())
+    if accs.self_program.key != ctx.program_id {
+        return Err(InvalidProgramOwner.into());
+    }
+    let mut payload = [0u8; 64];
+    payload[..32].copy_from_slice(&accs.vaa.pauser.to_bytes());
+    payload[32..].copy_from_slice(&accs.vaa.unpauser.to_bytes());
+    emit_event_cpi(
+        ctx,
+        &accs.event_authority,
+        &PAUSER_ADDRESSES_SET_EVENT_DISCRIMINATOR,
+        &payload,
+    )
 }

--- a/solana/modules/token_bridge/program/src/api/pause.rs
+++ b/solana/modules/token_bridge/program/src/api/pause.rs
@@ -4,7 +4,7 @@ use crate::{
         pauser,
         unpauser,
         write_paused,
-        CONFIG_FULL_LEN,
+        CONFIG_WITH_PAUSER_LEN,
     },
     TokenBridgeError::{
         InvalidPauser,
@@ -103,7 +103,7 @@ fn set_paused_state(
     paused: bool,
 ) -> Result<()> {
     // Reject if the Config account hasn't been migrated yet (legacy 32-byte layout).
-    if config_info.data_len() < CONFIG_FULL_LEN {
+    if config_info.data_len() < CONFIG_WITH_PAUSER_LEN {
         return Err(PauserNotConfigured.into());
     }
 

--- a/solana/modules/token_bridge/program/src/api/pause.rs
+++ b/solana/modules/token_bridge/program/src/api/pause.rs
@@ -1,0 +1,89 @@
+use crate::{
+    accounts::ConfigAccount,
+    types::{
+        read_pauser,
+        read_unpauser,
+        write_paused,
+        CONFIG_FULL_LEN,
+    },
+    TokenBridgeError::{
+        InvalidPauser,
+        PauserNotConfigured,
+    },
+};
+use solana_program::{
+    account_info::AccountInfo,
+    pubkey::Pubkey,
+};
+use solitaire::*;
+
+#[derive(FromAccounts)]
+pub struct Pause<'b> {
+    /// Caller must equal the configured pauser stored in the Config tail.
+    pub pauser: Signer<AccountInfo<'b>>,
+
+    pub config: Mut<ConfigAccount<'b, { AccountState::Initialized }>>,
+}
+
+#[derive(BorshDeserialize, BorshSerialize, Default)]
+pub struct PauseData {}
+
+pub fn pause(_ctx: &ExecutionContext, accs: &mut Pause, _data: PauseData) -> Result<()> {
+    set_paused_state(
+        accs.config.info(),
+        accs.pauser.key,
+        /* is_pauser_path */ true,
+        /* paused */ true,
+    )
+}
+
+#[derive(FromAccounts)]
+pub struct Unpause<'b> {
+    /// Caller must equal the configured unpauser stored in the Config tail.
+    pub unpauser: Signer<AccountInfo<'b>>,
+
+    pub config: Mut<ConfigAccount<'b, { AccountState::Initialized }>>,
+}
+
+#[derive(BorshDeserialize, BorshSerialize, Default)]
+pub struct UnpauseData {}
+
+pub fn unpause(_ctx: &ExecutionContext, accs: &mut Unpause, _data: UnpauseData) -> Result<()> {
+    set_paused_state(
+        accs.config.info(),
+        accs.unpauser.key,
+        /* is_pauser_path */ false,
+        /* paused */ false,
+    )
+}
+
+fn set_paused_state(
+    config_info: &AccountInfo,
+    signer: &Pubkey,
+    is_pauser_path: bool,
+    paused: bool,
+) -> Result<()> {
+    // Reject if the Config account hasn't been migrated yet (legacy 32-byte layout).
+    if config_info.data_len() < CONFIG_FULL_LEN {
+        return Err(PauserNotConfigured.into());
+    }
+
+    {
+        let data = config_info.data.borrow();
+        let configured = if is_pauser_path {
+            read_pauser(&data)
+        } else {
+            read_unpauser(&data)
+        };
+        if configured == Pubkey::default() {
+            return Err(PauserNotConfigured.into());
+        }
+        if &configured != signer {
+            return Err(InvalidPauser.into());
+        }
+    }
+
+    let mut data = config_info.data.borrow_mut();
+    write_paused(&mut data, paused);
+    Ok(())
+}

--- a/solana/modules/token_bridge/program/src/api/pause.rs
+++ b/solana/modules/token_bridge/program/src/api/pause.rs
@@ -8,7 +8,7 @@ use crate::{
     },
     TokenBridgeError::{
         InvalidPauser,
-        InvalidProgramOwner,
+        InvalidSelfProgram,
         PauserNotConfigured,
     },
 };
@@ -51,7 +51,7 @@ pub fn pause(ctx: &ExecutionContext, accs: &mut Pause, _data: PauseData) -> Resu
         /* paused */ true,
     )?;
     if accs.self_program.key != ctx.program_id {
-        return Err(InvalidProgramOwner.into());
+        return Err(InvalidSelfProgram.into());
     }
     emit_event_cpi(
         ctx,
@@ -86,7 +86,7 @@ pub fn unpause(ctx: &ExecutionContext, accs: &mut Unpause, _data: UnpauseData) -
         /* paused */ false,
     )?;
     if accs.self_program.key != ctx.program_id {
-        return Err(InvalidProgramOwner.into());
+        return Err(InvalidSelfProgram.into());
     }
     emit_event_cpi(
         ctx,

--- a/solana/modules/token_bridge/program/src/api/pause.rs
+++ b/solana/modules/token_bridge/program/src/api/pause.rs
@@ -20,13 +20,11 @@ use solitaire::*;
 
 /// Event discriminator: `SHA256("event:Paused")[0..8]`. Emitted via Anchor-style self-CPI
 /// when `pause` succeeds. Payload: 32-byte pauser pubkey.
-pub const PAUSED_EVENT_DISCRIMINATOR: [u8; 8] =
-    [0xac, 0xf8, 0x05, 0xfd, 0x31, 0xff, 0xff, 0xe8];
+pub const PAUSED_EVENT_DISCRIMINATOR: [u8; 8] = [0xac, 0xf8, 0x05, 0xfd, 0x31, 0xff, 0xff, 0xe8];
 
 /// Event discriminator: `SHA256("event:Unpaused")[0..8]`. Emitted via Anchor-style self-CPI
 /// when `unpause` succeeds. Payload: 32-byte unpauser pubkey.
-pub const UNPAUSED_EVENT_DISCRIMINATOR: [u8; 8] =
-    [0x9c, 0x96, 0x2f, 0xae, 0x78, 0xd8, 0x5d, 0x75];
+pub const UNPAUSED_EVENT_DISCRIMINATOR: [u8; 8] = [0x9c, 0x96, 0x2f, 0xae, 0x78, 0xd8, 0x5d, 0x75];
 
 #[derive(FromAccounts)]
 pub struct Pause<'b> {

--- a/solana/modules/token_bridge/program/src/api/pause.rs
+++ b/solana/modules/token_bridge/program/src/api/pause.rs
@@ -1,13 +1,14 @@
 use crate::{
     accounts::ConfigAccount,
     types::{
-        read_pauser,
-        read_unpauser,
+        pauser,
+        unpauser,
         write_paused,
         CONFIG_FULL_LEN,
     },
     TokenBridgeError::{
         InvalidPauser,
+        InvalidProgramOwner,
         PauserNotConfigured,
     },
 };
@@ -17,23 +18,48 @@ use solana_program::{
 };
 use solitaire::*;
 
+/// Event discriminator: `SHA256("event:Paused")[0..8]`. Emitted via Anchor-style self-CPI
+/// when `pause` succeeds. Payload: 32-byte pauser pubkey.
+pub const PAUSED_EVENT_DISCRIMINATOR: [u8; 8] =
+    [0xac, 0xf8, 0x05, 0xfd, 0x31, 0xff, 0xff, 0xe8];
+
+/// Event discriminator: `SHA256("event:Unpaused")[0..8]`. Emitted via Anchor-style self-CPI
+/// when `unpause` succeeds. Payload: 32-byte unpauser pubkey.
+pub const UNPAUSED_EVENT_DISCRIMINATOR: [u8; 8] =
+    [0x9c, 0x96, 0x2f, 0xae, 0x78, 0xd8, 0x5d, 0x75];
+
 #[derive(FromAccounts)]
 pub struct Pause<'b> {
     /// Caller must equal the configured pauser stored in the Config tail.
     pub pauser: Signer<AccountInfo<'b>>,
 
     pub config: Mut<ConfigAccount<'b, { AccountState::Initialized }>>,
+
+    /// Event authority PDA for Anchor CPI event signing.
+    pub event_authority: Info<'b>,
+
+    /// This program (for self-CPI).
+    pub self_program: Info<'b>,
 }
 
 #[derive(BorshDeserialize, BorshSerialize, Default)]
 pub struct PauseData {}
 
-pub fn pause(_ctx: &ExecutionContext, accs: &mut Pause, _data: PauseData) -> Result<()> {
+pub fn pause(ctx: &ExecutionContext, accs: &mut Pause, _data: PauseData) -> Result<()> {
     set_paused_state(
         accs.config.info(),
         accs.pauser.key,
         /* is_pauser_path */ true,
         /* paused */ true,
+    )?;
+    if accs.self_program.key != ctx.program_id {
+        return Err(InvalidProgramOwner.into());
+    }
+    emit_event_cpi(
+        ctx,
+        &accs.event_authority,
+        &PAUSED_EVENT_DISCRIMINATOR,
+        &accs.pauser.key.to_bytes(),
     )
 }
 
@@ -43,17 +69,32 @@ pub struct Unpause<'b> {
     pub unpauser: Signer<AccountInfo<'b>>,
 
     pub config: Mut<ConfigAccount<'b, { AccountState::Initialized }>>,
+
+    /// Event authority PDA for Anchor CPI event signing.
+    pub event_authority: Info<'b>,
+
+    /// This program (for self-CPI).
+    pub self_program: Info<'b>,
 }
 
 #[derive(BorshDeserialize, BorshSerialize, Default)]
 pub struct UnpauseData {}
 
-pub fn unpause(_ctx: &ExecutionContext, accs: &mut Unpause, _data: UnpauseData) -> Result<()> {
+pub fn unpause(ctx: &ExecutionContext, accs: &mut Unpause, _data: UnpauseData) -> Result<()> {
     set_paused_state(
         accs.config.info(),
         accs.unpauser.key,
         /* is_pauser_path */ false,
         /* paused */ false,
+    )?;
+    if accs.self_program.key != ctx.program_id {
+        return Err(InvalidProgramOwner.into());
+    }
+    emit_event_cpi(
+        ctx,
+        &accs.event_authority,
+        &UNPAUSED_EVENT_DISCRIMINATOR,
+        &accs.unpauser.key.to_bytes(),
     )
 }
 
@@ -71,10 +112,13 @@ fn set_paused_state(
     {
         let data = config_info.data.borrow();
         let configured = if is_pauser_path {
-            read_pauser(&data)
+            pauser(&data)
         } else {
-            read_unpauser(&data)
+            unpauser(&data)
         };
+        // Per whitepapers/0003_token_bridge.md Pausing: when a role is unassigned, the entry point MUST revert
+        // before comparing the caller against the configured role. The zero-pubkey can't be a
+        // Signer in practice on Solana, but the spec requires the explicit unassigned-check.
         if configured == Pubkey::default() {
             return Err(PauserNotConfigured.into());
         }

--- a/solana/modules/token_bridge/program/src/api/transfer.rs
+++ b/solana/modules/token_bridge/program/src/api/transfer.rs
@@ -110,6 +110,8 @@ pub fn transfer_native(
     accs: &mut TransferNative,
     data: TransferNativeData,
 ) -> Result<()> {
+    require_not_paused(accs.config.info())?;
+
     // Prevent transferring to the same chain.
     if data.target_chain == OUR_CHAIN_ID {
         return Err(InvalidChain.into());
@@ -311,6 +313,8 @@ pub fn transfer_wrapped(
     accs: &mut TransferWrapped,
     data: TransferWrappedData,
 ) -> Result<()> {
+    require_not_paused(accs.config.info())?;
+
     // Prevent transferring to the same chain.
     if data.target_chain == OUR_CHAIN_ID {
         return Err(InvalidChain.into());

--- a/solana/modules/token_bridge/program/src/api/transfer_payload.rs
+++ b/solana/modules/token_bridge/program/src/api/transfer_payload.rs
@@ -182,6 +182,8 @@ pub fn transfer_native_with_payload(
     accs: &mut TransferNativeWithPayload,
     data: TransferNativeWithPayloadData,
 ) -> Result<()> {
+    require_not_paused(accs.config.info())?;
+
     // Prevent transferring to the same chain.
     if data.target_chain == OUR_CHAIN_ID {
         return Err(InvalidChain.into());
@@ -311,6 +313,8 @@ pub fn transfer_wrapped_with_payload(
     accs: &mut TransferWrappedWithPayload,
     data: TransferWrappedWithPayloadData,
 ) -> Result<()> {
+    require_not_paused(accs.config.info())?;
+
     // Prevent transferring to the same chain.
     if data.target_chain == OUR_CHAIN_ID {
         return Err(InvalidChain.into());

--- a/solana/modules/token_bridge/program/src/instructions.rs
+++ b/solana/modules/token_bridge/program/src/instructions.rs
@@ -918,8 +918,9 @@ pub fn upgrade_contract(
     }
 }
 
-/// Builder for the `SetPauserAddresses` (action 5) governance instruction. Realloc's the existing
+/// Builder for the `SetPauserAddresses` (action 4) governance instruction. Realloc's the existing
 /// `Config` PDA from its legacy 32-byte layout to the 97-byte layout the first time it is called.
+/// Emits a `PauserAddressesSet` Anchor-style event via self-CPI (see `api::governance`).
 pub fn set_pauser_addresses(
     program_id: Pubkey,
     bridge_id: Pubkey,
@@ -933,6 +934,8 @@ pub fn set_pauser_addresses(
     // _consuming_ program (the token bridge), not the core bridge. See the existing
     // `register_chain` builder above for precedent.
     let (message_acc, claim_acc) = claimable_vaa(program_id, message_key, vaa);
+    let (event_authority, _) =
+        Pubkey::find_program_address(&[solitaire::EVENT_AUTHORITY_SEED], &program_id);
 
     Ok(Instruction {
         program_id,
@@ -941,6 +944,9 @@ pub fn set_pauser_addresses(
             AccountMeta::new(config_key, false),
             message_acc,
             claim_acc,
+            // Event-CPI accounts: PDA signer + self-program for `emit_event_cpi`.
+            AccountMeta::new_readonly(event_authority, false),
+            AccountMeta::new_readonly(program_id, false),
             // Dependencies
             AccountMeta::new_readonly(solana_program::sysvar::rent::id(), false),
             AccountMeta::new_readonly(solana_program::system_program::id(), false),
@@ -954,30 +960,40 @@ pub fn set_pauser_addresses(
 }
 
 /// Builder for the `Pause` instruction. Caller must equal the configured pauser stored in the
-/// `Config` tail (set via a `SetPauserAddresses` governance VAA).
+/// `Config` tail (set via a `SetPauserAddresses` governance VAA). Emits a `Paused` Anchor-style
+/// event via self-CPI.
 pub fn pause(program_id: Pubkey, pauser: Pubkey) -> solitaire::Result<Instruction> {
     let config_key = ConfigAccount::<'_, { AccountState::Initialized }>::key(None, &program_id);
+    let (event_authority, _) =
+        Pubkey::find_program_address(&[solitaire::EVENT_AUTHORITY_SEED], &program_id);
 
     Ok(Instruction {
         program_id,
         accounts: vec![
             AccountMeta::new_readonly(pauser, true),
             AccountMeta::new(config_key, false),
+            AccountMeta::new_readonly(event_authority, false),
+            AccountMeta::new_readonly(program_id, false),
         ],
         data: (crate::instruction::Instruction::Pause, PauseData {}).try_to_vec()?,
     })
 }
 
 /// Builder for the `Unpause` instruction. Caller must equal the configured unpauser stored in the
-/// `Config` tail (set via a `SetPauserAddresses` governance VAA).
+/// `Config` tail (set via a `SetPauserAddresses` governance VAA). Emits an `Unpaused` Anchor-style
+/// event via self-CPI.
 pub fn unpause(program_id: Pubkey, unpauser: Pubkey) -> solitaire::Result<Instruction> {
     let config_key = ConfigAccount::<'_, { AccountState::Initialized }>::key(None, &program_id);
+    let (event_authority, _) =
+        Pubkey::find_program_address(&[solitaire::EVENT_AUTHORITY_SEED], &program_id);
 
     Ok(Instruction {
         program_id,
         accounts: vec![
             AccountMeta::new_readonly(unpauser, true),
             AccountMeta::new(config_key, false),
+            AccountMeta::new_readonly(event_authority, false),
+            AccountMeta::new_readonly(program_id, false),
         ],
         data: (crate::instruction::Instruction::Unpause, UnpauseData {}).try_to_vec()?,
     })

--- a/solana/modules/token_bridge/program/src/instructions.rs
+++ b/solana/modules/token_bridge/program/src/instructions.rs
@@ -23,10 +23,13 @@ use crate::{
         },
         AttestTokenData,
         CreateWrappedData,
+        PauseData,
         RegisterChainData,
         SenderAccount,
+        SetPauserAddressesData,
         TransferNativeData,
         TransferWrappedData,
+        UnpauseData,
         UpgradeContractData,
     },
     messages::{
@@ -913,4 +916,69 @@ pub fn upgrade_contract(
             .try_to_vec()
             .unwrap(),
     }
+}
+
+/// Builder for the `SetPauserAddresses` (action 5) governance instruction. Realloc's the existing
+/// `Config` PDA from its legacy 32-byte layout to the 97-byte layout the first time it is called.
+pub fn set_pauser_addresses(
+    program_id: Pubkey,
+    bridge_id: Pubkey,
+    payer: Pubkey,
+    message_key: Pubkey,
+    vaa: PostVAAData,
+) -> solitaire::Result<Instruction> {
+    let _ = bridge_id; // Kept on the signature for parity with other governance builders.
+    let config_key = ConfigAccount::<'_, { AccountState::Initialized }>::key(None, &program_id);
+    // `claimable_vaa`'s first arg is misleadingly named — the Claim PDA is derived under the
+    // _consuming_ program (the token bridge), not the core bridge. See the existing
+    // `register_chain` builder above for precedent.
+    let (message_acc, claim_acc) = claimable_vaa(program_id, message_key, vaa);
+
+    Ok(Instruction {
+        program_id,
+        accounts: vec![
+            AccountMeta::new(payer, true),
+            AccountMeta::new(config_key, false),
+            message_acc,
+            claim_acc,
+            // Dependencies
+            AccountMeta::new_readonly(solana_program::sysvar::rent::id(), false),
+            AccountMeta::new_readonly(solana_program::system_program::id(), false),
+        ],
+        data: (
+            crate::instruction::Instruction::SetPauserAddresses,
+            SetPauserAddressesData {},
+        )
+            .try_to_vec()?,
+    })
+}
+
+/// Builder for the `Pause` instruction. Caller must equal the configured pauser stored in the
+/// `Config` tail (set via a `SetPauserAddresses` governance VAA).
+pub fn pause(program_id: Pubkey, pauser: Pubkey) -> solitaire::Result<Instruction> {
+    let config_key = ConfigAccount::<'_, { AccountState::Initialized }>::key(None, &program_id);
+
+    Ok(Instruction {
+        program_id,
+        accounts: vec![
+            AccountMeta::new_readonly(pauser, true),
+            AccountMeta::new(config_key, false),
+        ],
+        data: (crate::instruction::Instruction::Pause, PauseData {}).try_to_vec()?,
+    })
+}
+
+/// Builder for the `Unpause` instruction. Caller must equal the configured unpauser stored in the
+/// `Config` tail (set via a `SetPauserAddresses` governance VAA).
+pub fn unpause(program_id: Pubkey, unpauser: Pubkey) -> solitaire::Result<Instruction> {
+    let config_key = ConfigAccount::<'_, { AccountState::Initialized }>::key(None, &program_id);
+
+    Ok(Instruction {
+        program_id,
+        accounts: vec![
+            AccountMeta::new_readonly(unpauser, true),
+            AccountMeta::new(config_key, false),
+        ],
+        data: (crate::instruction::Instruction::Unpause, UnpauseData {}).try_to_vec()?,
+    })
 }

--- a/solana/modules/token_bridge/program/src/lib.rs
+++ b/solana/modules/token_bridge/program/src/lib.rs
@@ -107,6 +107,9 @@ pub enum TokenBridgeError {
     InvalidPauser,
     /// Configured pauser / unpauser is the zero pubkey, so that side of the pair is disabled.
     PauserNotConfigured,
+    /// `self_program` account passed by the caller does not match this program's `program_id`.
+    /// Only used to defensively guard the self-CPI that emits Anchor-style events.
+    InvalidProgramOwner,
 }
 
 impl From<TokenBridgeError> for SolitaireError {
@@ -116,6 +119,7 @@ impl From<TokenBridgeError> for SolitaireError {
 }
 
 solitaire! {
+    @event_cpi,
     Initialize => initialize,
     AttestToken => attest_token,
     CompleteNative => complete_native,

--- a/solana/modules/token_bridge/program/src/lib.rs
+++ b/solana/modules/token_bridge/program/src/lib.rs
@@ -109,7 +109,7 @@ pub enum TokenBridgeError {
     PauserNotConfigured,
     /// `self_program` account passed by the caller does not match this program's `program_id`.
     /// Only used to defensively guard the self-CPI that emits Anchor-style events.
-    InvalidProgramOwner,
+    InvalidSelfProgram,
 }
 
 impl From<TokenBridgeError> for SolitaireError {

--- a/solana/modules/token_bridge/program/src/lib.rs
+++ b/solana/modules/token_bridge/program/src/lib.rs
@@ -28,11 +28,14 @@ pub use api::{
     complete_wrapped_with_payload,
     create_wrapped,
     initialize,
+    pause,
     register_chain,
+    set_pauser_addresses,
     transfer_native,
     transfer_native_with_payload,
     transfer_wrapped,
     transfer_wrapped_with_payload,
+    unpause,
     upgrade_contract,
     AttestToken,
     AttestTokenData,
@@ -48,8 +51,12 @@ pub use api::{
     CreateWrappedData,
     Initialize,
     InitializeData,
+    Pause,
+    PauseData,
     RegisterChain,
     RegisterChainData,
+    SetPauserAddresses,
+    SetPauserAddressesData,
     TransferNative,
     TransferNativeData,
     TransferNativeWithPayload,
@@ -58,6 +65,8 @@ pub use api::{
     TransferWrappedData,
     TransferWrappedWithPayload,
     TransferWrappedWithPayloadData,
+    Unpause,
+    UnpauseData,
     UpgradeContract,
     UpgradeContractData,
 };
@@ -92,6 +101,12 @@ pub enum TokenBridgeError {
     NonexistentTokenMetadataAccount,
     NotMetadataV1Account,
     WrongMetadataAccount,
+    /// `paused == true`. Lifted only by a successful `unpause` call from the configured unpauser.
+    Paused,
+    /// Caller of `pause` / `unpause` is not the configured pauser / unpauser.
+    InvalidPauser,
+    /// Configured pauser / unpauser is the zero pubkey, so that side of the pair is disabled.
+    PauserNotConfigured,
 }
 
 impl From<TokenBridgeError> for SolitaireError {
@@ -114,4 +129,7 @@ solitaire! {
     CompleteWrappedWithPayload => complete_wrapped_with_payload,
     TransferWrappedWithPayload => transfer_wrapped_with_payload,
     TransferNativeWithPayload => transfer_native_with_payload,
+    SetPauserAddresses => set_pauser_addresses,
+    Pause => pause,
+    Unpause => unpause,
 }

--- a/solana/modules/token_bridge/program/src/messages.rs
+++ b/solana/modules/token_bridge/program/src/messages.rs
@@ -18,7 +18,10 @@ use byteorder::{
 use primitive_types::U256;
 use solana_program::{
     program_error::ProgramError::InvalidAccountData,
-    pubkey::Pubkey,
+    pubkey::{
+        Pubkey,
+        PUBKEY_BYTES,
+    },
 };
 use solitaire::SolitaireError;
 use std::{
@@ -369,8 +372,16 @@ impl SerializeGovernancePayload for GovernancePayloadUpgrade {
 impl DeserializeGovernancePayload for GovernancePayloadUpgrade {
 }
 
-/// Body of action 5 (`SetPauserAddressesSolana`) governance message — see
-/// whitepapers/0018_pauser.md. Action 4 (EVM variant) MUST be rejected on Solana.
+/// Body of the `SetPauserAddresses` (action 4) governance message — see the "Pausing" section of
+/// whitepapers/0003_token_bridge.md.
+///
+/// Wire format after the governance header:
+///   `pauser_len(u8) | pauser[pauser_len] | unpauser_len(u8) | unpauser[unpauser_len]`
+///
+/// On Solana each length must be either 32 (the native address size) or 0 (the role is left
+/// unassigned). Any other length is rejected. An all-zero 32-byte address is treated as equivalent
+/// to a zero-length encoding — both decode to `Pubkey::default()`, which `api::pause` rejects via
+/// the `PauserNotConfigured` check before comparing the caller.
 #[derive(PartialEq, Debug)]
 pub struct PayloadSetPauserAddresses {
     pub pauser: Pubkey,
@@ -380,7 +391,13 @@ pub struct PayloadSetPauserAddresses {
 impl SerializePayload for PayloadSetPauserAddresses {
     fn serialize<W: Write>(&self, v: &mut W) -> std::result::Result<(), SolitaireError> {
         self.write_governance_header(v)?;
+        // Canonical SVM encoding: always emit the full 32-byte length, even for the unassigned
+        // role (in which case the body is 32 bytes of zeros). The wire format also accepts a
+        // zero-length encoding on the receive side; either form decodes to `Pubkey::default()`.
+        // `PUBKEY_BYTES` is 32 and `as u8` is safe for that range.
+        v.write_u8(PUBKEY_BYTES as u8)?;
         v.write_all(&self.pauser.to_bytes())?;
+        v.write_u8(PUBKEY_BYTES as u8)?;
         v.write_all(&self.unpauser.to_bytes())?;
         Ok(())
     }
@@ -394,28 +411,41 @@ where
         let mut c = Cursor::new(buf);
         Self::check_governance_header(&mut c)?;
 
-        let mut pauser = [0u8; 32];
-        c.read_exact(&mut pauser)?;
-        let mut unpauser = [0u8; 32];
-        c.read_exact(&mut unpauser)?;
+        let pauser = read_length_prefixed_pubkey(&mut c)?;
+        let unpauser = read_length_prefixed_pubkey(&mut c)?;
 
         if c.position() != c.into_inner().len() as u64 {
             return Err(InvalidAccountData.into());
         }
 
-        Ok(PayloadSetPauserAddresses {
-            pauser: Pubkey::new(&pauser[..]),
-            unpauser: Pubkey::new(&unpauser[..]),
-        })
+        Ok(PayloadSetPauserAddresses { pauser, unpauser })
     }
 }
 
 impl SerializeGovernancePayload for PayloadSetPauserAddresses {
     const MODULE: &'static str = "TokenBridge";
-    const ACTION: u8 = 5;
+    const ACTION: u8 = 4;
 }
 
 impl DeserializeGovernancePayload for PayloadSetPauserAddresses {
+}
+
+/// Decode a single length-prefixed address from a `SetPauserAddresses` payload. Accepts either
+/// length 0 (role unassigned) or length 32 (Solana native address size); any other length is
+/// rejected. Both `len == 0` and `len == 32` with all-zero bytes decode to `Pubkey::default()`.
+fn read_length_prefixed_pubkey(
+    c: &mut Cursor<&mut &[u8]>,
+) -> std::result::Result<Pubkey, SolitaireError> {
+    let len = c.read_u8()?;
+    if len == 0 {
+        return Ok(Pubkey::default());
+    }
+    if usize::from(len) != PUBKEY_BYTES {
+        return Err(InvalidAccountData.into());
+    }
+    let mut bytes = [0u8; PUBKEY_BYTES];
+    c.read_exact(&mut bytes)?;
+    Ok(Pubkey::new(&bytes[..]))
 }
 
 #[cfg(test)]

--- a/solana/modules/token_bridge/program/src/messages.rs
+++ b/solana/modules/token_bridge/program/src/messages.rs
@@ -369,6 +369,55 @@ impl SerializeGovernancePayload for GovernancePayloadUpgrade {
 impl DeserializeGovernancePayload for GovernancePayloadUpgrade {
 }
 
+/// Body of action 5 (`SetPauserAddressesSolana`) governance message — see
+/// whitepapers/0018_pauser.md. Action 4 (EVM variant) MUST be rejected on Solana.
+#[derive(PartialEq, Debug)]
+pub struct PayloadSetPauserAddresses {
+    pub pauser: Pubkey,
+    pub unpauser: Pubkey,
+}
+
+impl SerializePayload for PayloadSetPauserAddresses {
+    fn serialize<W: Write>(&self, v: &mut W) -> std::result::Result<(), SolitaireError> {
+        self.write_governance_header(v)?;
+        v.write_all(&self.pauser.to_bytes())?;
+        v.write_all(&self.unpauser.to_bytes())?;
+        Ok(())
+    }
+}
+
+impl DeserializePayload for PayloadSetPauserAddresses
+where
+    Self: DeserializeGovernancePayload,
+{
+    fn deserialize(buf: &mut &[u8]) -> Result<Self, SolitaireError> {
+        let mut c = Cursor::new(buf);
+        Self::check_governance_header(&mut c)?;
+
+        let mut pauser = [0u8; 32];
+        c.read_exact(&mut pauser)?;
+        let mut unpauser = [0u8; 32];
+        c.read_exact(&mut unpauser)?;
+
+        if c.position() != c.into_inner().len() as u64 {
+            return Err(InvalidAccountData.into());
+        }
+
+        Ok(PayloadSetPauserAddresses {
+            pauser: Pubkey::new(&pauser[..]),
+            unpauser: Pubkey::new(&unpauser[..]),
+        })
+    }
+}
+
+impl SerializeGovernancePayload for PayloadSetPauserAddresses {
+    const MODULE: &'static str = "TokenBridge";
+    const ACTION: u8 = 5;
+}
+
+impl DeserializeGovernancePayload for PayloadSetPauserAddresses {
+}
+
 #[cfg(test)]
 #[allow(unused_imports)]
 mod tests {
@@ -376,6 +425,7 @@ mod tests {
         GovernancePayloadUpgrade,
         PayloadAssetMeta,
         PayloadGovernanceRegisterChain,
+        PayloadSetPauserAddresses,
         PayloadTransfer,
         PayloadTransferWithPayload,
     };
@@ -452,6 +502,19 @@ mod tests {
 
         let data = original.try_to_vec().unwrap();
         let deser = PayloadGovernanceRegisterChain::deserialize(&mut data.as_slice()).unwrap();
+
+        assert_eq!(original, deser);
+    }
+
+    #[test]
+    pub fn test_serde_gov_set_pauser_addresses() {
+        let original = PayloadSetPauserAddresses {
+            pauser: Pubkey::new_unique(),
+            unpauser: Pubkey::new_unique(),
+        };
+
+        let data = original.try_to_vec().unwrap();
+        let deser = PayloadSetPauserAddresses::deserialize(&mut data.as_slice()).unwrap();
 
         assert_eq!(original, deser);
     }

--- a/solana/modules/token_bridge/program/src/types.rs
+++ b/solana/modules/token_bridge/program/src/types.rs
@@ -93,11 +93,11 @@ impl Owned for Config {
 /// See the "Pausing" section of whitepapers/0003_token_bridge.md.
 
 // Account-size sentinels: a Config account is either CONFIG_BORSH_LEN (legacy / un-migrated)
-// or CONFIG_FULL_LEN (post-migration). Any other length on a successfully-deserialized account
+// or CONFIG_WITH_PAUSER_LEN (post-migration). Any other length on a successfully-deserialized account
 // would indicate corruption.
 pub const CONFIG_BORSH_LEN: usize = 32;
 pub const PAUSER_TAIL_LEN: usize = 1 + PUBKEY_BYTES + PUBKEY_BYTES;
-pub const CONFIG_FULL_LEN: usize = CONFIG_BORSH_LEN + PAUSER_TAIL_LEN;
+pub const CONFIG_WITH_PAUSER_LEN: usize = CONFIG_BORSH_LEN + PAUSER_TAIL_LEN;
 
 // Byte offsets inside the tail (relative to the start of the Config account).
 pub const PAUSED_OFFSET: usize = CONFIG_BORSH_LEN;
@@ -108,14 +108,14 @@ pub const UNPAUSER_OFFSET: usize = PAUSER_OFFSET + PUBKEY_BYTES;
 // silently corrupt the tail layout. (Written with `if ... { panic!() }` rather than `assert!`
 // because clippy's `assertions_on_constants` lint flags compile-time-constant `assert!` calls.)
 const _: () = {
-    if PAUSED_OFFSET >= CONFIG_FULL_LEN {
+    if PAUSED_OFFSET >= CONFIG_WITH_PAUSER_LEN {
         panic!("PAUSED_OFFSET must fall inside the tail");
     }
-    if PAUSER_OFFSET + PUBKEY_BYTES > CONFIG_FULL_LEN {
-        panic!("pauser slot must fit inside CONFIG_FULL_LEN");
+    if PAUSER_OFFSET + PUBKEY_BYTES > CONFIG_WITH_PAUSER_LEN {
+        panic!("pauser slot must fit inside CONFIG_WITH_PAUSER_LEN");
     }
-    if UNPAUSER_OFFSET + PUBKEY_BYTES != CONFIG_FULL_LEN {
-        panic!("unpauser slot must end exactly at CONFIG_FULL_LEN");
+    if UNPAUSER_OFFSET + PUBKEY_BYTES != CONFIG_WITH_PAUSER_LEN {
+        panic!("unpauser slot must end exactly at CONFIG_WITH_PAUSER_LEN");
     }
 };
 
@@ -125,7 +125,7 @@ const _: () = {
 /// store `0` or `1`, so a non-canonical byte should not occur in practice.
 #[must_use]
 pub fn paused(config_data: &[u8]) -> bool {
-    if config_data.len() < CONFIG_FULL_LEN {
+    if config_data.len() < CONFIG_WITH_PAUSER_LEN {
         return false;
     }
     match config_data[PAUSED_OFFSET] {
@@ -140,7 +140,7 @@ pub fn paused(config_data: &[u8]) -> bool {
 /// AND for accounts where governance explicitly set the role to the zero pubkey.
 #[must_use]
 pub fn pauser(config_data: &[u8]) -> Pubkey {
-    if config_data.len() < CONFIG_FULL_LEN {
+    if config_data.len() < CONFIG_WITH_PAUSER_LEN {
         return Pubkey::default();
     }
     Pubkey::new(&config_data[PAUSER_OFFSET..(PAUSER_OFFSET + PUBKEY_BYTES)])
@@ -149,7 +149,7 @@ pub fn pauser(config_data: &[u8]) -> Pubkey {
 /// Read the configured unpauser. Same legacy / unassigned semantics as [`pauser`].
 #[must_use]
 pub fn unpauser(config_data: &[u8]) -> Pubkey {
-    if config_data.len() < CONFIG_FULL_LEN {
+    if config_data.len() < CONFIG_WITH_PAUSER_LEN {
         return Pubkey::default();
     }
     Pubkey::new(&config_data[UNPAUSER_OFFSET..(UNPAUSER_OFFSET + PUBKEY_BYTES)])

--- a/solana/modules/token_bridge/program/src/types.rs
+++ b/solana/modules/token_bridge/program/src/types.rs
@@ -12,7 +12,10 @@ use solana_program::{
         IsInitialized,
         Pack,
     },
-    pubkey::Pubkey,
+    pubkey::{
+        Pubkey,
+        PUBKEY_BYTES,
+    },
 };
 use solitaire::{
     pack_type,
@@ -77,50 +80,93 @@ impl Owned for Config {
 ///
 /// Lazy migration: legacy 32-byte accounts are treated as "unpaused, no pauser configured".
 /// The first `SetPauserAddresses` governance VAA realloc's the account to
-/// `CONFIG_BORSH_LEN + PAUSER_TAIL_LEN` bytes and writes the tail.
+/// `CONFIG_BORSH_LEN + PAUSER_TAIL_LEN` bytes and writes the tail. After migration, both
+/// `pauser` and `unpauser` may still be set to `Pubkey::default()` via governance — this is
+/// the canonical "role unassigned" encoding, and `api::pause` reverts before comparing the
+/// caller in that case (see whitepapers/0003_token_bridge.md Pausing).
 ///
 /// Tail layout (97-byte total Config account):
-///   bytes 32 .. 33 : `paused` (u8, 0 = false, anything else = true)
+///   bytes 32 .. 33 : `paused` (u8, exactly 0 or 1 — see `write_paused` / `paused()`)
 ///   bytes 33 .. 65 : `pauser`   (Pubkey)
 ///   bytes 65 .. 97 : `unpauser` (Pubkey)
 ///
 /// See the "Pausing" section of whitepapers/0003_token_bridge.md.
+
+// Account-size sentinels: a Config account is either CONFIG_BORSH_LEN (legacy / un-migrated)
+// or CONFIG_FULL_LEN (post-migration). Any other length on a successfully-deserialized account
+// would indicate corruption.
 pub const CONFIG_BORSH_LEN: usize = 32;
-pub const PAUSED_OFFSET: usize = CONFIG_BORSH_LEN;
-pub const PAUSER_OFFSET: usize = PAUSED_OFFSET + 1;
-pub const UNPAUSER_OFFSET: usize = PAUSER_OFFSET + 32;
-pub const PAUSER_TAIL_LEN: usize = 1 + 32 + 32;
+pub const PAUSER_TAIL_LEN: usize = 1 + PUBKEY_BYTES + PUBKEY_BYTES;
 pub const CONFIG_FULL_LEN: usize = CONFIG_BORSH_LEN + PAUSER_TAIL_LEN;
 
-/// Read the `paused` flag, returning `false` for legacy (un-extended) accounts.
-pub fn read_paused(config_data: &[u8]) -> bool {
-    config_data.len() > PAUSED_OFFSET && config_data[PAUSED_OFFSET] != 0
+// Byte offsets inside the tail (relative to the start of the Config account).
+pub const PAUSED_OFFSET: usize = CONFIG_BORSH_LEN;
+pub const PAUSER_OFFSET: usize = PAUSED_OFFSET + 1;
+pub const UNPAUSER_OFFSET: usize = PAUSER_OFFSET + PUBKEY_BYTES;
+
+// Pin offset/length relationships at compile time so a future tweak to the constants can't
+// silently corrupt the tail layout. (Written with `if ... { panic!() }` rather than `assert!`
+// because clippy's `assertions_on_constants` lint flags compile-time-constant `assert!` calls.)
+const _: () = {
+    if PAUSED_OFFSET >= CONFIG_FULL_LEN {
+        panic!("PAUSED_OFFSET must fall inside the tail");
+    }
+    if PAUSER_OFFSET + PUBKEY_BYTES > CONFIG_FULL_LEN {
+        panic!("pauser slot must fit inside CONFIG_FULL_LEN");
+    }
+    if UNPAUSER_OFFSET + PUBKEY_BYTES != CONFIG_FULL_LEN {
+        panic!("unpauser slot must end exactly at CONFIG_FULL_LEN");
+    }
+};
+
+/// Read the `paused` flag. Returns `false` for legacy (un-migrated) accounts; otherwise the
+/// stored byte is interpreted strictly — `0` is unpaused, `1` is paused, any other value is
+/// considered corrupted and treated as paused (fail-closed). Writers (`write_paused`) only ever
+/// store `0` or `1`, so a non-canonical byte should not occur in practice.
+#[must_use]
+pub fn paused(config_data: &[u8]) -> bool {
+    if config_data.len() < CONFIG_FULL_LEN {
+        return false;
+    }
+    match config_data[PAUSED_OFFSET] {
+        0 => false,
+        1 => true,
+        // Fail-closed on corruption: any non-canonical byte is treated as paused.
+        _ => true,
+    }
 }
 
-/// Read the configured pauser. Returns the all-zero pubkey for legacy accounts (which pause.rs
-/// rejects via `PauserNotConfigured`), so callers don't need to special-case un-extended state.
-pub fn read_pauser(config_data: &[u8]) -> Pubkey {
-    if config_data.len() < UNPAUSER_OFFSET {
+/// Read the configured pauser. Returns `Pubkey::default()` for legacy (un-migrated) accounts
+/// AND for accounts where governance explicitly set the role to the zero pubkey.
+#[must_use]
+pub fn pauser(config_data: &[u8]) -> Pubkey {
+    if config_data.len() < CONFIG_FULL_LEN {
         return Pubkey::default();
     }
-    Pubkey::new(&config_data[PAUSER_OFFSET..PAUSER_OFFSET + 32])
+    Pubkey::new(&config_data[PAUSER_OFFSET..(PAUSER_OFFSET + PUBKEY_BYTES)])
 }
 
-/// Read the configured unpauser. Same legacy-account semantics as `read_pauser`.
-pub fn read_unpauser(config_data: &[u8]) -> Pubkey {
-    if config_data.len() < UNPAUSER_OFFSET + 32 {
+/// Read the configured unpauser. Same legacy / unassigned semantics as [`pauser`].
+#[must_use]
+pub fn unpauser(config_data: &[u8]) -> Pubkey {
+    if config_data.len() < CONFIG_FULL_LEN {
         return Pubkey::default();
     }
-    Pubkey::new(&config_data[UNPAUSER_OFFSET..UNPAUSER_OFFSET + 32])
+    Pubkey::new(&config_data[UNPAUSER_OFFSET..(UNPAUSER_OFFSET + PUBKEY_BYTES)])
 }
 
-pub fn write_paused(config_data: &mut [u8], paused: bool) {
-    config_data[PAUSED_OFFSET] = if paused { 1 } else { 0 };
+pub(crate) fn write_paused(config_data: &mut [u8], paused: bool) {
+    config_data[PAUSED_OFFSET] = u8::from(paused);
 }
 
-pub fn write_pauser_addresses(config_data: &mut [u8], pauser: &Pubkey, unpauser: &Pubkey) {
-    config_data[PAUSER_OFFSET..PAUSER_OFFSET + 32].copy_from_slice(&pauser.to_bytes());
-    config_data[UNPAUSER_OFFSET..UNPAUSER_OFFSET + 32].copy_from_slice(&unpauser.to_bytes());
+pub(crate) fn write_pauser_addresses(
+    config_data: &mut [u8],
+    pauser: &Pubkey,
+    unpauser: &Pubkey,
+) {
+    config_data[PAUSER_OFFSET..(PAUSER_OFFSET + PUBKEY_BYTES)].copy_from_slice(&pauser.to_bytes());
+    config_data[UNPAUSER_OFFSET..(UNPAUSER_OFFSET + PUBKEY_BYTES)]
+        .copy_from_slice(&unpauser.to_bytes());
 }
 
 /// Returns `Err(Paused)` if the bridge is currently paused. Legacy (un-extended) Config
@@ -129,7 +175,7 @@ pub fn require_not_paused(
     config_info: &solana_program::account_info::AccountInfo,
 ) -> solitaire::Result<()> {
     let data = config_info.data.borrow();
-    if read_paused(&data) {
+    if paused(&data) {
         return Err(crate::TokenBridgeError::Paused.into());
     }
     Ok(())

--- a/solana/modules/token_bridge/program/src/types.rs
+++ b/solana/modules/token_bridge/program/src/types.rs
@@ -84,7 +84,7 @@ impl Owned for Config {
 ///   bytes 33 .. 65 : `pauser`   (Pubkey)
 ///   bytes 65 .. 97 : `unpauser` (Pubkey)
 ///
-/// See whitepapers/0018_pauser.md.
+/// See the "Pausing" section of whitepapers/0003_token_bridge.md.
 pub const CONFIG_BORSH_LEN: usize = 32;
 pub const PAUSED_OFFSET: usize = CONFIG_BORSH_LEN;
 pub const PAUSER_OFFSET: usize = PAUSED_OFFSET + 1;

--- a/solana/modules/token_bridge/program/src/types.rs
+++ b/solana/modules/token_bridge/program/src/types.rs
@@ -159,11 +159,7 @@ pub(crate) fn write_paused(config_data: &mut [u8], paused: bool) {
     config_data[PAUSED_OFFSET] = u8::from(paused);
 }
 
-pub(crate) fn write_pauser_addresses(
-    config_data: &mut [u8],
-    pauser: &Pubkey,
-    unpauser: &Pubkey,
-) {
+pub(crate) fn write_pauser_addresses(config_data: &mut [u8], pauser: &Pubkey, unpauser: &Pubkey) {
     config_data[PAUSER_OFFSET..(PAUSER_OFFSET + PUBKEY_BYTES)].copy_from_slice(&pauser.to_bytes());
     config_data[UNPAUSER_OFFSET..(UNPAUSER_OFFSET + PUBKEY_BYTES)]
         .copy_from_slice(&unpauser.to_bytes());

--- a/solana/modules/token_bridge/program/src/types.rs
+++ b/solana/modules/token_bridge/program/src/types.rs
@@ -26,13 +26,31 @@ use spl_token::state::{
     Account,
     Mint,
 };
+use std::io;
 
 pub type Address = [u8; 32];
 pub type ChainID = u16;
 
-#[derive(Default, Clone, Copy, BorshDeserialize, BorshSerialize, Serialize, Deserialize)]
+#[derive(Default, Clone, Copy, BorshSerialize, Serialize, Deserialize)]
 pub struct Config {
     pub wormhole_bridge: Pubkey,
+}
+
+// Hand-rolled `BorshDeserialize` so `try_from_slice` tolerates the pauser tail (bytes 32..97)
+// that the realloc'd Config carries after the first `SetPauserAddresses` governance VAA.
+// The derived `try_from_slice` rejects any trailing bytes, which would break every handler
+// that peels `ConfigAccount` (transfer, complete, attest, …) on a migrated bridge.
+impl BorshDeserialize for Config {
+    fn deserialize(buf: &mut &[u8]) -> io::Result<Self> {
+        Ok(Config {
+            wormhole_bridge: <Pubkey as BorshDeserialize>::deserialize(buf)?,
+        })
+    }
+
+    fn try_from_slice(v: &[u8]) -> io::Result<Self> {
+        let mut cursor = v;
+        <Self as BorshDeserialize>::deserialize(&mut cursor)
+    }
 }
 
 #[cfg(not(feature = "cpi"))]
@@ -48,6 +66,73 @@ impl Owned for Config {
         use std::str::FromStr;
         AccountOwner::Other(Pubkey::from_str(env!("TOKEN_BRIDGE_ADDRESS")).unwrap())
     }
+}
+
+/// Pauser tail layout written at offset `CONFIG_BORSH_LEN` of the existing `Config` PDA.
+///
+/// Backwards-compatible extension: the `Config` Borsh struct itself stays 32 bytes, so existing
+/// SDK transactions that pass the Config as writable continue to round-trip — solitaire's
+/// `Persist::persist` calls Borsh `serialize` which writes only the first 32 bytes and leaves
+/// the tail untouched.
+///
+/// Lazy migration: legacy 32-byte accounts are treated as "unpaused, no pauser configured".
+/// The first `SetPauserAddresses` governance VAA realloc's the account to
+/// `CONFIG_BORSH_LEN + PAUSER_TAIL_LEN` bytes and writes the tail.
+///
+/// Tail layout (97-byte total Config account):
+///   bytes 32 .. 33 : `paused` (u8, 0 = false, anything else = true)
+///   bytes 33 .. 65 : `pauser`   (Pubkey)
+///   bytes 65 .. 97 : `unpauser` (Pubkey)
+///
+/// See whitepapers/0018_pauser.md.
+pub const CONFIG_BORSH_LEN: usize = 32;
+pub const PAUSED_OFFSET: usize = CONFIG_BORSH_LEN;
+pub const PAUSER_OFFSET: usize = PAUSED_OFFSET + 1;
+pub const UNPAUSER_OFFSET: usize = PAUSER_OFFSET + 32;
+pub const PAUSER_TAIL_LEN: usize = 1 + 32 + 32;
+pub const CONFIG_FULL_LEN: usize = CONFIG_BORSH_LEN + PAUSER_TAIL_LEN;
+
+/// Read the `paused` flag, returning `false` for legacy (un-extended) accounts.
+pub fn read_paused(config_data: &[u8]) -> bool {
+    config_data.len() > PAUSED_OFFSET && config_data[PAUSED_OFFSET] != 0
+}
+
+/// Read the configured pauser. Returns the all-zero pubkey for legacy accounts (which pause.rs
+/// rejects via `PauserNotConfigured`), so callers don't need to special-case un-extended state.
+pub fn read_pauser(config_data: &[u8]) -> Pubkey {
+    if config_data.len() < UNPAUSER_OFFSET {
+        return Pubkey::default();
+    }
+    Pubkey::new(&config_data[PAUSER_OFFSET..PAUSER_OFFSET + 32])
+}
+
+/// Read the configured unpauser. Same legacy-account semantics as `read_pauser`.
+pub fn read_unpauser(config_data: &[u8]) -> Pubkey {
+    if config_data.len() < UNPAUSER_OFFSET + 32 {
+        return Pubkey::default();
+    }
+    Pubkey::new(&config_data[UNPAUSER_OFFSET..UNPAUSER_OFFSET + 32])
+}
+
+pub fn write_paused(config_data: &mut [u8], paused: bool) {
+    config_data[PAUSED_OFFSET] = if paused { 1 } else { 0 };
+}
+
+pub fn write_pauser_addresses(config_data: &mut [u8], pauser: &Pubkey, unpauser: &Pubkey) {
+    config_data[PAUSER_OFFSET..PAUSER_OFFSET + 32].copy_from_slice(&pauser.to_bytes());
+    config_data[UNPAUSER_OFFSET..UNPAUSER_OFFSET + 32].copy_from_slice(&unpauser.to_bytes());
+}
+
+/// Returns `Err(Paused)` if the bridge is currently paused. Legacy (un-extended) Config
+/// accounts are treated as unpaused. Call from every non-governance, non-`unpause` entry point.
+pub fn require_not_paused(
+    config_info: &solana_program::account_info::AccountInfo,
+) -> solitaire::Result<()> {
+    let data = config_info.data.borrow();
+    if read_paused(&data) {
+        return Err(crate::TokenBridgeError::Paused.into());
+    }
+    Ok(())
 }
 
 #[derive(Default, Clone, Copy, BorshDeserialize, BorshSerialize, Serialize, Deserialize)]

--- a/solana/modules/token_bridge/program/tests/common.rs
+++ b/solana/modules/token_bridge/program/tests/common.rs
@@ -422,6 +422,69 @@ mod helpers {
         .await
     }
 
+    #[allow(dead_code)]
+    pub async fn set_pauser_addresses(
+        client: &mut BanksClient,
+        program: Pubkey,
+        bridge: Pubkey,
+        message_acc: Pubkey,
+        vaa: PostVAAData,
+        payer: &Keypair,
+    ) -> Result<(), BanksClientError> {
+        let instruction =
+            instructions::set_pauser_addresses(program, bridge, payer.pubkey(), message_acc, vaa)
+                .expect("Could not create SetPauserAddresses instruction");
+
+        execute(
+            client,
+            payer,
+            &[payer],
+            &[instruction],
+            CommitmentLevel::Processed,
+        )
+        .await
+    }
+
+    #[allow(dead_code)]
+    pub async fn pause(
+        client: &mut BanksClient,
+        program: Pubkey,
+        pauser: &Keypair,
+        payer: &Keypair,
+    ) -> Result<(), BanksClientError> {
+        let instruction = instructions::pause(program, pauser.pubkey())
+            .expect("Could not create Pause instruction");
+
+        execute(
+            client,
+            payer,
+            &[payer, pauser],
+            &[instruction],
+            CommitmentLevel::Processed,
+        )
+        .await
+    }
+
+    #[allow(dead_code)]
+    pub async fn unpause(
+        client: &mut BanksClient,
+        program: Pubkey,
+        unpauser: &Keypair,
+        payer: &Keypair,
+    ) -> Result<(), BanksClientError> {
+        let instruction = instructions::unpause(program, unpauser.pubkey())
+            .expect("Could not create Unpause instruction");
+
+        execute(
+            client,
+            payer,
+            &[payer, unpauser],
+            &[instruction],
+            CommitmentLevel::Processed,
+        )
+        .await
+    }
+
     pub async fn complete_native(
         client: &mut BanksClient,
         program: Pubkey,

--- a/solana/modules/token_bridge/program/tests/common.rs
+++ b/solana/modules/token_bridge/program/tests/common.rs
@@ -76,10 +76,13 @@ mod helpers {
         CompleteNativeData,
         CompleteNativeWithPayloadData,
         CompleteWrappedData,
+        CompleteWrappedWithPayloadData,
         CreateWrappedData,
         RegisterChainData,
         TransferNativeData,
+        TransferNativeWithPayloadData,
         TransferWrappedData,
+        TransferWrappedWithPayloadData,
     };
 
     use token_bridge::messages::{
@@ -588,6 +591,149 @@ mod helpers {
         for account in instruction.accounts.iter().enumerate() {
             println!("{}: {}", account.0, account.1.pubkey);
         }
+
+        execute(
+            client,
+            payer,
+            &[payer, redeemer],
+            &[instruction],
+            CommitmentLevel::Processed,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn transfer_native_with_payload(
+        client: &mut BanksClient,
+        program: Pubkey,
+        bridge: Pubkey,
+        payer: &Keypair,
+        message: &Keypair,
+        from: &Keypair,
+        from_owner: &Keypair,
+        mint: Pubkey,
+        amount: u64,
+        payload: Vec<u8>,
+    ) -> Result<(), BanksClientError> {
+        let instruction = instructions::transfer_native_with_payload(
+            program,
+            bridge,
+            payer.pubkey(),
+            message.pubkey(),
+            from.pubkey(),
+            mint,
+            TransferNativeWithPayloadData {
+                nonce: 0,
+                amount,
+                target_address: [0u8; 32],
+                target_chain: 2,
+                payload,
+                cpi_program_id: None,
+            },
+        )
+        .expect("Could not create Transfer Native With Payload");
+
+        execute(
+            client,
+            payer,
+            &[payer, from_owner, message],
+            &[
+                spl_token::instruction::approve(
+                    &spl_token::id(),
+                    &from.pubkey(),
+                    &token_bridge::accounts::AuthoritySigner::key(None, &program),
+                    &from_owner.pubkey(),
+                    &[],
+                    amount,
+                )
+                .unwrap(),
+                instruction,
+            ],
+            CommitmentLevel::Processed,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn transfer_wrapped_with_payload(
+        client: &mut BanksClient,
+        program: Pubkey,
+        bridge: Pubkey,
+        payer: &Keypair,
+        message: &Keypair,
+        from: Pubkey,
+        from_owner: &Keypair,
+        token_chain: u16,
+        token_address: Address,
+        amount: u64,
+        payload: Vec<u8>,
+    ) -> Result<(), BanksClientError> {
+        let instruction = instructions::transfer_wrapped_with_payload(
+            program,
+            bridge,
+            payer.pubkey(),
+            message.pubkey(),
+            from,
+            from_owner.pubkey(),
+            token_chain,
+            token_address,
+            TransferWrappedWithPayloadData {
+                nonce: 0,
+                amount,
+                target_address: [5u8; 32],
+                target_chain: 2,
+                payload,
+                cpi_program_id: None,
+            },
+        )
+        .expect("Could not create Transfer Wrapped With Payload");
+
+        execute(
+            client,
+            payer,
+            &[payer, from_owner, message],
+            &[
+                spl_token::instruction::approve(
+                    &spl_token::id(),
+                    &from,
+                    &token_bridge::accounts::AuthoritySigner::key(None, &program),
+                    &from_owner.pubkey(),
+                    &[],
+                    amount,
+                )
+                .unwrap(),
+                instruction,
+            ],
+            CommitmentLevel::Processed,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn complete_wrapped_with_payload(
+        client: &mut BanksClient,
+        program: Pubkey,
+        bridge: Pubkey,
+        message_acc: Pubkey,
+        vaa: PostVAAData,
+        payload: PayloadTransferWithPayload,
+        to: Pubkey,
+        redeemer: &Keypair,
+        payer: &Keypair,
+    ) -> Result<(), BanksClientError> {
+        let instruction = instructions::complete_wrapped_with_payload(
+            program,
+            bridge,
+            payer.pubkey(),
+            message_acc,
+            vaa,
+            payload,
+            to,
+            redeemer.pubkey(),
+            None,
+            CompleteWrappedWithPayloadData {},
+        )
+        .expect("Could not create Complete Wrapped With Payload instruction");
 
         execute(
             client,

--- a/solana/modules/token_bridge/program/tests/integration.rs
+++ b/solana/modules/token_bridge/program/tests/integration.rs
@@ -627,18 +627,41 @@ async fn transfer_native_with_payload_in() {
     .unwrap();
 }
 
-// ============================ Pauser tests (whitepapers/0018_pauser.md) ============================
+// ============== Pauser tests (whitepapers/0003_token_bridge.md, "Pausing" section) ==============
 //
 // These tests exercise the lazy migration of the `Config` PDA from the legacy 32-byte layout to
 // the 97-byte layout, the configured pauser/unpauser flow, and the `notPaused` gate on a
 // representative non-governance entry point. The legacy compatibility test then confirms an
 // un-migrated bridge still behaves identically to pre-upgrade.
 
-const SET_PAUSER_ADDRESSES_ACTION: u8 = 5;
+const SET_PAUSER_ADDRESSES_ACTION: u8 = 4;
 
 /// Build a `SetPauserAddresses` governance VAA, post it through the core bridge, and submit it
 /// to the token bridge. Returns the serialized payload so callers can assert what got applied.
 async fn submit_set_pauser_addresses(context: &mut Context, pauser: Pubkey, unpauser: Pubkey) {
+    let payload = PayloadSetPauserAddresses { pauser, unpauser };
+    let message = payload.try_to_vec().unwrap();
+    // Sanity-check the encoded wire format matches whitepaper 0003 §"Pausing":
+    //   module(32) | action(1)=4 | chain(2) | pauser_len(1)=32 | pauser(32)
+    //                                       | unpauser_len(1)=32 | unpauser(32)
+    // Total: 32 + 1 + 2 + 1 + 32 + 1 + 32 = 101 bytes.
+    assert_eq!(message[32], SET_PAUSER_ADDRESSES_ACTION);
+    assert_eq!(message[35], 32, "expected pauser_len = 32 (SVM native size)");
+    assert_eq!(message[68], 32, "expected unpauser_len = 32 (SVM native size)");
+    assert_eq!(message.len(), 101);
+
+    submit_raw_set_pauser_addresses(context, message)
+        .await
+        .expect("canonical SetPauserAddresses should succeed");
+}
+
+/// Build, post, and submit a `SetPauserAddresses` governance VAA carrying a caller-supplied raw
+/// payload. Returns the result of the on-chain submission so length-validation tests can assert
+/// on the rejection path without having to round-trip through `PayloadSetPauserAddresses`.
+async fn submit_raw_set_pauser_addresses(
+    context: &mut Context,
+    message: Vec<u8>,
+) -> std::result::Result<(), solana_program_test::BanksClientError> {
     let Context {
         ref payer,
         ref mut client,
@@ -652,12 +675,6 @@ async fn submit_set_pauser_addresses(context: &mut Context, pauser: Pubkey, unpa
     let nonce = rand::thread_rng().gen();
     let emitter = Keypair::from_bytes(&GOVERNANCE_KEY).unwrap();
     let sequence = seq.next(emitter.pubkey().to_bytes());
-
-    let payload = PayloadSetPauserAddresses { pauser, unpauser };
-    let message = payload.try_to_vec().unwrap();
-    // Sanity-check the encoded action byte matches the wire format from whitepaper 0018:
-    // module(32) + action(1) + chain(2) + body. The action byte is at offset 32.
-    assert_eq!(message[32], SET_PAUSER_ADDRESSES_ACTION);
 
     let (vaa, body, _) =
         common::generate_vaa(emitter.pubkey().to_bytes(), 1, message, nonce, sequence);
@@ -674,9 +691,34 @@ async fn submit_set_pauser_addresses(context: &mut Context, pauser: Pubkey, unpa
     let message_key =
         PostedVAA::<'_, { AccountState::MaybeInitialized }>::key(msg_derivation_data, bridge);
 
-    common::set_pauser_addresses(client, *token_bridge, *bridge, message_key, vaa, payer)
-        .await
-        .unwrap();
+    common::set_pauser_addresses(client, *token_bridge, *bridge, message_key, vaa, payer).await
+}
+
+/// Build a `SetPauserAddresses` governance payload with caller-controlled length-prefix bytes.
+/// `pauser_len` / `unpauser_len` are written verbatim, even if they don't match `pauser.len()` /
+/// `unpauser.len()`, so a test can construct malformed payloads (invalid length, all-zero, etc).
+fn build_set_pauser_addresses_payload(
+    pauser_len: u8,
+    pauser: &[u8],
+    unpauser_len: u8,
+    unpauser: &[u8],
+) -> Vec<u8> {
+    // "TokenBridge" left-padded to 32 bytes.
+    let module: [u8; 32] = {
+        let mut m = [0u8; 32];
+        let name = b"TokenBridge";
+        m[32 - name.len()..].copy_from_slice(name);
+        m
+    };
+    let mut payload = Vec::with_capacity(35 + 1 + pauser.len() + 1 + unpauser.len());
+    payload.extend_from_slice(&module);
+    payload.push(SET_PAUSER_ADDRESSES_ACTION); // action
+    payload.extend_from_slice(&1u16.to_be_bytes()); // OUR_CHAIN_ID = Solana
+    payload.push(pauser_len);
+    payload.extend_from_slice(pauser);
+    payload.push(unpauser_len);
+    payload.extend_from_slice(unpauser);
+    payload
 }
 
 /// Returns the raw `Config` account bytes — used to assert layout, paused flag, and tail
@@ -950,4 +992,147 @@ async fn legacy_unmigrated_compat() {
         CONFIG_BORSH_LEN,
         "transfers must not migrate the Config"
     );
+}
+
+// ============== SetPauserAddresses wire-format validation (whitepaper 0003) ==============
+//
+// Whitepaper 0003 §"Pausing" defines a length-prefixed encoding shared across runtimes:
+//
+//     module(32) | action(1)=4 | chain(2)
+//   | pauser_len(1)   | pauser[pauser_len]
+//   | unpauser_len(1) | unpauser[unpauser_len]
+//
+// On Solana each length must be 32 (native size) or 0 (role left unassigned). The receive
+// side must reject any other length and any trailing bytes after the second address. A
+// length-32 field of all zeros is equivalent to a zero-length field — both decode to
+// `Pubkey::default()` and the resulting role is treated as unassigned.
+
+#[tokio::test]
+async fn set_pauser_addresses_rejects_invalid_pauser_length() {
+    let mut context = set_up().await.unwrap();
+
+    // pauser_len = 20 (the EVM native size) must be rejected on Solana.
+    let pauser_body = [0xAAu8; 20];
+    let unpauser_body = [0xBBu8; 32];
+    let bad =
+        build_set_pauser_addresses_payload(20, &pauser_body, 32, &unpauser_body);
+
+    submit_raw_set_pauser_addresses(&mut context, bad)
+        .await
+        .expect_err("pauser_len = 20 must be rejected on SVM");
+
+    // Config must remain at the legacy size — no migration on a failed VAA.
+    let post = fetch_config_data(&mut context).await;
+    assert_eq!(post.len(), CONFIG_BORSH_LEN);
+}
+
+#[tokio::test]
+async fn set_pauser_addresses_rejects_invalid_unpauser_length() {
+    let mut context = set_up().await.unwrap();
+
+    let pauser_body = [0xAAu8; 32];
+    let unpauser_body = [0xBBu8; 33]; // off-by-one over the native size
+    let bad =
+        build_set_pauser_addresses_payload(32, &pauser_body, 33, &unpauser_body);
+
+    submit_raw_set_pauser_addresses(&mut context, bad)
+        .await
+        .expect_err("unpauser_len = 33 must be rejected on SVM");
+}
+
+#[tokio::test]
+async fn set_pauser_addresses_rejects_trailing_bytes() {
+    let mut context = set_up().await.unwrap();
+
+    let pauser_body = [0xAAu8; 32];
+    let unpauser_body = [0xBBu8; 32];
+    let mut bad = build_set_pauser_addresses_payload(32, &pauser_body, 32, &unpauser_body);
+    bad.extend_from_slice(&[0xCCu8; 5]); // trailing garbage
+
+    submit_raw_set_pauser_addresses(&mut context, bad)
+        .await
+        .expect_err("trailing bytes after unpauser must be rejected");
+}
+
+#[tokio::test]
+async fn set_pauser_addresses_zero_length_means_unassigned() {
+    let mut context = set_up().await.unwrap();
+
+    // pauser_len = 0, unpauser_len = 32 — exercises the "zero-length = unassigned" branch.
+    let unpauser_body = [0xBBu8; 32];
+    let payload = build_set_pauser_addresses_payload(0, &[], 32, &unpauser_body);
+    submit_raw_set_pauser_addresses(&mut context, payload)
+        .await
+        .expect("zero-length pauser is a valid encoding");
+
+    let post = fetch_config_data(&mut context).await;
+    assert_eq!(post.len(), CONFIG_FULL_LEN);
+    assert_eq!(
+        read_pauser(&post),
+        Pubkey::default(),
+        "zero-length pauser must decode as Pubkey::default()"
+    );
+    assert_eq!(read_unpauser(&post), Pubkey::new(&unpauser_body[..]));
+
+    // With pauser unassigned, the pause entry point must reject every caller — including a
+    // signer whose key is the all-zero pubkey would be, if we could construct it. We exercise
+    // the path with a non-zero stranger: the on-chain handler reverts with PauserNotConfigured
+    // BEFORE comparing the caller against the (zero) configured pauser.
+    let stranger = Keypair::new();
+    common::transfer(
+        &mut context.client,
+        &context.payer,
+        &stranger.pubkey(),
+        1_000_000_000,
+    )
+    .await
+    .unwrap();
+    common::pause(
+        &mut context.client,
+        context.token_bridge,
+        &stranger,
+        &context.payer,
+    )
+    .await
+    .expect_err("pause must reject when pauser is unassigned");
+}
+
+#[tokio::test]
+async fn set_pauser_addresses_all_zero_32_byte_is_unassigned() {
+    let mut context = set_up().await.unwrap();
+
+    // pauser_len = 32 with all-zero bytes is the "all-zero native-size address" encoding. Per
+    // the whitepaper it MUST be treated as equivalent to length 0 — i.e. unassigned.
+    let zero_pauser = [0u8; 32];
+    let unpauser_body = [0xBBu8; 32];
+    let payload = build_set_pauser_addresses_payload(32, &zero_pauser, 32, &unpauser_body);
+    submit_raw_set_pauser_addresses(&mut context, payload)
+        .await
+        .expect("length-32 all-zero pauser is a valid encoding");
+
+    let post = fetch_config_data(&mut context).await;
+    assert_eq!(read_pauser(&post), Pubkey::default());
+    assert_eq!(read_unpauser(&post), Pubkey::new(&unpauser_body[..]));
+
+    // Recovery: a follow-up VAA can assign a non-zero pauser without first having to "clear"
+    // the previous one.
+    let real_pauser = Pubkey::new_unique();
+    submit_set_pauser_addresses(&mut context, real_pauser, Pubkey::new(&unpauser_body[..])).await;
+    let post = fetch_config_data(&mut context).await;
+    assert_eq!(read_pauser(&post), real_pauser);
+}
+
+#[tokio::test]
+async fn set_pauser_addresses_rejects_legacy_action_id() {
+    let mut context = set_up().await.unwrap();
+
+    // The pre-merge SVM design used action 5. The whitepaper now mandates a single action 4
+    // shared across runtimes (the per-runtime split was explicitly rejected in the
+    // "Alternatives Considered" section). A VAA carrying the old action 5 must be rejected.
+    let mut payload = build_set_pauser_addresses_payload(32, &[0u8; 32], 32, &[0u8; 32]);
+    payload[32] = 5; // overwrite action byte
+
+    submit_raw_set_pauser_addresses(&mut context, payload)
+        .await
+        .expect_err("legacy action 5 must be rejected (current spec is action 4)");
 }

--- a/solana/modules/token_bridge/program/tests/integration.rs
+++ b/solana/modules/token_bridge/program/tests/integration.rs
@@ -56,7 +56,7 @@ use token_bridge::{
         unpauser as read_unpauser,
         Config,
         CONFIG_BORSH_LEN,
-        CONFIG_FULL_LEN,
+        CONFIG_WITH_PAUSER_LEN,
     },
 };
 
@@ -774,7 +774,7 @@ async fn set_pauser_addresses_lazy_migration() {
     let post = fetch_config_data(&mut context).await;
     assert_eq!(
         post.len(),
-        CONFIG_FULL_LEN,
+        CONFIG_WITH_PAUSER_LEN,
         "Config should grow to 97 bytes after migration"
     );
     assert!(
@@ -794,7 +794,7 @@ async fn set_pauser_addresses_lazy_migration() {
     let rotated = fetch_config_data(&mut context).await;
     assert_eq!(
         rotated.len(),
-        CONFIG_FULL_LEN,
+        CONFIG_WITH_PAUSER_LEN,
         "rotation must not change account size"
     );
     assert_eq!(read_pauser(&rotated), pauser_two);
@@ -1076,7 +1076,7 @@ async fn set_pauser_addresses_zero_length_means_unassigned() {
         .expect("zero-length pauser is a valid encoding");
 
     let post = fetch_config_data(&mut context).await;
-    assert_eq!(post.len(), CONFIG_FULL_LEN);
+    assert_eq!(post.len(), CONFIG_WITH_PAUSER_LEN);
     assert_eq!(
         read_pauser(&post),
         Pubkey::default(),

--- a/solana/modules/token_bridge/program/tests/integration.rs
+++ b/solana/modules/token_bridge/program/tests/integration.rs
@@ -40,10 +40,18 @@ use token_bridge::{
     messages::{
         PayloadAssetMeta,
         PayloadGovernanceRegisterChain,
+        PayloadSetPauserAddresses,
         PayloadTransfer,
         PayloadTransferWithPayload,
     },
-    types::Config,
+    types::{
+        read_paused,
+        read_pauser,
+        read_unpauser,
+        Config,
+        CONFIG_BORSH_LEN,
+        CONFIG_FULL_LEN,
+    },
 };
 
 mod common;
@@ -617,4 +625,329 @@ async fn transfer_native_with_payload_in() {
     )
     .await
     .unwrap();
+}
+
+// ============================ Pauser tests (whitepapers/0018_pauser.md) ============================
+//
+// These tests exercise the lazy migration of the `Config` PDA from the legacy 32-byte layout to
+// the 97-byte layout, the configured pauser/unpauser flow, and the `notPaused` gate on a
+// representative non-governance entry point. The legacy compatibility test then confirms an
+// un-migrated bridge still behaves identically to pre-upgrade.
+
+const SET_PAUSER_ADDRESSES_ACTION: u8 = 5;
+
+/// Build a `SetPauserAddresses` governance VAA, post it through the core bridge, and submit it
+/// to the token bridge. Returns the serialized payload so callers can assert what got applied.
+async fn submit_set_pauser_addresses(context: &mut Context, pauser: Pubkey, unpauser: Pubkey) {
+    let Context {
+        ref payer,
+        ref mut client,
+        ref bridge,
+        ref token_bridge,
+        ref guardian_keys,
+        ref mut seq,
+        ..
+    } = context;
+
+    let nonce = rand::thread_rng().gen();
+    let emitter = Keypair::from_bytes(&GOVERNANCE_KEY).unwrap();
+    let sequence = seq.next(emitter.pubkey().to_bytes());
+
+    let payload = PayloadSetPauserAddresses { pauser, unpauser };
+    let message = payload.try_to_vec().unwrap();
+    // Sanity-check the encoded action byte matches the wire format from whitepaper 0018:
+    // module(32) + action(1) + chain(2) + body. The action byte is at offset 32.
+    assert_eq!(message[32], SET_PAUSER_ADDRESSES_ACTION);
+
+    let (vaa, body, _) =
+        common::generate_vaa(emitter.pubkey().to_bytes(), 1, message, nonce, sequence);
+    let signature_set = common::verify_signatures(client, bridge, payer, body, guardian_keys, 0)
+        .await
+        .unwrap();
+    common::post_vaa(client, *bridge, payer, signature_set, vaa.clone())
+        .await
+        .unwrap();
+
+    let msg_derivation_data = &PostedVAADerivationData {
+        payload_hash: body.to_vec(),
+    };
+    let message_key =
+        PostedVAA::<'_, { AccountState::MaybeInitialized }>::key(msg_derivation_data, bridge);
+
+    common::set_pauser_addresses(client, *token_bridge, *bridge, message_key, vaa, payer)
+        .await
+        .unwrap();
+}
+
+/// Returns the raw `Config` account bytes — used to assert layout, paused flag, and tail
+/// pubkeys without going through the Borsh `Config` struct (which only covers the first 32
+/// bytes).
+async fn fetch_config_data(context: &mut Context) -> Vec<u8> {
+    let config_key =
+        ConfigAccount::<'_, { AccountState::Initialized }>::key(None, &context.token_bridge);
+    let account = context
+        .client
+        .get_account_with_commitment(
+            config_key,
+            solana_sdk::commitment_config::CommitmentLevel::Processed,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    account.data
+}
+
+#[tokio::test]
+async fn set_pauser_addresses_lazy_migration() {
+    let mut context = set_up().await.unwrap();
+
+    // Pre-migration: Config is the legacy 32-byte layout written by `initialize`.
+    let pre = fetch_config_data(&mut context).await;
+    assert_eq!(
+        pre.len(),
+        CONFIG_BORSH_LEN,
+        "expected legacy 32-byte Config before migration"
+    );
+    assert!(!read_paused(&pre));
+    assert_eq!(read_pauser(&pre), Pubkey::default());
+    assert_eq!(read_unpauser(&pre), Pubkey::default());
+
+    // First SetPauserAddresses: realloc 32 → 97 bytes, write the tail.
+    let pauser_one = Pubkey::new_unique();
+    let unpauser_one = Pubkey::new_unique();
+    submit_set_pauser_addresses(&mut context, pauser_one, unpauser_one).await;
+
+    let post = fetch_config_data(&mut context).await;
+    assert_eq!(
+        post.len(),
+        CONFIG_FULL_LEN,
+        "Config should grow to 97 bytes after migration"
+    );
+    assert!(
+        !read_paused(&post),
+        "fresh tail should default to paused = false"
+    );
+    assert_eq!(read_pauser(&post), pauser_one);
+    assert_eq!(read_unpauser(&post), unpauser_one);
+    // The first 32 bytes (wormhole_bridge) must survive realloc untouched.
+    assert_eq!(&post[..CONFIG_BORSH_LEN], &pre[..CONFIG_BORSH_LEN]);
+
+    // Second SetPauserAddresses: rotate keys, no realloc, paused flag preserved (still false).
+    let pauser_two = Pubkey::new_unique();
+    let unpauser_two = Pubkey::new_unique();
+    submit_set_pauser_addresses(&mut context, pauser_two, unpauser_two).await;
+
+    let rotated = fetch_config_data(&mut context).await;
+    assert_eq!(
+        rotated.len(),
+        CONFIG_FULL_LEN,
+        "rotation must not change account size"
+    );
+    assert_eq!(read_pauser(&rotated), pauser_two);
+    assert_eq!(read_unpauser(&rotated), unpauser_two);
+    assert!(!read_paused(&rotated));
+}
+
+#[tokio::test]
+async fn pause_blocks_transfer_and_unpause_restores() {
+    let mut context = set_up().await.unwrap();
+
+    // The pauser/unpauser must each be Solana keypairs because the on-chain handler requires
+    // them as `Signer`. Fund them so they can co-sign their respective instructions.
+    let pauser = Keypair::new();
+    let unpauser = Keypair::new();
+    common::transfer(
+        &mut context.client,
+        &context.payer,
+        &pauser.pubkey(),
+        1_000_000_000,
+    )
+    .await
+    .unwrap();
+    common::transfer(
+        &mut context.client,
+        &context.payer,
+        &unpauser.pubkey(),
+        1_000_000_000,
+    )
+    .await
+    .unwrap();
+
+    submit_set_pauser_addresses(&mut context, pauser.pubkey(), unpauser.pubkey()).await;
+
+    let Context {
+        ref payer,
+        ref mut client,
+        bridge,
+        token_bridge,
+        ref mint,
+        ref token_account,
+        ref token_authority,
+        ..
+    } = context;
+
+    // (1) Transfer succeeds while unpaused.
+    common::transfer_native(
+        client,
+        token_bridge,
+        bridge,
+        payer,
+        &Keypair::new(),
+        token_account,
+        token_authority,
+        mint.pubkey(),
+        100,
+    )
+    .await
+    .unwrap();
+
+    // (2) Wrong signer cannot pause (must equal the configured pauser).
+    let stranger = Keypair::new();
+    common::transfer(client, payer, &stranger.pubkey(), 1_000_000_000)
+        .await
+        .unwrap();
+    common::pause(client, token_bridge, &stranger, payer)
+        .await
+        .expect_err("pause from wrong signer must fail with InvalidPauser");
+
+    // (3) Configured pauser pauses, then transfer rejects with `Paused`.
+    common::pause(client, token_bridge, &pauser, payer)
+        .await
+        .unwrap();
+    let paused_data = client
+        .get_account(ConfigAccount::<'_, { AccountState::Initialized }>::key(
+            None,
+            &token_bridge,
+        ))
+        .await
+        .unwrap()
+        .unwrap()
+        .data;
+    assert!(
+        read_paused(&paused_data),
+        "Config tail should report paused=true"
+    );
+
+    common::transfer_native(
+        client,
+        token_bridge,
+        bridge,
+        payer,
+        &Keypair::new(),
+        token_account,
+        token_authority,
+        mint.pubkey(),
+        100,
+    )
+    .await
+    .expect_err("transfer must fail while paused");
+
+    // (4) Wrong signer cannot unpause either.
+    common::unpause(client, token_bridge, &stranger, payer)
+        .await
+        .expect_err("unpause from wrong signer must fail with InvalidPauser");
+
+    // (5) Configured unpauser unpauses, transfer succeeds again.
+    common::unpause(client, token_bridge, &unpauser, payer)
+        .await
+        .unwrap();
+    let unpaused_data = client
+        .get_account(ConfigAccount::<'_, { AccountState::Initialized }>::key(
+            None,
+            &token_bridge,
+        ))
+        .await
+        .unwrap()
+        .unwrap()
+        .data;
+    assert!(!read_paused(&unpaused_data));
+
+    common::transfer_native(
+        client,
+        token_bridge,
+        bridge,
+        payer,
+        &Keypair::new(),
+        token_account,
+        token_authority,
+        mint.pubkey(),
+        100,
+    )
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn legacy_unmigrated_compat() {
+    // No SetPauserAddresses is ever submitted, so Config stays at 32 bytes. Every existing
+    // transfer/complete entry point must behave exactly like the pre-upgrade implementation:
+    // the `notPaused` gate sees a too-short account and treats it as unpaused.
+    let mut context = set_up().await.unwrap();
+
+    let pre = fetch_config_data(&mut context).await;
+    assert_eq!(
+        pre.len(),
+        CONFIG_BORSH_LEN,
+        "Config must still be the legacy layout"
+    );
+
+    // pause / unpause both refuse on a legacy account.
+    let stranger = Keypair::new();
+    common::transfer(
+        &mut context.client,
+        &context.payer,
+        &stranger.pubkey(),
+        1_000_000_000,
+    )
+    .await
+    .unwrap();
+    common::pause(
+        &mut context.client,
+        context.token_bridge,
+        &stranger,
+        &context.payer,
+    )
+    .await
+    .expect_err("pause must fail on un-migrated Config (PauserNotConfigured)");
+    common::unpause(
+        &mut context.client,
+        context.token_bridge,
+        &stranger,
+        &context.payer,
+    )
+    .await
+    .expect_err("unpause must fail on un-migrated Config (PauserNotConfigured)");
+
+    // A native transfer still works — the gate is a no-op on legacy accounts.
+    let Context {
+        ref payer,
+        ref mut client,
+        bridge,
+        token_bridge,
+        ref mint,
+        ref token_account,
+        ref token_authority,
+        ..
+    } = context;
+    common::transfer_native(
+        client,
+        token_bridge,
+        bridge,
+        payer,
+        &Keypair::new(),
+        token_account,
+        token_authority,
+        mint.pubkey(),
+        100,
+    )
+    .await
+    .unwrap();
+
+    // The Config account size must not have changed as a side-effect of any transfer.
+    let post = fetch_config_data(&mut context).await;
+    assert_eq!(
+        post.len(),
+        CONFIG_BORSH_LEN,
+        "transfers must not migrate the Config"
+    );
 }

--- a/solana/modules/token_bridge/program/tests/integration.rs
+++ b/solana/modules/token_bridge/program/tests/integration.rs
@@ -4,6 +4,7 @@ use bridge::{
         PostedVAA,
         PostedVAADerivationData,
     },
+    PostVAAData,
     SerializePayload,
     OUR_CHAIN_ID,
 };
@@ -1150,26 +1151,83 @@ async fn set_pauser_addresses_rejects_legacy_action_id() {
 //
 // Per the "Pausing" section of whitepaper 0003, every user-facing entry point on the token
 // bridge must revert with `Paused` while the bridge is paused. The `require_not_paused`
-// helper in `types.rs` is wired into all of:
-//   - api::attest::attest_token
-//   - api::create_wrapped::create_wrapped
-//   - api::transfer::transfer_native / transfer_wrapped
-//   - api::transfer_payload::transfer_native_with_payload / transfer_wrapped_with_payload
-//   - api::complete_transfer::complete_native / complete_wrapped
-//   - api::complete_transfer_payload::complete_native_with_payload / complete_wrapped_with_payload
+// helper in `types.rs` is wired into all ten user entry points:
 //
-// Rather than spin up ten near-identical tests (each needs its own VAA + account setup), the
-// table-driven test below pauses the bridge once and exercises a representative subset of
-// these entry points sequentially. The subset is chosen so each distinct family of arguments
-// (outbound native, outbound wrapped, AssetMeta-driven create_wrapped, inbound transfer) is
-// represented at least once. The `*_with_payload` variants share the same gate call site as
-// their non-payload counterparts; the `pause_blocks_transfer_and_unpause_restores` test
-// already exercises the gate-followed-by-state-restore round trip end-to-end on transfer_native.
+//   1. api::attest::attest_token
+//   2. api::transfer::transfer_native
+//   3. api::transfer_payload::transfer_native_with_payload
+//   4. api::transfer::transfer_wrapped
+//   5. api::transfer_payload::transfer_wrapped_with_payload
+//   6. api::create_wrapped::create_wrapped
+//   7. api::complete_transfer::complete_native
+//   8. api::complete_transfer::complete_wrapped
+//   9. api::complete_transfer_payload::complete_native_with_payload
+//  10. api::complete_transfer_payload::complete_wrapped_with_payload
+//
+// The test below sets up bridge + wrapped-mint state ahead of time, pauses the bridge once,
+// and then drives every entry point with valid `FromAccounts` inputs so each call reaches the
+// `require_not_paused(...)` call site rather than failing in account validation. Each call is
+// expected to return an error while paused; an unpause + redo at the end verifies the gate
+// (not some misconfigured setup) is the sole reason the calls failed.
+
+/// Helper used inside `paused_blocks_all_user_entry_points` to build, post, and return the
+/// `(vaa, message_key)` pair for an inbound VAA that targets the token bridge. Takes the
+/// payload by reference so the caller retains ownership for the subsequent handler call.
+async fn post_inbound_vaa<P: SerializePayload>(
+    context: &mut Context,
+    emitter: [u8; 32],
+    chain: u16,
+    payload: &P,
+    sequence: u64,
+) -> (PostVAAData, Pubkey) {
+    let nonce = rand::thread_rng().gen();
+    let message = payload.try_to_vec().unwrap();
+    let (vaa, body, _) = common::generate_vaa(emitter, chain, message, nonce, sequence);
+    let signature_set = common::verify_signatures(
+        &mut context.client,
+        &context.bridge,
+        &context.payer,
+        body,
+        &context.guardian_keys,
+        0,
+    )
+    .await
+    .unwrap();
+    common::post_vaa(
+        &mut context.client,
+        context.bridge,
+        &context.payer,
+        signature_set,
+        vaa.clone(),
+    )
+    .await
+    .unwrap();
+    let message_key = PostedVAA::<'_, { AccountState::MaybeInitialized }>::key(
+        &PostedVAADerivationData {
+            payload_hash: body.to_vec(),
+        },
+        &context.bridge,
+    );
+    (vaa, message_key)
+}
 
 #[tokio::test]
 async fn paused_blocks_all_user_entry_points() {
     let mut context = set_up().await.unwrap();
     register_chain(&mut context).await;
+    // `register_chain` hardcodes `sequence = 0` without touching the `Sequencer`. Manually
+    // consume sequence 0 in the sequencer so subsequent governance VAAs from the same emitter
+    // don't collide on the Claim PDA (`AlreadyInitialized`).
+    let governance_emitter = Keypair::from_bytes(&GOVERNANCE_KEY)
+        .unwrap()
+        .pubkey()
+        .to_bytes();
+    let _consumed_zero = context.seq.next(governance_emitter);
+
+    // Set up wrapped-mint state (token_address = [1u8; 32], token_chain = 2) so the wrapped-side
+    // `FromAccounts` validation passes once we pause. `create_wrapped_account` internally posts
+    // an AssetMeta VAA from foreign emitter `[0u8; 32]` / chain 2 at sequence 2.
+    let wrapped_acc = create_wrapped_account(&mut context).await.unwrap();
 
     // Configure pauser/unpauser and pause the bridge.
     let pauser = Keypair::new();
@@ -1200,79 +1258,99 @@ async fn paused_blocks_all_user_entry_points() {
     .await
     .unwrap();
 
-    // (1) attest — emits AssetMeta for a native mint. Outbound, simplest path.
-    {
-        let message = Keypair::new();
-        common::attest(
-            &mut context.client,
-            context.token_bridge,
-            context.bridge,
-            &context.payer,
-            &message,
-            context.mint.pubkey(),
-            0,
-        )
-        .await
-        .expect_err("attest must fail while paused");
-    }
+    // --------------- Outbound entry points ---------------
 
-    // (2) transfer_native — outbound burn of native SPL token.
-    {
-        let message = Keypair::new();
-        common::transfer_native(
-            &mut context.client,
-            context.token_bridge,
-            context.bridge,
-            &context.payer,
-            &message,
-            &context.token_account,
-            &context.token_authority,
-            context.mint.pubkey(),
-            100,
-        )
-        .await
-        .expect_err("transfer_native must fail while paused");
-    }
+    // (1) attest — emits AssetMeta for a native mint.
+    common::attest(
+        &mut context.client,
+        context.token_bridge,
+        context.bridge,
+        &context.payer,
+        &Keypair::new(),
+        context.mint.pubkey(),
+        0,
+    )
+    .await
+    .expect_err("attest must fail while paused");
 
-    // (3) create_wrapped — inbound AssetMeta-driven wrapper creation.
+    // (2) transfer_native — outbound lock of native SPL tokens into custody.
+    common::transfer_native(
+        &mut context.client,
+        context.token_bridge,
+        context.bridge,
+        &context.payer,
+        &Keypair::new(),
+        &context.token_account,
+        &context.token_authority,
+        context.mint.pubkey(),
+        100,
+    )
+    .await
+    .expect_err("transfer_native must fail while paused");
+
+    // (3) transfer_native_with_payload — same outbound path, additional opaque payload.
+    common::transfer_native_with_payload(
+        &mut context.client,
+        context.token_bridge,
+        context.bridge,
+        &context.payer,
+        &Keypair::new(),
+        &context.token_account,
+        &context.token_authority,
+        context.mint.pubkey(),
+        100,
+        vec![1, 2, 3],
+    )
+    .await
+    .expect_err("transfer_native_with_payload must fail while paused");
+
+    // (4) transfer_wrapped — outbound burn of wrapped tokens. Uses the wrapped account created
+    //     during setup; the SPL approve preceding the bridge instruction is a separate ix that
+    //     succeeds on a zero-balance account, so we still reach `require_not_paused`.
+    common::transfer_wrapped(
+        &mut context.client,
+        context.token_bridge,
+        context.bridge,
+        &context.payer,
+        &Keypair::new(),
+        wrapped_acc,
+        &context.token_authority,
+        2,
+        [1u8; 32],
+        10_000_000,
+    )
+    .await
+    .expect_err("transfer_wrapped must fail while paused");
+
+    // (5) transfer_wrapped_with_payload — same outbound path, additional opaque payload.
+    common::transfer_wrapped_with_payload(
+        &mut context.client,
+        context.token_bridge,
+        context.bridge,
+        &context.payer,
+        &Keypair::new(),
+        wrapped_acc,
+        &context.token_authority,
+        2,
+        [1u8; 32],
+        10_000_000,
+        vec![4, 5, 6],
+    )
+    .await
+    .expect_err("transfer_wrapped_with_payload must fail while paused");
+
+    // --------------- Inbound entry points (each gets its own VAA) ---------------
+
+    // (6) create_wrapped — inbound AssetMeta-driven wrapper creation for a fresh foreign token.
     {
-        let nonce = rand::thread_rng().gen();
         let payload = PayloadAssetMeta {
-            token_address: [2u8; 32],
+            token_address: [2u8; 32], // different from the one set up by create_wrapped_account
             token_chain: 2,
             decimals: 7,
             symbol: "".to_string(),
             name: "".to_string(),
         };
-        let message = payload.try_to_vec().unwrap();
-        let (vaa, body, _) = common::generate_vaa([0u8; 32], 2, message, nonce, 42);
-        let signature_set = common::verify_signatures(
-            &mut context.client,
-            &context.bridge,
-            &context.payer,
-            body,
-            &context.guardian_keys,
-            0,
-        )
-        .await
-        .unwrap();
-        common::post_vaa(
-            &mut context.client,
-            context.bridge,
-            &context.payer,
-            signature_set,
-            vaa.clone(),
-        )
-        .await
-        .unwrap();
-        let msg_derivation_data = &PostedVAADerivationData {
-            payload_hash: body.to_vec(),
-        };
-        let message_key = PostedVAA::<'_, { AccountState::MaybeInitialized }>::key(
-            msg_derivation_data,
-            &context.bridge,
-        );
-
+        let (vaa, message_key) = post_inbound_vaa(&mut context, [0u8; 32], 2, &payload, 42).await;
         common::create_wrapped(
             &mut context.client,
             context.token_bridge,
@@ -1286,11 +1364,8 @@ async fn paused_blocks_all_user_entry_points() {
         .expect_err("create_wrapped must fail while paused");
     }
 
-    // (4) complete_native — inbound release of native custody. Construct a Transfer VAA that
-    //     targets the existing token account; the request must fail at the paused gate before
-    //     touching the custody account.
+    // (7) complete_native — release native custody to the existing token account.
     {
-        let nonce = rand::thread_rng().gen();
         let payload = PayloadTransfer {
             amount: U256::from(1u128),
             token_address: context.mint.pubkey().to_bytes(),
@@ -1299,35 +1374,7 @@ async fn paused_blocks_all_user_entry_points() {
             to_chain: 1,
             fee: U256::from(0u128),
         };
-        let message = payload.try_to_vec().unwrap();
-        let (vaa, body, _) = common::generate_vaa([0u8; 32], 2, message, nonce, 43);
-        let signature_set = common::verify_signatures(
-            &mut context.client,
-            &context.bridge,
-            &context.payer,
-            body,
-            &context.guardian_keys,
-            0,
-        )
-        .await
-        .unwrap();
-        common::post_vaa(
-            &mut context.client,
-            context.bridge,
-            &context.payer,
-            signature_set,
-            vaa.clone(),
-        )
-        .await
-        .unwrap();
-        let msg_derivation_data = &PostedVAADerivationData {
-            payload_hash: body.to_vec(),
-        };
-        let message_key = PostedVAA::<'_, { AccountState::MaybeInitialized }>::key(
-            msg_derivation_data,
-            &context.bridge,
-        );
-
+        let (vaa, message_key) = post_inbound_vaa(&mut context, [0u8; 32], 2, &payload, 43).await;
         common::complete_native(
             &mut context.client,
             context.token_bridge,
@@ -1341,6 +1388,86 @@ async fn paused_blocks_all_user_entry_points() {
         .expect_err("complete_native must fail while paused");
     }
 
+    // (8) complete_wrapped — mint wrapped tokens into the wrapped token account.
+    {
+        let payload = PayloadTransfer {
+            amount: U256::from(1u128),
+            token_address: [1u8; 32],
+            token_chain: 2,
+            to: wrapped_acc.to_bytes(),
+            to_chain: 1,
+            fee: U256::from(0u128),
+        };
+        let (vaa, message_key) = post_inbound_vaa(&mut context, [0u8; 32], 2, &payload, 44).await;
+        common::complete_transfer_wrapped(
+            &mut context.client,
+            context.token_bridge,
+            context.bridge,
+            message_key,
+            vaa,
+            payload,
+            &context.payer,
+        )
+        .await
+        .expect_err("complete_wrapped must fail while paused");
+    }
+
+    // (9) complete_native_with_payload — release native custody with a redeemer signature.
+    {
+        let payload = PayloadTransferWithPayload {
+            amount: U256::from(1u128),
+            token_address: context.mint.pubkey().to_bytes(),
+            token_chain: OUR_CHAIN_ID,
+            to: context.token_authority.pubkey().to_bytes(),
+            to_chain: OUR_CHAIN_ID,
+            from_address: Keypair::new().pubkey().to_bytes(),
+            payload: vec![1, 2, 3],
+        };
+        let (vaa, message_key) =
+            post_inbound_vaa(&mut context, [0u8; 32], CHAIN_ID_ETH, &payload, 45).await;
+        common::complete_native_with_payload(
+            &mut context.client,
+            context.token_bridge,
+            context.bridge,
+            message_key,
+            vaa,
+            payload,
+            context.token_account.pubkey(),
+            &context.token_authority,
+            &context.payer,
+        )
+        .await
+        .expect_err("complete_native_with_payload must fail while paused");
+    }
+
+    // (10) complete_wrapped_with_payload — mint wrapped tokens with a redeemer signature.
+    {
+        let payload = PayloadTransferWithPayload {
+            amount: U256::from(1u128),
+            token_address: [1u8; 32],
+            token_chain: 2,
+            to: context.token_authority.pubkey().to_bytes(),
+            to_chain: OUR_CHAIN_ID,
+            from_address: Keypair::new().pubkey().to_bytes(),
+            payload: vec![4, 5, 6],
+        };
+        let (vaa, message_key) =
+            post_inbound_vaa(&mut context, [0u8; 32], CHAIN_ID_ETH, &payload, 46).await;
+        common::complete_wrapped_with_payload(
+            &mut context.client,
+            context.token_bridge,
+            context.bridge,
+            message_key,
+            vaa,
+            payload,
+            wrapped_acc,
+            &context.token_authority,
+            &context.payer,
+        )
+        .await
+        .expect_err("complete_wrapped_with_payload must fail while paused");
+    }
+
     // Now unpause and verify at least one entry point is functional again — this proves the
     // gate is the sole reason the calls above were failing (not some unrelated misconfiguration).
     common::unpause(
@@ -1351,20 +1478,17 @@ async fn paused_blocks_all_user_entry_points() {
     )
     .await
     .unwrap();
-    {
-        let message = Keypair::new();
-        common::attest(
-            &mut context.client,
-            context.token_bridge,
-            context.bridge,
-            &context.payer,
-            &message,
-            context.mint.pubkey(),
-            0,
-        )
-        .await
-        .expect("attest must succeed after unpause");
-    }
+    common::attest(
+        &mut context.client,
+        context.token_bridge,
+        context.bridge,
+        &context.payer,
+        &Keypair::new(),
+        context.mint.pubkey(),
+        0,
+    )
+    .await
+    .expect("attest must succeed after unpause");
 }
 
 #[tokio::test]

--- a/solana/modules/token_bridge/program/tests/integration.rs
+++ b/solana/modules/token_bridge/program/tests/integration.rs
@@ -1571,6 +1571,106 @@ async fn rotate_pauser_addresses_while_paused() {
     assert!(!read_paused(&fetch_config_data(&mut context).await));
 }
 
+// ==================== Idempotency tests ====================
+//
+// whitepaper 0003 "Pausing" specifies that while paused, every entry point reverts except for
+// governance handlers, `pause` (no-op), and `unpause`. By symmetry, calling `unpause` on a bridge
+// that is already unpaused is also a no-op. `SetPauserAddresses` is governed by VAA replay
+// protection (the Claim PDA), so re-submitting the same payload via a *fresh* VAA succeeds and
+// rewrites the tail with identical bytes.
+
+#[tokio::test]
+async fn pause_is_idempotent() {
+    let mut context = set_up().await.unwrap();
+
+    let pauser = Keypair::new();
+    let unpauser = Keypair::new();
+    common::transfer(
+        &mut context.client,
+        &context.payer,
+        &pauser.pubkey(),
+        1_000_000_000,
+    )
+    .await
+    .unwrap();
+    submit_set_pauser_addresses(&mut context, pauser.pubkey(), unpauser.pubkey()).await;
+
+    // First pause: false -> true.
+    common::pause(
+        &mut context.client,
+        context.token_bridge,
+        &pauser,
+        &context.payer,
+    )
+    .await
+    .unwrap();
+    assert!(read_paused(&fetch_config_data(&mut context).await));
+
+    // Second pause on an already-paused bridge: succeeds, state unchanged.
+    common::pause(
+        &mut context.client,
+        context.token_bridge,
+        &pauser,
+        &context.payer,
+    )
+    .await
+    .expect("pause on already-paused bridge must be a no-op success");
+    assert!(read_paused(&fetch_config_data(&mut context).await));
+}
+
+#[tokio::test]
+async fn unpause_is_idempotent() {
+    let mut context = set_up().await.unwrap();
+
+    let pauser = Keypair::new();
+    let unpauser = Keypair::new();
+    common::transfer(
+        &mut context.client,
+        &context.payer,
+        &unpauser.pubkey(),
+        1_000_000_000,
+    )
+    .await
+    .unwrap();
+    submit_set_pauser_addresses(&mut context, pauser.pubkey(), unpauser.pubkey()).await;
+
+    // Fresh tail defaults to unpaused.
+    assert!(!read_paused(&fetch_config_data(&mut context).await));
+
+    // Unpause on an unpaused bridge: succeeds, state unchanged.
+    common::unpause(
+        &mut context.client,
+        context.token_bridge,
+        &unpauser,
+        &context.payer,
+    )
+    .await
+    .expect("unpause on already-unpaused bridge must be a no-op success");
+    assert!(!read_paused(&fetch_config_data(&mut context).await));
+}
+
+#[tokio::test]
+async fn set_pauser_addresses_is_idempotent() {
+    let mut context = set_up().await.unwrap();
+
+    let pauser = Pubkey::new_unique();
+    let unpauser = Pubkey::new_unique();
+
+    submit_set_pauser_addresses(&mut context, pauser, unpauser).await;
+    let first = fetch_config_data(&mut context).await;
+    assert_eq!(read_pauser(&first), pauser);
+    assert_eq!(read_unpauser(&first), unpauser);
+
+    // Second VAA with identical payload (fresh nonce/sequence so the Claim PDA differs and
+    // replay protection lets it through). The on-chain effect must be byte-identical.
+    submit_set_pauser_addresses(&mut context, pauser, unpauser).await;
+    let second = fetch_config_data(&mut context).await;
+    assert_eq!(
+        second, first,
+        "identical SetPauserAddresses payload must produce byte-identical Config",
+    );
+}
+
 // ==================== Event discriminator derivation pins ====================
 //
 // Each Anchor-style event discriminator is `SHA256("event:<EventName>")[..8]`. The constants in

--- a/solana/modules/token_bridge/program/tests/integration.rs
+++ b/solana/modules/token_bridge/program/tests/integration.rs
@@ -50,8 +50,6 @@ use token_bridge::{
         PayloadTransferWithPayload,
     },
     types::{
-        // Aliased locally to keep the test code free of name conflicts with the `pauser` /
-        // `unpauser` local variables and Keypairs the tests create.
         paused as read_paused,
         pauser as read_pauser,
         unpauser as read_unpauser,
@@ -653,8 +651,14 @@ async fn submit_set_pauser_addresses(context: &mut Context, pauser: Pubkey, unpa
     //                                       | unpauser_len(1)=32 | unpauser(32)
     // Total: 32 + 1 + 2 + 1 + 32 + 1 + 32 = 101 bytes.
     assert_eq!(message[32], SET_PAUSER_ADDRESSES_ACTION);
-    assert_eq!(message[35], 32, "expected pauser_len = 32 (SVM native size)");
-    assert_eq!(message[68], 32, "expected unpauser_len = 32 (SVM native size)");
+    assert_eq!(
+        message[35], 32,
+        "expected pauser_len = 32 (SVM native size)"
+    );
+    assert_eq!(
+        message[68], 32,
+        "expected unpauser_len = 32 (SVM native size)"
+    );
     assert_eq!(message.len(), 101);
 
     submit_raw_set_pauser_addresses(context, message)
@@ -1021,8 +1025,7 @@ async fn set_pauser_addresses_rejects_invalid_pauser_length() {
     // pauser_len = 20 (the EVM native size) must be rejected on Solana.
     let pauser_body = [0xAAu8; 20];
     let unpauser_body = [0xBBu8; 32];
-    let bad =
-        build_set_pauser_addresses_payload(20, &pauser_body, 32, &unpauser_body);
+    let bad = build_set_pauser_addresses_payload(20, &pauser_body, 32, &unpauser_body);
 
     submit_raw_set_pauser_addresses(&mut context, bad)
         .await
@@ -1039,8 +1042,7 @@ async fn set_pauser_addresses_rejects_invalid_unpauser_length() {
 
     let pauser_body = [0xAAu8; 32];
     let unpauser_body = [0xBBu8; 33]; // off-by-one over the native size
-    let bad =
-        build_set_pauser_addresses_payload(32, &pauser_body, 33, &unpauser_body);
+    let bad = build_set_pauser_addresses_payload(32, &pauser_body, 33, &unpauser_body);
 
     submit_raw_set_pauser_addresses(&mut context, bad)
         .await

--- a/solana/modules/token_bridge/program/tests/integration.rs
+++ b/solana/modules/token_bridge/program/tests/integration.rs
@@ -37,6 +37,11 @@ use token_bridge::{
         WrappedDerivationData,
         WrappedMint,
     },
+    api::{
+        PAUSED_EVENT_DISCRIMINATOR,
+        PAUSER_ADDRESSES_SET_EVENT_DISCRIMINATOR,
+        UNPAUSED_EVENT_DISCRIMINATOR,
+    },
     messages::{
         PayloadAssetMeta,
         PayloadGovernanceRegisterChain,
@@ -45,9 +50,11 @@ use token_bridge::{
         PayloadTransferWithPayload,
     },
     types::{
-        read_paused,
-        read_pauser,
-        read_unpauser,
+        // Aliased locally to keep the test code free of name conflicts with the `pauser` /
+        // `unpauser` local variables and Keypairs the tests create.
+        paused as read_paused,
+        pauser as read_pauser,
+        unpauser as read_unpauser,
         Config,
         CONFIG_BORSH_LEN,
         CONFIG_FULL_LEN,
@@ -627,7 +634,7 @@ async fn transfer_native_with_payload_in() {
     .unwrap();
 }
 
-// ============== Pauser tests (whitepapers/0003_token_bridge.md, "Pausing" section) ==============
+// ============== Pauser tests (whitepapers/0003_token_bridge.md Pausing) ==============
 //
 // These tests exercise the lazy migration of the `Config` PDA from the legacy 32-byte layout to
 // the 97-byte layout, the configured pauser/unpauser flow, and the `notPaused` gate on a
@@ -641,7 +648,7 @@ const SET_PAUSER_ADDRESSES_ACTION: u8 = 4;
 async fn submit_set_pauser_addresses(context: &mut Context, pauser: Pubkey, unpauser: Pubkey) {
     let payload = PayloadSetPauserAddresses { pauser, unpauser };
     let message = payload.try_to_vec().unwrap();
-    // Sanity-check the encoded wire format matches whitepaper 0003 §"Pausing":
+    // Sanity-check the encoded wire format matches whitepapers/0003_token_bridge.md Pausing:
     //   module(32) | action(1)=4 | chain(2) | pauser_len(1)=32 | pauser(32)
     //                                       | unpauser_len(1)=32 | unpauser(32)
     // Total: 32 + 1 + 2 + 1 + 32 + 1 + 32 = 101 bytes.
@@ -996,7 +1003,7 @@ async fn legacy_unmigrated_compat() {
 
 // ============== SetPauserAddresses wire-format validation (whitepaper 0003) ==============
 //
-// Whitepaper 0003 §"Pausing" defines a length-prefixed encoding shared across runtimes:
+// whitepapers/0003_token_bridge.md Pausing defines a length-prefixed encoding shared across runtimes:
 //
 //     module(32) | action(1)=4 | chain(2)
 //   | pauser_len(1)   | pauser[pauser_len]
@@ -1135,4 +1142,344 @@ async fn set_pauser_addresses_rejects_legacy_action_id() {
     submit_raw_set_pauser_addresses(&mut context, payload)
         .await
         .expect_err("legacy action 5 must be rejected (current spec is action 4)");
+}
+
+// ==================== Paused gate coverage across user entry points ====================
+//
+// Per the "Pausing" section of whitepaper 0003, every user-facing entry point on the token
+// bridge must revert with `Paused` while the bridge is paused. The `require_not_paused`
+// helper in `types.rs` is wired into all of:
+//   - api::attest::attest_token
+//   - api::create_wrapped::create_wrapped
+//   - api::transfer::transfer_native / transfer_wrapped
+//   - api::transfer_payload::transfer_native_with_payload / transfer_wrapped_with_payload
+//   - api::complete_transfer::complete_native / complete_wrapped
+//   - api::complete_transfer_payload::complete_native_with_payload / complete_wrapped_with_payload
+//
+// Rather than spin up ten near-identical tests (each needs its own VAA + account setup), the
+// table-driven test below pauses the bridge once and exercises a representative subset of
+// these entry points sequentially. The subset is chosen so each distinct family of arguments
+// (outbound native, outbound wrapped, AssetMeta-driven create_wrapped, inbound transfer) is
+// represented at least once. The `*_with_payload` variants share the same gate call site as
+// their non-payload counterparts; the `pause_blocks_transfer_and_unpause_restores` test
+// already exercises the gate-followed-by-state-restore round trip end-to-end on transfer_native.
+
+#[tokio::test]
+async fn paused_blocks_all_user_entry_points() {
+    let mut context = set_up().await.unwrap();
+    register_chain(&mut context).await;
+
+    // Configure pauser/unpauser and pause the bridge.
+    let pauser = Keypair::new();
+    let unpauser = Keypair::new();
+    common::transfer(
+        &mut context.client,
+        &context.payer,
+        &pauser.pubkey(),
+        1_000_000_000,
+    )
+    .await
+    .unwrap();
+    common::transfer(
+        &mut context.client,
+        &context.payer,
+        &unpauser.pubkey(),
+        1_000_000_000,
+    )
+    .await
+    .unwrap();
+    submit_set_pauser_addresses(&mut context, pauser.pubkey(), unpauser.pubkey()).await;
+    common::pause(
+        &mut context.client,
+        context.token_bridge,
+        &pauser,
+        &context.payer,
+    )
+    .await
+    .unwrap();
+
+    // (1) attest — emits AssetMeta for a native mint. Outbound, simplest path.
+    {
+        let message = Keypair::new();
+        common::attest(
+            &mut context.client,
+            context.token_bridge,
+            context.bridge,
+            &context.payer,
+            &message,
+            context.mint.pubkey(),
+            0,
+        )
+        .await
+        .expect_err("attest must fail while paused");
+    }
+
+    // (2) transfer_native — outbound burn of native SPL token.
+    {
+        let message = Keypair::new();
+        common::transfer_native(
+            &mut context.client,
+            context.token_bridge,
+            context.bridge,
+            &context.payer,
+            &message,
+            &context.token_account,
+            &context.token_authority,
+            context.mint.pubkey(),
+            100,
+        )
+        .await
+        .expect_err("transfer_native must fail while paused");
+    }
+
+    // (3) create_wrapped — inbound AssetMeta-driven wrapper creation.
+    {
+        let nonce = rand::thread_rng().gen();
+        let payload = PayloadAssetMeta {
+            token_address: [2u8; 32],
+            token_chain: 2,
+            decimals: 7,
+            symbol: "".to_string(),
+            name: "".to_string(),
+        };
+        let message = payload.try_to_vec().unwrap();
+        let (vaa, body, _) = common::generate_vaa([0u8; 32], 2, message, nonce, 42);
+        let signature_set = common::verify_signatures(
+            &mut context.client,
+            &context.bridge,
+            &context.payer,
+            body,
+            &context.guardian_keys,
+            0,
+        )
+        .await
+        .unwrap();
+        common::post_vaa(
+            &mut context.client,
+            context.bridge,
+            &context.payer,
+            signature_set,
+            vaa.clone(),
+        )
+        .await
+        .unwrap();
+        let msg_derivation_data = &PostedVAADerivationData {
+            payload_hash: body.to_vec(),
+        };
+        let message_key = PostedVAA::<'_, { AccountState::MaybeInitialized }>::key(
+            msg_derivation_data,
+            &context.bridge,
+        );
+
+        common::create_wrapped(
+            &mut context.client,
+            context.token_bridge,
+            context.bridge,
+            message_key,
+            vaa,
+            payload,
+            &context.payer,
+        )
+        .await
+        .expect_err("create_wrapped must fail while paused");
+    }
+
+    // (4) complete_native — inbound release of native custody. Construct a Transfer VAA that
+    //     targets the existing token account; the request must fail at the paused gate before
+    //     touching the custody account.
+    {
+        let nonce = rand::thread_rng().gen();
+        let payload = PayloadTransfer {
+            amount: U256::from(1u128),
+            token_address: context.mint.pubkey().to_bytes(),
+            token_chain: 1,
+            to: context.token_account.pubkey().to_bytes(),
+            to_chain: 1,
+            fee: U256::from(0u128),
+        };
+        let message = payload.try_to_vec().unwrap();
+        let (vaa, body, _) = common::generate_vaa([0u8; 32], 2, message, nonce, 43);
+        let signature_set = common::verify_signatures(
+            &mut context.client,
+            &context.bridge,
+            &context.payer,
+            body,
+            &context.guardian_keys,
+            0,
+        )
+        .await
+        .unwrap();
+        common::post_vaa(
+            &mut context.client,
+            context.bridge,
+            &context.payer,
+            signature_set,
+            vaa.clone(),
+        )
+        .await
+        .unwrap();
+        let msg_derivation_data = &PostedVAADerivationData {
+            payload_hash: body.to_vec(),
+        };
+        let message_key = PostedVAA::<'_, { AccountState::MaybeInitialized }>::key(
+            msg_derivation_data,
+            &context.bridge,
+        );
+
+        common::complete_native(
+            &mut context.client,
+            context.token_bridge,
+            context.bridge,
+            message_key,
+            vaa,
+            payload,
+            &context.payer,
+        )
+        .await
+        .expect_err("complete_native must fail while paused");
+    }
+
+    // Now unpause and verify at least one entry point is functional again — this proves the
+    // gate is the sole reason the calls above were failing (not some unrelated misconfiguration).
+    common::unpause(
+        &mut context.client,
+        context.token_bridge,
+        &unpauser,
+        &context.payer,
+    )
+    .await
+    .unwrap();
+    {
+        let message = Keypair::new();
+        common::attest(
+            &mut context.client,
+            context.token_bridge,
+            context.bridge,
+            &context.payer,
+            &message,
+            context.mint.pubkey(),
+            0,
+        )
+        .await
+        .expect("attest must succeed after unpause");
+    }
+}
+
+#[tokio::test]
+async fn rotate_pauser_addresses_while_paused() {
+    // Confirms that `submit_set_pauser_addresses` (a governance handler) is callable while the
+    // bridge is paused, that the new keys take effect atomically, and that the `paused` flag is
+    // preserved across the rotation (a rotation does not implicitly unpause).
+    let mut context = set_up().await.unwrap();
+
+    let pauser_one = Keypair::new();
+    let unpauser_one = Keypair::new();
+    common::transfer(
+        &mut context.client,
+        &context.payer,
+        &pauser_one.pubkey(),
+        1_000_000_000,
+    )
+    .await
+    .unwrap();
+    submit_set_pauser_addresses(&mut context, pauser_one.pubkey(), unpauser_one.pubkey()).await;
+    common::pause(
+        &mut context.client,
+        context.token_bridge,
+        &pauser_one,
+        &context.payer,
+    )
+    .await
+    .unwrap();
+    let paused_data = fetch_config_data(&mut context).await;
+    assert!(read_paused(&paused_data));
+
+    // Rotate to a new pauser / unpauser pair while paused.
+    let pauser_two = Keypair::new();
+    let unpauser_two = Keypair::new();
+    common::transfer(
+        &mut context.client,
+        &context.payer,
+        &unpauser_two.pubkey(),
+        1_000_000_000,
+    )
+    .await
+    .unwrap();
+    submit_set_pauser_addresses(&mut context, pauser_two.pubkey(), unpauser_two.pubkey()).await;
+
+    let post = fetch_config_data(&mut context).await;
+    assert_eq!(read_pauser(&post), pauser_two.pubkey());
+    assert_eq!(read_unpauser(&post), unpauser_two.pubkey());
+    assert!(
+        read_paused(&post),
+        "paused flag must be preserved across rotation",
+    );
+
+    // Old unpauser_one can no longer unpause.
+    common::transfer(
+        &mut context.client,
+        &context.payer,
+        &unpauser_one.pubkey(),
+        1_000_000_000,
+    )
+    .await
+    .unwrap();
+    common::unpause(
+        &mut context.client,
+        context.token_bridge,
+        &unpauser_one,
+        &context.payer,
+    )
+    .await
+    .expect_err("old unpauser must be rejected after rotation");
+
+    // New unpauser_two can.
+    common::unpause(
+        &mut context.client,
+        context.token_bridge,
+        &unpauser_two,
+        &context.payer,
+    )
+    .await
+    .unwrap();
+    assert!(!read_paused(&fetch_config_data(&mut context).await));
+}
+
+// ==================== Event discriminator derivation pins ====================
+//
+// Each Anchor-style event discriminator is `SHA256("event:<EventName>")[..8]`. The constants in
+// `api/pause.rs` and `api/governance.rs` are pre-computed; these tests re-derive them at test
+// time and assert equality, so a future change to either the event name string or the constant
+// fails CI rather than silently mis-emitting events that off-chain indexers can't decode.
+// Mirrors the `test_message_account_closed_discriminator_matches_sha256` check in the core
+// bridge integration tests.
+
+#[test]
+fn test_paused_event_discriminator_matches_sha256() {
+    let hash = solana_program::hash::hash(b"event:Paused");
+    let expected = &hash.to_bytes()[..8];
+    assert_eq!(
+        PAUSED_EVENT_DISCRIMINATOR, expected,
+        "PAUSED_EVENT_DISCRIMINATOR must equal SHA256(\"event:Paused\")[..8]",
+    );
+}
+
+#[test]
+fn test_unpaused_event_discriminator_matches_sha256() {
+    let hash = solana_program::hash::hash(b"event:Unpaused");
+    let expected = &hash.to_bytes()[..8];
+    assert_eq!(
+        UNPAUSED_EVENT_DISCRIMINATOR, expected,
+        "UNPAUSED_EVENT_DISCRIMINATOR must equal SHA256(\"event:Unpaused\")[..8]",
+    );
+}
+
+#[test]
+fn test_pauser_addresses_set_event_discriminator_matches_sha256() {
+    let hash = solana_program::hash::hash(b"event:PauserAddressesSet");
+    let expected = &hash.to_bytes()[..8];
+    assert_eq!(
+        PAUSER_ADDRESSES_SET_EVENT_DISCRIMINATOR, expected,
+        "PAUSER_ADDRESSES_SET_EVENT_DISCRIMINATOR must equal SHA256(\"event:PauserAddressesSet\")[..8]",
+    );
 }


### PR DESCRIPTION
This PR implements pauser functionality for the SVM Token Bridge.

- Design #4809
- Guardian #4810
- EVM WTT Pauser Role #4801
- SVM WTT Pauser Role #4802

Note, this change is intended to maintain full backwards compatibility for the program instructions, however it does so by adding the new fields to the existing Config which may break any consumer's borsh deserialization. In order to support this extension within the program, it adds custom parsing to not error when the length is not yet migrated length. The account is extended to the new length on the first set pauser governance. Until the first pauser is set, it is considered unpaused with no pauser/unpauser.