### PR TITLE
node(sdk): Clarify uses and limitations of vaa.Address

### DIFF
--- a/node/pkg/governor/governor.go
+++ b/node/pkg/governor/governor.go
@@ -60,6 +60,7 @@ type (
 		// Chain is the Wormhole chain ID of the token's source chain (where the token was minted).
 		Chain uint16
 		// Addr is the token's address on the source chain in Wormhole normalized format.
+		// See [vaa.Address]
 		Addr        string
 		Symbol      string
 		CoinGeckoId string

--- a/node/pkg/watchers/near/tx_processing.go
+++ b/node/pkg/watchers/near/tx_processing.go
@@ -22,10 +22,11 @@ import (
 )
 
 type NearWormholePublishEvent struct {
-	Standard    string `json:"standard"`
-	Event       string `json:"event"`
-	Data        string `json:"data"`
-	Nonce       uint32 `json:"nonce"`
+	Standard string `json:"standard"`
+	Event    string `json:"event"`
+	Data     string `json:"data"`
+	Nonce    uint32 `json:"nonce"`
+	// Emitter is sha256(account_name)
 	Emitter     string `json:"emitter"`
 	Seq         uint64 `json:"seq"`
 	BlockHeight uint64 `json:"block"`
@@ -177,14 +178,14 @@ func (e *Watcher) processWormholeLog(logger *zap.Logger, _ context.Context, job 
 		return errors.New("wormhole publish event.block does not equal receipt_outcome[x].block_height")
 	}
 
-	// SECURITY: extract emitter address and ensure that it has the correct format
-	emitter, err := hex.DecodeString(pubEvent.Emitter)
+	// SECURITY: extract emitterDigest and ensure that it has the correct format
+	emitterDigest, err := hex.DecodeString(pubEvent.Emitter)
 	if err != nil {
 		return err
 	}
 
-	// emitter is sha256(account_name), so it should be 32 bytes long.
-	if len(emitter) != 32 {
+	// [NearWormholePublishEvent.Emitter] is sha256(account_name), so it should be 32 bytes long.
+	if len(emitterDigest) != 32 {
 		logger.Error(
 			"Wormhole publish event malformed",
 			zap.String("error_type", "malformed_wormhole_event"),
@@ -196,8 +197,8 @@ func (e *Watcher) processWormholeLog(logger *zap.Logger, _ context.Context, job 
 	}
 
 	// Assemble the Message Publication Event
-	var a vaa.Address
-	copy(a[:], emitter)
+	var emitterDigestAddr vaa.Address
+	copy(emitterDigestAddr[:], emitterDigest)
 
 	txHashBytes, err := base58.Decode(job.txHash)
 	if err != nil {
@@ -241,7 +242,7 @@ func (e *Watcher) processWormholeLog(logger *zap.Logger, _ context.Context, job 
 		Nonce:            pubEvent.Nonce,
 		Sequence:         pubEvent.Seq,
 		EmitterChain:     vaa.ChainIDNear,
-		EmitterAddress:   a,
+		EmitterAddress:   emitterDigestAddr,
 		Payload:          pl,
 		ConsistencyLevel: 0,
 		IsReobservation:  job.isReobservation,

--- a/sdk/vaa/structs.go
+++ b/sdk/vaa/structs.go
@@ -51,8 +51,22 @@ type (
 	// Action of a VAA
 	Action uint8
 
-	// Address is a Wormhole protocol address, it contains the native chain's address. If the address data type of a
-	// chain is < 32bytes the value is zero-padded on the left.
+	// Address is a Wormhole protocol address otherwise referred to as a "wormhole normalized address." It typically
+	// contains the native chain's address for chains where the addresses are <= 32 bytes.
+	//
+	// If the address data type of a chain is < 32 bytes, the value is zero-padded on the left.
+	//
+	// For chains with addresses that support lengths greater than 32 bytes, this type MAY be used
+	// to represent an on-chain address by hashing it using an algorithm like sha256.
+	//
+	// For chains with variable length addresses, users MUST use this type in a consistently such that addresses
+	// can be uniquely identified. For example, if a chain supports addresses between length 2 and 64, this type
+	// should always encode addresses for that chain as sha256 digests. This helps to avoid a situation where
+	// addresses with length < 32 have zero-padded EVM-like addresses, but larger addresses on the same chain
+	// are represented as digests.
+	//
+	// Other uses of this type are NOT RECOMMENDED given that they can overload the semantic meaning of this field
+	// which already does a lot of conceptual work across disparate blockchain implementations.
 	Address [32]byte
 
 	// Signature of a single guardian

--- a/sdk/vaa/structs.go
+++ b/sdk/vaa/structs.go
@@ -59,7 +59,7 @@ type (
 	// For chains with addresses that support lengths greater than 32 bytes, this type MAY be used
 	// to represent an on-chain address by hashing it using an algorithm like sha256.
 	//
-	// For chains with variable length addresses, users MUST use this type in a consistently such that addresses
+	// For chains with variable length addresses, users MUST use this type consistently such that addresses
 	// can be uniquely identified. For example, if a chain supports addresses between length 2 and 64, this type
 	// should always encode addresses for that chain as sha256 digests. This helps to avoid a situation where
 	// addresses with length < 32 have zero-padded EVM-like addresses, but larger addresses on the same chain


### PR DESCRIPTION
Adds comments explaining how better to use the SDK's Address type and adds cosmetic refactors to some ambiguous callers.

I'm mainly adding this as a follow-up to several PR reviews where I erroneously recommended that all on-chain addresses be validated against the vaa.Address type. I wasn't aware of how this type ought to be used in several cases, so this should document the correct usage going forward.