### PR TITLE
node: reorder struct fields to reduce GC pointer scan area

### DIFF
--- a/node/pkg/common/chainlock.go
+++ b/node/pkg/common/chainlock.go
@@ -162,6 +162,12 @@ func (v VerificationState) String() string {
 	}
 }
 
+// MessagePublication represents an observation of a message being published on Wormhole.
+// It is the result of a direct on-chain observation of a message being published on a supported chain,
+// or the result of a gossiped observation of a message being published on the p2p network.
+// MessagePublication is the precursor to a [vaa.VAA], containing the same data but before signature verification.
+// It also has several metadata fields that are not part of the VAA signing digest and therefore MUST NOT be relied upon
+// for consensus. However, metadata fields SHOULD be consistent across all guardians for a given message.
 type MessagePublication struct {
 	// TxID is the chain-native transaction identifier where the wormhole
 	// message was emitted. TxID is per-guardian metadata: it is NOT hashed
@@ -191,21 +197,22 @@ type MessagePublication struct {
 	// whose buckets reach quorum at different observation subsets can still
 	// pick different majorities; recovery for that case is the audit /
 	// missing_observations reobs flow rather than the delegate-quorum path.
-	TxID      []byte
-	Timestamp time.Time
-
-	Nonce            uint32
-	Sequence         uint64
-	ConsistencyLevel uint8
-	EmitterChain     vaa.ChainID
-	EmitterAddress   vaa.Address
+	TxID []byte
 	// NOTE: there is no upper bound on the size of the payload. Wormhole supports arbitrary payloads
 	// due to the variance in transaction and block sizes between chains. However, during deserialization,
 	// payload lengths are bounds-checked against [PayloadLenMax] to prevent makeslice panics from malformed input.
 	// Similarly, for delegated chains, the entire payload needs to be sent over p2p and thus payload lengths are
 	// bounds-checked against [DelegatedPayloadLenMax] to avoid exceeding the p2p message size limit.
-	Payload         []byte
-	IsReobservation bool
+	Payload   []byte
+	Timestamp time.Time
+
+	// Non-pointer fields sorted by size
+	EmitterAddress   vaa.Address
+	Sequence         uint64
+	Nonce            uint32
+	EmitterChain     vaa.ChainID
+	ConsistencyLevel uint8
+	IsReobservation  bool
 
 	// Unreliable indicates if this message can be reobserved. If a message is considered unreliable it cannot be
 	// reobserved.
@@ -639,8 +646,8 @@ func (m *MessagePublication) UnmarshalBinary(data []byte) error {
 func (msg *MessagePublication) MarshalJSON() ([]byte, error) {
 	type Alias MessagePublication
 	return json.Marshal(&struct {
-		Timestamp int64
 		*Alias
+		Timestamp int64
 	}{
 		Timestamp: msg.Timestamp.Unix(),
 		Alias:     (*Alias)(msg),
@@ -650,8 +657,8 @@ func (msg *MessagePublication) MarshalJSON() ([]byte, error) {
 func (msg *MessagePublication) UnmarshalJSON(data []byte) error {
 	type Alias MessagePublication
 	aux := &struct {
-		Timestamp int64
 		*Alias
+		Timestamp int64
 	}{
 		Alias: (*Alias)(msg),
 	}

--- a/node/pkg/processor/benchmark_test.go
+++ b/node/pkg/processor/benchmark_test.go
@@ -118,12 +118,12 @@ func BenchmarkProfileHandleObservation(b *testing.B) {
 }
 
 type ProcessorData struct {
-	gossipAttestationSendC chan []byte
-	gossipVaaSendC         chan []byte
-	emitterChain           vaa.ChainID
-	emitterAddress         vaa.Address
 	guardianSigners        []guardiansigner.GuardianSigner
 	guardianAddrs          [][]byte
+	gossipAttestationSendC chan []byte
+	gossipVaaSendC         chan []byte
+	emitterAddress         vaa.Address
+	emitterChain           vaa.ChainID
 }
 
 func (pd *ProcessorData) messageID(seqNum uint64) string {

--- a/node/pkg/processor/delegated_guardian_config.go
+++ b/node/pkg/processor/delegated_guardian_config.go
@@ -40,14 +40,14 @@ type DelegatedGuardianChainConfig struct {
 	// Guardian's public key hashes truncated by the ETH standard hashing mechanism (20 bytes).
 	Keys []common.Address
 
-	// quorum value for this set of keys
-	// NOTE: This must be a positive integer in practice and should be guaranteed via the EVM ABI bindings in the EVM watcher
-	quorum int
-
 	// A map from address to index. Testing showed that, on average, a map is almost three times faster than a sequential search of the key slice.
 	// Testing also showed that the map was twice as fast as using a sorted slice and `slices.BinarySearchFunc`. That being said, on a 4GHz CPU,
 	// the sequential search takes an average of 800 nanos and the map look up takes about 260 nanos. Is this worth doing?
 	keyMap map[common.Address]int
+
+	// quorum value for this set of keys
+	// NOTE: This must be a positive integer in practice and should be guaranteed via the EVM ABI bindings in the EVM watcher
+	quorum int
 }
 
 // Quorum returns the current quorum value.
@@ -135,9 +135,9 @@ func (dc *DelegatedGuardianChainConfig) KeyIndex(addr common.Address) (int, bool
 }
 
 type DelegatedGuardianConfig struct {
-	mu sync.RWMutex
 	// TODO: Make it private to limit mutability by callers
 	Chains map[vaa.ChainID]*DelegatedGuardianChainConfig
+	mu     sync.RWMutex
 }
 
 // NewDelegatedGuardianConfig returns a new DelegatedGuardianConfig.

--- a/node/pkg/processor/delegated_guardian_config_test.go
+++ b/node/pkg/processor/delegated_guardian_config_test.go
@@ -196,9 +196,9 @@ func TestSet(t *testing.T) {
 
 func TestReadChainConfig(t *testing.T) {
 	type test struct {
-		chain     vaa.ChainID
 		keys      []common.Address
 		threshold int
+		chain     vaa.ChainID
 		exists    bool
 	}
 

--- a/node/pkg/processor/observation_test.go
+++ b/node/pkg/processor/observation_test.go
@@ -68,10 +68,10 @@ func TestHandleInboundSignedVAAWithQuorum(t *testing.T) {
 	badPrivateKey1, _ := ecdsa.GenerateKey(crypto.S256(), rand.Reader)
 
 	tests := []struct {
-		label      string
 		keyOrder   []*ecdsa.PrivateKey
 		indexOrder []uint8
 		addrs      []ethcommon.Address
+		label      string
 		errString  string
 	}{
 		{label: "GuardianSetNoKeys", keyOrder: []*ecdsa.PrivateKey{}, indexOrder: []uint8{}, addrs: []ethcommon.Address{},

--- a/node/pkg/processor/processor.go
+++ b/node/pkg/processor/processor.go
@@ -59,27 +59,27 @@ type (
 		firstObserved time.Time
 		// A re-observation request shall not be sent before this time.
 		nextRetry time.Time
-		// Number of times we sent a re-observation request
-		retryCtr uint
-		// Copy of our observation.
-		ourObservation Observation
-		// Map of signatures seen by guardian. During guardian set updates, this may contain signatures belonging
-		// to either the old or new guardian set.
-		signatures map[ethcommon.Address][]byte
-		// Flag set after reaching quorum and submitting the VAA.
-		submitted bool
-		// Flag set by the cleanup service after the settlement timeout has expired and misses were counted.
-		settled bool
-		// Human-readable description of the VAA's source, used for metrics.
-		source string
-		// Our observation in case we need to resubmit it to the batch publisher.
-		ourObs *gossipv1.Observation
 		// Copy of the bytes we submitted (ourObservation, but signed and serialized). Used for retransmissions.
 		ourMsg []byte
 		// The hash of the transaction in which the observation was made.  Used for re-observation requests.
 		txHash []byte
+		// Human-readable description of the VAA's source, used for metrics.
+		source string
+		// Copy of our observation.
+		ourObservation Observation
+		// Our observation in case we need to resubmit it to the batch publisher.
+		ourObs *gossipv1.Observation
+		// Map of signatures seen by guardian. During guardian set updates, this may contain signatures belonging
+		// to either the old or new guardian set.
+		signatures map[ethcommon.Address][]byte
 		// Copy of the guardian set valid at observation/injection time.
 		gs *common.GuardianSet
+		// Number of times we sent a re-observation request
+		retryCtr uint
+		// Flag set after reaching quorum and submitting the VAA.
+		submitted bool
+		// Flag set by the cleanup service after the settlement timeout has expired and misses were counted.
+		settled bool
 	}
 
 	observationMap map[string]*state
@@ -97,13 +97,13 @@ type (
 		// Map of delegate observations sent by guardian.
 		observations map[ethcommon.Address]*gossipv1.DelegateObservation
 
-		// Flag set after reaching quorum and submitting the VAA.
-		submitted bool
-
 		// Copy of the delegated guardian config valid at first observation time.
 		// This ensures that during delegated guardian set updates, quorum is checked
 		// against the config that was active when the message was first observed
 		cfg *DelegatedGuardianChainConfig
+
+		// Flag set after reaching quorum and submitting the VAA.
+		submitted bool
 	}
 
 	delegateObservationMap map[string]*delegateState
@@ -130,6 +130,11 @@ type PythNetVaaEntry struct {
 }
 
 type Processor struct {
+	// guardiandSigner is the guardian node's signer
+	guardianSigner guardiansigner.GuardianSigner
+
+	networkID string
+
 	// msgC is a channel of observed emitted messages
 	msgC <-chan *common.MessagePublication
 
@@ -164,8 +169,8 @@ type Processor struct {
 	// signedInC is a channel of inbound signed VAA observations from p2p
 	signedInC <-chan *gossipv1.SignedVAAWithQuorum
 
-	// guardianSigner is the guardian node's signer
-	guardianSigner guardiansigner.GuardianSigner
+	// managerC is the channel used to send signed VAAs to the manager service (nil if manager service is disabled)
+	managerC chan<- *vaa.VAA
 
 	logger *zap.Logger
 
@@ -188,28 +193,27 @@ type Processor struct {
 	state *aggregationState
 	// delegateState is the current delegate observation view
 	delegateState *delegateAggregationState
-	// gk pk as eth address
-	ourAddr ethcommon.Address
-
-	governor       *governor.ChainGovernor
-	acct           *accountant.Accountant
-	acctReadC      <-chan *common.MessagePublication
-	notary         *guardianNotary.Notary
-	pythnetVaas    map[string]PythNetVaaEntry
-	gatewayRelayer *gwrelayer.GatewayRelayer
-	updateVAALock  sync.Mutex
-	updatedVAAs    map[string]*updateVaaEntry
-	networkID      string
 
 	// batchObsvPubC is the internal channel used to publish observations to the batch processor for publishing.
 	batchObsvPubC chan *gossipv1.Observation
 
+	acctReadC <-chan *common.MessagePublication
+
+	pythnetVaas   map[string]PythNetVaaEntry
+	updatedVAAs   map[string]*updateVaaEntry
+	updateVAALock sync.Mutex
+
+	governor       *governor.ChainGovernor
+	acct           *accountant.Accountant
+	notary         *guardianNotary.Notary
+	gatewayRelayer *gwrelayer.GatewayRelayer
+
+	// gk pk as eth address
+	ourAddr ethcommon.Address
+
 	// delegatedGuardiansEnabled gates the delegated guardians protocol. When false, the processor
 	// always uses canonical guardian behavior and ignores incoming delegate observations.
 	delegatedGuardiansEnabled bool
-
-	// managerC is the channel used to send signed VAAs to the manager service (nil if manager service is disabled)
-	managerC chan<- *vaa.VAA
 }
 
 // updateVaaEntry is used to queue up a VAA to be written to the database.


### PR DESCRIPTION
Used the fieldalignment linter to reduce the memory required for structs used in message publications. https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/fieldalignment

Basically it's possible to declare the fields of a struct in an optimized order in Go such that it reduces the memory requirements. The rough process is to place pointer-type fields first, then declare variables in descending order
of size. The `fieldalignment` struct has some false positives as it reports theoretical minimums, but using
it iteratively can result in smaller structs.

---

## Details:

Total per-message GC scan savings: 56 B (-25%)
Saved for every observed message — the two major per-message structs are the MessagePublication and its tracking state:
```
  struct                  | before  | after   | delta
  ------------------------|---------|---------|------
  MessagePublication (GC) |  112 B  |   72 B  | -40 B
  state             (GC)  |  168 B  |  152 B  | -16 B
  ------------------------|---------|---------|------
  combined per message    |  280 B  |  224 B  | -56 B
  ```
 
How (MessagePublication, 128 B total struct):
  Before: pointer fields spread across offsets [0..112]
          0:   TxID (24, ptr)    48: EmitterAddr (32)    88: Timestamp (24, ptr)
          24:  Payload (24, ptr)   80: Sequence (8)
          GC scanned 112 B despite only 72 B of actual pointer fields
  After:  pointer fields contiguous at top [0..72]
          0:  TxID (24, ptr)   24: Payload (24, ptr)   48: Timestamp (24, ptr)
          72: EmitterAddr (32) ... non-pointer fields follow
          GC scanned exactly 72 B = the 3 pointer fields
How (state, 168 B total struct):
  Pushed non-pointer retryCtr (uint, 8 B) below the last pointer field
  instead of sitting between pointer-containing fields.
Other savings in processor:
  Processor struct:          288 -> 280 B total   (-8)
  DelegatedGuardianConfig:   resolved
  delegateState:             resolved
  DelegatedGuardianChainConfig: 40 -> 32 ptr B   (-8)

## Test instructions:
 
 1. Write fieldalignment-only config:
 ```sh
  $ cat > /tmp/fa.yml <<'EOF'
  version: "2"
  linters:
    enable: [govet]
    settings:
      govet:
        enable: [fieldalignment]
  EOF
  ```
 
 2. On main:
 ```sh
  $ cd node && golangci-lint run --config=/tmp/fa.yml ./pkg/common/ ./pkg/processor/
 ```
 3. On this branch, same command — compare MessagePublication:  (112->72) and state (168->152) improvements.