### PR TITLE
ci: Install JS dependencies from lockfiles

### DIFF
--- a/.github/workflows/locked-in.yml
+++ b/.github/workflows/locked-in.yml
@@ -1,0 +1,20 @@
+name: locked-in
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  locked-in:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: asymmetric-research/locked-in@74d8fd31d519ea9f4f95b01191dc6171df90f045 # v0.2.0
+        with:
+          commit: 74d8fd31d519ea9f4f95b01191dc6171df90f045

--- a/.github/workflows/locked-in.yml
+++ b/.github/workflows/locked-in.yml
@@ -11,10 +11,13 @@ permissions:
 jobs:
   locked-in:
     runs-on: ubuntu-latest
+    env:
+      LOCKED_IN_COMMIT: 74d8fd31d519ea9f4f95b01191dc6171df90f045 # v0.2.0
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: asymmetric-research/locked-in@74d8fd31d519ea9f4f95b01191dc6171df90f045 # v0.2.0
-        with:
-          commit: 74d8fd31d519ea9f4f95b01191dc6171df90f045
+      - name: Install locked-in from pinned source
+        run: cargo install --locked --git https://github.com/asymmetric-research/locked-in --rev "$LOCKED_IN_COMMIT" locked-in
+      - name: Run locked-in
+        run: locked-in

--- a/ethereum/Dockerfile
+++ b/ethereum/Dockerfile
@@ -9,7 +9,8 @@ FROM --platform=linux/amd64 node:22.16-bullseye-slim@sha256:550b434f7edc3a187586
 RUN apt-get update && apt-get -y install \
   git python make curl netcat vim
 
-RUN npm i typescript -g
+# keep in sync with sdk/js/package.json
+RUN npm i typescript@4.3.5 -g
 RUN apt-get -y install jq
 
 COPY --from=foundry /usr/local/bin/anvil /bin/anvil

--- a/near/Dockerfile.base
+++ b/near/Dockerfile.base
@@ -6,8 +6,10 @@ RUN rustup update
 RUN apt-get update && apt-get install apt-utils && apt-get install -y python3 npm curl make --no-install-recommends
 RUN apt-get install -y build-essential git
 
-RUN npm i -g n
-RUN n stable
+# n is not in any repo package.json; pinned to last stable v9 release
+RUN npm i -g n@9.2.3
+# keep in sync with .nvmrc
+RUN n 22.16.0
 
 COPY node_builder.sh /tmp
 

--- a/testing/Dockerfile.sdk.test
+++ b/testing/Dockerfile.sdk.test
@@ -4,7 +4,8 @@ FROM node:22.16-bullseye-slim@sha256:550b434f7edc3a1875860657a3e306752358029c957
 RUN apt-get update && apt-get -y install \
   git python3 make curl netcat vim
 
-RUN npm i typescript -g
+# keep in sync with sdk/js/package.json
+RUN npm i typescript@4.3.5 -g
 COPY --from=foundry /usr/local/bin/forge /bin/forge
 
 RUN mkdir -p /app

--- a/testing/solana-test-validator/Makefile
+++ b/testing/solana-test-validator/Makefile
@@ -5,7 +5,7 @@
 .FORCE:
 
 node_modules:
-	yarn
+	yarn install --frozen-lockfile
 
 artifacts:
 	cd ../../solana && \


### PR DESCRIPTION
- Replace `npm install` and similar with pinned versions and/or installation via lockfiles
- Add https://github.com/asymmetric-research/locked-in to lint for future violations of this policy

See also CONTRIBUTING.md on the JS package manager policy and motivations.