### PR TITLE
node(dgs): add small optimizations on canonical message handling path

### DIFF
--- a/node/pkg/processor/benchmark_test.go
+++ b/node/pkg/processor/benchmark_test.go
@@ -3,6 +3,7 @@ package processor
 import (
 	"context"
 	"fmt"
+	"math/big"
 	"os"
 	"runtime/pprof"
 	"testing"
@@ -20,7 +21,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/wormhole-foundation/wormhole/sdk/vaa"
 	"go.uber.org/zap"
+	"google.golang.org/protobuf/proto"
 )
+
+var benchmarkConsensusTxIDSink []byte
 
 /*
 No gwrelayer:
@@ -115,6 +119,161 @@ func BenchmarkProfileHandleObservation(b *testing.B) {
 		}
 	}
 	require.Equal(b, NumObservations, len(pd.gossipVaaSendC))
+}
+
+func BenchmarkCheckForDelegateQuorum(b *testing.B) {
+	// Thirteen delegates is a realistic upper bound for delegated guardian sets;
+	// the protocol-level hard bound is the 19-member normal guardian set.
+	const numDelegates = 13
+
+	signers := make([]ethCommon.Address, 0, numDelegates)
+	for i := 1; i <= numDelegates; i++ {
+		signers = append(signers, ethCommon.BigToAddress(big.NewInt(int64(i))))
+	}
+
+	cfg, err := NewDelegatedGuardianChainConfig(signers, vaa.CalculateQuorum(len(signers)))
+	require.NoError(b, err)
+
+	txHash := ethCommon.HexToHash("0x39c2f7f67fbce903d49bb24147668095f1b726acef3c19460da39e83c6929a2b").Bytes()
+	bucket := &delegateState{
+		firstObserved: time.Now(),
+		observations:  make(map[ethCommon.Address]*gossipv1.DelegateObservation, cfg.Quorum()),
+		cfg:           cfg,
+	}
+	for _, signer := range signers[:cfg.Quorum()] {
+		bucket.observations[signer] = makeDelegateObs(b, signer, txHash, false)
+	}
+
+	emitter, err := vaa.StringToAddress("000000000000000000000000b1731c586ca89a23809861c6103f0b96b3f57d92")
+	require.NoError(b, err)
+	mp := &common.MessagePublication{
+		TxID:             txHash,
+		Timestamp:        time.Unix(1746026862, 0),
+		Nonce:            0,
+		Sequence:         95838,
+		ConsistencyLevel: 1,
+		EmitterChain:     vaa.ChainIDMoonbeam,
+		EmitterAddress:   emitter,
+		Payload:          []byte("payload"),
+	}
+
+	// Keep the processor deliberately minimal. checkForDelegateQuorum dispatches
+	// to the downstream consensus path after quorum, but a nil guardian set makes
+	// handleMessage return before signing or VAA aggregation. That keeps this
+	// benchmark focused on delegate quorum accounting, TxID selection,
+	// normalization, and dispatch overhead.
+	p := &Processor{logger: zap.NewNop()}
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		bucket.submitted = false
+		if err := p.checkForDelegateQuorum(ctx, mp, bucket, cfg); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkConsensusTxID(b *testing.B) {
+	// Match the realistic delegated-set size used by BenchmarkCheckForDelegateQuorum.
+	const numDelegates = 13
+
+	signers := make([]ethCommon.Address, 0, numDelegates)
+	for i := 1; i <= numDelegates; i++ {
+		signers = append(signers, ethCommon.BigToAddress(big.NewInt(int64(i))))
+	}
+
+	b.Run("unanimous", func(b *testing.B) {
+		txHash := ethCommon.HexToHash("0x39c2f7f67fbce903d49bb24147668095f1b726acef3c19460da39e83c6929a2b").Bytes()
+		bucket := &delegateState{observations: make(map[ethCommon.Address]*gossipv1.DelegateObservation, len(signers))}
+		for _, signer := range signers {
+			bucket.observations[signer] = makeDelegateObs(b, signer, txHash, false)
+		}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for range b.N {
+			benchmarkConsensusTxIDSink = bucket.consensusTxID()
+		}
+	})
+
+	b.Run("unique", func(b *testing.B) {
+		bucket := &delegateState{observations: make(map[ethCommon.Address]*gossipv1.DelegateObservation, len(signers))}
+		for i, signer := range signers {
+			txHash := ethCommon.BigToHash(big.NewInt(int64(i + 1))).Bytes()
+			bucket.observations[signer] = makeDelegateObs(b, signer, txHash, false)
+		}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for range b.N {
+			benchmarkConsensusTxIDSink = bucket.consensusTxID()
+		}
+	})
+
+	b.Run("majority", func(b *testing.B) {
+		txMaj := ethCommon.HexToHash("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb").Bytes()
+		txMin := ethCommon.HexToHash("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").Bytes()
+		bucket := &delegateState{observations: make(map[ethCommon.Address]*gossipv1.DelegateObservation, len(signers))}
+		for i, signer := range signers {
+			txHash := txMin
+			if i < 7 {
+				txHash = txMaj
+			}
+			bucket.observations[signer] = makeDelegateObs(b, signer, txHash, false)
+		}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for range b.N {
+			benchmarkConsensusTxIDSink = bucket.consensusTxID()
+		}
+	})
+}
+
+func BenchmarkHandleSignedDelegateObservation(b *testing.B) {
+	// Thirteen delegates is a realistic upper bound for delegated guardian sets;
+	// this benchmark sends one valid observation, keeping the bucket below quorum
+	// so it measures signed-delegate validation, conversion, digesting, and bucket
+	// update without downstream consensus publication.
+	const numDelegates = 13
+
+	signers := make([]ethCommon.Address, 0, numDelegates)
+	for i := 1; i <= numDelegates; i++ {
+		signers = append(signers, ethCommon.BigToAddress(big.NewInt(int64(i))))
+	}
+	cfg, err := NewDelegatedGuardianChainConfig(signers, vaa.CalculateQuorum(len(signers)))
+	require.NoError(b, err)
+
+	dgc := NewDelegatedGuardianConfig()
+	require.NoError(b, dgc.Set(map[vaa.ChainID]*DelegatedGuardianChainConfig{
+		vaa.ChainIDMoonbeam: cfg,
+	}))
+
+	txHash := ethCommon.HexToHash("0x39c2f7f67fbce903d49bb24147668095f1b726acef3c19460da39e83c6929a2b").Bytes()
+	obs := makeDelegateObs(b, signers[0], txHash, false)
+	obsBytes, err := proto.Marshal(obs)
+	require.NoError(b, err)
+	signedObs := &gossipv1.SignedDelegateObservation{
+		DelegateObservation: obsBytes,
+		GuardianAddr:        signers[0].Bytes(),
+	}
+
+	p := &Processor{
+		logger:        zap.NewNop(),
+		dgc:           dgc,
+		delegateState: &delegateAggregationState{delegateObservationMap{}},
+	}
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		if err := p.handleSignedDelegateObservation(ctx, signedObs); err != nil {
+			b.Fatal(err)
+		}
+	}
 }
 
 type ProcessorData struct {

--- a/node/pkg/processor/observation.go
+++ b/node/pkg/processor/observation.go
@@ -762,18 +762,19 @@ func (p *Processor) handleSignedDelegateObservation(ctx context.Context, m *goss
 		return nil
 	}
 
-	return p.handleCanonicalDelegateObservation(ctx, cfg, &d)
+	return p.handleCanonicalDelegateObservation(ctx, cfg, &d, mp, hash)
 }
 
-// handleCanonicalDelegateObservation processes a delegate observation as a canonical guardian
-// This function assumes cfg corresponds to m.EmitterChain
+// handleCanonicalDelegateObservation processes a delegate observation as a canonical guardian.
+// This function assumes cfg corresponds to m.EmitterChain, and mp/hash were
+// derived from m by delegateObservationToMessagePublication and CreateDigest.
 //
 // SECURITY: This function must only be called if the current Guardian is a canonical Guardian for this chain.
 //
 // WARNING: This returns error if the Accountant fails to process the message and propagates it
 // to the `processor` which in turn interprets this as a signal to RESTART THE PROCESSOR.
 // Therefore, errors returned by this function effectively act as panics.
-func (p *Processor) handleCanonicalDelegateObservation(ctx context.Context, cfg *DelegatedGuardianChainConfig, m *gossipv1.DelegateObservation) error {
+func (p *Processor) handleCanonicalDelegateObservation(ctx context.Context, cfg *DelegatedGuardianChainConfig, m *gossipv1.DelegateObservation, mp *node_common.MessagePublication, hash string) error {
 	if cfg == nil {
 		p.logger.Warn("nil delegated guardian chain config")
 		return nil
@@ -788,26 +789,8 @@ func (p *Processor) handleCanonicalDelegateObservation(ctx context.Context, cfg 
 	}
 
 	addr := common.BytesToAddress(m.GuardianAddr)
-	mp, err := delegateObservationToMessagePublication(m)
-	if err != nil {
-		p.logger.Warn("failed to convert delegate observation to message publication",
-			zap.Uint32("emitter_chain", m.EmitterChain),
-			zap.String("emitter_address", hex.EncodeToString(m.EmitterAddress)),
-			zap.Uint64("sequence", m.Sequence),
-			zap.String("guardian_addr", addr.Hex()),
-			zap.Error(err),
-		)
-		delegateObservationsFailedTotal.WithLabelValues("invalid_delegate_observation").Inc()
-		return nil
-	}
 
 	delegateObservationsReceivedByGuardianAddressTotal.WithLabelValues(addr.Hex()).Inc()
-
-	// Key the delegate-state bucket by the VAA signing digest, matching the
-	// canonical observation path (pkg/processor/message.go). This excludes
-	// fields not encoded in the VAA (notably IsReobservation), so signatures
-	// from a partially-reobserved delegate set merge into one bucket.
-	hash := mp.CreateDigest()
 
 	// Get / create our state entry.
 	s := p.delegateState.observations[hash]
@@ -975,25 +958,44 @@ func (s *delegateState) consensusTxID() []byte {
 		txID  []byte
 		count int
 	}
-	counts := map[string]*entry{}
+
+	const maxDelegatedGuardianSetSize = 19
+
+	// Delegated guardian sets are bounded by the normal guardian set size. A
+	// fixed local buffer avoids map/string allocations on this hot path.
+	var fixedCounts [maxDelegatedGuardianSetSize]entry
+	counts := fixedCounts[:0]
+
+	maxIdx := -1
 	for _, obs := range s.observations {
-		key := string(obs.TxHash)
-		if e, exists := counts[key]; exists {
-			e.count++
-		} else {
-			counts[key] = &entry{txID: obs.TxHash, count: 1}
+		// Find the existing TxID bucket, if any. Linear search is cheaper than a
+		// map for the small delegated sets this path handles.
+		idx := -1
+		for i := range counts {
+			if bytes.Equal(counts[i].txID, obs.TxHash) {
+				idx = i
+				break
+			}
+		}
+		if idx == -1 {
+			// No TxID bucket exists, so this is the first time we've seen this TxID.
+			// Create a new bucket.
+			counts = append(counts, entry{txID: obs.TxHash})
+			idx = len(counts) - 1
+		}
+		counts[idx].count++
+
+		// Track the max-count TxID as counts change. Equal counts are broken by
+		// lexicographic TxID order so the result is deterministic despite Go map
+		// iteration order over s.observations.
+		if maxIdx == -1 ||
+			counts[idx].count > counts[maxIdx].count ||
+			(counts[idx].count == counts[maxIdx].count && bytes.Compare(counts[idx].txID, counts[maxIdx].txID) < 0) {
+			maxIdx = idx
 		}
 	}
-	var best *entry
-	for _, e := range counts {
-		if best == nil ||
-			e.count > best.count ||
-			(e.count == best.count && bytes.Compare(e.txID, best.txID) < 0) {
-			best = e
-		}
-	}
-	if best == nil {
+	if maxIdx == -1 {
 		return nil
 	}
-	return best.txID
+	return counts[maxIdx].txID
 }

--- a/node/pkg/processor/observation.go
+++ b/node/pkg/processor/observation.go
@@ -980,7 +980,7 @@ func (s *delegateState) consensusTxID() []byte {
 		if idx == -1 {
 			// No TxID bucket exists, so this is the first time we've seen this TxID.
 			// Create a new bucket.
-			counts = append(counts, entry{txID: obs.TxHash})
+			counts = append(counts, entry{txID: obs.TxHash, count: 0})
 			idx = len(counts) - 1
 		}
 		counts[idx].count++

--- a/node/pkg/processor/observation_test.go
+++ b/node/pkg/processor/observation_test.go
@@ -128,7 +128,7 @@ func TestHandleInboundSignedVAAWithQuorum(t *testing.T) {
 // makeDelegateObs builds a minimal DelegateObservation for the same VAA
 // (chain/emitter/sequence/payload), parameterized by the per-guardian fields
 // that don't affect the VAA digest: signer address, TxHash, IsReobservation.
-func makeDelegateObs(t *testing.T, signer ethcommon.Address, txHash []byte, isReobservation bool) *gossipv1.DelegateObservation {
+func makeDelegateObs(t testing.TB, signer ethcommon.Address, txHash []byte, isReobservation bool) *gossipv1.DelegateObservation {
 	t.Helper()
 	emitter, err := vaa.StringToAddress("000000000000000000000000b1731c586ca89a23809861c6103f0b96b3f57d92")
 	if err != nil {
@@ -148,6 +148,13 @@ func makeDelegateObs(t *testing.T, signer ethcommon.Address, txHash []byte, isRe
 		Unreliable:        false,
 		VerificationState: 0,
 	}
+}
+
+func makeDelegateMsgAndHash(t testing.TB, obs *gossipv1.DelegateObservation) (*common.MessagePublication, string) {
+	t.Helper()
+	mp, err := delegateObservationToMessagePublication(obs)
+	require.NoError(t, err)
+	return mp, mp.CreateDigest()
 }
 
 // TestHandleCanonicalDelegateObservation_BucketMergesAcrossIsReobservation feeds
@@ -182,11 +189,12 @@ func TestHandleCanonicalDelegateObservation_BucketMergesAcrossIsReobservation(t 
 	flags := []bool{false, false, true, true, true}
 	for i, signer := range signers {
 		obs := makeDelegateObs(t, signer, txID, flags[i])
+		mp, hash := makeDelegateMsgAndHash(t, obs)
 		// We don't drive checkForDelegateQuorum's downstream call here (that
 		// would require a full Processor); we stop after the bucket update.
 		// To do that, mark submitted on the bucket once it exists so the
 		// quorum-triggered downstream path is short-circuited.
-		_ = p.handleCanonicalDelegateObservation(t.Context(), cfg, obs)
+		_ = p.handleCanonicalDelegateObservation(t.Context(), cfg, obs, mp, hash)
 		if i == 0 {
 			// After the first observation, force submitted=true so subsequent
 			// calls return early without invoking the consensus handler.
@@ -305,14 +313,18 @@ func TestHandleCanonicalDelegateObservation_TxIDDisagreementWarn(t *testing.T) {
 	txA := ethcommon.HexToHash("0x39c2f7f67fbce903d49bb24147668095f1b726acef3c19460da39e83c6929a2b").Bytes()
 	txB := ethcommon.HexToHash("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").Bytes()
 
-	if err := p.handleCanonicalDelegateObservation(t.Context(), cfg, makeDelegateObs(t, signerA, txA, false)); err != nil {
+	obsA := makeDelegateObs(t, signerA, txA, false)
+	mpA, hashA := makeDelegateMsgAndHash(t, obsA)
+	if err := p.handleCanonicalDelegateObservation(t.Context(), cfg, obsA, mpA, hashA); err != nil {
 		t.Fatalf("first obs returned error: %v", err)
 	}
 	// Force submitted to short-circuit the quorum path on the second obs.
 	for _, s := range p.delegateState.observations {
 		s.submitted = true
 	}
-	if err := p.handleCanonicalDelegateObservation(t.Context(), cfg, makeDelegateObs(t, signerB, txB, false)); err != nil {
+	obsB := makeDelegateObs(t, signerB, txB, false)
+	mpB, hashB := makeDelegateMsgAndHash(t, obsB)
+	if err := p.handleCanonicalDelegateObservation(t.Context(), cfg, obsB, mpB, hashB); err != nil {
 		t.Fatalf("second obs returned error: %v", err)
 	}
 


### PR DESCRIPTION
This refactor removes unnecessary per-message work on the DGS canonical path.

The absolute latency saving is very small (sub-microsecond per message), but because it happens on every DGS-enabled message, the bigger win is reducing allocator and GC pressure under sustained DGS traffic. And anyway, might as well avoid unnecessary computation, right?

Summary:
- consensusTxID runs once quorum is met and currently sits in that path.
- The old consensusTxID allocated a map, converted every TxHash to a string key, allocated entries, then did a second pass to find the winner.
- The refactor uses a fixed 19-entry local buffer for TxID counting.

- handleSignedDelegateObservation runs on every canonical Guardian for DGS-enabled chains
- The old `handleSignedDelegateObservation` calculated the message publication hash twice, once in that function and again in `handleCanonicalDelegateObservation`
- the refactor passes along the hash and message publication to avoid re-calculating.

Measured with benchstat -count=20:
```
goos: darwin
goarch: arm64
pkg: github.com/certusone/wormhole/node/pkg/processor
cpu: Apple M3
                          │ before │ after  │
                          │ sec/op │ sec/op │
ConsensusTxID/unanimous-8   346.5n   144.5n  -58.30% (p=0.000 n=20)
ConsensusTxID/unique-8      903.2n   318.9n  -64.70% (p=0.000 n=20)
ConsensusTxID/majority-8    426.0n   158.2n  -62.85% (p=0.000 n=20)
                          │ before │ after │
                          │  B/op  │ B/op  │
ConsensusTxID/unanimous-8    448.0     0.0  -100.00% (p=0.000 n=20)
ConsensusTxID/unique-8      1288.0     0.0  -100.00% (p=0.000 n=20)
ConsensusTxID/majority-8     480.0     0.0  -100.00% (p=0.000 n=20)
                          │ before │ after │
                          │allocs/op│allocs/op│
ConsensusTxID/unanimous-8    14.00    0.00  -100.00% (p=0.000 n=20)
ConsensusTxID/unique-8       29.00    0.00  -100.00% (p=0.000 n=20)
ConsensusTxID/majority-8     15.00    0.00  -100.00% (p=0.000 n=20)
                                  │ before │ after │
                                  │ sec/op │ sec/op │
HandleSignedDelegateObservation-8   2.290µ   1.497µ  -34.65% (p=0.000 n=20)
                                  │ before │ after │
                                  │  B/op  │ B/op  │
HandleSignedDelegateObservation-8   1264.0   840.0  -33.54% (p=0.000 n=20)
                                  │ before │ after │
                                  │allocs/op│allocs/op│
HandleSignedDelegateObservation-8    32.00   20.00  -37.50% (p=0.000 n=20)
```