### PR TITLE
node: Upgrade to Go 1.26

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.25.10"
+          go-version: "1.26.3"
       - run: make node
 
   algorand:
@@ -282,7 +282,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.25.10"
+          go-version: "1.26.3"
       - run: cd sdk/vaa && go test -v -fuzz FuzzCalculateQuorum -run FuzzCalculateQuorum -fuzztime 15s
 
   # Run Go linters
@@ -301,7 +301,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.25.10"
+          go-version: "1.26.3"
       - name: Install formatter
         run: go install golang.org/x/tools/cmd/goimports@v0.8.0
       - name: Formatting checks
@@ -347,7 +347,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.25.10"
+          go-version: "1.26.3"
       # The go-ethereum and celo-blockchain packages both implement secp256k1 using the exact same header, but that causes duplicate symbols.
       - name: Run golang tests with coverage
         run: make test-coverage
@@ -366,7 +366,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.25.10"
+          go-version: "1.26.3"
       - name: Download coverage output
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.25.10"
+          go-version-file: node/go.mod
       - run: make node
 
   algorand:
@@ -266,6 +266,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
+          # Pinned to match the Wormchain Docker images; go.mod only declares Go 1.19 compatibility.
           go-version: "1.19.9"
       - run: |
           cd wormchain
@@ -282,7 +283,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.25.10"
+          go-version: "1.26.3"
       - run: cd sdk/vaa && go test -v -fuzz FuzzCalculateQuorum -run FuzzCalculateQuorum -fuzztime 15s
 
   # Run Go linters
@@ -301,7 +302,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.25.10"
+          go-version-file: node/go.mod
       - name: Install formatter
         run: go install golang.org/x/tools/cmd/goimports@v0.8.0
       - name: Formatting checks
@@ -345,11 +346,10 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.25.10"
+          go-version-file: node/go.mod
       # /usr/bin/true replaces test-binary execution, so live integration tests are compiled but never run.
       - name: Compile integration-tagged Go tests without running them
         run: make test-integration-compile
-      # The go-ethereum and celo-blockchain packages both implement secp256k1 using the exact same header, but that causes duplicate symbols.
       - name: Run golang tests with coverage
         run: make test-coverage
       - name: Upload coverage output
@@ -367,7 +367,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.25.10"
+          go-version-file: scripts/coverage-check/go.mod
       - name: Download coverage output
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
@@ -387,7 +387,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.25.10"
+          go-version-file: linters/go.mod
       - name: Run custom linter tests
         run: make -C linters test
 

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -4,7 +4,7 @@
 
 The following dependencies are required for local development:
 
-- [Go](https://golang.org/dl/) >= 1.25.10 (latest minor release is recommended)
+- [Go](https://golang.org/dl/) >= 1.26.3 (latest minor release is recommended)
     - [golangci-lint](https://golangci-lint.run/welcome/install/#install-from-sources) >= 2.1.2
 - [Tilt](http://tilt.dev/) >= 0.20.8
 - Any of the local Kubernetes clusters supported by Tilt.

--- a/Dockerfile.proto
+++ b/Dockerfile.proto
@@ -1,5 +1,5 @@
 # syntax=docker.io/docker/dockerfile:1.3@sha256:42399d4635eddd7a9b8a24be879d2f9a930d0ed040a61324cfdf59ef1357b3b2
-FROM docker.io/golang:1.25.10-bookworm@sha256:154bd7001b6eb339e88c964442c0ad6ed5e53f09844cc818a41ce4ecb3ce3b43 AS go-tools
+FROM docker.io/golang:1.26.3-bookworm@sha256:386d475a660466863d9f8c766fec64d7fdad3edac2c6a05020c09534d71edb4b AS go-tools
 
 RUN mkdir /app
 
@@ -10,7 +10,7 @@ RUN --mount=type=cache,target=/root/.cache --mount=type=cache,target=/go \
 	cd /app/tools && CGO_ENABLED=0 ./build.sh
 
 # syntax=docker.io/docker/dockerfile:1.3@sha256:42399d4635eddd7a9b8a24be879d2f9a930d0ed040a61324cfdf59ef1357b3b2
-FROM docker.io/golang:1.25.10-bookworm@sha256:154bd7001b6eb339e88c964442c0ad6ed5e53f09844cc818a41ce4ecb3ce3b43 AS go-build
+FROM docker.io/golang:1.26.3-bookworm@sha256:386d475a660466863d9f8c766fec64d7fdad3edac2c6a05020c09534d71edb4b AS go-build
 
 COPY --from=go-tools /app /app
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -113,7 +113,7 @@ All guardians **must run validators for wormchain**, the codename of [Wormhole G
 
 #### Pre-requisites
 
-- Ensure you have [Go](https://golang.org/dl/) >= 1.25.10 installed.
+- Ensure you have [Go](https://golang.org/dl/) >= 1.26.3 installed.
 
 #### Building wormchaind binary
 
@@ -304,7 +304,7 @@ The following Cosmos based nodes were added prior to Gateway and guardians need 
 For security reasons, we do not provide a pre-built binary. You need to check out the repo and build the
 guardiand binary from source. A Git repo is much harder to tamper with than release binaries.
 
-To build the Wormhole node, you need [Go](https://golang.org/dl/) >= 1.25.10
+To build the Wormhole node, you need [Go](https://golang.org/dl/) >= 1.26.3
 
 First, check out the version of the Wormhole repo that you want to deploy:
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -113,7 +113,7 @@ All guardians **must run validators for wormchain**, the codename of [Wormhole G
 
 #### Pre-requisites
 
-- Ensure you have [Go](https://golang.org/dl/) >= 1.25.10 installed.
+- Ensure you have [Go](https://golang.org/dl/) >= 1.26.3 installed.
 
 #### Building wormchaind binary
 
@@ -415,7 +415,7 @@ The following Cosmos based nodes were added prior to Gateway and guardians need 
 For security reasons, we do not provide a pre-built binary. You need to check out the repo and build the
 guardiand binary from source. A Git repo is much harder to tamper with than release binaries.
 
-To build the Wormhole node, you need [Go](https://golang.org/dl/) >= 1.25.10
+To build the Wormhole node, you need [Go](https://golang.org/dl/) >= 1.26.3
 
 First, check out the version of the Wormhole repo that you want to deploy:
 

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker.io/docker/dockerfile:1.3@sha256:42399d4635eddd7a9b8a24be879d2f9a930d0ed040a61324cfdf59ef1357b3b2
-FROM docker.io/golang:1.25.10-bookworm@sha256:154bd7001b6eb339e88c964442c0ad6ed5e53f09844cc818a41ce4ecb3ce3b43 AS dev
+FROM docker.io/golang:1.26.3-bookworm@sha256:386d475a660466863d9f8c766fec64d7fdad3edac2c6a05020c09534d71edb4b AS dev
 
 FROM dev AS build
 

--- a/node/go.mod
+++ b/node/go.mod
@@ -1,6 +1,6 @@
 module github.com/certusone/wormhole/node
 
-go 1.25.10
+go 1.26.3
 
 require (
 	github.com/cenkalti/backoff/v4 v4.2.0

--- a/node/go.mod
+++ b/node/go.mod
@@ -1,6 +1,6 @@
 module github.com/certusone/wormhole/node
 
-go 1.25.10
+go 1.26.6
 
 require (
 	github.com/cenkalti/backoff/v4 v4.2.0

--- a/node/hack/query/ccqlistener/Dockerfile
+++ b/node/hack/query/ccqlistener/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker.io/docker/dockerfile:1.3@sha256:42399d4635eddd7a9b8a24be879d2f9a930d0ed040a61324cfdf59ef1357b3b2
-FROM --platform=linux/amd64 docker.io/golang:1.25.10-bookworm@sha256:154bd7001b6eb339e88c964442c0ad6ed5e53f09844cc818a41ce4ecb3ce3b43 AS build
+FROM --platform=linux/amd64 docker.io/golang:1.26.3-bookworm@sha256:386d475a660466863d9f8c766fec64d7fdad3edac2c6a05020c09534d71edb4b AS build
 # libwasmvm.so is not compatible with arm
 
 WORKDIR /app

--- a/scripts/Dockerfile.lint
+++ b/scripts/Dockerfile.lint
@@ -1,5 +1,5 @@
 # syntax=docker.io/docker/dockerfile:1.3@sha256:42399d4635eddd7a9b8a24be879d2f9a930d0ed040a61324cfdf59ef1357b3b2
-FROM docker.io/golang:1.25.10-bookworm@sha256:154bd7001b6eb339e88c964442c0ad6ed5e53f09844cc818a41ce4ecb3ce3b43
+FROM docker.io/golang:1.26.3-bookworm@sha256:386d475a660466863d9f8c766fec64d7fdad3edac2c6a05020c09534d71edb4b
 
 RUN useradd -u 1000 -U -m -d /home/lint lint
 USER 1000

--- a/scripts/Dockerfile.lint
+++ b/scripts/Dockerfile.lint
@@ -1,5 +1,5 @@
 # syntax=docker.io/docker/dockerfile:1.3@sha256:42399d4635eddd7a9b8a24be879d2f9a930d0ed040a61324cfdf59ef1357b3b2
-FROM docker.io/golang:1.25.10-bookworm@sha256:154bd7001b6eb339e88c964442c0ad6ed5e53f09844cc818a41ce4ecb3ce3b43
+FROM docker.io/golang:1.26.3-bookworm@sha256:386d475a660466863d9f8c766fec64d7fdad3edac2c6a05020c09534d71edb4b
 
 # make: drives the custom linter build via linters/Makefile.
 RUN apt-get update && apt-get install -y --no-install-recommends make \

--- a/scripts/coverage-check/go.mod
+++ b/scripts/coverage-check/go.mod
@@ -1,4 +1,4 @@
 module github.com/certusone/wormhole/scripts/coverage-check
 
 // Should match what's used in CI
-go 1.25.10
+go 1.26.3


### PR DESCRIPTION
Keeping this in draft mode as #4823 was just merged and should go through a release cycle before we try to upgrade again.