### PR TITLE
fix(node): delegate quorum should use message publication digest

### DIFF
--- a/node/pkg/common/chainlock.go
+++ b/node/pkg/common/chainlock.go
@@ -213,6 +213,37 @@ func (msg *MessagePublication) VerificationState() VerificationState {
 	return msg.verificationState
 }
 
+// NormalizeForDelegateConsensus resets per-guardian metadata to safe defaults
+// for an MP that is the product of delegate-guardian quorum on a canonical
+// guardian.
+//
+// The fields hashed into the VAA signing digest (Timestamp, Nonce, Sequence,
+// ConsistencyLevel, EmitterChain, EmitterAddress, Payload) are the consensus
+// inputs and are preserved. TxID is preserved as-is here; it is NOT part of
+// the VAA signing digest and is NOT part of accountant's aggregation key, so
+// its value here is informational only (logs, persistence, the bytes in the
+// canonical's accountant submission payload). Callers may set it to a
+// deterministic value before invoking this method for tidiness, but no
+// downstream consensus depends on it.
+//
+// The fields reset here are also per-guardian metadata, but unlike TxID they
+// have safe canonical defaults that don't depend on any single delegate:
+//
+//   - IsReobservation: forced true. Canonicals can't trigger a reobservation
+//     for a delegated chain (no watcher is running for it), so treat the
+//     consensus result as already a reobservation and avoid further cycles.
+//   - Unreliable: forced false. Solana-only shortcut for skipping cleanup;
+//     never appropriate for a delegate-derived MP.
+//   - verificationState: forced NotApplicable. The canonical did not verify
+//     the transaction itself, and per-guardian verification results are not
+//     part of consensus. NotApplicable matches the documented contract for
+//     "no verification was performed on this guardian."
+func (msg *MessagePublication) NormalizeForDelegateConsensus() {
+	msg.IsReobservation = true
+	msg.Unreliable = false
+	msg.verificationState = NotApplicable
+}
+
 // SetVerificationState is the setter for verificationState. Returns an error if called in a way that likely indicates a programming mistake.
 // This includes cases where:
 // - an existing state would be overwritten by the NotVerified state

--- a/node/pkg/common/chainlock.go
+++ b/node/pkg/common/chainlock.go
@@ -163,6 +163,34 @@ func (v VerificationState) String() string {
 }
 
 type MessagePublication struct {
+	// TxID is the chain-native transaction identifier where the wormhole
+	// message was emitted. TxID is per-guardian metadata: it is NOT hashed
+	// into the VAA signing digest (see CreateVAA / CreateDigest), so guardians
+	// can disagree on TxID without producing different VAAs.
+	//
+	// TxID IS, however, part of the global-accountant contract's matching key
+	// within a pending transfer. PENDING_TRANSFERS is keyed by
+	// (emitter_chain, emitter_address, sequence), but within that key the
+	// contract stores a Vec<Data> whose entries are uniquely identified by
+	// (guardian_set_index, digest, tx_hash) — see
+	// cosmwasm/contracts/global-accountant/src/contract.rs. Signatures only
+	// merge across observations with matching tx_hash, so if guardians submit
+	// observations for the same VAA but with different TxIDs, their signatures
+	// land in separate Data entries and quorum is counted independently per
+	// entry. If no single entry reaches quorum on its own, the transfer
+	// stalls at the accountant — even when there are enough total signatures
+	// for the same VAA digest.
+	//
+	// Code paths that aggregate observations across guardians (e.g. delegate
+	// quorum on a canonical) should converge on a single TxID before
+	// submitting to the accountant; see the consensusTxID helper and
+	// NormalizeForDelegateConsensus in pkg/processor. That helper picks the
+	// bucket-majority TxID deterministically, which is sufficient for
+	// convergence when one TxID has a clear majority that's stable under
+	// observation arrival order — but with a near-even split, canonicals
+	// whose buckets reach quorum at different observation subsets can still
+	// pick different majorities; recovery for that case is the audit /
+	// missing_observations reobs flow rather than the delegate-quorum path.
 	TxID      []byte
 	Timestamp time.Time
 
@@ -213,18 +241,27 @@ func (msg *MessagePublication) VerificationState() VerificationState {
 	return msg.verificationState
 }
 
-// NormalizeForDelegateConsensus resets per-guardian metadata to safe defaults
-// for an MP that is the product of delegate-guardian quorum on a canonical
-// guardian.
+// NormalizeForDelegateConsensus resets per-guardian metadata on the consensus
+// MP that a canonical guardian forwards downstream after delegate quorum.
+//
+// The purpose is to keep the downstream pipeline (and any state the canonical
+// persists about the message) independent of *which* delegate's observation
+// happened to push the bucket over quorum. Without this, every per-guardian
+// field on the MP would last-writer-wins — different canonicals would
+// disagree on IsReobservation / Unreliable / verificationState based purely
+// on observation arrival order, and the same canonical's logs/database row
+// would depend on a delegate-set race. Resetting these fields to canonical-
+// safe defaults gives a single, reproducible consensus MP across canonicals.
 //
 // The fields hashed into the VAA signing digest (Timestamp, Nonce, Sequence,
 // ConsistencyLevel, EmitterChain, EmitterAddress, Payload) are the consensus
-// inputs and are preserved. TxID is preserved as-is here; it is NOT part of
-// the VAA signing digest and is NOT part of accountant's aggregation key, so
-// its value here is informational only (logs, persistence, the bytes in the
-// canonical's accountant submission payload). Callers may set it to a
-// deterministic value before invoking this method for tidiness, but no
-// downstream consensus depends on it.
+// inputs and are preserved. TxID is preserved as-is here; it is the caller's
+// responsibility to pick a deterministic TxID before invoking this method,
+// because while TxID is not in the VAA signing digest, it IS part of the
+// global-accountant contract's per-entry match — different TxIDs across
+// canonicals split signatures at the accountant and can prevent quorum
+// there. See the TxID field godoc and the consensusTxID helper in
+// pkg/processor.
 //
 // The fields reset here are also per-guardian metadata, but unlike TxID they
 // have safe canonical defaults that don't depend on any single delegate:
@@ -232,16 +269,21 @@ func (msg *MessagePublication) VerificationState() VerificationState {
 //   - IsReobservation: forced true. Canonicals can't trigger a reobservation
 //     for a delegated chain (no watcher is running for it), so treat the
 //     consensus result as already a reobservation and avoid further cycles.
-//   - Unreliable: forced false. Solana-only shortcut for skipping cleanup;
-//     never appropriate for a delegate-derived MP.
-//   - verificationState: forced NotApplicable. The canonical did not verify
-//     the transaction itself, and per-guardian verification results are not
-//     part of consensus. NotApplicable matches the documented contract for
-//     "no verification was performed on this guardian."
+//   - Unreliable: forced false. Unreliable=true is an SVM-only signal that
+//     the source chain can't re-observe the transaction, so the cleanup loop
+//     expires stuck observations after 5 minutes instead of issuing a
+//     re-observation request (see pkg/processor/cleanup.go). A delegate-derived
+//     MP doesn't carry that constraint at the canonical, so leave it reliable.
+//   - verificationState: forced NotVerified. The canonical did not run the
+//     transfer verifier on the underlying transaction and per-guardian
+//     verification results are not part of consensus. NotVerified is the
+//     honest signal here ("we did not attempt to verify"), as opposed to
+//     NotApplicable, which is reserved for "we determined verification was
+//     not required for this message" (e.g. non-token-transfer payloads).
 func (msg *MessagePublication) NormalizeForDelegateConsensus() {
 	msg.IsReobservation = true
 	msg.Unreliable = false
-	msg.verificationState = NotApplicable
+	msg.verificationState = NotVerified
 }
 
 // SetVerificationState is the setter for verificationState. Returns an error if called in a way that likely indicates a programming mistake.

--- a/node/pkg/common/chainlock_test.go
+++ b/node/pkg/common/chainlock_test.go
@@ -3,6 +3,7 @@ package common
 import (
 	"bytes"
 	"encoding/binary"
+	"encoding/hex"
 	"io"
 	"math"
 	"math/big"
@@ -11,6 +12,7 @@ import (
 	"time"
 
 	eth_common "github.com/ethereum/go-ethereum/common"
+	eth_crypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wormhole-foundation/wormhole/sdk/vaa"
@@ -963,5 +965,115 @@ func TestMessagePublication_IsWTT(t *testing.T) {
 			got := msg.IsWTT(tt.env)
 			assert.Equal(t, tt.want, got)
 		})
+	}
+}
+
+// TestIsReobservationDoesNotSplitDelegateQuorumBucket asserts the protocol invariant
+// that two otherwise-identical MessagePublications differing only in IsReobservation
+// produce the SAME bucket key for the canonical guardian's delegate-quorum check
+// (pkg/processor/observation.go:648). Today the bucket key is Keccak256(MarshalBinary),
+// and MarshalBinary writes IsReobservation as a byte (chainlock.go:332-337) — so this
+// test FAILS under current code, demonstrating the bug: a delegate set where some
+// guardians sign with IsReobservation=true and others with false splits across two
+// buckets and never reaches quorum on either.
+func TestIsReobservationDoesNotSplitDelegateQuorumBucket(t *testing.T) {
+	makeMP := func(isReobs bool) *MessagePublication {
+		emitter, err := vaa.StringToAddress("000000000000000000000000b1731c586ca89a23809861c6103f0b96b3f57d92")
+		require.NoError(t, err)
+		return &MessagePublication{
+			TxID:             eth_common.HexToHash("0x39c2f7f67fbce903d49bb24147668095f1b726acef3c19460da39e83c6929a2b").Bytes(),
+			Timestamp:        time.Unix(1746026862, 0), // 2026-04-28T15:27:42Z, from the field case
+			Nonce:            0,
+			Sequence:         95838,
+			ConsistencyLevel: 1,
+			EmitterChain:     vaa.ChainIDMoonbeam, // chain 16
+			EmitterAddress:   emitter,
+			Payload:          []byte("identical-tb-transfer-payload"),
+			IsReobservation:  isReobs,
+		}
+	}
+
+	original := makeMP(false)
+	reobs := makeMP(true)
+
+	require.Equal(t, original.MessageIDString(), reobs.MessageIDString(),
+		"sanity: VAA MessageID is identical")
+
+	bufA, err := original.MarshalBinary()
+	require.NoError(t, err)
+	bufB, err := reobs.MarshalBinary()
+	require.NoError(t, err)
+
+	hashA := eth_crypto.Keccak256Hash(bufA).Hex()
+	hashB := eth_crypto.Keccak256Hash(bufB).Hex()
+
+	t.Logf("MessageID:                   %s", original.MessageIDString())
+	t.Logf("hash (IsReobservation=false): %s", hashA)
+	t.Logf("hash (IsReobservation=true):  %s", hashB)
+
+	require.Equal(t, hashA, hashB,
+		"signatures for the same VAA must land in the same delegate-quorum bucket "+
+			"regardless of IsReobservation; today MarshalBinary includes the flag, "+
+			"which splits the bucket and prevents quorum")
+}
+
+// TestDelegateQuorumIsReobservationDoesNotPreventQuorum models the field case
+// (chain 16 / seq 95838): 8 valid delegate signatures split 4/4 because some
+// guardians signed with IsReobservation=false and others with true. With a
+// delegated set size of 7, quorum is 5, so neither sub-bucket reaches quorum
+// today. This test asserts the desired behavior: all 8 signatures must land
+// in a single bucket and that bucket must reach quorum. It FAILS under current
+// code, proving the bug.
+func TestDelegateQuorumIsReobservationDoesNotPreventQuorum(t *testing.T) {
+	emitter, err := vaa.StringToAddress("000000000000000000000000b1731c586ca89a23809861c6103f0b96b3f57d92")
+	require.NoError(t, err)
+	base := func(isReobs bool) *MessagePublication {
+		return &MessagePublication{
+			TxID:             eth_common.HexToHash("0x39c2f7f67fbce903d49bb24147668095f1b726acef3c19460da39e83c6929a2b").Bytes(),
+			Timestamp:        time.Unix(1746026862, 0),
+			Sequence:         95838,
+			ConsistencyLevel: 1,
+			EmitterChain:     vaa.ChainIDMoonbeam,
+			EmitterAddress:   emitter,
+			Payload:          []byte("payload"),
+			IsReobservation:  isReobs,
+		}
+	}
+
+	// The bucket-key derivation must come from the canonical's actual call site:
+	//   pkg/processor/observation.go:648 → Keccak256(MarshalBinary(mp)).Hex()
+	bucketKeyFor := func(isReobs bool) string {
+		buf, err := base(isReobs).MarshalBinary()
+		require.NoError(t, err)
+		return hex.EncodeToString(eth_crypto.Keccak256Hash(buf).Bytes())
+	}
+
+	// 8 distinct delegate guardians; 4 sign as original observation, 4 re-observed.
+	originalGuardians := []string{"000ac007", "178e21ad", "da798f68", "938f104a"}
+	reobsGuardians := []string{"178e21ad", "11b39756", "af45ced1", "f93124b7"}
+
+	buckets := map[string]int{}
+	for range originalGuardians {
+		buckets[bucketKeyFor(false)]++
+	}
+	for range reobsGuardians {
+		buckets[bucketKeyFor(true)]++
+	}
+
+	for hash, count := range buckets {
+		t.Logf("bucket %s: %d sigs", hash, count)
+	}
+
+	// Desired behavior: a single bucket holds every signature for this VAA.
+	require.Len(t, buckets, 1,
+		"all delegate signatures for the same VAA must land in one bucket, "+
+			"regardless of IsReobservation")
+
+	// And that bucket must clear quorum for a delegated set of 7 (CalculateQuorum = 5).
+	const setSize = 7
+	const quorum = (setSize*2)/3 + 1
+	for _, count := range buckets {
+		require.GreaterOrEqual(t, count, quorum,
+			"the merged bucket should reach quorum on its own")
 	}
 }

--- a/node/pkg/common/chainlock_test.go
+++ b/node/pkg/common/chainlock_test.go
@@ -966,6 +966,42 @@ func TestMessagePublication_IsWTT(t *testing.T) {
 	}
 }
 
+// TestNormalizeForDelegateConsensus verifies the per-guardian fields are reset
+// to safe defaults while consensus inputs (those hashed into CreateDigest) are
+// preserved.
+func TestNormalizeForDelegateConsensus(t *testing.T) {
+	emitter, err := vaa.StringToAddress("000000000000000000000000b1731c586ca89a23809861c6103f0b96b3f57d92")
+	require.NoError(t, err)
+
+	mp := &MessagePublication{
+		TxID:              eth_common.HexToHash("0x39c2f7f67fbce903d49bb24147668095f1b726acef3c19460da39e83c6929a2b").Bytes(),
+		Timestamp:         time.Unix(1746026862, 0),
+		Nonce:             42,
+		Sequence:          95838,
+		ConsistencyLevel:  1,
+		EmitterChain:      vaa.ChainIDMoonbeam,
+		EmitterAddress:    emitter,
+		Payload:           []byte("payload"),
+		IsReobservation:   false,
+		Unreliable:        true,
+		verificationState: Anomalous, // start in a non-default state
+	}
+
+	digestBefore := mp.CreateDigest()
+
+	mp.NormalizeForDelegateConsensus()
+
+	// Per-guardian fields are reset to safe defaults.
+	require.True(t, mp.IsReobservation, "IsReobservation must be forced true")
+	require.False(t, mp.Unreliable, "Unreliable must be forced false")
+	require.Equal(t, NotApplicable, mp.VerificationState(),
+		"verificationState must be NotApplicable on canonical delegate-derived MPs")
+
+	// Fields hashed into the VAA digest are preserved — verified by digest stability.
+	require.Equal(t, digestBefore, mp.CreateDigest(),
+		"CreateDigest must be unchanged because the normalized fields are not part of the VAA digest")
+}
+
 // TestIsReobservationDoesNotSplitDelegateQuorumBucket asserts the protocol invariant
 // that two otherwise-identical MessagePublications differing only in IsReobservation
 // produce the SAME bucket key for the canonical guardian's delegate-quorum check

--- a/node/pkg/common/chainlock_test.go
+++ b/node/pkg/common/chainlock_test.go
@@ -994,8 +994,8 @@ func TestNormalizeForDelegateConsensus(t *testing.T) {
 	// Per-guardian fields are reset to safe defaults.
 	require.True(t, mp.IsReobservation, "IsReobservation must be forced true")
 	require.False(t, mp.Unreliable, "Unreliable must be forced false")
-	require.Equal(t, NotApplicable, mp.VerificationState(),
-		"verificationState must be NotApplicable on canonical delegate-derived MPs")
+	require.Equal(t, NotVerified, mp.VerificationState(),
+		"verificationState must be NotVerified on canonical delegate-derived MPs — the canonical did not attempt verification")
 
 	// Fields hashed into the VAA digest are preserved — verified by digest stability.
 	require.Equal(t, digestBefore, mp.CreateDigest(),
@@ -1006,7 +1006,7 @@ func TestNormalizeForDelegateConsensus(t *testing.T) {
 // that two otherwise-identical MessagePublications differing only in IsReobservation
 // produce the SAME bucket key for the canonical guardian's delegate-quorum check
 // (pkg/processor/observation.go). The bucket key must match the canonical
-// observation path's key (pkg/processor/message.go:70 — the VAA SigningDigest,
+// observation path's key (pkg/processor/message.go — the VAA SigningDigest,
 // which is what CreateDigest returns), so that signatures across original and
 // re-observation flows merge into a single bucket.
 func TestIsReobservationDoesNotSplitDelegateQuorumBucket(t *testing.T) {
@@ -1067,7 +1067,7 @@ func TestDelegateQuorumIsReobservationDoesNotPreventQuorum(t *testing.T) {
 	}
 
 	// The bucket-key derivation must match the canonical observation path
-	// (pkg/processor/message.go:70 → v.SigningDigest()), which is exactly what
+	// (pkg/processor/message.go → v.SigningDigest()), which is exactly what
 	// MessagePublication.CreateDigest() returns.
 	bucketKeyFor := func(isReobs bool) string {
 		return base(isReobs).CreateDigest()

--- a/node/pkg/common/chainlock_test.go
+++ b/node/pkg/common/chainlock_test.go
@@ -3,7 +3,6 @@ package common
 import (
 	"bytes"
 	"encoding/binary"
-	"encoding/hex"
 	"io"
 	"math"
 	"math/big"
@@ -12,7 +11,6 @@ import (
 	"time"
 
 	eth_common "github.com/ethereum/go-ethereum/common"
-	eth_crypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/wormhole-foundation/wormhole/sdk/vaa"
@@ -971,11 +969,10 @@ func TestMessagePublication_IsWTT(t *testing.T) {
 // TestIsReobservationDoesNotSplitDelegateQuorumBucket asserts the protocol invariant
 // that two otherwise-identical MessagePublications differing only in IsReobservation
 // produce the SAME bucket key for the canonical guardian's delegate-quorum check
-// (pkg/processor/observation.go:648). Today the bucket key is Keccak256(MarshalBinary),
-// and MarshalBinary writes IsReobservation as a byte (chainlock.go:332-337) — so this
-// test FAILS under current code, demonstrating the bug: a delegate set where some
-// guardians sign with IsReobservation=true and others with false splits across two
-// buckets and never reaches quorum on either.
+// (pkg/processor/observation.go). The bucket key must match the canonical
+// observation path's key (pkg/processor/message.go:70 — the VAA SigningDigest,
+// which is what CreateDigest returns), so that signatures across original and
+// re-observation flows merge into a single bucket.
 func TestIsReobservationDoesNotSplitDelegateQuorumBucket(t *testing.T) {
 	makeMP := func(isReobs bool) *MessagePublication {
 		emitter, err := vaa.StringToAddress("000000000000000000000000b1731c586ca89a23809861c6103f0b96b3f57d92")
@@ -999,22 +996,15 @@ func TestIsReobservationDoesNotSplitDelegateQuorumBucket(t *testing.T) {
 	require.Equal(t, original.MessageIDString(), reobs.MessageIDString(),
 		"sanity: VAA MessageID is identical")
 
-	bufA, err := original.MarshalBinary()
-	require.NoError(t, err)
-	bufB, err := reobs.MarshalBinary()
-	require.NoError(t, err)
-
-	hashA := eth_crypto.Keccak256Hash(bufA).Hex()
-	hashB := eth_crypto.Keccak256Hash(bufB).Hex()
+	hashA := original.CreateDigest()
+	hashB := reobs.CreateDigest()
 
 	t.Logf("MessageID:                   %s", original.MessageIDString())
-	t.Logf("hash (IsReobservation=false): %s", hashA)
-	t.Logf("hash (IsReobservation=true):  %s", hashB)
+	t.Logf("digest (IsReobservation=false): %s", hashA)
+	t.Logf("digest (IsReobservation=true):  %s", hashB)
 
 	require.Equal(t, hashA, hashB,
-		"signatures for the same VAA must land in the same delegate-quorum bucket "+
-			"regardless of IsReobservation; today MarshalBinary includes the flag, "+
-			"which splits the bucket and prevents quorum")
+		"CreateDigest (VAA SigningDigest) must be invariant under IsReobservation")
 }
 
 // TestDelegateQuorumIsReobservationDoesNotPreventQuorum models the field case
@@ -1040,12 +1030,11 @@ func TestDelegateQuorumIsReobservationDoesNotPreventQuorum(t *testing.T) {
 		}
 	}
 
-	// The bucket-key derivation must come from the canonical's actual call site:
-	//   pkg/processor/observation.go:648 → Keccak256(MarshalBinary(mp)).Hex()
+	// The bucket-key derivation must match the canonical observation path
+	// (pkg/processor/message.go:70 → v.SigningDigest()), which is exactly what
+	// MessagePublication.CreateDigest() returns.
 	bucketKeyFor := func(isReobs bool) string {
-		buf, err := base(isReobs).MarshalBinary()
-		require.NoError(t, err)
-		return hex.EncodeToString(eth_crypto.Keccak256Hash(buf).Bytes())
+		return base(isReobs).CreateDigest()
 	}
 
 	// 8 distinct delegate guardians; 4 sign as original observation, 4 re-observed.

--- a/node/pkg/processor/delegate_obs.go
+++ b/node/pkg/processor/delegate_obs.go
@@ -30,7 +30,30 @@ func (p *Processor) publishDelegateObservation(d *gossipv1.DelegateObservation) 
 }
 
 // delegateObservationToMessagePublication converts a DelegateObservation into a MessagePublication that can be passed through the normal processor pipeline.
-// Returns error on invalid delegate observation input
+// Returns error on invalid delegate observation input.
+//
+// VERSION SKEW: several of the checks below are forward-incompatible — a
+// delegate guardian on a newer build can produce values that an older
+// canonical rejects here, causing the observation to be dropped before it
+// reaches the delegate-quorum bucket. Two cases are particularly relevant:
+//
+//   - KnownChainIDFromNumber: a new chain ID added on delegates ahead of
+//     canonicals is rejected. This is the intended behavior — the canonical
+//     genuinely cannot reason about a chain it doesn't know — but it does
+//     mean enabling delegated guardians for a new chain requires canonicals
+//     to be updated first.
+//
+//   - NumVariantsVerificationState: a new VerificationState variant added on
+//     delegates is rejected even though the canonical's consensus path
+//     normalizes this field away (NormalizeForDelegateConsensus → NotApplicable).
+//     If enough delegates upgrade ahead of canonicals, the silently-dropped
+//     observations reduce the effective quorum count and re-introduce the
+//     stall pattern — operators only see the per-observation
+//     "failed to convert delegate observation to message publication" warns,
+//     not a per-message symptom.
+//
+// When introducing changes that touch either check, plan canonical-first or
+// add explicit forward-compat handling here.
 func delegateObservationToMessagePublication(d *gossipv1.DelegateObservation) (*node_common.MessagePublication, error) {
 	if d == nil {
 		return nil, fmt.Errorf("nil delegate observation")

--- a/node/pkg/processor/delegate_obs.go
+++ b/node/pkg/processor/delegate_obs.go
@@ -32,28 +32,23 @@ func (p *Processor) publishDelegateObservation(d *gossipv1.DelegateObservation) 
 // delegateObservationToMessagePublication converts a DelegateObservation into a MessagePublication that can be passed through the normal processor pipeline.
 // Returns error on invalid delegate observation input.
 //
-// VERSION SKEW: several of the checks below are forward-incompatible — a
-// delegate guardian on a newer build can produce values that an older
-// canonical rejects here, causing the observation to be dropped before it
-// reaches the delegate-quorum bucket. Two cases are particularly relevant:
+// VERSION SKEW: the NumVariantsVerificationState check below is
+// forward-incompatible in a way worth flagging: a delegate guardian on a
+// newer build that adds a VerificationState variant will produce observations
+// the canonical rejects here, even though the canonical's consensus path
+// normalizes this field away (NormalizeForDelegateConsensus → NotVerified).
+// If enough delegates upgrade ahead of canonicals, the silently-dropped
+// observations reduce the effective quorum count and reintroduce the stall
+// pattern — operators only see the per-observation "failed to convert
+// delegate observation to message publication" warn, with no aggregated
+// signal that quorum is being denied. When extending VerificationState,
+// either deploy canonicals first or relax this check.
 //
-//   - KnownChainIDFromNumber: a new chain ID added on delegates ahead of
-//     canonicals is rejected. This is the intended behavior — the canonical
-//     genuinely cannot reason about a chain it doesn't know — but it does
-//     mean enabling delegated guardians for a new chain requires canonicals
-//     to be updated first.
-//
-//   - NumVariantsVerificationState: a new VerificationState variant added on
-//     delegates is rejected even though the canonical's consensus path
-//     normalizes this field away (NormalizeForDelegateConsensus → NotApplicable).
-//     If enough delegates upgrade ahead of canonicals, the silently-dropped
-//     observations reduce the effective quorum count and re-introduce the
-//     stall pattern — operators only see the per-observation
-//     "failed to convert delegate observation to message publication" warns,
-//     not a per-message symptom.
-//
-// When introducing changes that touch either check, plan canonical-first or
-// add explicit forward-compat handling here.
+// The KnownChainIDFromNumber check has the same forward-incompatibility
+// shape but is not flagged separately: a canonical that doesn't know an
+// emitter chain can't reason about it downstream anyway (governor wouldn't
+// catch transfers from it, etc.), so the deploy-ordering constraint isn't
+// specific to delegated guardians.
 func delegateObservationToMessagePublication(d *gossipv1.DelegateObservation) (*node_common.MessagePublication, error) {
 	if d == nil {
 		return nil, fmt.Errorf("nil delegate observation")

--- a/node/pkg/processor/observation.go
+++ b/node/pkg/processor/observation.go
@@ -122,13 +122,38 @@ func (p *Processor) handleMessagePublication(ctx context.Context, k *node_common
 	return p.processWithAccountant(ctx, k)
 }
 
-// handleDelegateConsensusMessagePublication runs an MP that has reached
-// delegate-guardian quorum on a canonical guardian through governor and
-// accountant only. The notary is intentionally skipped: each delegate already
-// gated its own broadcast on its local notary (processor.go), and per-guardian
-// notary-managed fields (e.g. verificationState) are not part of consensus, so
-// running the canonical's notary here would couple signing to delegate build
-// lockstep and re-introduce the silent-stall failure mode.
+// handleDelegateConsensusMessagePublication is the downstream pipeline for an
+// MP that has reached delegate-guardian quorum on a canonical guardian. It
+// runs governor + accountant, in that order, and (intentionally) skips the
+// notary.
+//
+// Why the notary is skipped:
+//
+// The notary inspects per-guardian, per-transaction state — the transfer
+// verifier's verdict, the canonical's local blackhole/delay queue — none of
+// which is an input to delegate consensus. Each delegate already consulted
+// its own notary before broadcasting (see processor.go's delegate-publish
+// path), and per-guardian notary-managed fields like verificationState are
+// normalized away on the consensus MP (see NormalizeForDelegateConsensus).
+//
+// Running the canonical's notary at this point would gate publication of
+// the consensus VAA on state the canonical maintains locally rather than on
+// consensus state. The canonical has no watcher for a delegated chain, so
+// the local state could be:
+//   - Empty (no transfer-verifier verdict was ever recorded), in which case
+//     the notary may return Unknown and the message stalls.
+//   - Inconsistent with delegates' view (e.g. canonical's blackhole queue
+//     contains the message ID for unrelated reasons), in which case the
+//     notary returns Blackhole and the canonical silently refuses to sign
+//     despite enough delegates having approved.
+//
+// In both cases delegate quorum has been reached, but the canonical never
+// publishes its signature and operators only see a per-canonical notary log
+// — no aggregated signal that signing is being suppressed. Skipping the
+// notary here keeps consensus signing dependent only on consensus inputs.
+//
+// A future change may re-introduce a notary check here that is compatible
+// with the delegate guardian set conditions.
 //
 // WARNING: like handleMessagePublication, an error from the accountant is
 // propagated to the processor and effectively acts as a panic.
@@ -663,7 +688,7 @@ func (p *Processor) handleSignedDelegateObservation(ctx context.Context, m *goss
 	}
 
 	// Key the delegate-state bucket by the VAA signing digest, matching the
-	// canonical observation path (pkg/processor/message.go:70). This excludes
+	// canonical observation path (pkg/processor/message.go). This excludes
 	// fields not encoded in the VAA (notably IsReobservation), so signatures
 	// from a partially-reobserved delegate set merge into one bucket.
 	hash := mp.CreateDigest()
@@ -779,7 +804,7 @@ func (p *Processor) handleCanonicalDelegateObservation(ctx context.Context, cfg 
 	delegateObservationsReceivedByGuardianAddressTotal.WithLabelValues(addr.Hex()).Inc()
 
 	// Key the delegate-state bucket by the VAA signing digest, matching the
-	// canonical observation path (pkg/processor/message.go:70). This excludes
+	// canonical observation path (pkg/processor/message.go). This excludes
 	// fields not encoded in the VAA (notably IsReobservation), so signatures
 	// from a partially-reobserved delegate set merge into one bucket.
 	hash := mp.CreateDigest()
@@ -799,12 +824,19 @@ func (p *Processor) handleCanonicalDelegateObservation(ctx context.Context, cfg 
 	}
 
 	// Detect TxID disagreement among delegates for the same VAA. TxID is not
-	// part of the VAA digest and is not part of accountant's aggregation key,
-	// so different TxIDs do not affect quorum, signing, or accountant — but
-	// disagreement indicates a buggy or malicious delegate (or, rarely, a
-	// chain reorg) and is the only signal operators get for that. The
-	// downstream MP carries the bucket-majority TxID via consensusTxID, which
-	// is itself informational. This warn is the actionable piece.
+	// part of the VAA signing digest, so disagreement does not split delegate
+	// quorum here on the canonical — but TxID IS part of the global-accountant
+	// contract's per-entry match (see the TxID field godoc on
+	// common.MessagePublication), so if canonicals submit divergent TxIDs to
+	// the accountant their signatures land in separate pending entries and
+	// quorum is counted per entry. consensusTxID picks the bucket-majority
+	// TxID for the downstream MP, which converges canonicals when the
+	// majority is stable under observation arrival order — i.e. the typical
+	// case where one TxID dominates. With a near-even split (e.g. 4/3 of 7)
+	// two canonicals can still bucket-at-quorum-time with different majorities
+	// and submit different TxIDs; the audit / missing_observations reobs flow
+	// is what eventually recovers that. This warn surfaces the underlying
+	// delegate disagreement to operators regardless.
 	for existingAddr, existing := range s.observations {
 		if existingAddr == addr {
 			continue
@@ -891,15 +923,22 @@ func (p *Processor) checkForDelegateQuorum(ctx context.Context, mp *node_common.
 
 	s.submitted = true
 
-	// Pick a deterministic TxID for the canonical's downstream MP. This is
-	// informational only — TxID is not part of the VAA digest and is not part
-	// of accountant's aggregation key (the accountant contract aggregates by
-	// (chain, emitter, sequence); see pkg/accountant/submit_obs.go TransferKey).
-	// Picking a stable value just makes this canonical's logs, database row,
-	// and submitted observation payload consistent rather than reflecting
-	// whichever delegate's observation happened to push the bucket over quorum.
-	// Real divergence is surfaced separately by the warning log in
-	// handleCanonicalDelegateObservation.
+	// Pick a deterministic TxID for the canonical's downstream MP. TxID is
+	// not part of the VAA signing digest, so any value here produces the same
+	// VAA — but TxID IS part of the global-accountant contract's per-entry
+	// match within a pending transfer (see the TxID field godoc on
+	// common.MessagePublication). Picking the bucket-majority TxID
+	// deterministically — same delegate observations → same choice — converges
+	// canonicals onto the same tx_hash for the accountant in the typical case
+	// where one TxID has a clear majority that doesn't depend on observation
+	// arrival order. With a near-even TxID split, two canonicals whose buckets
+	// reach quorum at different observation subsets can still pick different
+	// majorities and submit different TxIDs, splitting signatures across
+	// accountant entries; the audit / missing_observations reobs flow handles
+	// recovery in that case. Picking deterministically also makes the
+	// canonical's logs, database row, and submitted observation payload stable
+	// rather than last-writer-wins. Delegate disagreement is surfaced
+	// separately by the warning log in handleCanonicalDelegateObservation.
 	if tx := s.consensusTxID(); tx != nil {
 		mp.TxID = tx
 	}
@@ -917,12 +956,20 @@ func (p *Processor) checkForDelegateQuorum(ctx context.Context, mp *node_common.
 // iteration order — so two canonicals with the same observations always pick
 // the same TxID. Returns nil for an empty bucket.
 //
-// NOTE: this is informational only. TxID is not part of the VAA signing
-// digest and is not part of accountant's aggregation key, so the choice does
-// not affect quorum, signing, or accountant correctness. Its only purpose is
-// to make a canonical's logs/persistence/observation payload deterministic
-// rather than last-writer-wins. Operationally meaningful TxID divergence is
-// surfaced by the "delegate TxID disagreement" warn log, not by this function.
+// Determinism here matters for accountant convergence: TxID is part of the
+// global-accountant contract's per-entry match within a pending transfer
+// (see the TxID field godoc on common.MessagePublication), so if canonicals
+// submit differing TxIDs for the same VAA the contract splits signatures
+// across separate Data entries and quorum is counted per entry. A
+// deterministic majority pick converges canonicals onto the same tx_hash
+// in the typical case where one TxID has a clear majority that's stable
+// under arrival-order reshuffling. It does NOT guarantee convergence when
+// canonicals' buckets reach quorum at different observation subsets and the
+// TxID split is near-even — two canonicals can correctly compute different
+// majorities from different bucket states. Recovery for that case relies on
+// the audit / missing_observations reobs flow rather than on this pick.
+// Operationally meaningful divergence among delegates is surfaced separately
+// by the "delegate TxID disagreement" warn log.
 func (s *delegateState) consensusTxID() []byte {
 	type entry struct {
 		txID  []byte

--- a/node/pkg/processor/observation.go
+++ b/node/pkg/processor/observation.go
@@ -638,14 +638,11 @@ func (p *Processor) handleSignedDelegateObservation(ctx context.Context, m *goss
 		return nil
 	}
 
-	buf, err := mp.MarshalBinary()
-	if err != nil {
-		p.logger.Warn("failed to marshal message publication", mp.ZapFields(zap.Error(err))...)
-		delegateObservationsFailedTotal.WithLabelValues("invalid_message_publication").Inc()
-		return nil
-	}
-
-	hash := crypto.Keccak256Hash(buf).Hex()
+	// Key the delegate-state bucket by the VAA signing digest, matching the
+	// canonical observation path (pkg/processor/message.go:70). This excludes
+	// fields not encoded in the VAA (notably IsReobservation), so signatures
+	// from a partially-reobserved delegate set merge into one bucket.
+	hash := mp.CreateDigest()
 	s := p.delegateState.observations[hash]
 	if s != nil && s.submitted {
 		p.logger.Info("already submitted; ignoring additional observations for it",
@@ -757,12 +754,11 @@ func (p *Processor) handleCanonicalDelegateObservation(ctx context.Context, cfg 
 
 	delegateObservationsReceivedByGuardianAddressTotal.WithLabelValues(addr.Hex()).Inc()
 
-	buf, err := mp.MarshalBinary()
-	if err != nil {
-		p.logger.Warn("failed to marshal message publication", mp.ZapFields(zap.Error(err))...)
-		return nil
-	}
-	hash := crypto.Keccak256Hash(buf).Hex()
+	// Key the delegate-state bucket by the VAA signing digest, matching the
+	// canonical observation path (pkg/processor/message.go:70). This excludes
+	// fields not encoded in the VAA (notably IsReobservation), so signatures
+	// from a partially-reobserved delegate set merge into one bucket.
+	hash := mp.CreateDigest()
 
 	// Get / create our state entry.
 	s := p.delegateState.observations[hash]

--- a/node/pkg/processor/observation.go
+++ b/node/pkg/processor/observation.go
@@ -1,6 +1,7 @@
 package processor
 
 import (
+	"bytes"
 	"context"
 	"encoding/hex"
 	"fmt"
@@ -115,6 +116,29 @@ func (p *Processor) handleMessagePublication(ctx context.Context, k *node_common
 	}
 
 	if !p.processWithNotary(k) || !p.processWithGovernor(k) {
+		return nil
+	}
+
+	return p.processWithAccountant(ctx, k)
+}
+
+// handleDelegateConsensusMessagePublication runs an MP that has reached
+// delegate-guardian quorum on a canonical guardian through governor and
+// accountant only. The notary is intentionally skipped: each delegate already
+// gated its own broadcast on its local notary (processor.go), and per-guardian
+// notary-managed fields (e.g. verificationState) are not part of consensus, so
+// running the canonical's notary here would couple signing to delegate build
+// lockstep and re-introduce the silent-stall failure mode.
+//
+// WARNING: like handleMessagePublication, an error from the accountant is
+// propagated to the processor and effectively acts as a panic.
+func (p *Processor) handleDelegateConsensusMessagePublication(ctx context.Context, k *node_common.MessagePublication) error {
+	if k == nil {
+		p.logger.Warn("nil message publication")
+		return nil
+	}
+
+	if !p.processWithGovernor(k) {
 		return nil
 	}
 
@@ -774,6 +798,29 @@ func (p *Processor) handleCanonicalDelegateObservation(ctx context.Context, cfg 
 		p.delegateState.observations[hash] = s
 	}
 
+	// Detect TxID disagreement among delegates for the same VAA. TxID is not
+	// part of the VAA digest and is not part of accountant's aggregation key,
+	// so different TxIDs do not affect quorum, signing, or accountant — but
+	// disagreement indicates a buggy or malicious delegate (or, rarely, a
+	// chain reorg) and is the only signal operators get for that. The
+	// downstream MP carries the bucket-majority TxID via consensusTxID, which
+	// is itself informational. This warn is the actionable piece.
+	for existingAddr, existing := range s.observations {
+		if existingAddr == addr {
+			continue
+		}
+		if !bytes.Equal(existing.TxHash, m.TxHash) {
+			p.logger.Warn("delegate TxID disagreement",
+				zap.String("msgID", mp.MessageIDString()),
+				zap.String("guardian_a", existingAddr.Hex()),
+				zap.String("txid_a", hex.EncodeToString(existing.TxHash)),
+				zap.String("guardian_b", addr.Hex()),
+				zap.String("txid_b", hex.EncodeToString(m.TxHash)),
+			)
+			break
+		}
+	}
+
 	// Update our state.
 	s.observations[addr] = m
 
@@ -843,5 +890,63 @@ func (p *Processor) checkForDelegateQuorum(ctx context.Context, mp *node_common.
 	}
 
 	s.submitted = true
-	return p.handleMessagePublication(ctx, mp)
+
+	// Pick a deterministic TxID for the canonical's downstream MP. This is
+	// informational only — TxID is not part of the VAA digest and is not part
+	// of accountant's aggregation key (the accountant contract aggregates by
+	// (chain, emitter, sequence); see pkg/accountant/submit_obs.go TransferKey).
+	// Picking a stable value just makes this canonical's logs, database row,
+	// and submitted observation payload consistent rather than reflecting
+	// whichever delegate's observation happened to push the bucket over quorum.
+	// Real divergence is surfaced separately by the warning log in
+	// handleCanonicalDelegateObservation.
+	if tx := s.consensusTxID(); tx != nil {
+		mp.TxID = tx
+	}
+
+	// Reset per-guardian metadata on the consensus MP so downstream processing
+	// doesn't depend on whichever delegate's observation happened to push the
+	// bucket over quorum.
+	mp.NormalizeForDelegateConsensus()
+	return p.handleDelegateConsensusMessagePublication(ctx, mp)
+}
+
+// consensusTxID returns the majority TxID across the bucket's observations,
+// breaking ties by lexicographic TxID order. The result is a pure function of
+// bucket contents — independent of cfg, delegate-set updates, and Go map
+// iteration order — so two canonicals with the same observations always pick
+// the same TxID. Returns nil for an empty bucket.
+//
+// NOTE: this is informational only. TxID is not part of the VAA signing
+// digest and is not part of accountant's aggregation key, so the choice does
+// not affect quorum, signing, or accountant correctness. Its only purpose is
+// to make a canonical's logs/persistence/observation payload deterministic
+// rather than last-writer-wins. Operationally meaningful TxID divergence is
+// surfaced by the "delegate TxID disagreement" warn log, not by this function.
+func (s *delegateState) consensusTxID() []byte {
+	type entry struct {
+		txID  []byte
+		count int
+	}
+	counts := map[string]*entry{}
+	for _, obs := range s.observations {
+		key := string(obs.TxHash)
+		if e, exists := counts[key]; exists {
+			e.count++
+		} else {
+			counts[key] = &entry{txID: obs.TxHash, count: 1}
+		}
+	}
+	var best *entry
+	for _, e := range counts {
+		if best == nil ||
+			e.count > best.count ||
+			(e.count == best.count && bytes.Compare(e.txID, best.txID) < 0) {
+			best = e
+		}
+	}
+	if best == nil {
+		return nil
+	}
+	return best.txID
 }

--- a/node/pkg/processor/observation_test.go
+++ b/node/pkg/processor/observation_test.go
@@ -118,3 +118,214 @@ func TestHandleInboundSignedVAAWithQuorum(t *testing.T) {
 		})
 	}
 }
+
+// makeDelegateObs builds a minimal DelegateObservation for the same VAA
+// (chain/emitter/sequence/payload), parameterized by the per-guardian fields
+// that don't affect the VAA digest: signer address, TxHash, IsReobservation.
+func makeDelegateObs(t *testing.T, signer ethcommon.Address, txHash []byte, isReobservation bool) *gossipv1.DelegateObservation {
+	t.Helper()
+	emitter, err := vaa.StringToAddress("000000000000000000000000b1731c586ca89a23809861c6103f0b96b3f57d92")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &gossipv1.DelegateObservation{
+		EmitterChain:      uint32(vaa.ChainIDMoonbeam),
+		EmitterAddress:    emitter[:],
+		Sequence:          95838,
+		TxHash:            txHash,
+		Timestamp:         1746026862,
+		Nonce:             0,
+		ConsistencyLevel:  1,
+		Payload:           []byte("payload"),
+		GuardianAddr:      signer.Bytes(),
+		IsReobservation:   isReobservation,
+		Unreliable:        false,
+		VerificationState: 0,
+	}
+}
+
+// TestHandleCanonicalDelegateObservation_BucketMergesAcrossIsReobservation feeds
+// a delegated guardian set's worth of observations split across IsReobservation
+// values and verifies that:
+//   - All observations land in the SAME bucket (the bucket-key fix at
+//     observation.go:CreateDigest is invariant to IsReobservation).
+//   - No "delegate TxID disagreement" warning is emitted, because every
+//     observation carries the same TxID.
+func TestHandleCanonicalDelegateObservation_BucketMergesAcrossIsReobservation(t *testing.T) {
+	signers := []ethcommon.Address{
+		ethcommon.HexToAddress("0x000ac0076727b35fbea2dac28fee5ccb0fea768e"),
+		ethcommon.HexToAddress("0x178e21ad2e77ae06711549cfbb1f9c7a9d8096e8"),
+		ethcommon.HexToAddress("0xda798f6896a3331f64b48c12d1d57fd9cbe70811"),
+		ethcommon.HexToAddress("0x938f104aeb5581293216ce97d771e0cb721221b1"),
+		ethcommon.HexToAddress("0x42579bffbcf4276e290ab8e4c162bd4052b97970"),
+	}
+	cfg, err := NewDelegatedGuardianChainConfig(signers, vaa.CalculateQuorum(len(signers)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	observedCore, observedLogs := observer.New(zap.InfoLevel)
+	p := &Processor{
+		logger:        zap.New(observedCore),
+		delegateState: &delegateAggregationState{delegateObservationMap{}},
+	}
+
+	txID := ethcommon.HexToHash("0x39c2f7f67fbce903d49bb24147668095f1b726acef3c19460da39e83c6929a2b").Bytes()
+	// Mix IsReobservation values across the set; under the old bucket-key this
+	// would split the signatures across buckets and prevent quorum.
+	flags := []bool{false, false, true, true, true}
+	for i, signer := range signers {
+		obs := makeDelegateObs(t, signer, txID, flags[i])
+		// We don't drive checkForDelegateQuorum's downstream call here (that
+		// would require a full Processor); we stop after the bucket update.
+		// To do that, mark submitted on the bucket once it exists so the
+		// quorum-triggered downstream path is short-circuited.
+		_ = p.handleCanonicalDelegateObservation(t.Context(), cfg, obs)
+		if i == 0 {
+			// After the first observation, force submitted=true so subsequent
+			// calls return early without invoking the consensus handler.
+			for _, s := range p.delegateState.observations {
+				s.submitted = true
+			}
+		}
+	}
+
+	// Exactly one bucket — the IsReobservation split is gone.
+	assert.Len(t, p.delegateState.observations, 1,
+		"all delegate observations must land in a single bucket regardless of IsReobservation")
+
+	for _, s := range p.delegateState.observations {
+		assert.Len(t, s.observations, len(signers),
+			"every signer's observation should be in the bucket")
+	}
+
+	// No TxID-disagreement warnings — every signer used the same TxID.
+	for _, entry := range observedLogs.All() {
+		assert.NotEqual(t, "delegate TxID disagreement", entry.Message)
+	}
+}
+
+// TestConsensusTxID covers the per-bucket majority-TxID picker:
+//   - all observations agree → that TxID wins
+//   - simple majority → majority wins
+//   - tie → lex-smallest TxID wins (independent of cfg, delegate-set updates,
+//     and map iteration order)
+//   - empty bucket → nil
+func TestConsensusTxID(t *testing.T) {
+	signers := []ethcommon.Address{
+		ethcommon.HexToAddress("0x000ac0076727b35fbea2dac28fee5ccb0fea768e"),
+		ethcommon.HexToAddress("0x178e21ad2e77ae06711549cfbb1f9c7a9d8096e8"),
+		ethcommon.HexToAddress("0xda798f6896a3331f64b48c12d1d57fd9cbe70811"),
+		ethcommon.HexToAddress("0x938f104aeb5581293216ce97d771e0cb721221b1"),
+		ethcommon.HexToAddress("0x42579bffbcf4276e290ab8e4c162bd4052b97970"),
+	}
+	txA := ethcommon.HexToHash("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").Bytes()
+	txB := ethcommon.HexToHash("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb").Bytes()
+
+	t.Run("unanimous", func(t *testing.T) {
+		s := &delegateState{observations: map[ethcommon.Address]*gossipv1.DelegateObservation{}}
+		for _, sg := range signers {
+			s.observations[sg] = &gossipv1.DelegateObservation{TxHash: txA}
+		}
+		assert.Equal(t, txA, s.consensusTxID())
+	})
+
+	t.Run("majority_wins", func(t *testing.T) {
+		s := &delegateState{observations: map[ethcommon.Address]*gossipv1.DelegateObservation{}}
+		// 4 sigs txA, 1 sig txB. txB is lex-smaller than txA, but minority loses.
+		s.observations[signers[0]] = &gossipv1.DelegateObservation{TxHash: txA}
+		s.observations[signers[1]] = &gossipv1.DelegateObservation{TxHash: txA}
+		s.observations[signers[2]] = &gossipv1.DelegateObservation{TxHash: txA}
+		s.observations[signers[3]] = &gossipv1.DelegateObservation{TxHash: txA}
+		s.observations[signers[4]] = &gossipv1.DelegateObservation{TxHash: txB}
+		assert.Equal(t, txA, s.consensusTxID())
+	})
+
+	t.Run("tie_lex_smaller_wins", func(t *testing.T) {
+		// 2 sigs each — txA (0xaa…) is lex-smaller than txB (0xbb…), so txA wins.
+		// Repeated to defeat map-iteration randomness.
+		for i := 0; i < 50; i++ {
+			s := &delegateState{observations: map[ethcommon.Address]*gossipv1.DelegateObservation{}}
+			s.observations[signers[0]] = &gossipv1.DelegateObservation{TxHash: txB}
+			s.observations[signers[1]] = &gossipv1.DelegateObservation{TxHash: txA}
+			s.observations[signers[2]] = &gossipv1.DelegateObservation{TxHash: txB}
+			s.observations[signers[3]] = &gossipv1.DelegateObservation{TxHash: txA}
+			assert.Equal(t, txA, s.consensusTxID())
+		}
+	})
+
+	t.Run("tie_independent_of_signer_order", func(t *testing.T) {
+		// Swapping which signers carry which TxID must not change the result —
+		// the tie-break is on TxID bytes, not signer position.
+		for i := 0; i < 50; i++ {
+			s := &delegateState{observations: map[ethcommon.Address]*gossipv1.DelegateObservation{}}
+			s.observations[signers[0]] = &gossipv1.DelegateObservation{TxHash: txA}
+			s.observations[signers[1]] = &gossipv1.DelegateObservation{TxHash: txB}
+			s.observations[signers[2]] = &gossipv1.DelegateObservation{TxHash: txA}
+			s.observations[signers[3]] = &gossipv1.DelegateObservation{TxHash: txB}
+			assert.Equal(t, txA, s.consensusTxID())
+		}
+	})
+
+	t.Run("empty_bucket", func(t *testing.T) {
+		s := &delegateState{observations: map[ethcommon.Address]*gossipv1.DelegateObservation{}}
+		assert.Nil(t, s.consensusTxID())
+	})
+}
+
+// TestHandleCanonicalDelegateObservation_TxIDDisagreementWarn verifies that
+// when two delegates report the same VAA from different transactions, the
+// canonical emits the expected warning. TxID is not part of consensus, so the
+// observations still land in the same bucket — but the disagreement is logged
+// for operators.
+func TestHandleCanonicalDelegateObservation_TxIDDisagreementWarn(t *testing.T) {
+	signerA := ethcommon.HexToAddress("0x000ac0076727b35fbea2dac28fee5ccb0fea768e")
+	signerB := ethcommon.HexToAddress("0x178e21ad2e77ae06711549cfbb1f9c7a9d8096e8")
+	cfg, err := NewDelegatedGuardianChainConfig(
+		[]ethcommon.Address{signerA, signerB,
+			ethcommon.HexToAddress("0xda798f6896a3331f64b48c12d1d57fd9cbe70811")},
+		vaa.CalculateQuorum(3),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	observedCore, observedLogs := observer.New(zap.WarnLevel)
+	p := &Processor{
+		logger:        zap.New(observedCore),
+		delegateState: &delegateAggregationState{delegateObservationMap{}},
+	}
+
+	txA := ethcommon.HexToHash("0x39c2f7f67fbce903d49bb24147668095f1b726acef3c19460da39e83c6929a2b").Bytes()
+	txB := ethcommon.HexToHash("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").Bytes()
+
+	if err := p.handleCanonicalDelegateObservation(t.Context(), cfg, makeDelegateObs(t, signerA, txA, false)); err != nil {
+		t.Fatalf("first obs returned error: %v", err)
+	}
+	// Force submitted to short-circuit the quorum path on the second obs.
+	for _, s := range p.delegateState.observations {
+		s.submitted = true
+	}
+	if err := p.handleCanonicalDelegateObservation(t.Context(), cfg, makeDelegateObs(t, signerB, txB, false)); err != nil {
+		t.Fatalf("second obs returned error: %v", err)
+	}
+
+	// Both observations are in the same bucket — TxID is not part of the digest.
+	assert.Len(t, p.delegateState.observations, 1,
+		"different TxIDs must not split the bucket — TxID is not part of the VAA digest")
+
+	// Exactly one disagreement warning, naming both signers and TxIDs.
+	disagreementLogs := observedLogs.FilterMessage("delegate TxID disagreement").All()
+	if assert.Len(t, disagreementLogs, 1, "expected one TxID disagreement warning") {
+		entry := disagreementLogs[0]
+		fields := map[string]string{}
+		for _, f := range entry.Context {
+			fields[f.Key] = f.String
+		}
+		assert.Contains(t, fields["txid_a"], "39c2f7f6")
+		assert.Contains(t, fields["txid_b"], "aaaaaaaa")
+		assert.NotEmpty(t, fields["guardian_a"])
+		assert.NotEmpty(t, fields["guardian_b"])
+		assert.NotEmpty(t, fields["msgID"])
+	}
+}

--- a/node/pkg/processor/observation_test.go
+++ b/node/pkg/processor/observation_test.go
@@ -463,7 +463,7 @@ func TestCheckForDelegateQuorum_ConsensusPathContract(t *testing.T) {
 		IsReobservation:  false, // must be forced to true
 		Unreliable:       true,  // must be forced to false
 	}
-	require.NoError(t, mp.SetVerificationState(common.Anomalous)) // must be forced to NotApplicable
+	require.NoError(t, mp.SetVerificationState(common.Anomalous)) // must be forced to NotVerified
 
 	// The state entry handleMessage creates will be keyed by the VAA signing
 	// digest. CreateDigest hashes only the consensus fields (none of which
@@ -486,8 +486,8 @@ func TestCheckForDelegateQuorum_ConsensusPathContract(t *testing.T) {
 		"IsReobservation must be normalized to true on canonical delegate-consensus MPs")
 	assert.False(t, mp.Unreliable,
 		"Unreliable must be normalized to false on canonical delegate-consensus MPs")
-	assert.Equal(t, common.NotApplicable, mp.VerificationState(),
-		"verificationState must be normalized to NotApplicable on canonical delegate-consensus MPs")
+	assert.Equal(t, common.NotVerified, mp.VerificationState(),
+		"verificationState must be normalized to NotVerified on canonical delegate-consensus MPs")
 
 	// Downstream-routing contract: the MP must have flowed through
 	// handleDelegateConsensusMessagePublication → processWithGovernor →

--- a/node/pkg/processor/observation_test.go
+++ b/node/pkg/processor/observation_test.go
@@ -1,16 +1,22 @@
 package processor
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/rand"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/certusone/wormhole/node/pkg/common"
+	"github.com/certusone/wormhole/node/pkg/db"
+	"github.com/certusone/wormhole/node/pkg/guardiansigner"
+	guardianNotary "github.com/certusone/wormhole/node/pkg/notary"
 	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/wormhole-foundation/wormhole/sdk/vaa"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
@@ -328,4 +334,178 @@ func TestHandleCanonicalDelegateObservation_TxIDDisagreementWarn(t *testing.T) {
 		assert.NotEmpty(t, fields["guardian_b"])
 		assert.NotEmpty(t, fields["msgID"])
 	}
+}
+
+// TestCheckForDelegateQuorum_ConsensusPathContract locks down the
+// security-relevant invariants of checkForDelegateQuorum that the other unit
+// tests in this file exercise only in isolation:
+//
+//   - the bucket-majority TxID is copied to the MP that downstream sees,
+//   - per-guardian metadata (IsReobservation, Unreliable, verificationState)
+//     is normalized to canonical-safe defaults before downstream is called,
+//   - the bucket is marked submitted so late observations are dropped,
+//   - the MP reaches handleMessage (i.e. downstream routing completes through
+//     processWithGovernor and processWithAccountant).
+//
+// All assertions are positive-existence checks: the test asserts that
+// specific mutations and side effects DID happen, rather than that some log
+// line did NOT appear.
+//
+// What this test does NOT verify:
+//
+//  1. That the notary is skipped on the delegate-consensus path. The notary
+//     in this setup is non-nil but, for Moonbeam, returns Approve immediately
+//     (txverifier doesn't support Moonbeam), so a regression that re-introduces
+//     processWithNotary into handleDelegateConsensusMessagePublication would
+//     still pass every assertion here. The notary-skip property is enforced
+//     by code review of handleDelegateConsensusMessagePublication's body
+//     (no call to processWithNotary). Asserting it positively in a test
+//     requires either pre-populating the notary's blackhole set (no public
+//     API for that today) or refactoring Processor.notary to an interface
+//     so a recording fake can be injected — neither is part of this PR.
+//
+//  2. That governor and accountant are individually invoked. They are nil
+//     here, so processWithGovernor and processWithAccountant pass through
+//     trivially. The state.signatures assertion below proves handleMessage
+//     was reached, which proves both wrappers returned the "continue" branch,
+//     but it doesn't distinguish "called and approved" from "skipped because
+//     nil". A regression that drops processWithGovernor entirely from the
+//     consensus handler wouldn't be caught here.
+//
+//  3. That handleDelegateConsensusMessagePublication (vs handleMessagePublication)
+//     is the function called. The mp mutations happen BEFORE the dispatch at
+//     the end of checkForDelegateQuorum, so they fire regardless of which
+//     handler is invoked. Distinguishing the two handlers requires the same
+//     interface-based fake described in (1).
+func TestCheckForDelegateQuorum_ConsensusPathContract(t *testing.T) {
+	signers := []ethcommon.Address{
+		ethcommon.HexToAddress("0x000ac0076727b35fbea2dac28fee5ccb0fea768e"),
+		ethcommon.HexToAddress("0x178e21ad2e77ae06711549cfbb1f9c7a9d8096e8"),
+		ethcommon.HexToAddress("0xda798f6896a3331f64b48c12d1d57fd9cbe70811"),
+		ethcommon.HexToAddress("0x938f104aeb5581293216ce97d771e0cb721221b1"),
+		ethcommon.HexToAddress("0x42579bffbcf4276e290ab8e4c162bd4052b97970"),
+	}
+	cfg, err := NewDelegatedGuardianChainConfig(signers, vaa.CalculateQuorum(len(signers)))
+	require.NoError(t, err)
+
+	// Mixed TxIDs across the bucket: 3× txMaj, 2× txMin → txMaj is the majority.
+	// txMin is lexicographically smaller than txMaj, so a buggy implementation
+	// that fell back to lex-smallest regardless of count would pick txMin and
+	// fail the TxID assertion below.
+	txMaj := ethcommon.HexToHash("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb").Bytes()
+	txMin := ethcommon.HexToHash("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").Bytes()
+	txAssign := [][]byte{txMaj, txMaj, txMaj, txMin, txMin}
+
+	bucket := &delegateState{
+		firstObserved: time.Now(),
+		observations:  map[ethcommon.Address]*gossipv1.DelegateObservation{},
+		cfg:           cfg,
+	}
+	for i, sg := range signers {
+		bucket.observations[sg] = makeDelegateObs(t, sg, txAssign[i], false)
+	}
+
+	// Build a minimal-but-real Processor: enough state for handleMessage to
+	// run to completion (which is the downstream we want to observe), but
+	// nothing more. We use a non-nil notary to mirror the production setup —
+	// the canonical guardian DOES have a notary configured; the contract
+	// under test is that it's not consulted on the delegate-consensus path.
+	guardianDB := db.OpenDb(zap.NewNop(), nil)
+	t.Cleanup(func() { _ = guardianDB.Close() })
+	notary := guardianNotary.NewNotary(context.Background(), zap.NewNop(), guardianDB, common.GoTest)
+
+	ourSigner, err := guardiansigner.GenerateSignerWithPrivatekeyUnsafe(nil)
+	require.NoError(t, err)
+	ourAddr := crypto.PubkeyToAddress(ourSigner.PublicKey(t.Context()))
+
+	// 19-key guardian set so a single signature can't reach quorum and trigger
+	// HandleQuorum (which would pull in storeSignedVAA / broadcastSignedVAA).
+	// We only need handleMessage to run far enough to create the state entry.
+	gsKeys := make([]ethcommon.Address, 0, 19)
+	gsKeys = append(gsKeys, ourAddr)
+	for range 18 {
+		filler, fillerErr := crypto.GenerateKey()
+		require.NoError(t, fillerErr)
+		gsKeys = append(gsKeys, crypto.PubkeyToAddress(filler.PublicKey))
+	}
+	gs := common.NewGuardianSet(gsKeys, 0)
+
+	p := &Processor{
+		logger:         zap.NewNop(),
+		notary:         notary,
+		guardianSigner: ourSigner,
+		ourAddr:        ourAddr,
+		gs:             gs,
+		state:          &aggregationState{signatures: observationMap{}},
+		delegateState:  &delegateAggregationState{delegateObservationMap{}},
+		batchObsvPubC:  make(chan *gossipv1.Observation, 8),
+		gossipVaaSendC: make(chan []byte, 8),
+		updateVAALock:  sync.Mutex{},
+		updatedVAAs:    make(map[string]*updateVaaEntry),
+	}
+
+	emitter, err := vaa.StringToAddress("000000000000000000000000b1731c586ca89a23809861c6103f0b96b3f57d92")
+	require.NoError(t, err)
+
+	// mp going in has non-default per-guardian metadata. After quorum, those
+	// fields must be normalized regardless of what the trigger observation
+	// carried. TxID is set to the minority value so a regression that forgets
+	// to overwrite mp.TxID would leave the minority value in place.
+	mp := &common.MessagePublication{
+		TxID:             txMin,
+		Timestamp:        time.Unix(1746026862, 0),
+		Nonce:            0,
+		Sequence:         95838,
+		ConsistencyLevel: 1,
+		EmitterChain:     vaa.ChainIDMoonbeam,
+		EmitterAddress:   emitter,
+		Payload:          []byte("payload"),
+		IsReobservation:  false, // must be forced to true
+		Unreliable:       true,  // must be forced to false
+	}
+	require.NoError(t, mp.SetVerificationState(common.Anomalous)) // must be forced to NotApplicable
+
+	// The state entry handleMessage creates will be keyed by the VAA signing
+	// digest. CreateDigest hashes only the consensus fields (none of which
+	// NormalizeForDelegateConsensus touches), so this digest is stable across
+	// the call.
+	expectedHash := mp.CreateDigest()
+	require.Empty(t, p.state.signatures, "precondition: state map is empty before the call")
+
+	require.NoError(t, p.checkForDelegateQuorum(t.Context(), mp, bucket, cfg))
+
+	// Bucket-state contract: late observations for this digest must now be dropped.
+	require.True(t, bucket.submitted, "bucket must be marked submitted after quorum")
+
+	// MP-mutation contract — these are positive fingerprints that the
+	// delegate-consensus code path executed (NormalizeForDelegateConsensus and
+	// consensusTxID are only ever called from checkForDelegateQuorum).
+	assert.Equal(t, txMaj, mp.TxID,
+		"canonical MP must carry the bucket-majority TxID, not the trigger observation's TxID")
+	assert.True(t, mp.IsReobservation,
+		"IsReobservation must be normalized to true on canonical delegate-consensus MPs")
+	assert.False(t, mp.Unreliable,
+		"Unreliable must be normalized to false on canonical delegate-consensus MPs")
+	assert.Equal(t, common.NotApplicable, mp.VerificationState(),
+		"verificationState must be normalized to NotApplicable on canonical delegate-consensus MPs")
+
+	// Downstream-routing contract: the MP must have flowed through
+	// handleDelegateConsensusMessagePublication → processWithGovernor →
+	// processWithAccountant → handleMessage. handleMessage's side effect is
+	// to create p.state.signatures[hash] and populate s.txHash + s.signatures
+	// with our local signature. Asserting the entry exists is positive
+	// evidence the consensus handler routed correctly all the way through.
+	require.Len(t, p.state.signatures, 1,
+		"handleMessage must have created exactly one state entry for the consensus MP")
+	stateEntry := p.state.signatures[expectedHash]
+	require.NotNil(t, stateEntry, "state entry must be keyed by mp.CreateDigest()")
+	assert.Equal(t, txMaj, stateEntry.txHash,
+		"state entry must carry the consensus TxID (majority pick), not the trigger TxID")
+	assert.Contains(t, stateEntry.signatures, ourAddr,
+		"state entry must hold our own signature, produced by handleMessage")
+	require.NotNil(t, stateEntry.ourObservation, "state entry must hold the signed observation")
+	assert.True(t, stateEntry.ourObservation.IsReobservation(),
+		"signed observation must carry the normalized Reobservation=true flag")
+	assert.True(t, stateEntry.ourObservation.IsReliable(),
+		"signed observation must carry the normalized Unreliable=false flag (IsReliable returns !Unreliable)")
 }


### PR DESCRIPTION
On a chain with delegated guardians, when some delegates sign a message as an original observation (IsReobservation=false) and others as a re-observation (IsReobservation=true), the canonical guardians never reach delegate quorum even when a quorum of delegates have signed.

This is due to the canonical's per-message delegateState bucket being [keyed on](https://github.com/wormhole-foundation/wormhole/blob/f1da2892a723aa49c7eab2728415bda078356678/node/pkg/processor/observation.go#L641-L648) Keccak256(MarshalBinary(mp)). MarshalBinary [writes](https://github.com/wormhole-foundation/wormhole/blob/f1da2892a723aa49c7eab2728415bda078356678/node/pkg/common/chainlock.go#L332-L337) IsReobservation as a byte, so two otherwise-identical MessagePublications produce different bucket keys. Signatures get distributed across two buckets and neither reaches quorum. 

Here is an example of the mismatched case resulting in a loss of quorum: https://api.wormholescan.io/api/v1/observations/delegate/16/000000000000000000000000b1731c586ca89a23809861c6103f0b96b3f57d92/95838

This PR
1. Fixes the bug by using `CreateDigest` as the digest.
2. Skips the Notary on the delegate-consensus path. It cannot be guaranteed that there is a consensus of `verificationState`s across different guardian configurations and versions. The Notary is also run by the delegates before broadcasting their delegate observations. The Notary functionality can be amended in the future to handle canonical-only specific checks if desired.
3. Adds `MessagePublication.NormalizeForDelegateConsensus()` which resets per-guardian metadata (IsReobservation=true, Unreliable=false, verificationState=NotApplicable) on the canonical's post-quorum MP so downstream behavior doesn't depend on whichever delegate's observation arrived last. 
4. Resolves the TxID via `delegateState.consensusTxID()` which picks the bucket-majority TxID with a lex-smallest tie-break.
5. Adds a comment calling out that the checks enforced in `delegateObservationToMessagePublication` are **not** forward-compatible. I'm not comfortable with the forward incompatible nature of these checks, but this PR is about fixing a more obvious consensus failure whereas these are debatably desirable defensive checks.

A note on the accountant impact:
> While TxID isn't part of the VAA signing digest, it is part of the global-accountant contract's per-entry match: PENDING_TRANSFERS is keyed by (chain, emitter, sequence) but stores a Vec<Data> whose entries are uniquely identified by (guardian_set_index, digest, tx_hash), and signatures only merge across observations with matching tx_hash (cosmwasm/contracts/global-accountant/src/contract.rs:184-205). If canonicals submit divergent TxIDs for the same VAA, their signatures land in separate Data entries and quorum is counted per entry — so the transfer can stall at the accountant even with enough total signatures for the same digest. consensusTxID makes every canonical deterministically pick the same majority TxID from the delegate bucket, so all canonicals submit matching tx_hash and signatures merge into one entry. Recovery via the audit's missing_observations query exists if a split does happen (each guardian re-observation-requests the other side's TxID), but it's noisy and depends on the audit retry loop rather than the delegate-quorum path.