### PR TITLE
ci: bump zizmor action

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -22,6 +22,6 @@ jobs:
           persist-credentials: false
 
       - name: Run zizmor
-        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
         with:
           advanced-security: false


### PR DESCRIPTION
v0.5.6 of the GH Action matches the latest zizmor release.

https://github.com/zizmorcore/zizmor-action/releases/tag/v0.5.6
