### PR TITLE
sdk: Add function to convert on-chain times to Go timestamp

### DIFF
--- a/sdk/vaa/structs.go
+++ b/sdk/vaa/structs.go
@@ -189,6 +189,27 @@ func KnownChainIDFromNumber[N number](n N) (ChainID, error) {
 	return ChainIDUnset, fmt.Errorf("no known ChainID for input %d", n)
 }
 
+// TimeFromUnix converts an integer of any signed or unsigned type into a [time.Time], assuming the value
+// represents Unix seconds.
+// This function can be used to convert on-chain values that represent timestamps into Go's Time type.
+// For example, message publication events parsed from a Wormhole core contract might encode the timestamp in a uint64.
+// This function can parse that value into the wire-format value used by a VAA, returning an error if the on-chain value
+// does not represent a valid uint32 timestamp value.
+//
+// Returns an error if the value is negative or exceeds [math.MaxUint32], which
+// is the Wormhole protocol's on-wire timestamp precision. See also [VAA.serializeBody]
+func TimeFromUnix[N number](n N) (time.Time, error) {
+	if n < 0 {
+		return time.Time{}, fmt.Errorf("timestamp cannot be negative but got %d", n)
+	}
+	// Use intermediate uint64 to safely handle conversion and allow comparison with MaxUint32.
+	val := uint64(n)
+	if val > uint64(math.MaxUint32) {
+		return time.Time{}, fmt.Errorf("timestamp must be less than or equal to %d but got %d", math.MaxUint32, n)
+	}
+	return time.Unix(int64(n), 0), nil
+}
+
 // StringToKnownChainID converts from a string representation of a chain into a ChainID that is registered in the SDK.
 // The argument can be either a numeric string representation of a number or a known chain name such as "solana".
 // Inputs of unknown ChainIDs, including 0, will result in an error.

--- a/sdk/vaa/structs.go
+++ b/sdk/vaa/structs.go
@@ -203,6 +203,27 @@ func KnownChainIDFromNumber[N number](n N) (ChainID, error) {
 	return ChainIDUnset, fmt.Errorf("no known ChainID for input %d", n)
 }
 
+// TimeFromUnix converts an integer of any signed or unsigned type into a [time.Time], assuming the value
+// represents Unix seconds.
+// This function can be used to convert on-chain values that represent timestamps into Go's Time type.
+// For example, message publication events parsed from a Wormhole core contract might encode the timestamp in a uint64.
+// This function can parse that value into the wire-format value used by a VAA, returning an error if the on-chain value
+// does not represent a valid uint32 timestamp value.
+//
+// Returns an error if the value is negative or exceeds [math.MaxUint32], which
+// is the Wormhole protocol's on-wire timestamp precision. See also [VAA.serializeBody]
+func TimeFromUnix[N number](n N) (time.Time, error) {
+	if n < 0 {
+		return time.Time{}, fmt.Errorf("timestamp cannot be negative but got %d", n)
+	}
+	// Use intermediate uint64 to safely handle conversion and allow comparison with MaxUint32.
+	val := uint64(n)
+	if val > uint64(math.MaxUint32) {
+		return time.Time{}, fmt.Errorf("timestamp must be less than or equal to %d but got %d", math.MaxUint32, n)
+	}
+	return time.Unix(int64(n), 0), nil
+}
+
 // StringToKnownChainID converts from a string representation of a chain into a ChainID that is registered in the SDK.
 // The argument can be either a numeric string representation of a number or a known chain name such as "solana".
 // Inputs of unknown ChainIDs, including 0, will result in an error.

--- a/sdk/vaa/structs_test.go
+++ b/sdk/vaa/structs_test.go
@@ -15,6 +15,8 @@ import (
 	"testing"
 	"time"
 
+	stdmath "math"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -980,6 +982,61 @@ func TestChainIDFromNumber(t *testing.T) {
 				require.Error(t, err)
 				require.Equal(t, ChainIDUnset, got)
 			}
+		})
+	}
+}
+
+func TestTimeFromUnix(t *testing.T) {
+	type testCase[N number] struct {
+		name    string
+		input   N
+		wantErr bool
+		errMsg  string
+	}
+	// Use int64 to represent all error conditions (overflow, negative).
+	tests := []testCase[int64]{
+		{
+			name:    "valid",
+			input:   int64(1),
+			wantErr: false,
+		},
+		{
+			name:    "zero",
+			input:   int64(0),
+			wantErr: false,
+		},
+		{
+			name:    "max uint32",
+			input:   int64(stdmath.MaxUint32),
+			wantErr: false,
+		},
+		{
+			name:    "overflow",
+			input:   int64(stdmath.MaxUint32) + 1,
+			wantErr: true,
+			errMsg:  "timestamp must be less than or equal to",
+		},
+		{
+			name:    "negative",
+			input:   int64(-1),
+			wantErr: true,
+			errMsg:  "timestamp cannot be negative",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := TimeFromUnix(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errMsg != "" {
+					require.ErrorContains(t, err, tt.errMsg)
+				}
+				require.True(t, got.IsZero())
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.input, got.Unix())
 		})
 	}
 }

--- a/sdk/vaa/structs_test.go
+++ b/sdk/vaa/structs_test.go
@@ -10,12 +10,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	stdmath "math"
 	"math/big"
 	"reflect"
 	"testing"
 	"time"
-
-	stdmath "math"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
@@ -990,34 +989,40 @@ func TestTimeFromUnix(t *testing.T) {
 	type testCase[N number] struct {
 		name    string
 		input   N
+		want    time.Time
 		wantErr bool
 		errMsg  string
 	}
 	// Use int64 to represent all error conditions (overflow, negative).
 	tests := []testCase[int64]{
 		{
+			name:  "normal on-chain timestamp",
+			input: int64(1715790225),
+			want:  time.Date(2024, time.May, 15, 16, 23, 45, 0, time.UTC),
+		},
+		{
 			name:    "valid",
 			input:   int64(1),
 			wantErr: false,
 		},
 		{
-			name:    "zero",
-			input:   int64(0),
-			wantErr: false,
+			name:  "zero timestamp",
+			input: int64(0),
+			want:  time.Unix(0, 0).UTC(),
 		},
 		{
-			name:    "max uint32",
-			input:   int64(stdmath.MaxUint32),
-			wantErr: false,
+			name:  "uint32 max timestamp",
+			input: int64(stdmath.MaxUint32),
+			want:  time.Unix(int64(stdmath.MaxUint32), 0).UTC(),
 		},
 		{
-			name:    "overflow",
+			name:    "just over uint32 max timestamp",
 			input:   int64(stdmath.MaxUint32) + 1,
 			wantErr: true,
 			errMsg:  "timestamp must be less than or equal to",
 		},
 		{
-			name:    "negative",
+			name:    "negative timestamp",
 			input:   int64(-1),
 			wantErr: true,
 			errMsg:  "timestamp cannot be negative",
@@ -1037,6 +1042,9 @@ func TestTimeFromUnix(t *testing.T) {
 			}
 			require.NoError(t, err)
 			require.Equal(t, tt.input, got.Unix())
+			if !tt.want.IsZero() {
+				require.Equal(t, tt.want, got.UTC())
+			}
 		})
 	}
 }


### PR DESCRIPTION
Adds TimeFromUnix() to convert on-chain values to the VAA's wire format type.

We can use this function when building message publications. Currently, callers parse this value manually or else truncate the timestamp value by converting it to int64 (which also generates a gosec warning). We can replace this pattern with this function which should make the code a little easier to read and makes it so callers don't need to think much about handling the time value.

It can also allow us to remove the lint exceptions rather than continuing to cover them up. This also has the fringe benefit of making Wormhole safe past 2107...!