### PR TITLE
ci: Update Claude workflow to make code quality comments

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -116,6 +116,7 @@ jobs:
             - **Self-check for contradictions**: After drafting each finding, re-read it and ask: does any sentence weaken or contradict the severity I assigned? If so, either downgrade the severity or remove the hedging language. Never flag something and then immediately explain why it is probably fine.
             - **Be concise**: No filler, no praise, no emoji. State the issue, show the problematic code, explain the fix. 2-4 sentences per finding.
             - **Respect the codebase**: Use CONTRIBUTING.md and SAFETY_CRITICAL_MODE.md for guidance on style, conventions, and project context. Follow existing patterns when suggesting fixes.
+            - **Code Quality**: Follow DRY: identify code reuse opportunities especially for common operations that can be done by standard library calls, common libraries (e.g. go-ethereum), or the project's sdk/ methods.
 
             ### Before Submitting Your Review
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,8 @@ and code reviews are our most important tools to accomplish that.
 
 - Commits should be small and have a meaningful commit message. One commit should, roughly, be "one idea" and
   be as atomic as possible. A feature can consist of many such commits.
+- Where possible, use standard libraries, common dependencies, or SDK functions instead of re-implementing validation
+from scratch. This helps prevent duplication and drift for routine tasks, and helps the codebase stay lean and well-tested.
 - Feature flags and interface evolution are better than breaking changes and long-lived feature branches.
 - We optimize for reading, not for writing - over its lifetime, code is read much more often than written.
   Small commits, meaningful commit messages and useful comments make it easier to review code and improve the
@@ -161,9 +163,18 @@ Resources for writing good commit messages:
 
 ## Comment Conventions
 
+Make use of tools like Go's [doclinks](https://go.dev/doc/comment#doclinks) and Rust's [intra-doc links](https://doc.rust-lang.org/rustdoc/write-documentation/linking-to-items-by-name.html)
+to cross-correlate comments, especially when a field or structure is used 'at a distance' and modifying it could cause
+side-effects for other parts of the codebase.
+
+Comments should be full sentences in the present tense.
+
+Avoid referring to specific line numbers that may become stale.
+Avoid phrasing comments as changelogs e.g. "The function now returns an error instead of a string".
+
 ### Go
 
-Go code should follow the [Go Doc Comments](https://go.dev/doc/comment) standard.
+Go code should follow the [Go Doc Comments](https://go.dev/doc/comment) standard. 
 
 ### TypeScript
 
@@ -173,7 +184,10 @@ TypeScript code should follow the [TSDoc](https://tsdoc.org/) standard.
 
 You must format your code with `goimports` before submitting.
 You can install it with `go install golang.org/x/tools/cmd/goimports@latest` and run it with `goimports -d ./`.
-You can enable it in VSCode with the following in your `settings.json`.
+
+### Configuration: VSCode 
+
+You can enable goimports in VSCode with the following in your `settings.json`.
 
 ```json
   "go.useLanguageServer": true,
@@ -211,3 +225,9 @@ Places to find out more about existing test coverage and how to run those tests:
   - Run: `cd algorand && make test`
 
 The best place to understand how we invoke these tests via GitHub Actions on every commit can be found via `./.github/workflows/*.yml` and the best place to observe the results of these builds can be found via [https://github.com/wormhole-foundation/wormhole/actions](https://github.com/wormhole-foundation/wormhole/actions).
+
+### Code Coverage
+
+Refer to [Makefile] for instructions on checking on and updating code coverage.
+
+When adding new unit tests, please update the code coverage metrics.

--- a/cspell-custom-words.txt
+++ b/cspell-custom-words.txt
@@ -55,6 +55,8 @@ Cyfrin
 datagram
 denoms
 devnet
+doclink
+doclinks
 Dogecoin
 dymension
 Dymension


### PR DESCRIPTION
These changes are intended to help LLMs add comments to code that might already be covered by standard library functions, common libraries, or our SDK.

A common failure mode for LLM-assisted programming is that the LLM will often choose to in-line validation locally rather than look around at best practices or SDK or utils methods elsewhere in the codebase. This causes the codebase to grow in size, which makes it harder to wrangle both for humans and LLMs. (Larger code bases means more competition in the LLM's context window.)

- Add Claude instructions so that it can identify code reuse opportunities
- Add code quality guidelines to CONTRIBUTING.md

---

This PR is ready for review.

It's in draft mode because I want to get https://github.com/asymmetric-research/locked-in/pull/21 merged first. After that, I'll update the commit hash in the github actions file and fix other violations.