### PR TITLE
feat(node): multi uri for manager signers

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -408,9 +408,9 @@ def build_node_yaml():
             if manager_service:
                 container["command"] += [
                     "--managerServiceEnabled",
-                    "--dogecoinManagerSignerUri",
+                    "--dogecoinManagerSignerUris",
                     "file:///tmp/bridge.key",
-                    "--xrplManagerSignerUri",
+                    "--xrplManagerSignerUris",
                     "file:///tmp/bridge.key"
                 ]
 

--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -1968,11 +1968,11 @@ func runNode(cmd *cobra.Command, args []string) {
 		}
 		// Ensure the manager signer is not the same as the guardian signer in non-devnet environments
 		if env != common.UnsafeDevNet && uri == *guardianSignerUri {
-			logger.Fatal("dogecoinManagerSignerUri must be different from guardianSignerUri in non-devnet environments")
+			logger.Fatal("dogecoinManagerSignerUris must be different from guardianSignerUri in non-devnet environments")
 		}
 		dogecoinSigner, err := guardiansigner.NewGuardianSignerFromUriWithPurpose(rootCtx, uri, env == common.UnsafeDevNet, "manager-dogecoin")
 		if err != nil {
-			logger.Fatal("failed to create dogecoin manager signer", zap.String("uri", uri), zap.Error(err))
+			logger.Fatal("failed to create dogecoin manager signer", zap.Error(err))
 		}
 		managerSigners[vaa.ChainIDDogecoin] = append(managerSigners[vaa.ChainIDDogecoin], dogecoinSigner)
 
@@ -1990,11 +1990,11 @@ func runNode(cmd *cobra.Command, args []string) {
 			continue
 		}
 		if env != common.UnsafeDevNet && uri == *guardianSignerUri {
-			logger.Fatal("xrplManagerSignerUri must be different from guardianSignerUri in non-devnet environments")
+			logger.Fatal("xrplManagerSignerUris must be different from guardianSignerUri in non-devnet environments")
 		}
 		xrplSigner, err := guardiansigner.NewGuardianSignerFromUriWithPurpose(rootCtx, uri, env == common.UnsafeDevNet, "manager-xrpl")
 		if err != nil {
-			logger.Fatal("failed to create XRPL manager signer", zap.String("uri", uri), zap.Error(err))
+			logger.Fatal("failed to create XRPL manager signer", zap.Error(err))
 		}
 		managerSigners[vaa.ChainIDXRPL] = append(managerSigners[vaa.ChainIDXRPL], xrplSigner)
 

--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -311,9 +311,9 @@ var (
 	featureFlags  []string
 	notaryEnabled *bool
 
-	managerServiceEnabled    *bool
-	dogecoinManagerSignerUri *string
-	xrplManagerSignerUri     *string
+	managerServiceEnabled     *bool
+	dogecoinManagerSignerUris []string
+	xrplManagerSignerUris     []string
 )
 
 func init() {
@@ -560,8 +560,8 @@ func init() {
 	notaryEnabled = NodeCmd.Flags().Bool("notaryEnabled", false, "Run the notary")
 
 	managerServiceEnabled = NodeCmd.Flags().Bool("managerServiceEnabled", false, "Run the manager service")
-	dogecoinManagerSignerUri = NodeCmd.Flags().String("dogecoinManagerSignerUri", "", "Dogecoin manager signer URI")
-	xrplManagerSignerUri = NodeCmd.Flags().String("xrplManagerSignerUri", "", "XRPL manager signer URI")
+	NodeCmd.Flags().StringSliceVarP(&dogecoinManagerSignerUris, "dogecoinManagerSignerUris", "", []string{}, "Dogecoin manager signer URI(s)")
+	NodeCmd.Flags().StringSliceVarP(&xrplManagerSignerUris, "xrplManagerSignerUris", "", []string{}, "XRPL manager signer URI(s)")
 }
 
 var (
@@ -1961,17 +1961,20 @@ func runNode(cmd *cobra.Command, args []string) {
 	}
 
 	// Initialize manager signers map
-	managerSigners := make(map[vaa.ChainID]guardiansigner.GuardianSigner)
-	if *dogecoinManagerSignerUri != "" {
+	managerSigners := make(map[vaa.ChainID][]guardiansigner.GuardianSigner)
+	for _, uri := range dogecoinManagerSignerUris {
+		if uri == "" {
+			continue
+		}
 		// Ensure the manager signer is not the same as the guardian signer in non-devnet environments
-		if env != common.UnsafeDevNet && *dogecoinManagerSignerUri == *guardianSignerUri {
+		if env != common.UnsafeDevNet && uri == *guardianSignerUri {
 			logger.Fatal("dogecoinManagerSignerUri must be different from guardianSignerUri in non-devnet environments")
 		}
-		dogecoinSigner, err := guardiansigner.NewGuardianSignerFromUriWithPurpose(rootCtx, *dogecoinManagerSignerUri, env == common.UnsafeDevNet, "manager-dogecoin")
+		dogecoinSigner, err := guardiansigner.NewGuardianSignerFromUriWithPurpose(rootCtx, uri, env == common.UnsafeDevNet, "manager-dogecoin")
 		if err != nil {
-			logger.Fatal("failed to create dogecoin manager signer", zap.Error(err))
+			logger.Fatal("failed to create dogecoin manager signer", zap.String("uri", uri), zap.Error(err))
 		}
-		managerSigners[vaa.ChainIDDogecoin] = dogecoinSigner
+		managerSigners[vaa.ChainIDDogecoin] = append(managerSigners[vaa.ChainIDDogecoin], dogecoinSigner)
 
 		// Log the 33-byte compressed public key for use in P2SH multisig
 		pubKey := dogecoinSigner.PublicKey(rootCtx)
@@ -1982,15 +1985,18 @@ func runNode(cmd *cobra.Command, args []string) {
 		compressedPubKey := btcecPubKey.SerializeCompressed()
 		logger.Info("initialized dogecoin manager signer", zap.String("compressed_public_key", fmt.Sprintf("%x", compressedPubKey)))
 	}
-	if *xrplManagerSignerUri != "" {
-		if env != common.UnsafeDevNet && *xrplManagerSignerUri == *guardianSignerUri {
+	for _, uri := range xrplManagerSignerUris {
+		if uri == "" {
+			continue
+		}
+		if env != common.UnsafeDevNet && uri == *guardianSignerUri {
 			logger.Fatal("xrplManagerSignerUri must be different from guardianSignerUri in non-devnet environments")
 		}
-		xrplSigner, err := guardiansigner.NewGuardianSignerFromUriWithPurpose(rootCtx, *xrplManagerSignerUri, env == common.UnsafeDevNet, "manager-xrpl")
+		xrplSigner, err := guardiansigner.NewGuardianSignerFromUriWithPurpose(rootCtx, uri, env == common.UnsafeDevNet, "manager-xrpl")
 		if err != nil {
-			logger.Fatal("failed to create XRPL manager signer", zap.Error(err))
+			logger.Fatal("failed to create XRPL manager signer", zap.String("uri", uri), zap.Error(err))
 		}
-		managerSigners[vaa.ChainIDXRPL] = xrplSigner
+		managerSigners[vaa.ChainIDXRPL] = append(managerSigners[vaa.ChainIDXRPL], xrplSigner)
 
 		// Log the XRPL r-address
 		xrplPubKey := xrplSigner.PublicKey(rootCtx)

--- a/node/pkg/manager/helpers_test.go
+++ b/node/pkg/manager/helpers_test.go
@@ -296,8 +296,8 @@ func TestGetFeatureString_Empty(t *testing.T) {
 func TestGetFeatureString_SingleChain(t *testing.T) {
 	pubKey := bytes.Repeat([]byte{0x01}, 33)
 	c := &ManagerService{
-		signerPubKeys: map[vaa.ChainID][]byte{
-			vaa.ChainIDXRPL: pubKey,
+		signerPubKeys: map[vaa.ChainID][][]byte{
+			vaa.ChainIDXRPL: {pubKey},
 		},
 	}
 	expected := "manager:" + chainIDFeaturePart(vaa.ChainIDXRPL, pubKey)
@@ -308,9 +308,9 @@ func TestGetFeatureString_MultipleChainsSorted(t *testing.T) {
 	xrplKey := bytes.Repeat([]byte{0xaa}, 33)
 	dogeKey := bytes.Repeat([]byte{0xbb}, 33)
 	c := &ManagerService{
-		signerPubKeys: map[vaa.ChainID][]byte{
-			vaa.ChainIDXRPL:     xrplKey,
-			vaa.ChainIDDogecoin: dogeKey,
+		signerPubKeys: map[vaa.ChainID][][]byte{
+			vaa.ChainIDXRPL:     {xrplKey},
+			vaa.ChainIDDogecoin: {dogeKey},
 		},
 	}
 

--- a/node/pkg/manager/manager.go
+++ b/node/pkg/manager/manager.go
@@ -10,7 +10,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -1126,17 +1126,16 @@ func (c *ManagerService) GetFeatureString() string {
 	}
 
 	// Collect chain IDs and sort them for consistent output
-	chainIDs := make([]int, 0, len(c.signerPubKeys))
+	chainIDs := make([]vaa.ChainID, 0, len(c.signerPubKeys))
 	for chainID := range c.signerPubKeys {
-		chainIDs = append(chainIDs, int(chainID))
+		chainIDs = append(chainIDs, chainID)
 	}
-	sort.Ints(chainIDs)
+	slices.Sort(chainIDs)
 
 	// Build the feature string with chain ID and public key
 	var parts []string
 	for _, id := range chainIDs {
-		pubKeys := c.signerPubKeys[vaa.ChainID(id)] // #nosec G115 -- id was converted from ChainID (uint16) above
-		for _, pubKey := range pubKeys {
+		for _, pubKey := range c.signerPubKeys[id] {
 			parts = append(parts, fmt.Sprintf("%d/%s", id, hex.EncodeToString(pubKey)))
 		}
 	}

--- a/node/pkg/manager/manager.go
+++ b/node/pkg/manager/manager.go
@@ -64,45 +64,16 @@ type ManagerSetConfig struct {
 	N uint8
 	// PublicKeys are the compressed secp256k1 public keys of the manager signers
 	PublicKeys [][]byte
-}
-
-// SignerMatch represents a local signer that is part of a manager set.
-type SignerMatch struct {
-	// ManagerSetIndex is this signer's index within the manager set (0-based)
-	ManagerSetIndex uint8
-	// LocalSignerIndex is the index into the local signers slice for this chain
-	LocalSignerIndex int
+	// pubKeyIndex maps each compressed public key (as a string) to its position
+	// within PublicKeys for O(1) lookups by FindSignerByPubKey.
+	pubKeyIndex map[string]uint8
 }
 
 // FindSignerByPubKey checks if a compressed public key is in this manager set.
-// Returns the manager set index and true if found, or 0 and false otherwise.
+// Returns the signer index and true if found, or 0 and false otherwise.
 func (c *ManagerSetConfig) FindSignerByPubKey(compressedPubKey []byte) (uint8, bool) {
-	for i, pk := range c.PublicKeys {
-		if bytes.Equal(compressedPubKey, pk) {
-			return uint8(i), true // #nosec G115 -- i < N which is uint8
-		}
-	}
-	return 0, false
-}
-
-// FindSigners checks which of the given signers' public keys are in this manager set.
-// Returns a SignerMatch for each local signer found in the set.
-func (c *ManagerSetConfig) FindSigners(ctx context.Context, signers []guardiansigner.GuardianSigner) []SignerMatch {
-	var matches []SignerMatch
-	for localIdx, signer := range signers {
-		signerPubKey := signer.PublicKey(ctx)
-		signerCompressed := compressPublicKey(&signerPubKey)
-		for i, pk := range c.PublicKeys {
-			if bytes.Equal(signerCompressed, pk) {
-				matches = append(matches, SignerMatch{
-					ManagerSetIndex:  uint8(i), // #nosec G115 -- i < N which is uint8
-					LocalSignerIndex: localIdx,
-				})
-				break
-			}
-		}
-	}
-	return matches
+	i, ok := c.pubKeyIndex[string(compressedPubKey)]
+	return i, ok
 }
 
 // ManagerService manages manager-related processing of VAAs.
@@ -114,6 +85,11 @@ type ManagerService struct {
 	emitters []emitterEntry
 	signers  map[vaa.ChainID][]guardiansigner.GuardianSigner
 	// signerPubKeys stores the compressed secp256k1 public keys for each chain's signers.
+	// Invariant: for every chain, len(signerPubKeys[chain]) == len(signers[chain]) and the
+	// slices are index-aligned (signerPubKeys[chain][i] is the pubkey for signers[chain][i]).
+	// Both maps are populated together in NewManagerService and never mutated afterwards, so
+	// indexing chainPubKeys[i] alongside chainSigners[i] is safe. Any future code that mutates
+	// either map must preserve this pairing.
 	signerPubKeys map[vaa.ChainID][][]byte
 	// managerTxSendC is the channel for sending manager transactions to be signed and broadcast via gossip.
 	managerTxSendC chan<- *gossipv1.ManagerTransaction
@@ -486,6 +462,17 @@ func (c *ManagerService) storeSignature(sig *ManagerSignature) {
 			Total:            managerSet.N,
 			Signatures:       make(map[uint8][][]byte),
 		}
+	} else if aggTx.ManagerSetIndex != sig.ManagerSetIndex {
+		// Signatures must all be from the same manager set; otherwise SignerIndex
+		// values from different sets would collide in aggTx.Signatures. This can
+		// occur when managers read the current manager set on either side of a
+		// rotation (e.g. for XRPL, where the payload does not embed an index).
+		c.logger.Warn("dropping signature with mismatched manager set index",
+			zap.String("vaa_id", sig.VAAID),
+			zap.Uint32("aggregated_index", aggTx.ManagerSetIndex),
+			zap.Uint32("signature_index", sig.ManagerSetIndex),
+		)
+		return
 	}
 
 	// Check if we already have this signature

--- a/node/pkg/manager/manager.go
+++ b/node/pkg/manager/manager.go
@@ -64,11 +64,45 @@ type ManagerSetConfig struct {
 	N uint8
 	// PublicKeys are the compressed secp256k1 public keys of the manager signers
 	PublicKeys [][]byte
-	// IsSigner indicates whether this node is part of the manager set
-	IsSigner bool
-	// SignerIndex is this node's index within the manager set (0-based)
-	// Only valid if IsSigner is true
-	SignerIndex uint8
+}
+
+// SignerMatch represents a local signer that is part of a manager set.
+type SignerMatch struct {
+	// ManagerSetIndex is this signer's index within the manager set (0-based)
+	ManagerSetIndex uint8
+	// LocalSignerIndex is the index into the local signers slice for this chain
+	LocalSignerIndex int
+}
+
+// FindSignerByPubKey checks if a compressed public key is in this manager set.
+// Returns the manager set index and true if found, or 0 and false otherwise.
+func (c *ManagerSetConfig) FindSignerByPubKey(compressedPubKey []byte) (uint8, bool) {
+	for i, pk := range c.PublicKeys {
+		if bytes.Equal(compressedPubKey, pk) {
+			return uint8(i), true // #nosec G115 -- i < N which is uint8
+		}
+	}
+	return 0, false
+}
+
+// FindSigners checks which of the given signers' public keys are in this manager set.
+// Returns a SignerMatch for each local signer found in the set.
+func (c *ManagerSetConfig) FindSigners(ctx context.Context, signers []guardiansigner.GuardianSigner) []SignerMatch {
+	var matches []SignerMatch
+	for localIdx, signer := range signers {
+		signerPubKey := signer.PublicKey(ctx)
+		signerCompressed := compressPublicKey(&signerPubKey)
+		for i, pk := range c.PublicKeys {
+			if bytes.Equal(signerCompressed, pk) {
+				matches = append(matches, SignerMatch{
+					ManagerSetIndex:  uint8(i), // #nosec G115 -- i < N which is uint8
+					LocalSignerIndex: localIdx,
+				})
+				break
+			}
+		}
+	}
+	return matches
 }
 
 // ManagerService manages manager-related processing of VAAs.
@@ -78,9 +112,9 @@ type ManagerService struct {
 	vaaC     <-chan *vaa.VAA
 	env      common.Environment
 	emitters []emitterEntry
-	signers  map[vaa.ChainID]guardiansigner.GuardianSigner
-	// signerPubKeys stores the compressed secp256k1 public keys for each chain's signer.
-	signerPubKeys map[vaa.ChainID][]byte
+	signers  map[vaa.ChainID][]guardiansigner.GuardianSigner
+	// signerPubKeys stores the compressed secp256k1 public keys for each chain's signers.
+	signerPubKeys map[vaa.ChainID][][]byte
 	// managerTxSendC is the channel for sending manager transactions to be signed and broadcast via gossip.
 	managerTxSendC chan<- *gossipv1.ManagerTransaction
 	// managerTxRecvC receives verified manager transactions from other manager nodes via gossip.
@@ -103,7 +137,7 @@ func NewManagerService(
 	logger *zap.Logger,
 	vaaC <-chan *vaa.VAA,
 	env common.Environment,
-	signers map[vaa.ChainID]guardiansigner.GuardianSigner,
+	signers map[vaa.ChainID][]guardiansigner.GuardianSigner,
 	managerTxSendC chan<- *gossipv1.ManagerTransaction,
 	managerTxRecvC <-chan *gossipv1.ManagerTransaction,
 	database *db.Database,
@@ -128,10 +162,14 @@ func NewManagerService(
 	}
 
 	// Compute compressed public keys for each signer
-	signerPubKeys := make(map[vaa.ChainID][]byte)
-	for chainID, signer := range signers {
-		pubKey := signer.PublicKey(ctx)
-		signerPubKeys[chainID] = compressPublicKey(&pubKey)
+	signerPubKeys := make(map[vaa.ChainID][][]byte)
+	for chainID, chainSigners := range signers {
+		keys := make([][]byte, len(chainSigners))
+		for i, signer := range chainSigners {
+			pubKey := signer.PublicKey(ctx)
+			keys[i] = compressPublicKey(&pubKey)
+		}
+		signerPubKeys[chainID] = keys
 	}
 
 	// Create reader for dynamic manager set loading
@@ -199,8 +237,7 @@ func parseEmitters(sdkEmitters []struct {
 
 // getManagerSet retrieves a manager set by chain ID and index.
 func (c *ManagerService) getManagerSet(ctx context.Context, chainID vaa.ChainID, index uint32) (*ManagerSetConfig, error) {
-	signer := c.signers[chainID]
-	return c.reader.GetManagerSet(ctx, chainID, index, signer)
+	return c.reader.GetManagerSet(ctx, chainID, index)
 }
 
 // Run starts the manager service and begins processing incoming VAAs.
@@ -509,9 +546,9 @@ func (c *ManagerService) handleUTXOPayload(v *vaa.VAA) {
 		zap.Int("num_outputs", len(payload.Outputs)),
 	)
 
-	// Check if we have a signer for the destination chain
-	signer, ok := c.signers[payload.DestinationChain]
-	if !ok {
+	// Check if we have signers for the destination chain
+	chainSigners, ok := c.signers[payload.DestinationChain]
+	if !ok || len(chainSigners) == 0 {
 		c.logger.Warn("no signer configured for destination chain",
 			zap.String("message_id", v.MessageID()),
 			zap.Stringer("destination_chain", payload.DestinationChain),
@@ -519,26 +556,31 @@ func (c *ManagerService) handleUTXOPayload(v *vaa.VAA) {
 		return
 	}
 
-	// Sign the transaction inputs
-	sig, err := c.signUTXOTransaction(v, payload, signer)
-	if err != nil {
-		c.logger.Error("failed to sign UTXO transaction",
+	chainPubKeys := c.signerPubKeys[payload.DestinationChain]
+
+	// Sign with each signer configured for this chain
+	for i, signer := range chainSigners {
+		sig, err := c.signUTXOTransaction(v, payload, signer, chainPubKeys[i])
+		if err != nil {
+			c.logger.Error("failed to sign UTXO transaction",
+				zap.String("message_id", v.MessageID()),
+				zap.Error(err),
+			)
+			continue
+		}
+
+		c.logger.Info("signed manager transaction",
 			zap.String("message_id", v.MessageID()),
-			zap.Error(err),
+			zap.Stringer("destination_chain", sig.DestinationChain),
+			zap.Uint8("signer_index", sig.SignerIndex),
+			zap.Int("num_signatures", len(sig.InputSignatures)),
 		)
-		return
-	}
 
-	c.logger.Info("signed manager transaction",
-		zap.String("message_id", v.MessageID()),
-		zap.Stringer("destination_chain", sig.DestinationChain),
-		zap.Int("num_signatures", len(sig.InputSignatures)),
-	)
-
-	if c.managerTxSendC != nil {
-		c.broadcastSignature(sig)
+		if c.managerTxSendC != nil {
+			c.broadcastSignature(sig)
+		}
+		c.storeSignature(sig)
 	}
-	c.storeSignature(sig)
 }
 
 // handleXRPLPayload processes an XRPL release payload from a VAA.
@@ -559,34 +601,39 @@ func (c *ManagerService) handleXRPLPayload(v *vaa.VAA) {
 		zap.Uint8("token_type", uint8(payload.Token.Type)),
 	)
 
-	// Check if we have an XRPL signer
-	signer, ok := c.signers[vaa.ChainIDXRPL]
-	if !ok {
+	// Check if we have XRPL signers
+	chainSigners, ok := c.signers[vaa.ChainIDXRPL]
+	if !ok || len(chainSigners) == 0 {
 		c.logger.Warn("no signer configured for XRPL",
 			zap.String("message_id", v.MessageID()),
 		)
 		return
 	}
 
-	// Sign the XRPL transaction
-	sig, err := c.signXRPLTransaction(v, payload, signer)
-	if err != nil {
-		c.logger.Error("failed to sign XRPL transaction",
+	chainPubKeys := c.signerPubKeys[vaa.ChainIDXRPL]
+
+	// Sign with each signer configured for XRPL
+	for i, signer := range chainSigners {
+		sig, err := c.signXRPLTransaction(v, payload, signer, chainPubKeys[i])
+		if err != nil {
+			c.logger.Error("failed to sign XRPL transaction",
+				zap.String("message_id", v.MessageID()),
+				zap.Error(err),
+			)
+			continue
+		}
+
+		c.logger.Info("signed XRPL manager transaction",
 			zap.String("message_id", v.MessageID()),
-			zap.Error(err),
+			zap.Stringer("destination_chain", sig.DestinationChain),
+			zap.Uint8("signer_index", sig.SignerIndex),
 		)
-		return
-	}
 
-	c.logger.Info("signed XRPL manager transaction",
-		zap.String("message_id", v.MessageID()),
-		zap.Stringer("destination_chain", sig.DestinationChain),
-	)
-
-	if c.managerTxSendC != nil {
-		c.broadcastSignature(sig)
+		if c.managerTxSendC != nil {
+			c.broadcastSignature(sig)
+		}
+		c.storeSignature(sig)
 	}
-	c.storeSignature(sig)
 }
 
 // handleXRPLTicketRefill processes an XRPL ticket refill payload from a VAA.
@@ -606,34 +653,39 @@ func (c *ManagerService) handleXRPLTicketRefill(v *vaa.VAA) {
 		zap.Uint64("request_count", payload.RequestCount),
 	)
 
-	// Check if we have an XRPL signer
-	signer, ok := c.signers[vaa.ChainIDXRPL]
-	if !ok {
+	// Check if we have XRPL signers
+	chainSigners, ok := c.signers[vaa.ChainIDXRPL]
+	if !ok || len(chainSigners) == 0 {
 		c.logger.Warn("no signer configured for XRPL",
 			zap.String("message_id", v.MessageID()),
 		)
 		return
 	}
 
-	// Sign the XRPL TicketCreate transaction
-	sig, err := c.signXRPLTicketRefillTransaction(v, payload, signer)
-	if err != nil {
-		c.logger.Error("failed to sign XRPL ticket refill transaction",
+	chainPubKeys := c.signerPubKeys[vaa.ChainIDXRPL]
+
+	// Sign with each signer configured for XRPL
+	for i, signer := range chainSigners {
+		sig, err := c.signXRPLTicketRefillTransaction(v, payload, signer, chainPubKeys[i])
+		if err != nil {
+			c.logger.Error("failed to sign XRPL ticket refill transaction",
+				zap.String("message_id", v.MessageID()),
+				zap.Error(err),
+			)
+			continue
+		}
+
+		c.logger.Info("signed XRPL ticket refill transaction",
 			zap.String("message_id", v.MessageID()),
-			zap.Error(err),
+			zap.Stringer("destination_chain", sig.DestinationChain),
+			zap.Uint8("signer_index", sig.SignerIndex),
 		)
-		return
-	}
 
-	c.logger.Info("signed XRPL ticket refill transaction",
-		zap.String("message_id", v.MessageID()),
-		zap.Stringer("destination_chain", sig.DestinationChain),
-	)
-
-	if c.managerTxSendC != nil {
-		c.broadcastSignature(sig)
+		if c.managerTxSendC != nil {
+			c.broadcastSignature(sig)
+		}
+		c.storeSignature(sig)
 	}
-	c.storeSignature(sig)
 }
 
 // signXRPLTicketRefillTransaction signs an XRPL TicketCreate transaction for the given ticket refill payload.
@@ -641,6 +693,7 @@ func (c *ManagerService) signXRPLTicketRefillTransaction(
 	v *vaa.VAA,
 	payload *vaa.XRPLTicketRefillPayload,
 	signer guardiansigner.GuardianSigner,
+	signerPubKey []byte,
 ) (*ManagerSignature, error) {
 	// Get the current manager set for XRPL (XRFL payload doesn't embed a manager set index)
 	managerSet, err := c.getCurrentManagerSet(c.ctx, vaa.ChainIDXRPL)
@@ -648,9 +701,10 @@ func (c *ManagerService) signXRPLTicketRefillTransaction(
 		return nil, fmt.Errorf("failed to get current manager set for XRPL: %w", err)
 	}
 
-	// Verify this node is part of the manager set
-	if !managerSet.IsSigner {
-		return nil, fmt.Errorf("this node is not part of the XRPL manager set")
+	// Verify this signer is part of the manager set
+	signerIndex, ok := managerSet.FindSignerByPubKey(signerPubKey)
+	if !ok {
+		return nil, fmt.Errorf("this signer is not part of the XRPL manager set")
 	}
 
 	// Build the XRPL TicketCreate transaction
@@ -660,7 +714,6 @@ func (c *ManagerService) signXRPLTicketRefillTransaction(
 	}
 
 	// Derive this signer's XRPL address from compressed public key
-	signerPubKey := c.signerPubKeys[vaa.ChainIDXRPL]
 	signerAddress, err := xrpl.CompressedPubKeyToAddress(signerPubKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to derive signer XRPL address: %w", err)
@@ -689,7 +742,7 @@ func (c *ManagerService) signXRPLTicketRefillTransaction(
 		VAAID:            v.MessageID(),
 		DestinationChain: vaa.ChainIDXRPL,
 		ManagerSetIndex:  managerSet.Index,
-		SignerIndex:      managerSet.SignerIndex,
+		SignerIndex:      signerIndex,
 		InputSignatures:  [][]byte{derSig},
 	}, nil
 }
@@ -710,34 +763,39 @@ func (c *ManagerService) handleXRPLBurnTicket(v *vaa.VAA) {
 		zap.Uint64("ticket_id", payload.TicketID),
 	)
 
-	// Check if we have an XRPL signer
-	signer, ok := c.signers[vaa.ChainIDXRPL]
-	if !ok {
+	// Check if we have XRPL signers
+	chainSigners, ok := c.signers[vaa.ChainIDXRPL]
+	if !ok || len(chainSigners) == 0 {
 		c.logger.Warn("no signer configured for XRPL",
 			zap.String("message_id", v.MessageID()),
 		)
 		return
 	}
 
-	// Sign the XRPL AccountSet (burn) transaction
-	sig, err := c.signXRPLBurnTicketTransaction(v, payload, signer)
-	if err != nil {
-		c.logger.Error("failed to sign XRPL burn ticket transaction",
+	chainPubKeys := c.signerPubKeys[vaa.ChainIDXRPL]
+
+	// Sign with each signer configured for XRPL
+	for i, signer := range chainSigners {
+		sig, err := c.signXRPLBurnTicketTransaction(v, payload, signer, chainPubKeys[i])
+		if err != nil {
+			c.logger.Error("failed to sign XRPL burn ticket transaction",
+				zap.String("message_id", v.MessageID()),
+				zap.Error(err),
+			)
+			continue
+		}
+
+		c.logger.Info("signed XRPL burn ticket transaction",
 			zap.String("message_id", v.MessageID()),
-			zap.Error(err),
+			zap.Stringer("destination_chain", sig.DestinationChain),
+			zap.Uint8("signer_index", sig.SignerIndex),
 		)
-		return
-	}
 
-	c.logger.Info("signed XRPL burn ticket transaction",
-		zap.String("message_id", v.MessageID()),
-		zap.Stringer("destination_chain", sig.DestinationChain),
-	)
-
-	if c.managerTxSendC != nil {
-		c.broadcastSignature(sig)
+		if c.managerTxSendC != nil {
+			c.broadcastSignature(sig)
+		}
+		c.storeSignature(sig)
 	}
-	c.storeSignature(sig)
 }
 
 // signXRPLBurnTicketTransaction signs an XRPL AccountSet no-op transaction for the given burn ticket payload.
@@ -745,6 +803,7 @@ func (c *ManagerService) signXRPLBurnTicketTransaction(
 	v *vaa.VAA,
 	payload *vaa.XRPLBurnTicketPayload,
 	signer guardiansigner.GuardianSigner,
+	signerPubKey []byte,
 ) (*ManagerSignature, error) {
 	// Get the current manager set for XRPL (XBRN payload doesn't embed a manager set index)
 	managerSet, err := c.getCurrentManagerSet(c.ctx, vaa.ChainIDXRPL)
@@ -752,9 +811,10 @@ func (c *ManagerService) signXRPLBurnTicketTransaction(
 		return nil, fmt.Errorf("failed to get current manager set for XRPL: %w", err)
 	}
 
-	// Verify this node is part of the manager set
-	if !managerSet.IsSigner {
-		return nil, fmt.Errorf("this node is not part of the XRPL manager set")
+	// Verify this signer is part of the manager set
+	signerIndex, ok := managerSet.FindSignerByPubKey(signerPubKey)
+	if !ok {
+		return nil, fmt.Errorf("this signer is not part of the XRPL manager set")
 	}
 
 	// Build the XRPL AccountSet (burn) transaction
@@ -764,7 +824,6 @@ func (c *ManagerService) signXRPLBurnTicketTransaction(
 	}
 
 	// Derive this signer's XRPL address from compressed public key
-	signerPubKey := c.signerPubKeys[vaa.ChainIDXRPL]
 	signerAddress, err := xrpl.CompressedPubKeyToAddress(signerPubKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to derive signer XRPL address: %w", err)
@@ -793,7 +852,7 @@ func (c *ManagerService) signXRPLBurnTicketTransaction(
 		VAAID:            v.MessageID(),
 		DestinationChain: vaa.ChainIDXRPL,
 		ManagerSetIndex:  managerSet.Index,
-		SignerIndex:      managerSet.SignerIndex,
+		SignerIndex:      signerIndex,
 		InputSignatures:  [][]byte{derSig},
 	}, nil
 }
@@ -804,10 +863,11 @@ func (c *ManagerService) signUTXOTransaction(
 	v *vaa.VAA,
 	payload *vaa.UTXOUnlockPayload,
 	signer guardiansigner.GuardianSigner,
+	signerPubKey []byte,
 ) (*ManagerSignature, error) {
 	switch payload.DestinationChain {
 	case vaa.ChainIDDogecoin:
-		return c.signDogecoinTransaction(v, payload, signer)
+		return c.signDogecoinTransaction(v, payload, signer, signerPubKey)
 	default:
 		return nil, fmt.Errorf("unsupported UTXO destination chain: %s", payload.DestinationChain)
 	}
@@ -819,6 +879,7 @@ func (c *ManagerService) signDogecoinTransaction(
 	v *vaa.VAA,
 	payload *vaa.UTXOUnlockPayload,
 	signer guardiansigner.GuardianSigner,
+	signerPubKey []byte,
 ) (*ManagerSignature, error) {
 	// Look up the specific manager set by index from the payload (fetch dynamically if needed)
 	managerSet, err := c.getManagerSet(c.ctx, vaa.ChainIDDogecoin, payload.DelegatedManagerSetIndex)
@@ -826,9 +887,10 @@ func (c *ManagerService) signDogecoinTransaction(
 		return nil, fmt.Errorf("failed to get manager set for Dogecoin: %w", err)
 	}
 
-	// Verify this node is part of the manager set
-	if !managerSet.IsSigner {
-		return nil, fmt.Errorf("this node is not part of the Dogecoin manager set (index %d)", payload.DelegatedManagerSetIndex)
+	// Verify this signer is part of the manager set
+	signerIndex, ok := managerSet.FindSignerByPubKey(signerPubKey)
+	if !ok {
+		return nil, fmt.Errorf("this signer is not part of the Dogecoin manager set (index %d)", payload.DelegatedManagerSetIndex)
 	}
 
 	// Build redeem scripts for each input
@@ -893,7 +955,7 @@ func (c *ManagerService) signDogecoinTransaction(
 		VAAID:            v.MessageID(),
 		DestinationChain: payload.DestinationChain,
 		ManagerSetIndex:  payload.DelegatedManagerSetIndex,
-		SignerIndex:      uint8(managerSet.SignerIndex),
+		SignerIndex:      signerIndex,
 		InputSignatures:  inputSignatures,
 	}, nil
 }
@@ -941,6 +1003,7 @@ func (c *ManagerService) signXRPLTransaction(
 	v *vaa.VAA,
 	payload *vaa.XRPLReleasePayload,
 	signer guardiansigner.GuardianSigner,
+	signerPubKey []byte,
 ) (*ManagerSignature, error) {
 	// Get the current manager set for XRPL (XREL payload doesn't embed a manager set index)
 	managerSet, err := c.getCurrentManagerSet(c.ctx, vaa.ChainIDXRPL)
@@ -948,9 +1011,10 @@ func (c *ManagerService) signXRPLTransaction(
 		return nil, fmt.Errorf("failed to get current manager set for XRPL: %w", err)
 	}
 
-	// Verify this node is part of the manager set
-	if !managerSet.IsSigner {
-		return nil, fmt.Errorf("this node is not part of the XRPL manager set")
+	// Verify this signer is part of the manager set
+	signerIndex, ok := managerSet.FindSignerByPubKey(signerPubKey)
+	if !ok {
+		return nil, fmt.Errorf("this signer is not part of the XRPL manager set")
 	}
 
 	// Build the XRPL Payment transaction
@@ -960,7 +1024,6 @@ func (c *ManagerService) signXRPLTransaction(
 	}
 
 	// Derive this signer's XRPL address from compressed public key
-	signerPubKey := c.signerPubKeys[vaa.ChainIDXRPL]
 	signerAddress, err := xrpl.CompressedPubKeyToAddress(signerPubKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to derive signer XRPL address: %w", err)
@@ -989,7 +1052,7 @@ func (c *ManagerService) signXRPLTransaction(
 		VAAID:            v.MessageID(),
 		DestinationChain: vaa.ChainIDXRPL,
 		ManagerSetIndex:  managerSet.Index,
-		SignerIndex:      managerSet.SignerIndex,
+		SignerIndex:      signerIndex,
 		InputSignatures:  [][]byte{derSig},
 	}, nil
 }
@@ -1007,8 +1070,7 @@ func convertEthSigToXRPLDER(ethSig []byte) ([]byte, error) {
 // getCurrentManagerSet retrieves the current manager set for a chain by first looking up
 // the current index from the contract.
 func (c *ManagerService) getCurrentManagerSet(ctx context.Context, chainID vaa.ChainID) (*ManagerSetConfig, error) {
-	signer := c.signers[chainID]
-	return c.reader.GetCurrentManagerSet(ctx, chainID, signer)
+	return c.reader.GetCurrentManagerSet(ctx, chainID)
 }
 
 // compressPublicKey converts an ECDSA public key to compressed secp256k1 format (33 bytes).
@@ -1068,8 +1130,9 @@ func (c *ManagerService) GetPendingTransactionByID(vaaID string) *db.AggregatedT
 }
 
 // GetFeatureString returns the feature flag string for heartbeat messages.
-// Format: "manager:CHAIN_ID/COMPRESSED_PUBKEY_HEX" for single chain
-// or "manager:CHAIN_ID1/PUBKEY1|CHAIN_ID2/PUBKEY2" for multiple chains.
+// Format: "manager:CHAIN_ID/COMPRESSED_PUBKEY_HEX" for single chain/signer
+// or "manager:CHAIN_ID1/PUBKEY1|CHAIN_ID2/PUBKEY2" for multiple chains/signers.
+// When a chain has multiple signers, each is listed as a separate entry.
 func (c *ManagerService) GetFeatureString() string {
 	if len(c.signerPubKeys) == 0 {
 		return ""
@@ -1083,10 +1146,12 @@ func (c *ManagerService) GetFeatureString() string {
 	sort.Ints(chainIDs)
 
 	// Build the feature string with chain ID and public key
-	parts := make([]string, 0, len(chainIDs))
+	var parts []string
 	for _, id := range chainIDs {
-		pubKey := c.signerPubKeys[vaa.ChainID(id)] // #nosec G115 -- id was converted from ChainID (uint16) above
-		parts = append(parts, fmt.Sprintf("%d/%s", id, hex.EncodeToString(pubKey)))
+		pubKeys := c.signerPubKeys[vaa.ChainID(id)] // #nosec G115 -- id was converted from ChainID (uint16) above
+		for _, pubKey := range pubKeys {
+			parts = append(parts, fmt.Sprintf("%d/%s", id, hex.EncodeToString(pubKey)))
+		}
 	}
 
 	return "manager:" + strings.Join(parts, "|")

--- a/node/pkg/manager/manager_test.go
+++ b/node/pkg/manager/manager_test.go
@@ -97,12 +97,10 @@ func TestSignDogecoinTransaction_EmptyInputs(t *testing.T) {
 	}
 	reader.cache[vaa.ChainIDDogecoin] = map[uint32]*ManagerSetConfig{
 		0: {
-			Index:       0,
-			M:           2,
-			N:           3,
-			PublicKeys:  [][]byte{dummyPubKey, dummyPubKey, dummyPubKey},
-			IsSigner:    true,
-			SignerIndex: 0,
+			Index:      0,
+			M:          2,
+			N:          3,
+			PublicKeys: [][]byte{dummyPubKey, dummyPubKey, dummyPubKey},
 		},
 	}
 
@@ -111,8 +109,8 @@ func TestSignDogecoinTransaction_EmptyInputs(t *testing.T) {
 	svc := &ManagerService{
 		ctx:    ctx,
 		logger: logger,
-		signers: map[vaa.ChainID]guardiansigner.GuardianSigner{
-			vaa.ChainIDDogecoin: signer,
+		signers: map[vaa.ChainID][]guardiansigner.GuardianSigner{
+			vaa.ChainIDDogecoin: {signer},
 		},
 		reader: reader,
 	}
@@ -131,7 +129,7 @@ func TestSignDogecoinTransaction_EmptyInputs(t *testing.T) {
 		},
 	}
 
-	_, err := svc.signDogecoinTransaction(v, payload, signer)
+	_, err := svc.signDogecoinTransaction(v, payload, signer, dummyPubKey)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid redeemScripts length")
 }

--- a/node/pkg/manager/manager_test.go
+++ b/node/pkg/manager/manager_test.go
@@ -97,10 +97,11 @@ func TestSignDogecoinTransaction_EmptyInputs(t *testing.T) {
 	}
 	reader.cache[vaa.ChainIDDogecoin] = map[uint32]*ManagerSetConfig{
 		0: {
-			Index:      0,
-			M:          2,
-			N:          3,
-			PublicKeys: [][]byte{dummyPubKey, dummyPubKey, dummyPubKey},
+			Index:       0,
+			M:           2,
+			N:           3,
+			PublicKeys:  [][]byte{dummyPubKey, dummyPubKey, dummyPubKey},
+			pubKeyIndex: map[string]uint8{string(dummyPubKey): 0},
 		},
 	}
 

--- a/node/pkg/manager/reader.go
+++ b/node/pkg/manager/reader.go
@@ -1,13 +1,11 @@
 package manager
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"sync"
 
 	"github.com/certusone/wormhole/node/pkg/common"
-	"github.com/certusone/wormhole/node/pkg/guardiansigner"
 	"github.com/certusone/wormhole/node/pkg/manager/delegatedmanagersetabi"
 	ethCommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -57,12 +55,10 @@ func NewManagerSetReader(
 
 // GetManagerSet retrieves a manager set by chain ID and index.
 // It first checks the cache; on cache miss, it fetches from the contract and caches the result.
-// The signer parameter is used to determine if this node is part of the manager set.
 func (r *ManagerSetReader) GetManagerSet(
 	ctx context.Context,
 	chainID vaa.ChainID,
 	index uint32,
-	signer guardiansigner.GuardianSigner,
 ) (*ManagerSetConfig, error) {
 	// Check cache first
 	r.mu.RLock()
@@ -106,7 +102,7 @@ func (r *ManagerSetReader) GetManagerSet(
 	}
 
 	// Parse the manager set bytes
-	set, err := r.parseManagerSetBytes(ctx, data, index, signer)
+	set, err := r.parseManagerSetBytes(data, index)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse manager set bytes: %w", err)
 	}
@@ -124,7 +120,6 @@ func (r *ManagerSetReader) GetManagerSet(
 		zap.Uint32("index", index),
 		zap.Uint8("m", set.M),
 		zap.Uint8("n", set.N),
-		zap.Bool("is_signer", set.IsSigner),
 	)
 
 	return set, nil
@@ -136,7 +131,6 @@ func (r *ManagerSetReader) GetManagerSet(
 func (r *ManagerSetReader) GetCurrentManagerSet(
 	ctx context.Context,
 	chainID vaa.ChainID,
-	signer guardiansigner.GuardianSigner,
 ) (*ManagerSetConfig, error) {
 	// Create a fresh connection for this call
 	client, err := ethclient.DialContext(ctx, r.rpcURL)
@@ -165,16 +159,14 @@ func (r *ManagerSetReader) GetCurrentManagerSet(
 	)
 
 	// Reuse the existing GetManagerSet method (which handles caching)
-	return r.GetManagerSet(ctx, chainID, index, signer)
+	return r.GetManagerSet(ctx, chainID, index)
 }
 
 // parseManagerSetBytes parses the raw bytes from the contract into a ManagerSetConfig.
 // Format: Type (1 byte) | M (1 byte) | N (1 byte) | PublicKeys (N * 33 bytes)
 func (r *ManagerSetReader) parseManagerSetBytes(
-	ctx context.Context,
 	data []byte,
 	index uint32,
-	signer guardiansigner.GuardianSigner,
 ) (*ManagerSetConfig, error) {
 	var set vaa.Secp256k1MultisigManagerSet
 	if err := set.Deserialize(data); err != nil {
@@ -187,27 +179,10 @@ func (r *ManagerSetReader) parseManagerSetBytes(
 		pubKeys[i] = pk[:]
 	}
 
-	// Determine if this node is a signer
-	var isSigner bool
-	var signerIndex uint8
-	if signer != nil && ctx != nil {
-		signerPubKey := signer.PublicKey(ctx)
-		signerCompressed := compressPublicKey(&signerPubKey)
-		for i, pk := range pubKeys {
-			if bytes.Equal(signerCompressed, pk) {
-				isSigner = true
-				signerIndex = uint8(i) // #nosec G115 -- i < n which is uint8
-				break
-			}
-		}
-	}
-
 	return &ManagerSetConfig{
-		Index:       index,
-		M:           set.M,
-		N:           set.N,
-		PublicKeys:  pubKeys,
-		IsSigner:    isSigner,
-		SignerIndex: signerIndex,
+		Index:      index,
+		M:          set.M,
+		N:          set.N,
+		PublicKeys: pubKeys,
 	}, nil
 }

--- a/node/pkg/manager/reader.go
+++ b/node/pkg/manager/reader.go
@@ -173,16 +173,19 @@ func (r *ManagerSetReader) parseManagerSetBytes(
 		return nil, fmt.Errorf("failed to deserialize manager set: %w", err)
 	}
 
-	// Convert [33]byte arrays to []byte slices
+	// Convert [33]byte arrays to []byte slices and build a pubkey -> index map for O(1) lookups
 	pubKeys := make([][]byte, set.N)
-	for i, pk := range set.PublicKeys {
-		pubKeys[i] = pk[:]
+	pubKeyIndex := make(map[string]uint8, set.N)
+	for i := range set.N {
+		pubKeys[i] = set.PublicKeys[i][:]
+		pubKeyIndex[string(set.PublicKeys[i][:])] = i
 	}
 
 	return &ManagerSetConfig{
-		Index:      index,
-		M:          set.M,
-		N:          set.N,
-		PublicKeys: pubKeys,
+		Index:       index,
+		M:           set.M,
+		N:           set.N,
+		PublicKeys:  pubKeys,
+		pubKeyIndex: pubKeyIndex,
 	}, nil
 }

--- a/node/pkg/manager/reader_test.go
+++ b/node/pkg/manager/reader_test.go
@@ -20,7 +20,7 @@ func TestGetManagerSet_Dogecoin_Index1(t *testing.T) {
 	reader, err := NewManagerSetReader(logger, common.TestNet, rpcURL)
 	require.NoError(t, err)
 
-	set, err := reader.GetManagerSet(ctx, vaa.ChainIDDogecoin, 1, nil)
+	set, err := reader.GetManagerSet(ctx, vaa.ChainIDDogecoin, 1)
 	require.NoError(t, err)
 
 	// Verify basic properties
@@ -31,10 +31,9 @@ func TestGetManagerSet_Dogecoin_Index1(t *testing.T) {
 	for i, pk := range set.PublicKeys {
 		assert.Len(t, pk, 33, "expected compressed secp256k1 public key at index %d", i)
 	}
-	assert.False(t, set.IsSigner, "expected IsSigner=false when no signer provided")
 
 	// Verify caching works
-	set2, err := reader.GetManagerSet(ctx, vaa.ChainIDDogecoin, 1, nil)
+	set2, err := reader.GetManagerSet(ctx, vaa.ChainIDDogecoin, 1)
 	require.NoError(t, err)
 	assert.Equal(t, set, set2, "expected cached result")
 }

--- a/node/pkg/node/node.go
+++ b/node/pkg/node/node.go
@@ -115,7 +115,7 @@ type G struct {
 	publicrpcServer    *grpc.Server
 	alternatePublisher *altpub.AlternatePublisher
 	managerService     *manager.ManagerService
-	managerSigners     map[vaa.ChainID]guardiansigner.GuardianSigner
+	managerSigners     map[vaa.ChainID][]guardiansigner.GuardianSigner
 
 	// runnables
 	runnablesWithScissors map[string]supervisor.Runnable

--- a/node/pkg/node/options.go
+++ b/node/pkg/node/options.go
@@ -291,7 +291,7 @@ func GuardianOptionNotary(notaryEnabled bool) *GuardianOption {
 // The delegatedManagerSetRPC is the Ethereum RPC URL for fetching manager sets from the
 // DelegatedManagerSet contract.
 // Dependencies: db
-func GuardianOptionManagerService(managerServiceEnabled bool, signers map[vaa.ChainID]guardiansigner.GuardianSigner, delegatedManagerSetRPC string) *GuardianOption {
+func GuardianOptionManagerService(managerServiceEnabled bool, signers map[vaa.ChainID][]guardiansigner.GuardianSigner, delegatedManagerSetRPC string) *GuardianOption {
 	return &GuardianOption{
 		name:         "manager",
 		dependencies: []string{"db"},


### PR DESCRIPTION
This PR modifies the manager service to accept an array of signers. This is useful both for testnet testing of a 5/7 multisig under one guardian and for mainnet rotation of running a prior set's key alongside a new key.