### PR TITLE
node: Validate and sanitize RPC URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ sui.log.*
 sui/examples/wrapped_coin
 *.prof
 /coverage-check
+scripts/coverage-check/coverage-check
 # Only used for internal testing
 *.testnet.yaml
 coverage.txt

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -238,6 +238,10 @@ linters:
           - prealloc
         path: _test\.go
       - linters:
+          - gosec
+        path: _test\.go
+        text: 'G101'
+      - linters:
           - exhaustruct
         path: (?i).*mock.*
       - linters:

--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -1200,7 +1200,7 @@ func runNode(cmd *cobra.Command, args []string) {
 		}
 
 		// Connect to wormchain for the accountant.
-		logger.Info("Connecting to wormchain for accountant", zap.String("wormchainURL", *wormchainURL), zap.String("keyPath", keyPathName), zap.String("component", "gacct"))
+		logger.Info("Connecting to wormchain for accountant", zap.String("wormchainURL", common.SafeURLForLogging(*wormchainURL)), zap.String("keyPath", keyPathName), zap.String("component", "gacct"))
 		accountantWormchainConn, err = wormconn.NewConn(*wormchainURL, wormchainKey, wormchainId)
 		if err != nil {
 			logger.Fatal("failed to connect to wormchain for accountant", zap.Error(err), zap.String("component", "gacct"))
@@ -1236,7 +1236,7 @@ func runNode(cmd *cobra.Command, args []string) {
 		}
 
 		// Connect to wormchain for the NTT accountant.
-		logger.Info("Connecting to wormchain for NTT accountant", zap.String("wormchainURL", *wormchainURL), zap.String("keyPath", keyPathName), zap.String("component", "gacct"))
+		logger.Info("Connecting to wormchain for NTT accountant", zap.String("wormchainURL", common.SafeURLForLogging(*wormchainURL)), zap.String("keyPath", keyPathName), zap.String("component", "gacct"))
 		accountantNttWormchainConn, err = wormconn.NewConn(*wormchainURL, wormchainKey, wormchainId)
 		if err != nil {
 			logger.Fatal("failed to connect to wormchain for NTT accountant", zap.Error(err), zap.String("component", "gacct"))
@@ -1270,7 +1270,7 @@ func runNode(cmd *cobra.Command, args []string) {
 			logger.Fatal("failed to load private key", zap.Error(err), zap.String("component", "gwrelayer"))
 		}
 
-		logger.Info("Connecting to wormchain", zap.String("wormchainURL", *wormchainURL), zap.String("keyPath", wormchainKeyPathName), zap.String("component", "gwrelayer"))
+		logger.Info("Connecting to wormchain", zap.String("wormchainURL", common.SafeURLForLogging(*wormchainURL)), zap.String("keyPath", wormchainKeyPathName), zap.String("component", "gwrelayer"))
 		gatewayRelayerWormchainConn, err = wormconn.NewConn(*wormchainURL, wormchainKey, wormchainId)
 		if err != nil {
 			logger.Fatal("failed to connect to wormchain", zap.Error(err), zap.String("component", "gwrelayer"))

--- a/node/cmd/txverifier/evm.go
+++ b/node/cmd/txverifier/evm.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 
+	nodecommon "github.com/certusone/wormhole/node/pkg/common"
 	"github.com/certusone/wormhole/node/pkg/telemetry"
 	txverifier "github.com/certusone/wormhole/node/pkg/txverifier"
 	"github.com/certusone/wormhole/node/pkg/version"
@@ -117,7 +118,7 @@ func runTransferVerifierEvm(cmd *cobra.Command, args []string) {
 
 	logger.Info("Starting EVM transfer verifier")
 
-	logger.Debug("EVM rpc connection", zap.String("url", *evmRpc))
+	logger.Debug("EVM rpc connection", zap.String("url", nodecommon.SafeURLForLogging(*evmRpc)))
 	logger.Debug("EVM core contract", zap.String("address", *evmCoreContract))
 	logger.Debug("EVM token bridge contract", zap.String("address", *evmTokenBridgeContract))
 	logger.Debug("EVM wrapped native asset contract", zap.String("address", *wrappedNativeContract))

--- a/node/cmd/txverifier/sui.go
+++ b/node/cmd/txverifier/sui.go
@@ -124,14 +124,14 @@ func runTransferVerifierSui(cmd *cobra.Command, args []string) {
 	// Verify CLI parameters
 	if *suiRPC == "" || *suiCoreBridgePackageId == "" || *suiTokenBridgeEmitter == "" || *suiTokenBridgePackageId == "" {
 		logger.Fatal("One or more CLI parameters are empty",
-			zap.String("suiRPC", *suiRPC),
+			zap.String("suiRPC", common.SafeURLForLogging(*suiRPC)),
 			zap.String("suiCoreBridgePackageId", *suiCoreBridgePackageId),
 			zap.String("suiTokenBridgeEmitter", *suiTokenBridgeEmitter),
 			zap.String("suiTokenBridgePackageId", *suiTokenBridgePackageId))
 	}
 
 	logger.Info("Starting Sui transfer verifier")
-	logger.Debug("Sui rpc connection", zap.String("url", *suiRPC))
+	logger.Debug("Sui rpc connection", zap.String("url", common.SafeURLForLogging(*suiRPC)))
 	logger.Debug("Sui core bridge package ID", zap.String("packageId", *suiCoreBridgePackageId))
 	logger.Debug("Sui token bridge package ID", zap.String("packageId", *suiTokenBridgePackageId))
 	logger.Debug("Sui token bridge emitter", zap.String("address", *suiTokenBridgeEmitter))

--- a/node/pkg/accountant/watcher.go
+++ b/node/pkg/accountant/watcher.go
@@ -39,16 +39,16 @@ func (acct *Accountant) watcher(ctx context.Context, isNTT bool) error {
 	}
 	errC := make(chan error)
 
-	acct.logger.Info(fmt.Sprintf("acctwatch: creating %s watcher", tag), zap.String("url", acct.wsUrl), zap.String("contract", contract))
+	acct.logger.Info(fmt.Sprintf("acctwatch: creating %s watcher", tag), zap.String("url", common.SafeURLForLogging(acct.wsUrl)), zap.String("contract", contract))
 	tmConn, err := tmHttp.New(acct.wsUrl, "/websocket")
 	if err != nil {
 		connectionErrors.Inc()
-		return fmt.Errorf("failed to establish %s tendermint connection: %w", tag, err)
+		return fmt.Errorf("failed to establish %s tendermint connection: %s", tag, common.SafeErrorForLogging(err, acct.wsUrl))
 	}
 
 	if startErr := tmConn.Start(); startErr != nil {
 		connectionErrors.Inc()
-		return fmt.Errorf("failed to start %s tendermint connection: %w", tag, startErr)
+		return fmt.Errorf("failed to start %s tendermint connection: %s", tag, common.SafeErrorForLogging(startErr, acct.wsUrl))
 	}
 	defer func() {
 		if stopErr := tmConn.Stop(); stopErr != nil {

--- a/node/pkg/adminrpc/adminserver.go
+++ b/node/pkg/adminrpc/adminserver.go
@@ -1101,17 +1101,17 @@ func (s *nodePrivilegedService) fetchMissing(
 	defer cancel()
 
 	for _, node := range nodes {
-		req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf(
-			"%s/v1/signed_vaa/%d/%s/%d", node, chain, addr, seq), nil)
+		requestURL := fmt.Sprintf("%s/v1/signed_vaa/%d/%s/%d", node, chain, addr, seq)
+		req, err := http.NewRequestWithContext(ctx, "GET", requestURL, nil)
 		if err != nil {
-			return false, fmt.Errorf("failed to create request: %w", err)
+			return false, fmt.Errorf("failed to create request: %s", common.SafeErrorForLogging(err, requestURL))
 		}
 
 		// #nosec G704 -- Admin RPC: BackfillNodes from authorized admin request
 		resp, err := c.Do(req)
 		if err != nil {
 			s.logger.Warn("failed to fetch missing VAA",
-				zap.String("node", node),
+				zap.String("node", common.SafeURLForLogging(node)),
 				zap.String("chain", chain.String()),
 				zap.String("address", addr),
 				zap.Uint64("sequence", seq),
@@ -1674,8 +1674,9 @@ func (s *nodePrivilegedService) GetAndObserveMissingVAAs(ctx context.Context, re
 	// Create the actual request
 	httpRequest, err := http.NewRequestWithContext(ctx, http.MethodPost, url, jsonBodyReader)
 	if err != nil {
-		fmt.Printf("GetAndObserveMissingVAAs: could not create request: %s\n", err)
-		return nil, err
+		safeErr := common.SafeErrorForLogging(err, url)
+		fmt.Printf("GetAndObserveMissingVAAs: could not create request: %s\n", safeErr)
+		return nil, fmt.Errorf("could not create request: %s", safeErr)
 	}
 
 	httpRequest.Header.Set("Content-Type", "application/json")
@@ -1687,8 +1688,9 @@ func (s *nodePrivilegedService) GetAndObserveMissingVAAs(ctx context.Context, re
 	// #nosec G704 -- Admin RPC: URL from authorized admin request
 	results, err := client.Do(httpRequest)
 	if err != nil {
-		fmt.Printf("GetAndObserveMissingVAAs: error making http request: %s\n", err)
-		return nil, err
+		safeErr := common.SafeErrorForLogging(err, url)
+		fmt.Printf("GetAndObserveMissingVAAs: error making http request: %s\n", safeErr)
+		return nil, fmt.Errorf("error making http request: %s", safeErr)
 	}
 
 	defer results.Body.Close()

--- a/node/pkg/adminrpc/adminserver.go
+++ b/node/pkg/adminrpc/adminserver.go
@@ -1110,12 +1110,13 @@ func (s *nodePrivilegedService) fetchMissing(
 		// #nosec G704 -- Admin RPC: BackfillNodes from authorized admin request
 		resp, err := c.Do(req)
 		if err != nil {
+			safeErr := common.SafeErrorForLogging(err, requestURL)
 			s.logger.Warn("failed to fetch missing VAA",
 				zap.String("node", common.SafeURLForLogging(node)),
 				zap.String("chain", chain.String()),
 				zap.String("address", addr),
 				zap.Uint64("sequence", seq),
-				zap.Error(err),
+				zap.String("error", safeErr),
 			)
 			continue
 		}
@@ -1132,7 +1133,7 @@ func (s *nodePrivilegedService) fetchMissing(
 			if err := json.NewDecoder(resp.Body).Decode(&respBody); err != nil {
 				resp.Body.Close()
 				s.logger.Warn("failed to decode VAA response",
-					zap.String("node", node),
+					zap.String("node", common.SafeURLForLogging(node)),
 					zap.String("chain", chain.String()),
 					zap.String("address", addr),
 					zap.Uint64("sequence", seq),
@@ -1146,7 +1147,7 @@ func (s *nodePrivilegedService) fetchMissing(
 			if err != nil {
 				resp.Body.Close()
 				s.logger.Warn("failed to decode VAA body",
-					zap.String("node", node),
+					zap.String("node", common.SafeURLForLogging(node)),
 					zap.String("chain", chain.String()),
 					zap.String("address", addr),
 					zap.Uint64("sequence", seq),

--- a/node/pkg/altpub/alternate_pub.go
+++ b/node/pkg/altpub/alternate_pub.go
@@ -236,7 +236,7 @@ func NewAlternatePublisher(logger *zap.Logger, guardianAddr []byte, configs []st
 		}
 
 		if _, exists := labels[ep.label]; exists {
-			return nil, fmt.Errorf("duplicate label in --additionalPublishEndpoint '%s'", config)
+			return nil, fmt.Errorf("duplicate label in --additionalPublishEndpoint '%s'", sanitizeAdditionalPublishEndpointConfig(config))
 		}
 
 		labels[ep.label] = struct{}{}
@@ -264,23 +264,24 @@ func NewAlternatePublisher(logger *zap.Logger, guardianAddr []byte, configs []st
 
 // parseEndpoint parses an `--additionalPublishEndpoint` parameter into an Endpoint object. It returns an error if the string is invalid.
 func parseEndpoint(config string) (*Endpoint, error) {
+	safeConfig := sanitizeAdditionalPublishEndpointConfig(config)
 	fields := strings.Split(config, ";")
 	if len(fields) < 2 {
-		return nil, fmt.Errorf("not enough fields in --additionalPublishEndpoint '%s': should be at least 2, there are %d", config, len(fields))
+		return nil, fmt.Errorf("not enough fields in --additionalPublishEndpoint '%s': should be at least 2, there are %d", safeConfig, len(fields))
 	}
 
 	if len(fields) > 4 {
-		return nil, fmt.Errorf("too many fields in --additionalPublishEndpoint '%s': may not be more than 4, there are %d", config, len(fields))
+		return nil, fmt.Errorf("too many fields in --additionalPublishEndpoint '%s': may not be more than 4, there are %d", safeConfig, len(fields))
 	}
 
 	label := fields[0]
 	if len(label) == 0 {
-		return nil, fmt.Errorf("invalid label in --additionalPublishEndpoint '%s': may not be zero length", config)
+		return nil, fmt.Errorf("invalid label in --additionalPublishEndpoint '%s': may not be zero length", safeConfig)
 	}
 
 	baseUrl := fields[1]
 	if valid := common.ValidateURL(baseUrl, []string{"http", "https"}); !valid {
-		return nil, fmt.Errorf("invalid url in --additionalPublishEndpoint '%s': must be `http` or `https`", config)
+		return nil, fmt.Errorf("invalid url in --additionalPublishEndpoint '%s': must be `http` or `https`", safeConfig)
 	}
 
 	delay := time.Duration(0)
@@ -288,7 +289,7 @@ func parseEndpoint(config string) (*Endpoint, error) {
 		var err error
 		delay, err = time.ParseDuration(fields[2])
 		if err != nil {
-			return nil, fmt.Errorf("invalid delay duration in --additionalPublishEndpoint '%s', delay %s: %w", config, fields[2], err)
+			return nil, fmt.Errorf("invalid delay duration in --additionalPublishEndpoint '%s', delay %s: %w", safeConfig, fields[2], err)
 		}
 	}
 
@@ -304,7 +305,7 @@ func parseEndpoint(config string) (*Endpoint, error) {
 		for _, str := range chainIds {
 			chainId, err := vaa.StringToKnownChainID(str)
 			if err != nil {
-				return nil, fmt.Errorf("invalid chain ID --additionalPublishEndpoint '%s' ('%s'): %w", config, str, err)
+				return nil, fmt.Errorf("invalid chain ID --additionalPublishEndpoint '%s' ('%s'): %w", safeConfig, str, err)
 			}
 
 			enabledChainsMap[chainId] = struct{}{}
@@ -332,6 +333,16 @@ func parseEndpoint(config string) (*Endpoint, error) {
 	return ep, nil
 }
 
+func sanitizeAdditionalPublishEndpointConfig(config string) string {
+	fields := strings.Split(config, ";")
+	if len(fields) < 2 || fields[1] == "" {
+		return config
+	}
+
+	fields[1] = common.SafeURLForLogging(fields[1])
+	return strings.Join(fields, ";")
+}
+
 // GetFeatures returns the status string to be published in P2P heartbeats. For now, it just returns a static string
 // listing the enabled endpoints, but in the future, it might return the actual status of each endpoint or something.
 // NOTE: `node.getStaticFeatureFlags` assumes that this does not change after initialization.
@@ -353,7 +364,7 @@ func (ap *AlternatePublisher) Run(ctx context.Context) error {
 	ap.startHttpWorkers(ctx, client, errC)
 
 	for _, ep := range ap.endpoints {
-		ap.logger.Info("Enabling endpoint", zap.String("endpoint", ep.label), zap.String("url", ep.baseUrl), zap.Stringer("delay", ep.delay), zap.Stringer("enabledChains", ep.enabledChains))
+		ap.logger.Info("Enabling endpoint", zap.String("endpoint", ep.label), zap.String("url", common.SafeURLForLogging(ep.baseUrl)), zap.Stringer("delay", ep.delay), zap.Stringer("enabledChains", ep.enabledChains))
 		if ep.delay != 0 {
 			worker := &BatchWorker{ap, ep}
 			common.RunWithScissors(ctx, errC, fmt.Sprintf("alt_pub_batcher_%s", ep.label), worker.batchWorker)
@@ -464,7 +475,7 @@ func (ap *AlternatePublisher) httpPost(ctx context.Context, client *http.Client,
 	r, err := http.NewRequestWithContext(ctx, "POST", req.url, bytes.NewBuffer(bytes.Clone(req.data)))
 	if err != nil {
 		requestFailed.WithLabelValues(req.ep.label, "create_failed").Inc()
-		return fmt.Errorf("create failed: %w", err)
+		return fmt.Errorf("create failed: %s", common.SafeErrorForLogging(err, req.url))
 	}
 	r.Header.Add("Content-Type", "application/octet-stream")
 
@@ -477,7 +488,7 @@ func (ap *AlternatePublisher) httpPost(ctx context.Context, client *http.Client,
 		} else {
 			requestFailed.WithLabelValues(req.ep.label, "post_failed").Inc()
 		}
-		return fmt.Errorf("post failed: %w", err)
+		return fmt.Errorf("post failed: %s", common.SafeErrorForLogging(err, req.url))
 	}
 	stop := time.Now()
 	resp.Body.Close()

--- a/node/pkg/common/url_verification.go
+++ b/node/pkg/common/url_verification.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"errors"
 	"net"
 	"net/url"
 	"strings"
@@ -39,4 +40,71 @@ func ValidateURL(urlStr string, validSchemes []string) bool {
 		}
 	}
 	return false
+}
+
+// SafeURLForLogging returns only the host and port for a URL-like string.
+// It intentionally omits userinfo, path, query, and fragment because those may contain credentials.
+func SafeURLForLogging(urlStr string) string {
+	if urlStr == "" {
+		return ""
+	}
+
+	parsedURL, err := url.Parse(urlStr)
+	if err != nil || parsedURL.Host == "" {
+		// Schemeless host:port strings parse as scheme:opaque. Parse them again
+		// as network-path references so URL.Hostname can extract the host.
+		parsedURL, err = url.Parse("//" + urlStr)
+	}
+	if err != nil {
+		return "<invalid-url>"
+	}
+
+	if host := parsedURL.Host; host != "" {
+		return host
+	}
+
+	return "<invalid-url>"
+}
+
+// SafeErrorForLogging returns an error string with a raw URL replaced by its safe logging form.
+func SafeErrorForLogging(err error, urlStr string) string {
+	if err == nil {
+		return ""
+	}
+	if urlStr == "" {
+		return err.Error()
+	}
+
+	safeURL := SafeURLForLogging(urlStr)
+	errStr := err.Error()
+
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) && urlErr.URL != "" {
+		// url.Error carries the URL separately. Sanitize that exact value in the
+		// full error string so wrapped errors keep their additional context.
+		errStr = strings.ReplaceAll(errStr, urlErr.URL, SafeURLForLogging(urlErr.URL))
+	}
+
+	errStr = strings.ReplaceAll(errStr, urlStr, safeURL)
+
+	parsedURL, parseErr := url.Parse(urlStr)
+	if parseErr != nil {
+		return errStr
+	}
+
+	// Some libraries report URLs through url.URL.String(), which can escape or otherwise
+	// canonicalize the original string.
+	canonicalURL := parsedURL.String()
+	errStr = strings.ReplaceAll(errStr, canonicalURL, safeURL)
+
+	if parsedURL.User != nil {
+		if _, hasPassword := parsedURL.User.Password(); hasPassword {
+			// net/http redacts userinfo passwords as "***" in *url.Error while leaving
+			// path and query values intact, so the raw URL no longer matches exactly.
+			redactedURL := strings.Replace(canonicalURL, parsedURL.User.String()+"@", parsedURL.User.Username()+":***@", 1)
+			errStr = strings.ReplaceAll(errStr, redactedURL, safeURL)
+		}
+	}
+
+	return errStr
 }

--- a/node/pkg/common/url_verification_test.go
+++ b/node/pkg/common/url_verification_test.go
@@ -1,6 +1,8 @@
 package common
 
 import (
+	"fmt"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -37,4 +39,53 @@ func TestValidateURL(t *testing.T) {
 		result := ValidateURL(test.urlStr, test.validSchemes)
 		assert.Equal(t, test.expected, result)
 	}
+}
+
+func TestSafeURLForLogging(t *testing.T) {
+	tests := []struct {
+		name     string
+		urlStr   string
+		expected string
+	}{
+		{name: "https with credentials", urlStr: "https://user:pass@example.com/path?api_key=secret", expected: "example.com"},
+		{name: "websocket", urlStr: "wss://rpc.example.com/websocket", expected: "rpc.example.com"},
+		{name: "host port without scheme", urlStr: "example.com:8080/path?token=secret", expected: "example.com:8080"},
+		{name: "credentials without scheme", urlStr: "user:pass@example.com/path?api_key=secret", expected: "example.com"},
+		{name: "ipv6", urlStr: "http://[::1]:8545/path", expected: "[::1]:8545"},
+		{name: "ipv6 without scheme", urlStr: "[::1]:8545/path", expected: "[::1]:8545"},
+		{name: "empty", urlStr: "", expected: ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, SafeURLForLogging(test.urlStr))
+		})
+	}
+}
+
+func TestSafeErrorForLogging(t *testing.T) {
+	rawURL := "https://user:pass@example.com/path?api_key=secret"
+	err := assert.AnError
+	assert.Equal(t, err.Error(), SafeErrorForLogging(err, rawURL))
+
+	err = &urlErrorForTest{msg: "failed to dial " + rawURL}
+	assert.Equal(t, "failed to dial example.com", SafeErrorForLogging(err, rawURL))
+
+	err = &url.Error{Op: "Post", URL: "https://user:***@example.com/path?api_key=secret", Err: assert.AnError}
+	assert.Equal(t, "Post \"example.com\": assert.AnError general error for testing", SafeErrorForLogging(err, rawURL))
+
+	err = fmt.Errorf("post failed: %w", err)
+	assert.Equal(t, "post failed: Post \"example.com\": assert.AnError general error for testing", SafeErrorForLogging(err, rawURL))
+
+	rawURL = "https://user:pass@example.com/path with spaces?api_key=secret"
+	err = &urlErrorForTest{msg: "failed to dial https://user:pass@example.com/path%20with%20spaces?api_key=secret"}
+	assert.Equal(t, "failed to dial example.com", SafeErrorForLogging(err, rawURL))
+}
+
+type urlErrorForTest struct {
+	msg string
+}
+
+func (e *urlErrorForTest) Error() string {
+	return e.msg
 }

--- a/node/pkg/manager/reader.go
+++ b/node/pkg/manager/reader.go
@@ -40,7 +40,7 @@ func NewManagerSetReader(
 
 	logger.Info("initialized manager set reader",
 		zap.String("contract", contractAddr),
-		zap.String("rpc", rpcURL),
+		zap.String("rpc", common.SafeURLForLogging(rpcURL)),
 		zap.String("env", string(env)),
 	)
 
@@ -79,7 +79,7 @@ func (r *ManagerSetReader) GetManagerSet(
 	// Create a fresh connection for this call
 	client, err := ethclient.DialContext(ctx, r.rpcURL)
 	if err != nil {
-		return nil, fmt.Errorf("failed to connect to RPC %s: %w", r.rpcURL, err)
+		return nil, fmt.Errorf("failed to connect to RPC %s: %s", common.SafeURLForLogging(r.rpcURL), common.SafeErrorForLogging(err, r.rpcURL))
 	}
 	defer client.Close()
 
@@ -135,7 +135,7 @@ func (r *ManagerSetReader) GetCurrentManagerSet(
 	// Create a fresh connection for this call
 	client, err := ethclient.DialContext(ctx, r.rpcURL)
 	if err != nil {
-		return nil, fmt.Errorf("failed to connect to RPC %s: %w", r.rpcURL, err)
+		return nil, fmt.Errorf("failed to connect to RPC %s: %s", common.SafeURLForLogging(r.rpcURL), common.SafeErrorForLogging(err, r.rpcURL))
 	}
 	defer client.Close()
 

--- a/node/pkg/node/options.go
+++ b/node/pkg/node/options.go
@@ -549,6 +549,10 @@ func GuardianOptionWatchers(watcherConfigs []watchers.WatcherConfig, ibcWatcherC
 						MsgC:     chainMsgC[chainID],
 						ObsvReqC: chainObsvReqC[chainID],
 					})
+
+					watchers.RegisterRPCURL(chainID, ibcWatcherConfig.Websocket)
+					watchers.RegisterRPCURL(chainID, ibcWatcherConfig.Lcd)
+					watchers.RegisterRPCURL(chainID, ibcWatcherConfig.BlockHeightURL)
 				}
 
 				if len(chainConfig) > 0 {

--- a/node/pkg/processor/processor.go
+++ b/node/pkg/processor/processor.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"net"
 	"slices"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -25,6 +27,7 @@ import (
 	"github.com/certusone/wormhole/node/pkg/gwrelayer"
 	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
 	"github.com/certusone/wormhole/node/pkg/supervisor"
+	"github.com/certusone/wormhole/node/pkg/watchers"
 	"github.com/wormhole-foundation/wormhole/sdk/vaa"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -210,6 +213,9 @@ type Processor struct {
 
 	// managerC is the channel used to send signed VAAs to the manager service (nil if manager service is disabled)
 	managerC chan<- *vaa.VAA
+
+	// publicRpcLogged tracks which chains have already had a public RPC warning logged.
+	publicRpcLogged map[vaa.ChainID]struct{}
 }
 
 // updateVaaEntry is used to queue up a VAA to be written to the database.
@@ -284,6 +290,109 @@ var (
 // batchObsvPubChanSize specifies the size of the channel used to publish observation batches. Allow five seconds worth.
 const batchObsvPubChanSize = p2p.MaxObservationBatchSize * 5
 
+// publicRPCDenyList contains domains for known public RPC endpoints.
+// Guardians using these for watcher URLs are at risk of serving incorrect data,
+// which can lead to consensus issues when the guardian is part of the delegated guardian set.
+var publicRPCDenyList = map[string]struct{}{
+	"infura.io":       {},
+	"alchemy.com":     {},
+	"quiknode.pro":    {},
+	"ankr.com":        {},
+	"blastapi.io":     {},
+	"publicnode.com":  {},
+	"llamarpc.com":    {},
+	"1rpc.io":         {},
+	"nodereal.io":     {},
+	"bnbchain.org":    {},
+	"pocket.network":  {},
+	"monad.xyz":       {},
+	"monadinfra.com":  {},
+	"hyperliquid.xyz": {},
+	"t.conduit.xyz":   {},
+	"drpc.org":        {},
+	"tenderly.co":     {},
+	"stakely.io":      {},
+	"tatum.io":        {},
+}
+
+func publicRPCDomain(host string) (string, bool) {
+	host = strings.ToLower(strings.TrimSpace(host))
+	if hostWithoutPort, _, err := net.SplitHostPort(host); err == nil {
+		host = hostWithoutPort
+	}
+	host = strings.TrimSuffix(host, ".")
+	for domain := host; domain != ""; {
+		if _, exists := publicRPCDenyList[domain]; exists {
+			return domain, true
+		}
+
+		_, parentDomain, foundParentDomain := strings.Cut(domain, ".")
+		if !foundParentDomain {
+			return "", false
+		}
+		domain = parentDomain
+	}
+
+	return "", false
+}
+
+// checkPublicRpcEndpoints checks all chains in the DGS for public RPC URLs.
+// It logs an error once per chain per run if a public RPC endpoint is detected.
+// This is a safety measure: delegating guardians that use public RPC endpoints
+// risk producing incorrect VAAs, which can cause consensus failures.
+func (p *Processor) checkPublicRpcEndpoints() {
+	if !p.delegatedGuardiansEnabled {
+		return
+	}
+	if p.dgc == nil {
+		p.logger.Debug("public RPC endpoint check skipped: delegated guardian config is nil")
+		return
+	}
+
+	allChains := p.dgc.ReadAll()
+	if len(allChains) == 0 {
+		p.logger.Warn("public RPC endpoint check skipped: delegated guardian config has no chains")
+		return
+	}
+
+	for chainID, cfg := range allChains {
+		// Only check chains where this guardian is a delegated guardian
+		if _, ok := cfg.KeyIndex(p.ourAddr); !ok {
+			continue
+		}
+
+		// Skip if we've already logged for this chain.
+		if _, logged := p.publicRpcLogged[chainID]; logged {
+			continue
+		}
+
+		rpcURLs := watchers.RPCURLs(chainID)
+		if len(rpcURLs) == 0 {
+			continue
+		}
+
+		for _, rpcURL := range rpcURLs {
+			hostname := common.SafeURLForLogging(rpcURL)
+			if hostname == "<invalid-url>" {
+				continue
+			}
+
+			if domain, ok := publicRPCDomain(hostname); ok {
+				p.logger.Error("public RPC endpoint detected for delegated guardian chain",
+					zap.Stringer("chainID", chainID),
+					zap.String("rpcHost", hostname),
+					zap.String("matchedDomain", domain),
+				)
+				p.publicRpcLogged[chainID] = struct{}{}
+			}
+
+			if _, logged := p.publicRpcLogged[chainID]; logged {
+				break
+			}
+		}
+	}
+}
+
 func NewProcessor(
 	ctx context.Context,
 	db *guardianDB.Database,
@@ -345,6 +454,7 @@ func NewProcessor(
 		dgc:                       dgc,
 		delegatedGuardiansEnabled: delegatedGuardiansEnabled,
 		managerC:                  managerC,
+		publicRpcLogged:           make(map[vaa.ChainID]struct{}),
 	}
 }
 
@@ -509,6 +619,8 @@ func (p *Processor) Run(ctx context.Context) error {
 
 			if err := p.dgc.Set(chains); err != nil {
 				p.logger.Error("delegate guardian config update failed", zap.Error(err))
+			} else {
+				p.checkPublicRpcEndpoints()
 			}
 			dgConfig.mu.Unlock()
 		case k := <-p.msgC:

--- a/node/pkg/processor/public_rpc_test.go
+++ b/node/pkg/processor/public_rpc_test.go
@@ -1,0 +1,36 @@
+package processor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPublicRPCDomain(t *testing.T) {
+	tests := []struct {
+		name           string
+		host           string
+		expectedDomain string
+		expectedMatch  bool
+	}{
+		{name: "exact match", host: "publicnode.com", expectedDomain: "publicnode.com", expectedMatch: true},
+		{name: "exact match with port", host: "publicnode.com:443", expectedDomain: "publicnode.com", expectedMatch: true},
+		{name: "subdomain match", host: "rpc.monad.xyz", expectedDomain: "monad.xyz", expectedMatch: true},
+		{name: "subdomain match with port", host: "mainnet.infura.io:443", expectedDomain: "infura.io", expectedMatch: true},
+		{name: "nested subdomain match", host: "rpc-plume-mainnet-1.t.conduit.xyz", expectedDomain: "t.conduit.xyz", expectedMatch: true},
+		{name: "nested subdomain match with port", host: "rpc-plume-mainnet-1.t.conduit.xyz:443", expectedDomain: "t.conduit.xyz", expectedMatch: true},
+		{name: "case insensitive", host: "RPC.HYPERLIQUID.XYZ", expectedDomain: "hyperliquid.xyz", expectedMatch: true},
+		{name: "trailing dot", host: "polygon-mainnet.quiknode.pro.", expectedDomain: "quiknode.pro", expectedMatch: true},
+		{name: "trailing dot with port", host: "polygon-mainnet.quiknode.pro.:443", expectedDomain: "quiknode.pro", expectedMatch: true},
+		{name: "ipv6 with port", host: "[::1]:8545", expectedMatch: false},
+		{name: "no match", host: "guardian.example.com", expectedMatch: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			domain, ok := publicRPCDomain(test.host)
+			assert.Equal(t, test.expectedMatch, ok)
+			assert.Equal(t, test.expectedDomain, domain)
+		})
+	}
+}

--- a/node/pkg/suiclient/suigrpc.go
+++ b/node/pkg/suiclient/suigrpc.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 
 	pb "github.com/block-vision/sui-go-sdk/pb/sui/rpc/v2"
+	"github.com/certusone/wormhole/node/pkg/common"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"go.uber.org/zap"
@@ -366,7 +367,7 @@ func NewSuiGrpcClient(rpcURL string, logger *zap.Logger, extraOpts ...grpc.DialO
 	conn, err := grpc.NewClient(rpcURL, opts...)
 
 	if err != nil {
-		return nil, fmt.Errorf("sui gRPC client creation failed: %w", err)
+		return nil, fmt.Errorf("sui gRPC client creation failed: %s", common.SafeErrorForLogging(err, rpcURL))
 	}
 
 	grpcLedgerServiceClient := &GrpcLedgerServiceClient{

--- a/node/pkg/telemetry/loki.go
+++ b/node/pkg/telemetry/loki.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/blendle/zapdriver"
+	"github.com/certusone/wormhole/node/pkg/common"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"google.golang.org/api/option"
@@ -124,7 +125,7 @@ func NewLokiCloudLogger(ctx context.Context, logger *zap.Logger, url string, pro
 	serverURL := flagext.URLValue{}
 	err := serverURL.Set(url)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse Loki client url: %v", err)
+		return nil, fmt.Errorf("failed to parse Loki client url: %s", common.SafeErrorForLogging(err, url))
 	}
 
 	cfg := client.Config{

--- a/node/pkg/telemetry/prom_remote_write/scrape.go
+++ b/node/pkg/telemetry/prom_remote_write/scrape.go
@@ -3,8 +3,10 @@ package promremotew
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"net/http"
 
+	"github.com/certusone/wormhole/node/pkg/common"
 	"github.com/golang/snappy"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
@@ -59,8 +61,9 @@ func ScrapeAndSendLocalMetrics(ctx context.Context, info PromTelemetryInfo, logg
 	// requestURL := fmt.Sprintf("https://%s:%s@%s", info.PromRemoteUser, info.PromRemoteKey, info.PromRemoteURL)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, info.PromRemoteURL, bodyReader)
 	if err != nil {
-		logger.Error("Could not create request", zap.Error(err))
-		return err
+		safeErr := common.SafeErrorForLogging(err, info.PromRemoteURL)
+		logger.Error("Could not create request", zap.String("error", safeErr))
+		return fmt.Errorf("could not create request: %s", safeErr)
 	}
 	req.Header.Set("Content-Encoding", "snappy")
 	req.Header.Set("Content-Type", "application/x-protobuf")
@@ -70,8 +73,9 @@ func ScrapeAndSendLocalMetrics(ctx context.Context, info PromTelemetryInfo, logg
 	// #nosec G704 -- Prometheus remote write URL from configuration
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
-		logger.Error("Error creating http request", zap.Error(err))
-		return err
+		safeErr := common.SafeErrorForLogging(err, info.PromRemoteURL)
+		logger.Error("Error creating http request", zap.String("error", safeErr))
+		return fmt.Errorf("error creating http request: %s", safeErr)
 	}
 
 	defer res.Body.Close()

--- a/node/pkg/watchers/algorand/config.go
+++ b/node/pkg/watchers/algorand/config.go
@@ -37,5 +37,7 @@ func (wc *WatcherConfig) Create(
 	_ chan<- *common.GuardianSet,
 	_ common.Environment,
 ) (supervisor.Runnable, interfaces.Reobserver, error) {
+	watchers.RegisterRPCURL(wc.ChainID, wc.IndexerRPC)
+	watchers.RegisterRPCURL(wc.ChainID, wc.AlgodRPC)
 	return NewWatcher(wc.IndexerRPC, wc.IndexerToken, wc.AlgodRPC, wc.AlgodToken, wc.AppID, msgC, obsvReqC).Run, nil, nil
 }

--- a/node/pkg/watchers/algorand/watcher.go
+++ b/node/pkg/watchers/algorand/watcher.go
@@ -221,15 +221,13 @@ func (e *Watcher) Run(ctx context.Context) error {
 
 	logger.Info("Starting watcher",
 		zap.String("watcher_name", "algorand"),
-		zap.String("indexerRPC", e.indexerRPC),
-		zap.String("indexerToken", e.indexerToken),
-		zap.String("algodRPC", e.algodRPC),
-		zap.String("algodToken", e.algodToken),
+		zap.String("indexerURL", common.SafeURLForLogging(e.indexerRPC)),
+		zap.String("algodURL", common.SafeURLForLogging(e.algodRPC)),
 		zap.Uint64("appid", e.appid),
 	)
 
-	logger.Info("Algorand watcher connecting to indexer  ", zap.String("url", e.indexerRPC))
-	logger.Info("Algorand watcher connecting to RPC node ", zap.String("url", e.algodRPC))
+	logger.Info("Algorand watcher connecting to indexer  ", zap.String("indexerURL", common.SafeURLForLogging(e.indexerRPC)))
+	logger.Info("Algorand watcher connecting to RPC node ", zap.String("algodURL", common.SafeURLForLogging(e.algodRPC)))
 
 	timer := time.NewTicker(time.Second * 1)
 	defer timer.Stop()

--- a/node/pkg/watchers/algorand/watcher.go
+++ b/node/pkg/watchers/algorand/watcher.go
@@ -234,16 +234,18 @@ func (e *Watcher) Run(ctx context.Context) error {
 
 	indexerClient, err := indexer.MakeClient(e.indexerRPC, e.indexerToken)
 	if err != nil {
-		logger.Error("indexer make client", zap.Error(err))
+		safeErr := common.SafeErrorForLogging(err, e.indexerRPC)
+		logger.Error("indexer make client", zap.String("error", safeErr))
 		p2p.DefaultRegistry.AddErrorCount(vaa.ChainIDAlgorand, 1)
-		return err
+		return fmt.Errorf("indexer make client: %s", safeErr)
 	}
 
 	algodClient, err := algod.MakeClient(e.algodRPC, e.algodToken)
 	if err != nil {
-		logger.Error("algod client", zap.Error(err))
+		safeErr := common.SafeErrorForLogging(err, e.algodRPC)
+		logger.Error("algod client", zap.String("error", safeErr))
 		p2p.DefaultRegistry.AddErrorCount(vaa.ChainIDAlgorand, 1)
-		return err
+		return fmt.Errorf("algod client: %s", safeErr)
 	}
 
 	// Get the node version for troubleshooting
@@ -251,9 +253,10 @@ func (e *Watcher) Run(ctx context.Context) error {
 
 	status, err := algodClient.StatusAfterBlock(0).Do(ctx)
 	if err != nil {
-		logger.Error("StatusAfterBlock", zap.Error(err))
+		safeErr := common.SafeErrorForLogging(err, e.algodRPC)
+		logger.Error("StatusAfterBlock", zap.String("error", safeErr))
 		p2p.DefaultRegistry.AddErrorCount(vaa.ChainIDAlgorand, 1)
-		return err
+		return fmt.Errorf("StatusAfterBlock: %s", safeErr)
 	}
 
 	e.next_round = status.LastRound + 1
@@ -278,7 +281,7 @@ func (e *Watcher) Run(ctx context.Context) error {
 
 			result, err := indexerClient.SearchForTransactions().TXID(base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(r.TxHash)).Do(ctx)
 			if err != nil {
-				logger.Error("SearchForTransactions", zap.Error(err))
+				logger.Error("SearchForTransactions", zap.String("error", common.SafeErrorForLogging(err, e.indexerRPC)))
 				p2p.DefaultRegistry.AddErrorCount(vaa.ChainIDAlgorand, 1)
 				break
 			}
@@ -287,7 +290,7 @@ func (e *Watcher) Run(ctx context.Context) error {
 
 				block, err := algodClient.Block(r).Do(ctx)
 				if err != nil {
-					logger.Error("SearchForTransactions", zap.Error(err))
+					logger.Error("SearchForTransactions", zap.String("error", common.SafeErrorForLogging(err, e.algodRPC)))
 					p2p.DefaultRegistry.AddErrorCount(vaa.ChainIDAlgorand, 1)
 					break
 				}
@@ -300,7 +303,7 @@ func (e *Watcher) Run(ctx context.Context) error {
 		case <-timer.C:
 			status, err := algodClient.Status().Do(ctx)
 			if err != nil {
-				logger.Error(fmt.Sprintf("algodClient.Status: %s", err.Error()))
+				logger.Error(fmt.Sprintf("algodClient.Status: %s", common.SafeErrorForLogging(err, e.algodRPC)))
 				p2p.DefaultRegistry.AddErrorCount(vaa.ChainIDAlgorand, 1)
 				continue
 			}
@@ -309,7 +312,7 @@ func (e *Watcher) Run(ctx context.Context) error {
 				for {
 					block, err := algodClient.Block(e.next_round).Do(ctx)
 					if err != nil {
-						logger.Error(fmt.Sprintf("algodClient.Block %d: %s", e.next_round, err.Error()))
+						logger.Error(fmt.Sprintf("algodClient.Block %d: %s", e.next_round, common.SafeErrorForLogging(err, e.algodRPC)))
 						p2p.DefaultRegistry.AddErrorCount(vaa.ChainIDAlgorand, 1)
 						break
 					}
@@ -355,7 +358,7 @@ func (e *Watcher) logVersion(ctx context.Context, logger *zap.Logger, client *al
 	versionResult, err := versionRPC.Do(ctx)
 	if err != nil {
 		logger.Error("problem retrieving node version",
-			zap.Error(err),
+			zap.String("error", common.SafeErrorForLogging(err, e.algodRPC)),
 			zap.String("network", networkName),
 		)
 		return

--- a/node/pkg/watchers/aptos/config.go
+++ b/node/pkg/watchers/aptos/config.go
@@ -39,5 +39,6 @@ func (wc *WatcherConfig) Create(
 	if err != nil {
 		return nil, nil, err
 	}
+	watchers.RegisterRPCURL(wc.ChainID, wc.Rpc)
 	return w.Run, nil, nil
 }

--- a/node/pkg/watchers/aptos/watcher.go
+++ b/node/pkg/watchers/aptos/watcher.go
@@ -132,7 +132,7 @@ func (e *Watcher) Run(ctx context.Context) error {
 
 	logger.Info("Starting watcher",
 		zap.String("watcher_name", e.networkID),
-		zap.String("rpc", e.aptosRPC),
+		zap.String("rpcURL", common.SafeURLForLogging(e.aptosRPC)),
 		zap.String("account", e.aptosAccount),
 		zap.String("handle", e.aptosHandle),
 	)
@@ -146,9 +146,9 @@ func (e *Watcher) Run(ctx context.Context) error {
 	var aptosHealth = fmt.Sprintf(`%s/v1`, e.aptosRPC)
 
 	logger.Info("watcher connecting to RPC node ",
-		zap.String("url", e.aptosRPC),
-		zap.String("eventsQuery", eventsEndpoint),
-		zap.String("healthQuery", aptosHealth),
+		zap.String("rpcURL", common.SafeURLForLogging(e.aptosRPC)),
+		zap.String("eventsURL", common.SafeURLForLogging(eventsEndpoint)),
+		zap.String("healthURL", common.SafeURLForLogging(aptosHealth)),
 	)
 
 	// the events have sequence numbers associated with them in the aptos API
@@ -295,7 +295,7 @@ func (e *Watcher) retrievePayload(s string) ([]byte, error) {
 	//nolint:gosec // the URL is hard-coded to the Aptos RPC endpoint.
 	res, err := http.Get(s)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get payload: %s", common.SafeErrorForLogging(err, s))
 	}
 	defer res.Body.Close()
 	body, err := common.SafeRead(res.Body)

--- a/node/pkg/watchers/cosmwasm/config.go
+++ b/node/pkg/watchers/cosmwasm/config.go
@@ -35,5 +35,7 @@ func (wc *WatcherConfig) Create(
 	_ chan<- *common.GuardianSet,
 	env common.Environment,
 ) (supervisor.Runnable, interfaces.Reobserver, error) {
+	watchers.RegisterRPCURL(wc.ChainID, wc.Websocket)
+	watchers.RegisterRPCURL(wc.ChainID, wc.Lcd)
 	return NewWatcher(wc.Websocket, wc.Lcd, wc.Contract, msgC, obsvReqC, wc.ChainID, env).Run, nil, nil
 }

--- a/node/pkg/watchers/cosmwasm/watcher.go
+++ b/node/pkg/watchers/cosmwasm/watcher.go
@@ -153,20 +153,20 @@ func (e *Watcher) Run(ctx context.Context) error {
 
 	logger.Info("Starting watcher",
 		zap.String("watcher_name", "cosmwasm"),
-		zap.String("urlWS", e.urlWS),
-		zap.String("urlLCD", e.urlLCD),
+		zap.String("wsURL", common.SafeURLForLogging(e.urlWS)),
+		zap.String("lcdURL", common.SafeURLForLogging(e.urlLCD)),
 		zap.String("contract", e.contract),
 		zap.String("chainID", e.chainID.String()),
 	)
 
-	logger.Info("connecting to websocket", zap.String("network", e.networkName), zap.String("url", e.urlWS))
+	logger.Info("connecting to websocket", zap.String("network", e.networkName), zap.String("wsURL", common.SafeURLForLogging(e.urlWS)))
 
 	//nolint:bodyclose // The close is down below. The linter misses it.
 	c, _, err := websocket.Dial(ctx, e.urlWS, nil)
 	if err != nil {
 		p2p.DefaultRegistry.AddErrorCount(e.chainID, 1)
 		connectionErrors.WithLabelValues(e.networkName, "websocket_dial_error").Inc()
-		return fmt.Errorf("websocket dial failed: %w", err)
+		return fmt.Errorf("websocket dial failed: %s", common.SafeErrorForLogging(err, e.urlWS))
 	}
 	defer c.Close(websocket.StatusNormalClosure, "")
 

--- a/node/pkg/watchers/cosmwasm/watcher.go
+++ b/node/pkg/watchers/cosmwasm/watcher.go
@@ -213,9 +213,10 @@ func (e *Watcher) Run(ctx context.Context) error {
 			case <-t.C:
 				msm := time.Now()
 				// Query and report height and set currentSlotHeight
-				resp, err := client.Get(fmt.Sprintf("%s/%s", e.urlLCD, e.latestBlockURL)) //nolint:noctx // TODO FIXME we should propagate context with Deadline here.
+				requestURL := fmt.Sprintf("%s/%s", e.urlLCD, e.latestBlockURL)
+				resp, err := client.Get(requestURL) //nolint:noctx // TODO FIXME we should propagate context with Deadline here.
 				if err != nil {
-					logger.Error("query latest block response error", zap.String("network", e.networkName), zap.Error(err))
+					logger.Error("query latest block response error", zap.String("network", e.networkName), zap.String("error", common.SafeErrorForLogging(err, requestURL)))
 					continue
 				}
 				blocksBody, err := common.SafeRead(resp.Body)
@@ -269,9 +270,10 @@ func (e *Watcher) Run(ctx context.Context) error {
 				}
 
 				// Query for tx by hash
-				resp, err := client.Get(fmt.Sprintf("%s/cosmos/tx/v1beta1/txs/%s", e.urlLCD, tx)) //nolint:noctx // TODO FIXME we should propagate context with Deadline here.
+				requestURL := fmt.Sprintf("%s/cosmos/tx/v1beta1/txs/%s", e.urlLCD, tx)
+				resp, err := client.Get(requestURL) //nolint:noctx // TODO FIXME we should propagate context with Deadline here.
 				if err != nil {
-					logger.Error("query tx response error", zap.String("network", e.networkName), zap.Error(err))
+					logger.Error("query tx response error", zap.String("network", e.networkName), zap.String("error", common.SafeErrorForLogging(err, requestURL)))
 					continue
 				}
 				txBody, err := common.SafeRead(resp.Body)

--- a/node/pkg/watchers/evm/by_transaction.go
+++ b/node/pkg/watchers/evm/by_transaction.go
@@ -21,6 +21,22 @@ var (
 	LogMessagePublishedTopic = eth_common.HexToHash("0x6eb224fb001ed210e379b335e35efe88672a8ce935d981a6896b27ffdf52a3b2")
 )
 
+type connectorWithRPCURL interface {
+	RPCURL() string
+}
+
+func safeConnectorErrorForLogging(err error, ethConn any) string {
+	if err == nil {
+		return ""
+	}
+
+	if connector, ok := ethConn.(connectorWithRPCURL); ok {
+		return common.SafeErrorForLogging(err, connector.RPCURL())
+	}
+
+	return err.Error()
+}
+
 // isValidCoreBridgeMessagePublicationLog checks that a log entry was emitted by the expected contract,
 // has the expected LogMessagePublished event topic, and has not been removed
 // due to a chain reorganization. This is called from both the real-time
@@ -55,7 +71,7 @@ func MessageEventsForTransaction(
 	// API only returns transactions that have been included in a block. Nothing in the mempool
 	receipt, err := ethConn.TransactionReceipt(ctx, tx)
 	if receipt == nil || err != nil {
-		return nil, 0, nil, fmt.Errorf("failed to get transaction receipt: %w", err)
+		return nil, 0, nil, fmt.Errorf("failed to get transaction receipt: %s", safeConnectorErrorForLogging(err, ethConn))
 	}
 
 	// SECURITY
@@ -74,7 +90,7 @@ func MessageEventsForTransaction(
 	// Get block
 	blockTime, err := ethConn.TimeOfBlockByHash(ctx, receipt.BlockHash)
 	if err != nil {
-		return nil, 0, nil, fmt.Errorf("failed to get block time: %w", err)
+		return nil, 0, nil, fmt.Errorf("failed to get block time: %s", safeConnectorErrorForLogging(err, ethConn))
 	}
 
 	msgs := make([]*common.MessagePublication, 0, len(receipt.Logs))

--- a/node/pkg/watchers/evm/ccq_backfill.go
+++ b/node/pkg/watchers/evm/ccq_backfill.go
@@ -193,12 +193,12 @@ func ccqBackFillDetermineMaxBatchSize(ctx context.Context, logger *zap.Logger, c
 			}
 			prevSuccess = batchSize
 		} else {
-			logger.Info("batch query failed", zap.Int64("batchSize", batchSize), zap.Error(err))
+			logger.Info("batch query failed", zap.Int64("batchSize", batchSize), zap.String("error", safeConnectorErrorForLogging(err, conn)))
 			prevFailure = batchSize
 		}
 		batchSize = (prevFailure + prevSuccess) / 2
 		if batchSize == 0 {
-			return 0, nil, fmt.Errorf("failed to determine batch size: %w", err)
+			return 0, nil, fmt.Errorf("failed to determine batch size: %s", safeConnectorErrorForLogging(err, conn))
 		}
 
 		time.Sleep(delay) //nolint:forbidigo // TODO: This code should be refactored to not use time.Sleep
@@ -254,10 +254,10 @@ func (w *Watcher) ccqBackfillGetBlocks(ctx context.Context, initialBlockNum uint
 			zap.Uint64("initialBlockNum", initialBlockNum),
 			zap.Int64("numBlocks", numBlocks),
 			zap.Uint64("finalBlockNum", blockNum),
-			zap.Error(err),
+			zap.String("error", safeConnectorErrorForLogging(err, w.ethConn)),
 		)
 
-		return nil, err
+		return nil, fmt.Errorf("failed to get batch of blocks: %s", safeConnectorErrorForLogging(err, w.ethConn))
 	}
 
 	blocks := Blocks{}

--- a/node/pkg/watchers/evm/chain_config.go
+++ b/node/pkg/watchers/evm/chain_config.go
@@ -244,7 +244,7 @@ func QueryEvmChainID(ctx context.Context, url string) (uint64, error) {
 	var str string
 	err = c.CallContext(ctx, &str, "eth_chainId")
 	if err != nil {
-		return 0, fmt.Errorf("failed to read evm chain id: %w", err)
+		return 0, fmt.Errorf("failed to read evm chain id: %s", common.SafeErrorForLogging(err, url))
 	}
 
 	evmChainID, err := strconv.ParseUint(strings.TrimPrefix(str, "0x"), 16, 64)
@@ -274,7 +274,7 @@ func (w *Watcher) verifyEvmChainID(ctx context.Context, logger *zap.Logger, url 
 	var str string
 	err = c.CallContext(ctx, &str, "eth_chainId")
 	if err != nil {
-		return fmt.Errorf("failed to read evm chain id: %w", err)
+		return fmt.Errorf("failed to read evm chain id: %s", common.SafeErrorForLogging(err, url))
 	}
 
 	evmChainID, err := strconv.ParseUint(strings.TrimPrefix(str, "0x"), 16, 64)

--- a/node/pkg/watchers/evm/chain_config.go
+++ b/node/pkg/watchers/evm/chain_config.go
@@ -55,6 +55,10 @@ type (
 	EnvMap map[vaa.ChainID]EnvEntry
 )
 
+const (
+	EVMCallTimeout = 15 * time.Second
+)
+
 var (
 	ErrInvalidEnv = errors.New("invalid environment")
 	ErrNotFound   = errors.New("not found")
@@ -225,14 +229,14 @@ func GetChainConfigMap(env common.Environment) (EnvMap, error) {
 	return EnvMap{}, ErrInvalidEnv
 }
 
-// QueryEvmChainID queries the specified RPC for the EVM chain ID.
+// QueryEvmChainID queries the specified RPC for the EVM chain ID via the `eth_chainId` RPC endpoint.
 func QueryEvmChainID(ctx context.Context, url string) (uint64, error) {
 	timeout, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 
 	c, err := rpc.DialContext(timeout, url)
 	if err != nil {
-		return 0, fmt.Errorf("failed to connect to endpoint: %w", err)
+		return 0, fmt.Errorf("failed to connect to endpoint: %s", common.SafeErrorForLogging(err, url))
 	}
 	// The context only bounds the dial; the client must be closed explicitly.
 	defer c.Close()
@@ -258,12 +262,12 @@ func (w *Watcher) verifyEvmChainID(ctx context.Context, logger *zap.Logger, url 
 		return nil
 	}
 
-	timeout, cancel := context.WithTimeout(ctx, 15*time.Second)
+	timeout, cancel := context.WithTimeout(ctx, EVMCallTimeout)
 	defer cancel()
 
 	c, err := rpc.DialContext(timeout, url)
 	if err != nil {
-		return fmt.Errorf("failed to connect to endpoint: %w", err)
+		return fmt.Errorf("failed to connect to endpoint: %s", common.SafeErrorForLogging(err, url))
 	}
 	defer c.Close()
 
@@ -286,7 +290,7 @@ func (w *Watcher) verifyEvmChainID(ctx context.Context, logger *zap.Logger, url 
 	logger.Info("queried evm chain id", zap.Uint64("expected", expectedEvmChainID), zap.Uint64("actual", evmChainID))
 
 	if evmChainID != uint64(expectedEvmChainID) {
-		return fmt.Errorf("evm chain ID miss match, expected %d, received %d", expectedEvmChainID, evmChainID)
+		return fmt.Errorf("evm chain ID mismatch, expected %d, received %d", expectedEvmChainID, evmChainID)
 	}
 
 	return nil

--- a/node/pkg/watchers/evm/config.go
+++ b/node/pkg/watchers/evm/config.go
@@ -41,6 +41,7 @@ func (wc *WatcherConfig) Create(
 	setC chan<- *common.GuardianSet,
 	env common.Environment,
 ) (supervisor.Runnable, interfaces.Reobserver, error) {
+	watchers.RegisterRPCURL(wc.ChainID, wc.Rpc)
 
 	// only actually use the guardian set channel if wc.GuardianSetUpdateChain == true
 	var setWriteC chan<- *common.GuardianSet = nil

--- a/node/pkg/watchers/evm/connectors/batch_poller.go
+++ b/node/pkg/watchers/evm/connectors/batch_poller.go
@@ -62,6 +62,14 @@ func NewBatchPollConnector(_ context.Context, logger *zap.Logger, baseConnector 
 	return connector
 }
 
+func (b *BatchPollConnector) RPCURL() string {
+	if connector, ok := b.Connector.(rpcURLErrorSanitizer); ok {
+		return connector.RPCURL()
+	}
+
+	return ""
+}
+
 func (b *BatchPollConnector) SubscribeForBlocks(ctx context.Context, errC chan error, sink chan<- *NewBlock) (ethereum.Subscription, error) {
 	// Use the standard geth head sink to get latest blocks. We do this so that we will be notified of rollbacks. The following document
 	// indicates that the subscription will receive a replay of all blocks affected by a rollback. This is important for latest because the
@@ -76,8 +84,8 @@ func (b *BatchPollConnector) SubscribeForBlocks(ctx context.Context, errC chan e
 	// Get the initial blocks.
 	lastBlocks, err := b.getBlocks(ctx, b.logger)
 	if err != nil {
-		b.logger.Error("failed to get initial blocks", zap.Error(err))
-		return headerSubscription, fmt.Errorf("failed to get initial blocks: %w", err)
+		b.logger.Error("failed to get initial blocks", zap.String("error", safeConnectorErrorForLogging(err, b.Connector)))
+		return headerSubscription, fmt.Errorf("failed to get initial blocks: %s", safeConnectorErrorForLogging(err, b.Connector))
 	}
 
 	errCount := 0
@@ -104,9 +112,9 @@ func (b *BatchPollConnector) SubscribeForBlocks(ctx context.Context, errC chan e
 				lastBlocks, err = b.pollBlocks(ctx, sink, lastBlocks)
 				if err != nil {
 					errCount++
-					b.logger.Error("batch polling encountered an error", zap.Int("errCount", errCount), zap.Error(err))
+					b.logger.Error("batch polling encountered an error", zap.Int("errCount", errCount), zap.String("error", safeConnectorErrorForLogging(err, b.Connector)))
 					if errCount > 3 {
-						errC <- fmt.Errorf("polling encountered too many errors: %w", err) // Note on channel capacity: The watcher will exit anyway
+						errC <- fmt.Errorf("polling encountered too many errors: %s", safeConnectorErrorForLogging(err, b.Connector)) // Note on channel capacity: The watcher will exit anyway
 						return nil
 					}
 				} else if errCount != 0 {
@@ -251,7 +259,7 @@ func (b *BatchPollConnector) getBlocks(ctx context.Context, logger *zap.Logger) 
 
 	err := b.Connector.RawBatchCallContext(timeout, batch)
 	if err != nil {
-		logger.Error("failed to get blocks", zap.Error(err))
+		logger.Error("failed to get blocks", zap.String("error", safeConnectorErrorForLogging(err, b.Connector)))
 		return nil, err
 	}
 

--- a/node/pkg/watchers/evm/connectors/block_utils.go
+++ b/node/pkg/watchers/evm/connectors/block_utils.go
@@ -26,7 +26,7 @@ func GetBlock(ctx context.Context, conn Connector, str string, blockFinality Fin
 	var m BlockMarshaller
 	err := conn.RawCallContext(timeout, &m, "eth_getBlockByNumber", str, false)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get block for %s: %w", str, err)
+		return nil, fmt.Errorf("failed to get block for %s: %s", str, safeConnectorErrorForLogging(err, conn))
 	}
 	if m.Number == nil {
 		return nil, fmt.Errorf("failed to unmarshal block for %s: Number is nil", str)

--- a/node/pkg/watchers/evm/connectors/ethereum.go
+++ b/node/pkg/watchers/evm/connectors/ethereum.go
@@ -28,6 +28,7 @@ type EthereumBaseConnector struct {
 	logger      *zap.Logger
 	client      *ethClient.Client
 	rawClient   *ethRpc.Client
+	rawURL      string
 	filterer    *ethAbi.AbiFilterer
 	caller      *ethAbi.AbiCaller
 	dgCaller    *dgAbi.DelegatedguardiansCaller
@@ -69,6 +70,7 @@ func NewEthereumBaseConnector(ctx context.Context, networkName, rawUrl string, a
 		filterer:    filterer,
 		caller:      caller,
 		rawClient:   rawClient,
+		rawURL:      rawUrl,
 		dgCaller:    dgCaller,
 		dgAddress:   dgAddress,
 	}, nil
@@ -80,6 +82,10 @@ func (e *EthereumBaseConnector) NetworkName() string {
 
 func (e *EthereumBaseConnector) ContractAddress() ethCommon.Address {
 	return e.address
+}
+
+func (e *EthereumBaseConnector) RPCURL() string {
+	return e.rawURL
 }
 
 func (e *EthereumBaseConnector) GetCurrentGuardianSetIndex(ctx context.Context) (uint32, error) {

--- a/node/pkg/watchers/evm/connectors/instant_finality.go
+++ b/node/pkg/watchers/evm/connectors/instant_finality.go
@@ -26,6 +26,14 @@ func NewInstantFinalityConnector(baseConnector Connector, logger *zap.Logger) *I
 	return connector
 }
 
+func (c *InstantFinalityConnector) RPCURL() string {
+	if connector, ok := c.Connector.(rpcURLErrorSanitizer); ok {
+		return connector.RPCURL()
+	}
+
+	return ""
+}
+
 func (c *InstantFinalityConnector) SubscribeForBlocks(ctx context.Context, errC chan error, sink chan<- *NewBlock) (ethereum.Subscription, error) {
 	headSink := make(chan *ethTypes.Header, 2)
 	headerSubscription, err := c.Connector.Client().SubscribeNewHead(ctx, headSink)

--- a/node/pkg/watchers/evm/connectors/poller.go
+++ b/node/pkg/watchers/evm/connectors/poller.go
@@ -120,14 +120,14 @@ func (p *PollConnector) SubscribeForBlocks(ctx context.Context, errC chan error,
 				lastBlocks, err = p.pollBlocks(ctx, sink, lastBlocks)
 				if err != nil {
 					errCount++
-					p.logger.Error("poll connector encountered an error", zap.Int("errCount", errCount), zap.Error(err))
+					p.logger.Error("poll connector encountered an error", zap.Int("errCount", errCount), zap.String("error", safeConnectorErrorForLogging(err, p.Connector)))
 					if errCount > pollMaxErrors {
 						// Return the error rather than writing to errC directly: a
 						// blocking send could hang if the watcher is already shutting
 						// down and no longer reading errC, which would prevent the
 						// deferred signalUnsubscribed from running. RunWithScissors
 						// delivers the returned error to errC without blocking.
-						return fmt.Errorf("polling encountered too many errors: %w", err)
+						return fmt.Errorf("polling encountered too many errors: %s", safeConnectorErrorForLogging(err, p.Connector))
 					}
 				} else if errCount != 0 {
 					errCount = 0
@@ -178,13 +178,13 @@ func (p *PollConnector) watchLogMessagePublishedFrom(ctx context.Context, errC c
 				latest, err := GetBlockByFinality(ctx, p.Connector, Latest)
 				if err != nil {
 					errCount++
-					p.logger.Error("log poller failed to get latest block", zap.Int("errCount", errCount), zap.Error(err))
+					p.logger.Error("log poller failed to get latest block", zap.Int("errCount", errCount), zap.String("error", safeConnectorErrorForLogging(err, p.Connector)))
 					if errCount > pollMaxErrors {
 						// Return rather than send to errC directly: a blocking send could hang
 						// during watcher shutdown and strand the deferred signalUnsubscribed,
 						// re-introducing the Unsubscribe deadlock. RunWithScissors forwards
 						// the returned error to errC without blocking.
-						return fmt.Errorf("log polling encountered too many errors: %w", err)
+						return fmt.Errorf("log polling encountered too many errors: %s", safeConnectorErrorForLogging(err, p.Connector))
 					}
 					timer.Reset(p.Delay)
 					continue
@@ -214,13 +214,13 @@ func (p *PollConnector) watchLogMessagePublishedFrom(ctx context.Context, errC c
 					cancel()
 					if err != nil {
 						errCount++
-						p.logger.Error("log poller failed to get logs", zap.Int("errCount", errCount), zap.Error(err), zap.Uint64("fromBlock", fromBlock), zap.Uint64("toBlock", toBlock))
+						p.logger.Error("log poller failed to get logs", zap.Int("errCount", errCount), zap.String("error", safeConnectorErrorForLogging(err, p.Connector)), zap.Uint64("fromBlock", fromBlock), zap.Uint64("toBlock", toBlock))
 						if errCount > pollMaxErrors {
 							// Return rather than send to errC directly: a blocking send could hang
 							// during watcher shutdown and strand the deferred signalUnsubscribed,
 							// re-introducing the Unsubscribe deadlock. RunWithScissors forwards
 							// the returned error to errC without blocking.
-							return fmt.Errorf("log polling encountered too many errors: %w", err)
+							return fmt.Errorf("log polling encountered too many errors: %s", safeConnectorErrorForLogging(err, p.Connector))
 						}
 						timer.Reset(p.Delay)
 						continue
@@ -257,7 +257,7 @@ func (p *PollConnector) TimeOfBlockByHash(ctx context.Context, hash ethCommon.Ha
 	var m *BlockMarshaller
 	err := p.RawCallContext(ctx, &m, "eth_getBlockByHash", hash, false)
 	if err != nil {
-		return 0, fmt.Errorf("failed to get block by hash: %w", err)
+		return 0, fmt.Errorf("failed to get block by hash: %s", safeConnectorErrorForLogging(err, p.Connector))
 	}
 	// eth_getBlockByHash returns a JSON null result for an unknown block, which
 	// unmarshals into a nil pointer without an error. Mirror go-ethereum's

--- a/node/pkg/watchers/evm/connectors/url_sanitization.go
+++ b/node/pkg/watchers/evm/connectors/url_sanitization.go
@@ -1,0 +1,19 @@
+package connectors
+
+import nodeCommon "github.com/certusone/wormhole/node/pkg/common"
+
+type rpcURLErrorSanitizer interface {
+	RPCURL() string
+}
+
+func safeConnectorErrorForLogging(err error, connector Connector) string {
+	if err == nil {
+		return ""
+	}
+
+	if sanitizer, ok := connector.(rpcURLErrorSanitizer); ok {
+		return nodeCommon.SafeErrorForLogging(err, sanitizer.RPCURL())
+	}
+
+	return err.Error()
+}

--- a/node/pkg/watchers/evm/connectors/url_sanitization_test.go
+++ b/node/pkg/watchers/evm/connectors/url_sanitization_test.go
@@ -1,0 +1,31 @@
+package connectors
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type testRPCURLConnector struct {
+	*mockConnectorForPoller
+	rpcURL string
+}
+
+func (t *testRPCURLConnector) RPCURL() string {
+	return t.rpcURL
+}
+
+func TestSafeConnectorErrorForLogging(t *testing.T) {
+	rawURL := "https://user:pass@example.com/path?api_key=secret"
+	err := errors.New("request failed for " + rawURL)
+
+	assert.Equal(t, "", safeConnectorErrorForLogging(nil, &mockConnectorForPoller{}))
+	assert.Equal(t, err.Error(), safeConnectorErrorForLogging(err, &mockConnectorForPoller{}))
+
+	connector := &testRPCURLConnector{
+		mockConnectorForPoller: &mockConnectorForPoller{},
+		rpcURL:                 rawURL,
+	}
+	assert.Equal(t, "request failed for example.com", safeConnectorErrorForLogging(err, connector))
+}

--- a/node/pkg/watchers/evm/reobserve.go
+++ b/node/pkg/watchers/evm/reobserve.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/certusone/wormhole/node/pkg/common"
 	"github.com/certusone/wormhole/node/pkg/watchers/evm/connectors"
 	eth_common "github.com/ethereum/go-ethereum/common"
 	"github.com/wormhole-foundation/wormhole/sdk/vaa"
@@ -143,7 +144,7 @@ func (w *Watcher) handleReobservationRequest(ctx context.Context, chainId vaa.Ch
 
 // Reobserve is the interface for reobserving using a custom URL. It opens a connection to that URL and does the reobservation on it.
 func (w *Watcher) Reobserve(ctx context.Context, chainID vaa.ChainID, txID []byte, customEndpoint string) (uint32, error) {
-	w.logger.Info("received a request to reobserve using a custom endpoint", zap.Stringer("chainID", chainID), zap.Any("txID", txID), zap.String("url", customEndpoint))
+	w.logger.Info("received a request to reobserve using a custom endpoint", zap.Stringer("chainID", chainID), zap.Any("txID", txID), zap.String("customEndpointURL", common.SafeURLForLogging(customEndpoint)))
 
 	// Verify that this endpoint is for the correct chain.
 	if err := w.verifyEvmChainID(ctx, w.logger, customEndpoint); err != nil {
@@ -156,7 +157,8 @@ func (w *Watcher) Reobserve(ctx context.Context, chainID vaa.ChainID, txID []byt
 	// Connect to the node using the appropriate type of connector and the custom endpoint.
 	ethConn, _, _, err := w.createConnector(timeout, customEndpoint)
 	if err != nil {
-		return 0, fmt.Errorf(`failed to connect to endpoint "%v": %w`, customEndpoint, err)
+		connectErrMsg := common.SafeErrorForLogging(err, customEndpoint)
+		return 0, fmt.Errorf(`failed to connect to endpoint "%v": %s`, common.SafeURLForLogging(customEndpoint), connectErrMsg)
 	}
 	defer ethConn.Close()
 

--- a/node/pkg/watchers/evm/reobserve.go
+++ b/node/pkg/watchers/evm/reobserve.go
@@ -165,7 +165,7 @@ func (w *Watcher) Reobserve(ctx context.Context, chainID vaa.ChainID, txID []byt
 	// Get the current finalized and safe blocks.
 	_, finalized, safe, err := ethConn.GetLatest(timeout)
 	if err != nil {
-		return 0, fmt.Errorf(`failed to get latest blocks: %w`, err)
+		return 0, fmt.Errorf(`failed to get latest blocks: %s`, common.SafeErrorForLogging(err, customEndpoint))
 	}
 
 	// Finally, do the reobservation and return the number of messages observed.

--- a/node/pkg/watchers/evm/verify_chain_config/verify.go
+++ b/node/pkg/watchers/evm/verify_chain_config/verify.go
@@ -144,7 +144,7 @@ func verifyFinality(ctx context.Context, url string, finalized, safe bool) error
 
 	c, err := rpc.DialContext(timeout, url)
 	if err != nil {
-		return fmt.Errorf("failed to connect to endpoint: %w", err)
+		return fmt.Errorf("failed to connect to endpoint: %s", common.SafeErrorForLogging(err, url))
 	}
 
 	type Marshaller struct {
@@ -175,7 +175,7 @@ func verifyContractAddr(ctx context.Context, url string, contractAddr string) er
 
 	rawClient, err := ethRpc.DialContext(timeout, url)
 	if err != nil {
-		return fmt.Errorf("failed to connect: %w", err)
+		return fmt.Errorf("failed to connect: %s", common.SafeErrorForLogging(err, url))
 	}
 
 	client := ethClient.NewClient(rawClient)
@@ -199,7 +199,7 @@ func verifyCCLContractAddr(ctx context.Context, url string, contractAddr string)
 
 	rawClient, err := ethRpc.DialContext(timeout, url)
 	if err != nil {
-		return fmt.Errorf("failed to connect: %w", err)
+		return fmt.Errorf("failed to connect: %s", common.SafeErrorForLogging(err, url))
 	}
 
 	client := ethClient.NewClient(rawClient)

--- a/node/pkg/watchers/evm/verify_chain_config/verify.go
+++ b/node/pkg/watchers/evm/verify_chain_config/verify.go
@@ -187,7 +187,7 @@ func verifyContractAddr(ctx context.Context, url string, contractAddr string) er
 
 	_, err = caller.GetCurrentGuardianSetIndex(&ethBind.CallOpts{Context: timeout})
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to verify contract address: %s", common.SafeErrorForLogging(err, url))
 	}
 
 	return nil
@@ -206,7 +206,7 @@ func verifyCCLContractAddr(ctx context.Context, url string, contractAddr string)
 
 	_, err = evm.CCLReadContract(ctx, client, ethCommon.HexToAddress(contractAddr), ethCommon.Address{})
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to verify ccl contract address: %s", common.SafeErrorForLogging(err, url))
 	}
 
 	return nil

--- a/node/pkg/watchers/evm/watcher.go
+++ b/node/pkg/watchers/evm/watcher.go
@@ -266,7 +266,7 @@ func (w *Watcher) Run(parentCtx context.Context) error {
 
 	logger.Info("Starting watcher",
 		zap.String("watcher_name", "evm"),
-		zap.String("url", w.url),
+		zap.String("rpcURL", common.SafeURLForLogging(w.url)),
 		zap.String("contract", w.contract.String()),
 		zap.String("networkName", w.networkName),
 		zap.String("chainID", w.chainID.String()),
@@ -299,7 +299,7 @@ func (w *Watcher) Run(parentCtx context.Context) error {
 		if err != nil {
 			ethConnectionErrors.WithLabelValues(w.networkName, "dial_error").Inc()
 			p2p.DefaultRegistry.AddErrorCount(w.chainID, 1)
-			return fmt.Errorf(`failed to create connection to url "%s": %w`, w.url, err)
+			return fmt.Errorf(`failed to create connection to url "%s": %s`, common.SafeURLForLogging(w.url), common.SafeErrorForLogging(err, w.url))
 		}
 
 		// Close this Run's connector on return so its goroutines exit.
@@ -347,7 +347,7 @@ func (w *Watcher) Run(parentCtx context.Context) error {
 			}
 			logger.Info("initialized Transfer Verifier",
 				zap.String("watcher_name", "evm"),
-				zap.String("url", w.url),
+				zap.String("rpcURL", common.SafeURLForLogging(w.url)),
 				zap.String("contract", w.contract.String()),
 			)
 		}
@@ -699,7 +699,7 @@ func (w *Watcher) getFinality(ctx context.Context) (bool, bool, error) {
 
 		c, err := rpc.DialContext(timeout, w.url)
 		if err != nil {
-			return false, false, fmt.Errorf("failed to connect to endpoint: %w", err)
+			return false, false, fmt.Errorf("failed to connect to endpoint: %s", common.SafeErrorForLogging(err, w.url))
 		}
 		// The context only bounds the dial; the client must be closed explicitly.
 		defer c.Close()
@@ -1254,7 +1254,7 @@ func (w *Watcher) createConnector(ctx context.Context, url string) (ethConn conn
 
 	baseConnector, err := connectors.NewEthereumBaseConnector(ctx, w.networkName, url, w.contract, w.dgContractAddr, w.logger)
 	if err != nil {
-		err = fmt.Errorf("dialing eth client failed: %w", err)
+		err = fmt.Errorf("dialing eth client failed: %s", common.SafeErrorForLogging(err, url))
 		return
 	}
 

--- a/node/pkg/watchers/ibc/watcher.go
+++ b/node/pkg/watchers/ibc/watcher.go
@@ -212,9 +212,9 @@ func (w *Watcher) Run(ctx context.Context) error {
 
 	w.logger.Info("Starting watcher",
 		zap.String("watcher_name", "ibc"),
-		zap.String("wsUrl", w.wsUrl),
-		zap.String("lcdUrl", w.lcdUrl),
-		zap.String("blockHeightUrl", w.blockHeightUrl),
+		zap.String("wsURL", common.SafeURLForLogging(w.wsUrl)),
+		zap.String("lcdURL", common.SafeURLForLogging(w.lcdUrl)),
+		zap.String("blockHeightURL", common.SafeURLForLogging(w.blockHeightUrl)),
 		zap.String("contractAddress", w.contractAddress),
 	)
 
@@ -227,9 +227,9 @@ func (w *Watcher) Run(ctx context.Context) error {
 	blockHeightUrl = blockHeightUrl + "/abci_info"
 
 	w.logger.Info("creating watcher",
-		zap.String("wsUrl", w.wsUrl),
-		zap.String("lcdUrl", w.lcdUrl),
-		zap.String("blockHeightUrl", blockHeightUrl),
+		zap.String("wsURL", common.SafeURLForLogging(w.wsUrl)),
+		zap.String("lcdURL", common.SafeURLForLogging(w.lcdUrl)),
+		zap.String("blockHeightURL", common.SafeURLForLogging(blockHeightUrl)),
 		zap.String("contract", w.contractAddress),
 		zap.String("features", GetFeatures()),
 	)
@@ -243,7 +243,7 @@ func (w *Watcher) Run(ctx context.Context) error {
 	c, _, err := websocket.Dial(ctx, w.wsUrl, nil)
 	if err != nil {
 		ibcErrors.WithLabelValues("websocket_dial_error").Inc()
-		return fmt.Errorf("failed to establish tendermint websocket connection: %w", err)
+		return fmt.Errorf("failed to establish tendermint websocket connection: %s", common.SafeErrorForLogging(err, w.wsUrl))
 	}
 	defer c.Close(websocket.StatusNormalClosure, "")
 

--- a/node/pkg/watchers/ibc/watcher.go
+++ b/node/pkg/watchers/ibc/watcher.go
@@ -587,7 +587,10 @@ func parseIbcReceivePublishEvent(logger *zap.Logger, desiredContract string, eve
 	if err != nil {
 		return evt, err
 	}
-	evt.Msg.Timestamp = time.Unix(snumber, 0)
+	evt.Msg.Timestamp, err = vaa.TimeFromUnix(snumber)
+	if err != nil {
+		return evt, err
+	}
 
 	str, err = attributes.GetAsString("message.message")
 	if err != nil {

--- a/node/pkg/watchers/ibc/watcher.go
+++ b/node/pkg/watchers/ibc/watcher.go
@@ -388,7 +388,7 @@ func (w *Watcher) handleQueryBlockHeight(ctx context.Context, queryUrl string) e
 		case <-t.C:
 			resp, err := client.Get(queryUrl) //nolint:noctx // TODO FIXME we should propagate context with Deadline here.
 			if err != nil {
-				return fmt.Errorf("failed to query latest block: %w", err)
+				return fmt.Errorf("failed to query latest block: %s", common.SafeErrorForLogging(err, queryUrl))
 			}
 			body, err := common.SafeRead(resp.Body)
 			resp.Body.Close()
@@ -453,9 +453,10 @@ func (w *Watcher) handleObservationRequests(ctx context.Context, ce *chainEntry)
 			}
 
 			// Query for tx by hash.
-			resp, err := client.Get(fmt.Sprintf("%s/cosmos/tx/v1beta1/txs/%s", w.lcdUrl, reqTxHashStr)) //nolint:noctx // TODO FIXME we should propagate context with Deadline here.
+			requestURL := fmt.Sprintf("%s/cosmos/tx/v1beta1/txs/%s", w.lcdUrl, reqTxHashStr)
+			resp, err := client.Get(requestURL) //nolint:noctx // TODO FIXME we should propagate context with Deadline here.
 			if err != nil {
-				w.logger.Error("query tx response error", zap.String("chain", ce.chainName), zap.Error(err))
+				w.logger.Error("query tx response error", zap.String("chain", ce.chainName), zap.String("error", common.SafeErrorForLogging(err, requestURL)))
 				continue
 			}
 			txBody, err := common.SafeRead(resp.Body)
@@ -764,7 +765,7 @@ func (w *Watcher) queryChannelIdToChainIdMapping() (map[string]vaa.ChainID, erro
 	query := fmt.Sprintf(`%s/cosmwasm/wasm/v1/contract/%s/smart/%s`, w.lcdUrl, w.contractAddress, allChannelChainsQuery)
 	resp, err := client.Get(query) //nolint:noctx // TODO FIXME we should propagate context with Deadline here.
 	if err != nil {
-		return nil, fmt.Errorf("query failed: %w", err)
+		return nil, fmt.Errorf("query failed: %s", common.SafeErrorForLogging(err, query))
 	}
 	body, err := common.SafeRead(resp.Body)
 	if err != nil {

--- a/node/pkg/watchers/near/config.go
+++ b/node/pkg/watchers/near/config.go
@@ -34,6 +34,7 @@ func (wc *WatcherConfig) Create(
 	_ chan<- *common.GuardianSet,
 	env common.Environment,
 ) (supervisor.Runnable, interfaces.Reobserver, error) {
+	watchers.RegisterRPCURL(wc.ChainID, wc.Rpc)
 	var mainnet = (env == common.MainNet)
 	return NewWatcher(wc.Rpc, wc.Contract, msgC, obsvReqC, mainnet).Run, nil, nil
 }

--- a/node/pkg/watchers/near/watcher.go
+++ b/node/pkg/watchers/near/watcher.go
@@ -280,7 +280,7 @@ func (e *Watcher) Run(ctx context.Context) error {
 		zap.String("watcher_name", "near"),
 		zap.Bool("mainnet", e.mainnet),
 		zap.String("wormholeAccount", e.wormholeAccount),
-		zap.String("nearRPC", e.nearRPC),
+		zap.String("rpcURL", common.SafeURLForLogging(e.nearRPC)),
 	)
 
 	e.errC = make(chan error)
@@ -295,7 +295,7 @@ func (e *Watcher) Run(ctx context.Context) error {
 	// Get the node version for troubleshooting
 	e.logVersion(ctx, logger)
 
-	logger.Info("Near watcher connecting to RPC node ", zap.String("url", e.nearRPC))
+	logger.Info("Near watcher connecting to RPC node ", zap.String("rpcURL", common.SafeURLForLogging(e.nearRPC)))
 
 	// start metrics reporter
 	common.RunWithScissors(ctx, e.errC, "metrics", e.runMetrics)

--- a/node/pkg/watchers/solana/ccq.go
+++ b/node/pkg/watchers/solana/ccq.go
@@ -12,6 +12,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/certusone/wormhole/node/pkg/common"
 	"github.com/certusone/wormhole/node/pkg/query"
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/rpc"
@@ -139,7 +140,7 @@ func (w *SolanaWatcher) ccqBaseHandleSolanaAccountQueryRequest(
 			zap.String("requestId", requestId),
 			zap.Any("accounts", accounts),
 			zap.Any("params", params),
-			zap.Error(err),
+			zap.String("error", common.SafeErrorForLogging(err, w.rpcUrl)),
 		)
 
 		w.ccqSendErrorResponse(queryRequest, query.QueryRetryNeeded)
@@ -165,7 +166,7 @@ func (w *SolanaWatcher) ccqBaseHandleSolanaAccountQueryRequest(
 			w.ccqLogger.Error(fmt.Sprintf("failed to read block time for %s query request", tag),
 				zap.String("requestId", requestId),
 				zap.Uint64("slotNumber", info.Context.Slot),
-				zap.Error(err),
+				zap.String("error", common.SafeErrorForLogging(err, w.rpcUrl)),
 			)
 
 			w.ccqSendErrorResponse(queryRequest, query.QueryRetryNeeded)
@@ -177,7 +178,7 @@ func (w *SolanaWatcher) ccqBaseHandleSolanaAccountQueryRequest(
 			w.ccqLogger.Error(fmt.Sprintf("repeatedly failed to read block time for %s query request, giving up", tag),
 				zap.String("requestId", requestId),
 				zap.Uint64("slotNumber", info.Context.Slot),
-				zap.Error(err),
+				zap.String("error", common.SafeErrorForLogging(err, w.rpcUrl)),
 			)
 
 			w.ccqSendErrorResponse(queryRequest, query.QueryRetryNeeded)

--- a/node/pkg/watchers/solana/client.go
+++ b/node/pkg/watchers/solana/client.go
@@ -363,14 +363,14 @@ func NewSolanaWatcher(
 }
 
 func (s *SolanaWatcher) setupSubscription(ctx context.Context, logger *zap.Logger) (*websocket.Conn, error) {
-	logger.Info(fmt.Sprintf("%s watcher connecting to WS node ", s.chainID.String()), zap.String("url", s.wsUrl))
+	logger.Info(fmt.Sprintf("%s watcher connecting to WS node ", s.chainID.String()), zap.String("wsURL", common.SafeURLForLogging(s.wsUrl)))
 
 	ws, resp, err := websocket.Dial(ctx, s.wsUrl, nil)
 	if resp != nil && resp.Body != nil {
 		resp.Body.Close()
 	}
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to establish websocket connection: %s", common.SafeErrorForLogging(err, s.wsUrl))
 	}
 
 	s.subId = uuid.New().String()
@@ -454,8 +454,8 @@ func (s *SolanaWatcher) Run(ctx context.Context) error {
 
 	logger.Info("Starting watcher",
 		zap.String("watcher_name", s.chainID.String()),
-		zap.String("rpcUrl", s.rpcUrl),
-		zap.String("wsUrl", s.wsUrl),
+		zap.String("rpcURL", common.SafeURLForLogging(s.rpcUrl)),
+		zap.String("wsURL", common.SafeURLForLogging(s.wsUrl)),
 		zap.String("contract", contractAddr),
 		zap.String("rawContract", s.rawContract),
 		zap.String("shimContract", s.shimContractStr),

--- a/node/pkg/watchers/solana/client.go
+++ b/node/pkg/watchers/solana/client.go
@@ -513,7 +513,7 @@ func (s *SolanaWatcher) Run(ctx context.Context) error {
 				}
 
 				//nolint:contextcheck // Passed via the 's' object instead of as a parameter.
-				numObservations, err := s.handleReobservationRequest(chainId, m.TxHash, s.rpcClient)
+				numObservations, err := s.handleReobservationRequest(chainId, m.TxHash, s.rpcClient, s.rpcUrl)
 				if err != nil {
 					logger.Error("failed to process observation request",
 						zap.Uint32("chainID", m.ChainId),
@@ -537,8 +537,9 @@ func (s *SolanaWatcher) Run(ctx context.Context) error {
 				if err != nil {
 					p2p.DefaultRegistry.AddErrorCount(s.chainID, 1)
 					solanaConnectionErrors.WithLabelValues(s.networkName, string(s.commitment), "get_slot_error").Inc()
-					s.errC <- err // Note on channel capacity: The watcher will exit anyway
-					return err
+					safeErr := fmt.Errorf("%s", common.SafeErrorForLogging(err, s.rpcUrl))
+					s.errC <- safeErr // Note on channel capacity: The watcher will exit anyway
+					return safeErr
 				}
 
 				currentSolanaHeight.WithLabelValues(s.networkName, string(s.commitment)).Set(float64(slot))
@@ -668,7 +669,7 @@ func (s *SolanaWatcher) fetchBlock(ctx context.Context, logger *zap.Logger, slot
 			return true
 		} else {
 			if logger.Level().Enabled(zapcore.DebugLevel) {
-				logger.Debug("failed to request block", zap.Error(err), zap.Uint64("slot", slot))
+				logger.Debug("failed to request block", zap.String("error", common.SafeErrorForLogging(err, s.rpcUrl)), zap.Uint64("slot", slot))
 			}
 			p2p.DefaultRegistry.AddErrorCount(s.chainID, 1)
 			solanaConnectionErrors.WithLabelValues(s.networkName, string(s.commitment), "get_confirmed_block_error").Inc()
@@ -722,7 +723,7 @@ func (s *SolanaWatcher) fetchBlock(ctx context.Context, logger *zap.Logger, slot
 			continue
 		}
 
-		s.processTransaction(ctx, s.rpcClient, tx, txRpc.Meta, slot, false)
+		s.processTransaction(ctx, s.rpcClient, s.rpcUrl, tx, txRpc.Meta, slot, false)
 	}
 
 	if emptyRetry > 0 && logger.Level().Enabled(zapcore.DebugLevel) {
@@ -736,7 +737,7 @@ func (s *SolanaWatcher) fetchBlock(ctx context.Context, logger *zap.Logger, slot
 }
 
 // processTransaction processes a transaction and publishes any Wormhole events.
-func (s *SolanaWatcher) processTransaction(ctx context.Context, rpcClient *rpc.Client, tx *solana.Transaction, meta *rpc.TransactionMeta, slot uint64, isReobservation bool) (numObservations uint32) {
+func (s *SolanaWatcher) processTransaction(ctx context.Context, rpcClient *rpc.Client, rpcURL string, tx *solana.Transaction, meta *rpc.TransactionMeta, slot uint64, isReobservation bool) (numObservations uint32) {
 	// SECURITY: Validate transaction metadata before accessing fields
 	if metadataErr := validateTransactionMeta(meta); metadataErr != nil {
 		if s.logger.Level().Enabled(zapcore.DebugLevel) {
@@ -837,7 +838,7 @@ func (s *SolanaWatcher) processTransaction(ctx context.Context, rpcClient *rpc.C
 				}
 			}
 		} else {
-			found, err := s.processInstruction(ctx, rpcClient, slot, inst, programIndex, tx, signature, i, isReobservation)
+			found, err := s.processInstruction(ctx, rpcClient, rpcURL, slot, inst, programIndex, tx, signature, i, isReobservation)
 			if err != nil {
 				s.logger.Error("malformed Wormhole instruction",
 					zap.Error(err),
@@ -908,7 +909,7 @@ func (s *SolanaWatcher) processTransaction(ctx context.Context, rpcClient *rpc.C
 						}
 					}
 				} else {
-					found, err := s.processInstruction(ctx, rpcClient, slot, inst, programIndex, tx, signature, innerIdx, isReobservation)
+					found, err := s.processInstruction(ctx, rpcClient, rpcURL, slot, inst, programIndex, tx, signature, innerIdx, isReobservation)
 					if err != nil {
 						s.logger.Error("malformed Wormhole instruction",
 							zap.Error(err),
@@ -936,7 +937,7 @@ func (s *SolanaWatcher) processTransaction(ctx context.Context, rpcClient *rpc.C
 	return
 }
 
-func (s *SolanaWatcher) processInstruction(ctx context.Context, rpcClient *rpc.Client, slot uint64, inst solana.CompiledInstruction, programIndex uint16, tx *solana.Transaction, signature solana.Signature, idx int, isReobservation bool) (bool, error) {
+func (s *SolanaWatcher) processInstruction(ctx context.Context, rpcClient *rpc.Client, rpcURL string, slot uint64, inst solana.CompiledInstruction, programIndex uint16, tx *solana.Transaction, signature solana.Signature, idx int, isReobservation bool) (bool, error) {
 	if inst.ProgramIDIndex != programIndex {
 		return false, nil
 	}
@@ -990,15 +991,15 @@ func (s *SolanaWatcher) processInstruction(ctx context.Context, rpcClient *rpc.C
 	}
 
 	common.RunWithScissors(ctx, s.errC, "retryFetchMessageAccount", func(ctx context.Context) error {
-		s.retryFetchMessageAccount(ctx, rpcClient, acc, slot, 0, isReobservation, signature)
+		s.retryFetchMessageAccount(ctx, rpcClient, rpcURL, acc, slot, 0, isReobservation, signature)
 		return nil
 	})
 
 	return true, nil
 }
 
-func (s *SolanaWatcher) retryFetchMessageAccount(ctx context.Context, rpcClient *rpc.Client, acc solana.PublicKey, slot uint64, retry uint, isReobservation bool, signature solana.Signature) {
-	_, retryable := s.fetchMessageAccount(ctx, rpcClient, acc, slot, isReobservation, signature)
+func (s *SolanaWatcher) retryFetchMessageAccount(ctx context.Context, rpcClient *rpc.Client, rpcURL string, acc solana.PublicKey, slot uint64, retry uint, isReobservation bool, signature solana.Signature) {
+	_, retryable := s.fetchMessageAccount(ctx, rpcClient, rpcURL, acc, slot, isReobservation, signature)
 
 	if retryable {
 		if retry >= maxRetries {
@@ -1017,13 +1018,13 @@ func (s *SolanaWatcher) retryFetchMessageAccount(ctx context.Context, rpcClient 
 			zap.Uint("retry", retry))
 
 		common.RunWithScissors(ctx, s.errC, "retryFetchMessageAccount", func(ctx context.Context) error {
-			s.retryFetchMessageAccount(ctx, rpcClient, acc, slot, retry+1, isReobservation, signature)
+			s.retryFetchMessageAccount(ctx, rpcClient, rpcURL, acc, slot, retry+1, isReobservation, signature)
 			return nil
 		})
 	}
 }
 
-func (s *SolanaWatcher) fetchMessageAccount(ctx context.Context, rpcClient *rpc.Client, acc solana.PublicKey, slot uint64, isReobservation bool, signature solana.Signature) (numObservations uint32, retryable bool) {
+func (s *SolanaWatcher) fetchMessageAccount(ctx context.Context, rpcClient *rpc.Client, rpcURL string, acc solana.PublicKey, slot uint64, isReobservation bool, signature solana.Signature) (numObservations uint32, retryable bool) {
 	// Fetching account
 	rCtx, cancel := context.WithTimeout(ctx, rpcTimeout)
 	defer cancel()
@@ -1037,7 +1038,7 @@ func (s *SolanaWatcher) fetchMessageAccount(ctx context.Context, rpcClient *rpc.
 		p2p.DefaultRegistry.AddErrorCount(s.chainID, 1)
 		solanaConnectionErrors.WithLabelValues(s.networkName, string(s.commitment), "get_account_info_error").Inc()
 		s.logger.Warn("failed to request account",
-			zap.Error(err),
+			zap.String("error", common.SafeErrorForLogging(err, rpcURL)),
 			zap.Uint64("slot", slot),
 			zap.Stringer("account", acc))
 		return 0, true

--- a/node/pkg/watchers/solana/client_test.go
+++ b/node/pkg/watchers/solana/client_test.go
@@ -709,7 +709,7 @@ func TestProcessInstructionEarlyReturns(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			found, err := s.processInstruction(context.TODO(), nil, 1, tc.inst, 0, tx, signature, 0, false)
+			found, err := s.processInstruction(context.TODO(), nil, "", 1, tc.inst, 0, tx, signature, 0, false)
 			if tc.wantErr {
 				require.Error(t, err)
 				return
@@ -774,7 +774,7 @@ func TestProcessInstructionValidPostMessage(t *testing.T) {
 				Accounts:       []uint16{0, 1, 0, 0, 0, 0, 0, 0},
 			}
 
-			found, err := s.processInstruction(context.Background(), rpcClient, 1, inst, 0, tx, tx.Signatures[0], 0, false)
+			found, err := s.processInstruction(context.Background(), rpcClient, m.URL, 1, inst, 0, tx, tx.Signatures[0], 0, false)
 			require.NoError(t, err)
 			assert.True(t, found)
 
@@ -1086,7 +1086,7 @@ func TestProcessTransaction(t *testing.T) {
 				InnerInstructions: tc.innerInstructions,
 			}
 
-			num := s.processTransaction(context.Background(), rpcClient, tx, meta, 42, false)
+			num := s.processTransaction(context.Background(), rpcClient, m.URL, tx, meta, 42, false)
 			assert.Equal(t, tc.wantObservations, num)
 
 			// Drain published messages and verify count.
@@ -1237,7 +1237,7 @@ func TestFetchMessageAccount(t *testing.T) {
 			m.SetAccount(messageAccount, tc.accountOwner, tc.accountData)
 			rpcClient := rpc.New(m.URL)
 
-			numObservations, retryable := s.fetchMessageAccount(context.TODO(), rpcClient, messageAccount, 1, tc.reobservation, solana.SignatureFromBytes([]byte{}))
+			numObservations, retryable := s.fetchMessageAccount(context.TODO(), rpcClient, m.URL, messageAccount, 1, tc.reobservation, solana.SignatureFromBytes([]byte{}))
 
 			assert.Equal(t, tc.wantObservations, numObservations)
 			assert.Equal(t, tc.retryable, retryable)
@@ -1258,7 +1258,7 @@ func TestFetchMessageAccount(t *testing.T) {
 		defer m.Close()
 		m.SetAccountError(messageAccount, "rpc down")
 
-		num, retryable := s.fetchMessageAccount(context.TODO(), rpc.New(m.URL), messageAccount, 1, false, solana.Signature{})
+		num, retryable := s.fetchMessageAccount(context.TODO(), rpc.New(m.URL), m.URL, messageAccount, 1, false, solana.Signature{})
 		assert.Equal(t, uint32(0), num)
 		assert.True(t, retryable)
 	})
@@ -1268,7 +1268,7 @@ func TestFetchMessageAccount(t *testing.T) {
 		defer m.Close()
 		// No account registered: handler returns value=null.
 
-		num, retryable := s.fetchMessageAccount(context.TODO(), rpc.New(m.URL), messageAccount, 1, false, solana.Signature{})
+		num, retryable := s.fetchMessageAccount(context.TODO(), rpc.New(m.URL), m.URL, messageAccount, 1, false, solana.Signature{})
 		assert.Equal(t, uint32(0), num)
 		assert.True(t, retryable)
 	})

--- a/node/pkg/watchers/solana/close_event_test.go
+++ b/node/pkg/watchers/solana/close_event_test.go
@@ -273,12 +273,12 @@ func TestClosePostedMessageSkippedDuringNormalProcessing(t *testing.T) {
 	require.NoError(t, err)
 
 	// Process as normal (non-reobservation) — should produce NO observation.
-	numObs := s.processTransaction(context.Background(), nil, tx, txRpc.Meta, 100, false)
+	numObs := s.processTransaction(context.Background(), nil, "", tx, txRpc.Meta, 100, false)
 	assert.Equal(t, uint32(0), numObs)
 	assert.Equal(t, 0, len(msgC), "normal processing must not generate observation for close events")
 
 	// Process as reobservation — should produce an observation.
-	numObs = s.processTransaction(context.Background(), nil, tx, txRpc.Meta, 100, true)
+	numObs = s.processTransaction(context.Background(), nil, "", tx, txRpc.Meta, 100, true)
 	assert.Equal(t, uint32(1), numObs)
 	assert.Equal(t, 1, len(msgC), "reobservation should generate observation for close events")
 

--- a/node/pkg/watchers/solana/config.go
+++ b/node/pkg/watchers/solana/config.go
@@ -41,6 +41,9 @@ func (wc *WatcherConfig) Create(
 	_ chan<- *common.GuardianSet,
 	_ common.Environment,
 ) (supervisor.Runnable, interfaces.Reobserver, error) {
+	watchers.RegisterRPCURL(wc.ChainID, wc.Rpc)
+	watchers.RegisterRPCURL(wc.ChainID, wc.Websocket)
+
 	solAddress, err := solana_types.PublicKeyFromBase58(wc.Contract)
 	if err != nil {
 		return nil, nil, err

--- a/node/pkg/watchers/solana/reobserve.go
+++ b/node/pkg/watchers/solana/reobserve.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/certusone/wormhole/node/pkg/common"
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/rpc"
 	"github.com/wormhole-foundation/wormhole/sdk/vaa"
@@ -64,7 +65,7 @@ func (s *SolanaWatcher) handleReobservationRequest(chainId vaa.ChainID, txID []b
 // when the passed in context gets deleted. This is also why we don't close the rpcClient in this function. It will get deleted / closed
 // when the go routine exits.
 func (s *SolanaWatcher) Reobserve(_ context.Context, chainID vaa.ChainID, txID []byte, customEndpoint string) (uint32, error) {
-	s.logger.Info("received a request to reobserve using a custom endpoint", zap.Stringer("chainID", chainID), zap.Any("txID", txID), zap.String("url", customEndpoint))
+	s.logger.Info("received a request to reobserve using a custom endpoint", zap.Stringer("chainID", chainID), zap.Any("txID", txID), zap.String("customEndpointURL", common.SafeURLForLogging(customEndpoint)))
 	rpcClient := rpc.New(customEndpoint)
 	//nolint:contextcheck // See comment above for the reason why we don't use the passed in context.
 	return s.handleReobservationRequest(chainID, txID, rpcClient)

--- a/node/pkg/watchers/solana/reobserve.go
+++ b/node/pkg/watchers/solana/reobserve.go
@@ -13,7 +13,7 @@ import (
 
 // handleReobservationRequest performs a reobservation request and publishes any observed transactions.
 // SECURITY: Only the finalized watcher handles reobservations. Set in configuration of watcher for Solana chains.
-func (s *SolanaWatcher) handleReobservationRequest(chainId vaa.ChainID, txID []byte, rpcClient *rpc.Client) (numObservations uint32, err error) {
+func (s *SolanaWatcher) handleReobservationRequest(chainId vaa.ChainID, txID []byte, rpcClient *rpc.Client, customEndpoint string) (numObservations uint32, err error) {
 	if chainId != s.chainID {
 		return 0, fmt.Errorf("unexpected chain id: %v", chainId)
 	}
@@ -21,7 +21,7 @@ func (s *SolanaWatcher) handleReobservationRequest(chainId vaa.ChainID, txID []b
 		acc := solana.PublicKeyFromBytes(txID)
 		s.logger.Info("received observation request with account id", zap.String("account", acc.String()))
 		rCtx, cancel := context.WithTimeout(s.ctx, rpcTimeout)
-		numObservations, _ = s.fetchMessageAccount(rCtx, rpcClient, acc, 0, true, solana.Signature{})
+		numObservations, _ = s.fetchMessageAccount(rCtx, rpcClient, customEndpoint, acc, 0, true, solana.Signature{})
 		cancel()
 	} else if len(txID) == SolanaSignatureLen { // Request by transaction ID
 		signature := solana.SignatureFromBytes(txID)
@@ -38,7 +38,7 @@ func (s *SolanaWatcher) handleReobservationRequest(chainId vaa.ChainID, txID []b
 		)
 		cancel()
 		if err != nil {
-			return 0, fmt.Errorf("failed to get transaction for observation request: %v", err)
+			return 0, fmt.Errorf("failed to get transaction for observation request: %s", common.SafeErrorForLogging(err, customEndpoint))
 		}
 
 		if metadataErr := validateTransactionMeta(result.Meta); metadataErr != nil {
@@ -53,7 +53,7 @@ func (s *SolanaWatcher) handleReobservationRequest(chainId vaa.ChainID, txID []b
 		if err != nil {
 			return 0, fmt.Errorf("failed to extract transaction for observation request: %v", err)
 		}
-		numObservations = s.processTransaction(s.ctx, rpcClient, tx, result.Meta, result.Slot, true)
+		numObservations = s.processTransaction(s.ctx, rpcClient, customEndpoint, tx, result.Meta, result.Slot, true)
 	} else {
 		return 0, fmt.Errorf("ignoring an observation request of unexpected length: %d", len(txID))
 	}
@@ -68,5 +68,5 @@ func (s *SolanaWatcher) Reobserve(_ context.Context, chainID vaa.ChainID, txID [
 	s.logger.Info("received a request to reobserve using a custom endpoint", zap.Stringer("chainID", chainID), zap.Any("txID", txID), zap.String("customEndpointURL", common.SafeURLForLogging(customEndpoint)))
 	rpcClient := rpc.New(customEndpoint)
 	//nolint:contextcheck // See comment above for the reason why we don't use the passed in context.
-	return s.handleReobservationRequest(chainID, txID, rpcClient)
+	return s.handleReobservationRequest(chainID, txID, rpcClient, customEndpoint)
 }

--- a/node/pkg/watchers/solana/tx_for_addr.go
+++ b/node/pkg/watchers/solana/tx_for_addr.go
@@ -17,6 +17,7 @@ import (
 	"slices"
 	"time"
 
+	"github.com/certusone/wormhole/node/pkg/common"
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/rpc"
 	"go.uber.org/zap"
@@ -76,7 +77,7 @@ func (s *SolanaWatcher) getPrevWormholeSignature() (solana.Signature, error) {
 	})
 
 	if err != nil {
-		return solana.Signature{}, err
+		return solana.Signature{}, fmt.Errorf("%s", common.SafeErrorForLogging(err, s.rpcUrl))
 	}
 
 	if len(signatures) == 0 {
@@ -132,7 +133,7 @@ func (s *SolanaWatcher) getTransactionSignatures() ([]*rpc.TransactionSignature,
 			Limit:      &limit,
 		})
 		if err != nil {
-			return results, fmt.Errorf("GetSignaturesForAddressWithOpts failed: %w", err)
+			return results, fmt.Errorf("GetSignaturesForAddressWithOpts failed: %s", common.SafeErrorForLogging(err, s.rpcUrl))
 		}
 		if len(batchSignatures) == 0 {
 			break
@@ -175,7 +176,7 @@ func (s *SolanaWatcher) processTransactionWithRetry(signature solana.Signature) 
 				continue
 			}
 
-			s.logger.Error("failed to get transaction for signature", zap.Stringer("signature", signature), zap.Error(err))
+			s.logger.Error("failed to get transaction for signature", zap.Stringer("signature", signature), zap.String("error", common.SafeErrorForLogging(err, s.rpcUrl)))
 			return
 		}
 
@@ -193,7 +194,7 @@ func (s *SolanaWatcher) processTransactionWithRetry(signature solana.Signature) 
 			return
 		}
 
-		_ = s.processTransaction(s.ctx, s.rpcClient, tx, result.Meta, result.Slot, false)
+		_ = s.processTransaction(s.ctx, s.rpcClient, s.rpcUrl, tx, result.Meta, result.Slot, false)
 		return
 	}
 

--- a/node/pkg/watchers/sui/config.go
+++ b/node/pkg/watchers/sui/config.go
@@ -35,6 +35,7 @@ func (wc *WatcherConfig) Create(
 	_ chan<- *common.GuardianSet,
 	env common.Environment,
 ) (supervisor.Runnable, interfaces.Reobserver, error) {
+	watchers.RegisterRPCURL(wc.ChainID, wc.Rpc)
 	var devMode = (env == common.UnsafeDevNet)
 
 	watcher, err := NewWatcher(

--- a/node/pkg/watchers/sui/watcher.go
+++ b/node/pkg/watchers/sui/watcher.go
@@ -288,7 +288,7 @@ func (e *Watcher) Run(ctx context.Context) error {
 
 	logger.Info("Starting watcher",
 		zap.String("watcher_name", "sui"),
-		zap.String("suiRPC", e.suiRPC),
+		zap.String("rpcURL", common.SafeURLForLogging(e.suiRPC)),
 		zap.String("suiMoveEventType", e.suiMoveEventType),
 		zap.Bool("unsafeDevMode", e.unsafeDevMode),
 	)

--- a/node/pkg/watchers/sui/watcher.go
+++ b/node/pkg/watchers/sui/watcher.go
@@ -130,7 +130,7 @@ func NewWatcher(
 		// Create the Sui gRPC client used by the transfer verifier to query transactions and objects.
 		suiClient, err := suiclient.NewSuiGrpcClient(suiRPC, nil, suiGrpcDialOpts(unsafeDevMode)...)
 		if err != nil {
-			return nil, fmt.Errorf("failed to create Sui gRPC client for transfer verifier: %w", err)
+			return nil, fmt.Errorf("failed to create Sui gRPC client for transfer verifier: %s", common.SafeErrorForLogging(err, suiRPC))
 		}
 
 		// Create the new suiTxVerifier
@@ -265,7 +265,7 @@ func (e *Watcher) handleReobservation(ctx context.Context, logger *zap.Logger, c
 		suiclient.TransactionFieldEvents,
 	})
 	if err != nil {
-		logger.Error("sui_fetch_obvs_req failed", zap.String("txhash", tx58), zap.Error(err))
+		logger.Error("sui_fetch_obvs_req failed", zap.String("txhash", tx58), zap.String("error", common.SafeErrorForLogging(err, e.suiRPC)))
 		p2p.DefaultRegistry.AddErrorCount(vaa.ChainIDSui, 1)
 		return
 	}
@@ -301,7 +301,7 @@ func (e *Watcher) Run(ctx context.Context) error {
 	if client == nil {
 		grpcClient, err := suiclient.NewSuiGrpcClient(e.suiRPC, logger, suiGrpcDialOpts(e.unsafeDevMode)...)
 		if err != nil {
-			return fmt.Errorf("failed to create Sui gRPC client: %w", err)
+			return fmt.Errorf("failed to create Sui gRPC client: %s", common.SafeErrorForLogging(err, e.suiRPC))
 		}
 		client = grpcClient
 		defer func() {
@@ -314,7 +314,7 @@ func (e *Watcher) Run(ctx context.Context) error {
 	// Get the latest checkpoint sequence number to confirm connectivity before reporting healthy.
 	initialCheckpoint, err := client.GetLatestCheckpoint(ctx, []string{suiclient.CheckpointFieldSequenceNumber})
 	if err != nil {
-		return fmt.Errorf("failed to get latest checkpoint sequence number: %w", err)
+		return fmt.Errorf("failed to get latest checkpoint sequence number: %s", common.SafeErrorForLogging(err, e.suiRPC))
 	} else if initialCheckpoint.SequenceNumber == nil {
 		return fmt.Errorf("latest checkpoint response missing sequence number")
 	}
@@ -334,7 +334,7 @@ func (e *Watcher) Run(ctx context.Context) error {
 
 		subscription, err := client.SubscribeToTransactionEvent(ctx, e.suiMoveEventType, eventChan)
 		if err != nil {
-			return fmt.Errorf("sui_data_pump failed to subscribe to events: %w", err)
+			return fmt.Errorf("sui_data_pump failed to subscribe to events: %s", common.SafeErrorForLogging(err, e.suiRPC))
 		}
 		defer subscription.Unsubscribe()
 
@@ -345,7 +345,7 @@ func (e *Watcher) Run(ctx context.Context) error {
 				return ctx.Err()
 
 			case subErr := <-subscription.Err():
-				return fmt.Errorf("sui_data_pump subscription error: %w", subErr)
+				return fmt.Errorf("sui_data_pump subscription error: %s", common.SafeErrorForLogging(subErr, e.suiRPC))
 
 			case txEvent := <-eventChan:
 				if txEvent.TxDigest == "" {
@@ -370,7 +370,7 @@ func (e *Watcher) Run(ctx context.Context) error {
 			case <-timer.C:
 				checkpoint, err := client.GetLatestCheckpoint(ctx, []string{suiclient.CheckpointFieldSequenceNumber})
 				if err != nil {
-					logger.Error("Failed to get latest checkpoint sequence number", zap.Error(err))
+					logger.Error("Failed to get latest checkpoint sequence number", zap.String("error", common.SafeErrorForLogging(err, e.suiRPC)))
 				} else if checkpoint.SequenceNumber == nil {
 					logger.Error("latest checkpoint response missing sequence number")
 				} else {

--- a/node/pkg/watchers/watchers.go
+++ b/node/pkg/watchers/watchers.go
@@ -1,6 +1,8 @@
 package watchers
 
 import (
+	"sync"
+
 	"github.com/certusone/wormhole/node/pkg/common"
 	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
 	"github.com/certusone/wormhole/node/pkg/query"
@@ -35,3 +37,37 @@ var (
 			Help: "Total number of reobservations completed by chain and observation type",
 		}, []string{"chain", "type"})
 )
+
+var (
+	rpcURLsMu sync.RWMutex
+	rpcURLs   = map[vaa.ChainID][]string{}
+)
+
+// RegisterRPCURL records the RPC URL used by a watcher for a chain.
+func RegisterRPCURL(chainID vaa.ChainID, rpcURL string) {
+	if rpcURL == "" {
+		return
+	}
+
+	rpcURLsMu.Lock()
+	defer rpcURLsMu.Unlock()
+	for _, existingURL := range rpcURLs[chainID] {
+		if existingURL == rpcURL {
+			return
+		}
+	}
+	rpcURLs[chainID] = append(rpcURLs[chainID], rpcURL)
+}
+
+// RPCURLs returns the RPC URLs registered for a chain.
+func RPCURLs(chainID vaa.ChainID) []string {
+	rpcURLsMu.RLock()
+	defer rpcURLsMu.RUnlock()
+	chainRPCURLs := rpcURLs[chainID]
+	if len(chainRPCURLs) == 0 {
+		return nil
+	}
+	ret := make([]string, len(chainRPCURLs))
+	copy(ret, chainRPCURLs)
+	return ret
+}

--- a/node/pkg/watchers/watchers_test.go
+++ b/node/pkg/watchers/watchers_test.go
@@ -1,0 +1,34 @@
+package watchers
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/wormhole-foundation/wormhole/sdk/vaa"
+)
+
+func TestRegisterRPCURL(t *testing.T) {
+	rpcURLsMu.Lock()
+	rpcURLs = map[vaa.ChainID][]string{}
+	rpcURLsMu.Unlock()
+
+	RegisterRPCURL(vaa.ChainIDEthereum, "")
+	if urls := RPCURLs(vaa.ChainIDEthereum); urls != nil {
+		t.Fatalf("expected empty URLs to be ignored, got %v", urls)
+	}
+
+	RegisterRPCURL(vaa.ChainIDEthereum, "https://eth.example")
+	RegisterRPCURL(vaa.ChainIDEthereum, "https://eth.example")
+	RegisterRPCURL(vaa.ChainIDEthereum, "https://eth-backup.example")
+
+	urls := RPCURLs(vaa.ChainIDEthereum)
+	want := []string{"https://eth.example", "https://eth-backup.example"}
+	if !slices.Equal(urls, want) {
+		t.Fatalf("unexpected URLs: got %v, want %v", urls, want)
+	}
+
+	urls[0] = "https://mutated.example"
+	if got := RPCURLs(vaa.ChainIDEthereum); !slices.Equal(got, want) {
+		t.Fatalf("RPCURLs returned mutable backing storage: got %v, want %v", got, want)
+	}
+}

--- a/node/pkg/watchers/xrpl/config.go
+++ b/node/pkg/watchers/xrpl/config.go
@@ -35,6 +35,7 @@ func (wc *WatcherConfig) Create(
 	_ chan<- *common.GuardianSet,
 	env common.Environment,
 ) (supervisor.Runnable, interfaces.Reobserver, error) {
+	watchers.RegisterRPCURL(wc.ChainID, wc.RPC)
 	var devMode = (env == common.UnsafeDevNet)
 
 	watcher := NewWatcher(

--- a/node/pkg/watchers/xrpl/watcher.go
+++ b/node/pkg/watchers/xrpl/watcher.go
@@ -118,7 +118,7 @@ func (w *Watcher) Run(ctx context.Context) error {
 
 	logger.Info("Starting watcher",
 		zap.String("watcher_name", "xrpl"),
-		zap.String("rpc", w.rpc),
+		zap.String("rpcURL", common.SafeURLForLogging(w.rpc)),
 		zap.String("contract", w.contract),
 		zap.Strings("nttAccounts", w.nttAccounts),
 		zap.Bool("unsafeDevMode", w.unsafeDevMode),
@@ -139,7 +139,7 @@ func (w *Watcher) Run(ctx context.Context) error {
 		_ = w.client.Disconnect()
 	}()
 
-	logger.Info("Connected to XRPL node", zap.String("rpc", w.rpc))
+	logger.Info("Connected to XRPL node", zap.String("rpcURL", common.SafeURLForLogging(w.rpc)))
 
 	// Initialize the parser with the watcher's fetchMPTAssetScale method
 	w.parser = NewParser(w.contract, w.nttAccounts, w.fetchMPTAssetScale)

--- a/node/pkg/watchers/xrpl/watcher.go
+++ b/node/pkg/watchers/xrpl/watcher.go
@@ -133,7 +133,7 @@ func (w *Watcher) Run(ctx context.Context) error {
 
 	w.client = websocket.NewClient(cfg)
 	if err := w.client.Connect(); err != nil {
-		return fmt.Errorf("failed to connect to XRPL node: %w", err)
+		return fmt.Errorf("failed to connect to XRPL node: %s", common.SafeErrorForLogging(err, w.rpc))
 	}
 	defer func() {
 		_ = w.client.Disconnect()
@@ -294,7 +294,7 @@ func (w *Watcher) subscribeAndProcess(ctx context.Context) error {
 
 	_, err := w.client.Request(subscribeReq)
 	if err != nil {
-		return fmt.Errorf("failed to subscribe to accounts %v: %w", accounts, err)
+		return fmt.Errorf("failed to subscribe to accounts %v: %s", accounts, common.SafeErrorForLogging(err, w.rpc))
 	}
 
 	w.logger.Info("Subscribed to accounts",

--- a/node/pkg/wormconn/clientconn.go
+++ b/node/pkg/wormconn/clientconn.go
@@ -9,6 +9,7 @@ import (
 	sdktx "github.com/cosmos/cosmos-sdk/types/tx"
 
 	"github.com/btcsuite/btcutil/bech32"
+	"github.com/certusone/wormhole/node/pkg/common"
 	wormchain "github.com/wormhole-foundation/wormchain/app"
 
 	"google.golang.org/grpc"
@@ -39,7 +40,7 @@ func NewConn(target string, privateKey cryptotypes.PrivKey, chainId string) (*Cl
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to dial wormchain target %s: %s", common.SafeURLForLogging(target), common.SafeErrorForLogging(err, target))
 	}
 
 	encCfg := MakeEncodingConfig(wormchain.ModuleBasics)


### PR DESCRIPTION
- Checks watcher's URLs against a deny-list of public RPC URLs. Logs an error when a public RPC URL is found for a delegated guardian. This should prevent problems where a delegate is not correct pointed at a full node.
- Sanitizes URLs in logs so that path parts are not included. (These can sometimes contain API keys or other sensitive strings).
- Normalizes logged field names across watchers for the 'watcher started' log