### PR TITLE
Aptos Watcher Tests + event type check

### DIFF
--- a/node/pkg/watchers/aptos/config.go
+++ b/node/pkg/watchers/aptos/config.go
@@ -26,7 +26,7 @@ func (wc *WatcherConfig) GetChainID() vaa.ChainID {
 	return wc.ChainID
 }
 
-//nolint:unparam // Reobserver return is always nil; Aptos uses the legacy obsvReqC channel rather than the Reobserver interface.
+//nolint:unparam // error is always nil here but the return type is required to satisfy the interface.
 func (wc *WatcherConfig) Create(
 	msgC chan<- *common.MessagePublication,
 	obsvReqC <-chan *gossipv1.ObservationRequest,

--- a/node/pkg/watchers/aptos/config.go
+++ b/node/pkg/watchers/aptos/config.go
@@ -26,7 +26,7 @@ func (wc *WatcherConfig) GetChainID() vaa.ChainID {
 	return wc.ChainID
 }
 
-//nolint:unparam // error is always nil here but the return type is required to satisfy the interface.
+//nolint:unparam // Reobserver return is always nil; Aptos uses the legacy obsvReqC channel rather than the Reobserver interface.
 func (wc *WatcherConfig) Create(
 	msgC chan<- *common.MessagePublication,
 	obsvReqC <-chan *gossipv1.ObservationRequest,
@@ -35,5 +35,9 @@ func (wc *WatcherConfig) Create(
 	_ chan<- *common.GuardianSet,
 	_ common.Environment,
 ) (supervisor.Runnable, interfaces.Reobserver, error) {
-	return NewWatcher(wc.ChainID, wc.NetworkID, wc.Rpc, wc.Account, wc.Handle, msgC, obsvReqC).Run, nil, nil
+	w, err := NewWatcher(wc.ChainID, wc.NetworkID, wc.Rpc, wc.Account, wc.Handle, msgC, obsvReqC)
+	if err != nil {
+		return nil, nil, err
+	}
+	return w.Run, nil, nil
 }

--- a/node/pkg/watchers/aptos/watcher.go
+++ b/node/pkg/watchers/aptos/watcher.go
@@ -209,7 +209,7 @@ func (e *Watcher) Run(ctx context.Context) error {
 
 			events := gjson.ParseBytes(eventsJson)
 
-			if err := e.processPollingBatch(logger, events, &nextSequence); err != nil {
+			if err = e.processPollingBatch(logger, events, &nextSequence); err != nil {
 				return err
 			}
 

--- a/node/pkg/watchers/aptos/watcher.go
+++ b/node/pkg/watchers/aptos/watcher.go
@@ -30,11 +30,10 @@ type (
 		chainID   vaa.ChainID
 		networkID string
 
-		aptosRPC     string
-		aptosAccount string
-		aptosHandle  string
-		// aptosEventType is derived from aptosHandle.
-		aptosEventType string
+		aptosRPC       string
+		aptosAccount   string // Wormhole contract address
+		aptosHandle    string // Event to subscribe to Aptos RPC
+		aptosEventType string // aptosEventType is derived from aptosHandle.
 
 		msgC          chan<- *common.MessagePublication
 		obsvReqC      <-chan *gossipv1.ObservationRequest
@@ -83,10 +82,18 @@ func NewWatcher(
 	if !strings.HasSuffix(aptosHandle, "Handle") {
 		return nil, fmt.Errorf("aptosHandle %q does not end with 'Handle'", aptosHandle)
 	}
-	// Validate the configured contract address
-	if _, ok := parseAptosAddr(aptosAccount); !ok {
-		return nil, fmt.Errorf("aptosAccount %q is not a valid Aptos address", aptosAccount)
+	// Validate the handle's structure (<address>::<module>::<struct>) and its embedded address.
+	if err := validateAptosHandle(aptosHandle); err != nil {
+		return nil, err
 	}
+
+	// Validate the configured contract address. parseAptosAddr requires a valid, lowercase Aptos
+	// address so that verifyEventType can match it against the (always lowercased) event fields with
+	// an exact comparison. Fail fast on misconfiguration.
+	if _, ok := parseAptosAddr(aptosAccount); !ok {
+		return nil, fmt.Errorf("aptosAccount %q is not a valid lowercase Aptos address", aptosAccount)
+	}
+
 	return &Watcher{
 		chainID:        chainID,
 		networkID:      string(networkID),
@@ -187,7 +194,7 @@ func (e *Watcher) Run(ctx context.Context) error {
 
 			outcomes := gjson.ParseBytes(body)
 
-			e.processReobsBatch(logger, outcomes, nativeSeq)
+			e.processReobservationBatch(logger, outcomes, nativeSeq)
 
 		case <-timer.C:
 			s := ""
@@ -300,6 +307,7 @@ func (e *Watcher) processPollingBatch(logger *zap.Logger, events gjson.Result, n
 		// Consume this slot regardless of outcome so a skipped event is never re-fetched.
 		*nextSequence = eventSeq + 1
 
+		// SECURITY: Aptos event type validation
 		if err := e.verifyEventType(event); err != nil {
 			logger.Error("aptos event failed verification",
 				zap.Error(err),
@@ -332,7 +340,7 @@ func (e *Watcher) processPollingBatch(logger *zap.Logger, events gjson.Result, n
 
 // processReobsBatch handles the response to a reobservation lookup. The query
 // uses limit=1 so outcomes is expected to be a zero- or one-element array.
-func (e *Watcher) processReobsBatch(logger *zap.Logger, outcomes gjson.Result, nativeSeq uint64) {
+func (e *Watcher) processReobservationBatch(logger *zap.Logger, outcomes gjson.Result, nativeSeq uint64) {
 	for _, aptosEvent := range outcomes.Array() {
 		newSeq := aptosEvent.Get("sequence_number")
 		if !newSeq.Exists() {
@@ -344,6 +352,7 @@ func (e *Watcher) processReobsBatch(logger *zap.Logger, outcomes gjson.Result, n
 			break
 		}
 
+		// SECURITY: Aptos event type validation
 		if err := e.verifyEventType(aptosEvent); err != nil {
 			logger.Error("aptos event failed verification",
 				zap.Error(err),
@@ -369,28 +378,37 @@ func (e *Watcher) processReobsBatch(logger *zap.Logger, outcomes gjson.Result, n
 	}
 }
 
-// normalize0x strips an optional leading "0x" prefix so a configured value without it still
+// stripHexadecimalPrefix strips an optional leading "0x" prefix so a configured value without it still
 // matches the chain's 0x-prefixed representation.
-func normalize0x(s string) string {
+func stripHexadecimalPrefix(s string) string {
 	return strings.TrimPrefix(s, "0x")
 }
 
-// aptosAddrEqual reports whether two Aptos account addresses are equal. Each is decoded to its
-// canonical 32-byte form, so the "0x"/"0X" prefix, letter casing, and leading-zero padding are
-// all ignored. Returns false if either side is not a valid address.
-func aptosAddrEqual(actualAddr, expectedAddr string) bool {
-	actual, actualOK := parseAptosAddr(actualAddr)
-	expected, expectedOK := parseAptosAddr(expectedAddr)
-	return actualOK && expectedOK && actual == expected
+// validateAptosHandle checks that the event handle has the canonical
+// "<address>::<module>::<struct>" shape and that its address segment is a valid, lowercase Aptos
+// address. Splitting on "::" must yield exactly three segments; the explicit length check guards the
+// parts[0] access below from an out-of-bounds read.
+func validateAptosHandle(handle string) error {
+	parts := strings.Split(handle, "::")
+	if len(parts) != 3 {
+		return fmt.Errorf("aptosHandle %q must have the form <address>::<module>::<struct>", handle)
+	}
+	if _, ok := parseAptosAddr(parts[0]); !ok {
+		return fmt.Errorf("aptosHandle address segment %q is not a valid lowercase Aptos address", parts[0])
+	}
+	return nil
 }
 
-// parseAptosAddr decodes a hex Aptos address into its canonical 32-byte form.
+// parseAptosAddr decodes a hex Aptos address into its canonical 32-byte form. The address must be
+// lowercase with an optional lowercase "0x" prefix; uppercase hex (or a "0X" prefix) is rejected so
+// that a configured address compares equal to the always-lowercased values returned by the Aptos API.
 func parseAptosAddr(addr string) ([32]byte, bool) {
 	var out [32]byte
-	if len(addr) >= 2 && addr[0] == '0' && (addr[1] == 'x' || addr[1] == 'X') {
-		addr = addr[2:]
-	}
+	addr = stripHexadecimalPrefix(addr)
 	if len(addr) == 0 || len(addr) > 64 {
+		return out, false
+	}
+	if addr != strings.ToLower(addr) {
 		return out, false
 	}
 	decoded, err := hex.DecodeString(addr)
@@ -409,9 +427,9 @@ func (e *Watcher) verifyEventType(event gjson.Result) error {
 		return fmt.Errorf("event missing 'type' field")
 	}
 
-	// The type must match exactly, modulo the optional leading "0x" prefix. Casing is significant:
+	// The type must match exactly.
 	// Aptos returns the canonical type string, and Move module/struct names are case-sensitive.
-	if normalize0x(t.String()) != normalize0x(e.aptosEventType) {
+	if stripHexadecimalPrefix(t.String()) != stripHexadecimalPrefix(e.aptosEventType) {
 		return fmt.Errorf("event type mismatch: got %q, want %q", t.String(), e.aptosEventType)
 	}
 
@@ -421,7 +439,7 @@ func (e *Watcher) verifyEventType(event gjson.Result) error {
 	if !guidAddr.Exists() {
 		return fmt.Errorf("event missing 'guid.account_address' field")
 	}
-	if !aptosAddrEqual(guidAddr.String(), e.aptosAccount) {
+	if stripHexadecimalPrefix(guidAddr.String()) != stripHexadecimalPrefix(e.aptosAccount) {
 		return fmt.Errorf("event guid.account_address mismatch: got %q, want %q", guidAddr.String(), e.aptosAccount)
 	}
 
@@ -461,7 +479,7 @@ func (e *Watcher) observeData(logger *zap.Logger, data gjson.Result, nativeSeq u
 		return
 	}
 
-	pl, err := hex.DecodeString(strings.TrimPrefix(s, "0x"))
+	pl, err := hex.DecodeString(stripHexadecimalPrefix(s))
 	if err != nil {
 		logger.Error("payload decode", zap.Error(err))
 		return

--- a/node/pkg/watchers/aptos/watcher.go
+++ b/node/pkg/watchers/aptos/watcher.go
@@ -324,7 +324,6 @@ func (e *Watcher) processPollingBatch(logger *zap.Logger, events gjson.Result, n
 		// Validates and publishes the message to the processor
 		e.observeData(logger, data, eventSeq, false)
 	}
-	return
 }
 
 // processReobsBatch handles the response to a reobservation lookup. The query
@@ -365,7 +364,6 @@ func (e *Watcher) processReobsBatch(logger *zap.Logger, outcomes gjson.Result, n
 		// Validates and publishes the message to the processor
 		e.observeData(logger, data, nativeSeq, true)
 	}
-	return
 }
 
 // normalize0x strips the optional "0x" prefix so that values from config and

--- a/node/pkg/watchers/aptos/watcher.go
+++ b/node/pkg/watchers/aptos/watcher.go
@@ -66,6 +66,20 @@ func NewWatcher(
 	msgC chan<- *common.MessagePublication,
 	obsvReqC <-chan *gossipv1.ObservationRequest,
 ) (*Watcher, error) {
+
+	/*
+		The Aptos smart contracts have two items to consider:
+		- WormholeMessageHandle - searchable event
+		- WormholeMessage - decoded event data
+
+		During event validation, the code checks that the event is a 'state::WormholeMessage' type.
+		This check prevents bugs where the RPC returns an event of the wrong type to the watcher.
+		To do this, the text 'Handle' is removed from the `aptosHandle` to derive
+		the name of the event. This is done in order to avoid passing another parameter to the watcher.
+
+		This is only be convention this optimization can be done. If the Aptos smart contracts or
+		watcher was ever changed, this would no longer work and should be changed.
+	*/
 	if !strings.HasSuffix(aptosHandle, "Handle") {
 		return nil, fmt.Errorf("aptosHandle %q does not end with 'Handle'", aptosHandle)
 	}
@@ -169,9 +183,7 @@ func (e *Watcher) Run(ctx context.Context) error {
 
 			outcomes := gjson.ParseBytes(body)
 
-			if err := e.processReobsBatch(logger, outcomes, nativeSeq); err != nil {
-				return err
-			}
+			e.processReobsBatch(logger, outcomes, nativeSeq)
 
 		case <-timer.C:
 			s := ""
@@ -209,9 +221,7 @@ func (e *Watcher) Run(ctx context.Context) error {
 
 			events := gjson.ParseBytes(eventsJson)
 
-			if err = e.processPollingBatch(logger, events, &nextSequence); err != nil {
-				return err
-			}
+			e.processPollingBatch(logger, events, &nextSequence)
 
 			health, err := e.retrievePayload(aptosHealth)
 			if err != nil {
@@ -272,7 +282,7 @@ func (e *Watcher) retrievePayload(s string) ([]byte, error) {
 // processPollingBatch iterates the events returned by the polling endpoint,
 // advancing nextSequence as events are consumed. Returns a non-nil error if
 // the watcher should exit (event type mismatch).
-func (e *Watcher) processPollingBatch(logger *zap.Logger, events gjson.Result, nextSequence *uint64) error {
+func (e *Watcher) processPollingBatch(logger *zap.Logger, events gjson.Result, nextSequence *uint64) {
 	// the endpoint returns an array of events, ordered by sequence id (ASC)
 	for _, event := range events.Array() {
 		eventSequence := event.Get("sequence_number")
@@ -282,9 +292,18 @@ func (e *Watcher) processPollingBatch(logger *zap.Logger, events gjson.Result, n
 		eventSeq := eventSequence.Uint()
 
 		if err := e.verifyEventType(event); err != nil {
-			logger.Error("event type mismatch, exiting watcher", zap.Error(err))
+			logger.Error("aptos event failed verification",
+				zap.Error(err),
+				zap.Uint64("eventSequence", eventSeq),
+				zap.String("eventType", event.Get("type").String()),
+				zap.String("guidAccountAddress", event.Get("guid.account_address").String()),
+				zap.String("guidCreationNumber", event.Get("guid.creation_number").String()),
+				zap.String("expectedType", e.aptosEventType),
+				zap.String("account", e.aptosAccount),
+				zap.String("handle", e.aptosHandle),
+			)
 			p2p.DefaultRegistry.AddErrorCount(e.chainID, 1)
-			return fmt.Errorf("aptos event type mismatch: %w", err)
+			continue
 		}
 
 		if *nextSequence == 0 && eventSeq != 0 {
@@ -305,13 +324,13 @@ func (e *Watcher) processPollingBatch(logger *zap.Logger, events gjson.Result, n
 		// Validates and publishes the message to the processor
 		e.observeData(logger, data, eventSeq, false)
 	}
-	return nil
+	return
 }
 
 // processReobsBatch handles the response to a reobservation lookup. The query
 // uses limit=1 so outcomes is expected to be a zero- or one-element array.
 // Returns a non-nil error if the watcher should exit (event type mismatch).
-func (e *Watcher) processReobsBatch(logger *zap.Logger, outcomes gjson.Result, nativeSeq uint64) error {
+func (e *Watcher) processReobsBatch(logger *zap.Logger, outcomes gjson.Result, nativeSeq uint64) {
 	for _, aptosEvent := range outcomes.Array() {
 		newSeq := aptosEvent.Get("sequence_number")
 		if !newSeq.Exists() {
@@ -324,9 +343,18 @@ func (e *Watcher) processReobsBatch(logger *zap.Logger, outcomes gjson.Result, n
 		}
 
 		if err := e.verifyEventType(aptosEvent); err != nil {
-			logger.Error("event type mismatch, exiting watcher", zap.Error(err))
+			logger.Error("aptos event failed verification",
+				zap.Error(err),
+				zap.Uint64("eventSequence", nativeSeq),
+				zap.String("eventType", aptosEvent.Get("type").String()),
+				zap.String("guidAccountAddress", aptosEvent.Get("guid.account_address").String()),
+				zap.String("guidCreationNumber", aptosEvent.Get("guid.creation_number").String()),
+				zap.String("expectedType", e.aptosEventType),
+				zap.String("account", e.aptosAccount),
+				zap.String("handle", e.aptosHandle),
+			)
 			p2p.DefaultRegistry.AddErrorCount(e.chainID, 1)
-			return fmt.Errorf("aptos event type mismatch: %w", err)
+			continue
 		}
 
 		data := aptosEvent.Get("data")
@@ -337,7 +365,7 @@ func (e *Watcher) processReobsBatch(logger *zap.Logger, outcomes gjson.Result, n
 		// Validates and publishes the message to the processor
 		e.observeData(logger, data, nativeSeq, true)
 	}
-	return nil
+	return
 }
 
 // normalize0x strips the optional "0x" prefix so that values from config and

--- a/node/pkg/watchers/aptos/watcher.go
+++ b/node/pkg/watchers/aptos/watcher.go
@@ -77,8 +77,8 @@ func NewWatcher(
 		To do this, the text 'Handle' is removed from the `aptosHandle` to derive
 		the name of the event. This is done in order to avoid passing another parameter to the watcher.
 
-		This is only be convention this optimization can be done. If the Aptos smart contracts or
-		watcher was ever changed, this would no longer work and should be changed.
+		This is only by the current convention this optimization can be done. If the Aptos smart contracts or
+		watcher event consumption were ever changed, this may no longer work.
 	*/
 	if !strings.HasSuffix(aptosHandle, "Handle") {
 		return nil, fmt.Errorf("aptosHandle %q does not end with 'Handle'", aptosHandle)

--- a/node/pkg/watchers/aptos/watcher.go
+++ b/node/pkg/watchers/aptos/watcher.go
@@ -33,6 +33,8 @@ type (
 		aptosRPC     string
 		aptosAccount string
 		aptosHandle  string
+		// aptosEventType is derived from aptosHandle.
+		aptosEventType string
 
 		msgC          chan<- *common.MessagePublication
 		obsvReqC      <-chan *gossipv1.ObservationRequest
@@ -63,17 +65,21 @@ func NewWatcher(
 	aptosHandle string,
 	msgC chan<- *common.MessagePublication,
 	obsvReqC <-chan *gossipv1.ObservationRequest,
-) *Watcher {
-	return &Watcher{
-		chainID:       chainID,
-		networkID:     string(networkID),
-		aptosRPC:      aptosRPC,
-		aptosAccount:  aptosAccount,
-		aptosHandle:   aptosHandle,
-		msgC:          msgC,
-		obsvReqC:      obsvReqC,
-		readinessSync: common.MustConvertChainIdToReadinessSyncing(chainID),
+) (*Watcher, error) {
+	if !strings.HasSuffix(aptosHandle, "Handle") {
+		return nil, fmt.Errorf("aptosHandle %q does not end with 'Handle'", aptosHandle)
 	}
+	return &Watcher{
+		chainID:        chainID,
+		networkID:      string(networkID),
+		aptosRPC:       aptosRPC,
+		aptosAccount:   aptosAccount,
+		aptosHandle:    aptosHandle,
+		aptosEventType: strings.TrimSuffix(aptosHandle, "Handle"),
+		msgC:           msgC,
+		obsvReqC:       obsvReqC,
+		readinessSync:  common.MustConvertChainIdToReadinessSyncing(chainID),
+	}, nil
 }
 
 func (e *Watcher) Run(ctx context.Context) error {
@@ -93,8 +99,8 @@ func (e *Watcher) Run(ctx context.Context) error {
 	// Get the node version for troubleshooting
 	e.logVersion(logger)
 
-	// SECURITY: the API guarantees that we only get the events from the right
-	// contract
+	// SECURITY: the API guarantees that we only get the events from the right contract.
+	// Additional defense-in-depth check to verify that this is the case.
 	var eventsEndpoint = fmt.Sprintf(`%s/v1/accounts/%s/events/%s/event`, e.aptosRPC, e.aptosAccount, e.aptosHandle)
 	var aptosHealth = fmt.Sprintf(`%s/v1`, e.aptosRPC)
 
@@ -163,23 +169,8 @@ func (e *Watcher) Run(ctx context.Context) error {
 
 			outcomes := gjson.ParseBytes(body)
 
-			for _, chunk := range outcomes.Array() {
-				newSeq := chunk.Get("sequence_number")
-				if !newSeq.Exists() {
-					break
-				}
-
-				if newSeq.Uint() != nativeSeq {
-					logger.Error("newSeq != nativeSeq")
-					break
-
-				}
-
-				data := chunk.Get("data")
-				if !data.Exists() {
-					break
-				}
-				e.observeData(logger, data, nativeSeq, true)
+			if err := e.processReobsBatch(logger, outcomes, nativeSeq); err != nil {
+				return err
 			}
 
 		case <-timer.C:
@@ -218,30 +209,8 @@ func (e *Watcher) Run(ctx context.Context) error {
 
 			events := gjson.ParseBytes(eventsJson)
 
-			// the endpoint returns an array of events, ordered by sequence
-			// id (ASC)
-			for _, event := range events.Array() {
-				eventSequence := event.Get("sequence_number")
-				if !eventSequence.Exists() {
-					continue
-				}
-
-				eventSeq := eventSequence.Uint()
-				if nextSequence == 0 && eventSeq != 0 {
-					// Avoid publishing an old observation on startup. This does not block the first message on a new chain (when eventSeq would be zero).
-					nextSequence = eventSeq + 1
-					continue
-				}
-
-				// this is interesting in the last iteration, whereby we
-				// find the next sequence that comes after the array
-				nextSequence = eventSeq + 1
-
-				data := event.Get("data")
-				if !data.Exists() {
-					continue
-				}
-				e.observeData(logger, data, eventSeq, false)
+			if err := e.processPollingBatch(logger, events, &nextSequence); err != nil {
+				return err
 			}
 
 			health, err := e.retrievePayload(aptosHealth)
@@ -299,6 +268,104 @@ func (e *Watcher) retrievePayload(s string) ([]byte, error) {
 	return body, err
 }
 
+// Compares event type to the watchers event
+// processPollingBatch iterates the events returned by the polling endpoint,
+// advancing nextSequence as events are consumed. Returns a non-nil error if
+// the watcher should exit (event type mismatch).
+func (e *Watcher) processPollingBatch(logger *zap.Logger, events gjson.Result, nextSequence *uint64) error {
+	// the endpoint returns an array of events, ordered by sequence id (ASC)
+	for _, event := range events.Array() {
+		eventSequence := event.Get("sequence_number")
+		if !eventSequence.Exists() {
+			continue
+		}
+		eventSeq := eventSequence.Uint()
+
+		if err := e.verifyEventType(event); err != nil {
+			logger.Error("event type mismatch, exiting watcher", zap.Error(err))
+			p2p.DefaultRegistry.AddErrorCount(e.chainID, 1)
+			return fmt.Errorf("aptos event type mismatch: %w", err)
+		}
+
+		if *nextSequence == 0 && eventSeq != 0 {
+			// Avoid publishing an old observation on startup. This does not block the first message on a new chain (when eventSeq would be zero).
+			*nextSequence = eventSeq + 1
+			continue
+		}
+
+		// this is interesting in the last iteration, whereby we
+		// find the next sequence that comes after the array
+		*nextSequence = eventSeq + 1
+
+		data := event.Get("data")
+		if !data.Exists() {
+			continue
+		}
+
+		// Validates and publishes the message to the processor
+		e.observeData(logger, data, eventSeq, false)
+	}
+	return nil
+}
+
+// processReobsBatch handles the response to a reobservation lookup. The query
+// uses limit=1 so outcomes is expected to be a zero- or one-element array.
+// Returns a non-nil error if the watcher should exit (event type mismatch).
+func (e *Watcher) processReobsBatch(logger *zap.Logger, outcomes gjson.Result, nativeSeq uint64) error {
+	for _, aptosEvent := range outcomes.Array() {
+		newSeq := aptosEvent.Get("sequence_number")
+		if !newSeq.Exists() {
+			break
+		}
+
+		if newSeq.Uint() != nativeSeq {
+			logger.Error("newSeq != nativeSeq")
+			break
+		}
+
+		if err := e.verifyEventType(aptosEvent); err != nil {
+			logger.Error("event type mismatch, exiting watcher", zap.Error(err))
+			p2p.DefaultRegistry.AddErrorCount(e.chainID, 1)
+			return fmt.Errorf("aptos event type mismatch: %w", err)
+		}
+
+		data := aptosEvent.Get("data")
+		if !data.Exists() {
+			break
+		}
+
+		// Validates and publishes the message to the processor
+		e.observeData(logger, data, nativeSeq, true)
+	}
+	return nil
+}
+
+// Verify that the event on the response lines up with the
+// event on the subscription URL. Defense-in-depth check.
+func (e *Watcher) verifyEventType(event gjson.Result) error {
+	t := event.Get("type")
+	if !t.Exists() {
+		return fmt.Errorf("event missing 'type' field")
+	}
+
+	// Type must be an exact string match. The casing matters.
+	if t.String() != e.aptosEventType {
+		return fmt.Errorf("event type mismatch: got %q, want %q", t.String(), e.aptosEventType)
+	}
+
+	// The GUID identifies the on-chain EventHandle that emitted the event;
+	// account_address must equal the configured core bridge account.
+	guidAddr := event.Get("guid.account_address")
+	if !guidAddr.Exists() {
+		return fmt.Errorf("event missing 'guid.account_address' field")
+	}
+	if !strings.EqualFold(guidAddr.String(), e.aptosAccount) {
+		return fmt.Errorf("event guid.account_address mismatch: got %q, want %q", guidAddr.String(), e.aptosAccount)
+	}
+
+	return nil
+}
+
 func (e *Watcher) observeData(logger *zap.Logger, data gjson.Result, nativeSeq uint64, isReobservation bool) {
 	em := data.Get("sender")
 	if !em.Exists() {
@@ -310,6 +377,8 @@ func (e *Watcher) observeData(logger *zap.Logger, data gjson.Result, nativeSeq u
 	binary.BigEndian.PutUint64(emitter, em.Uint())
 
 	// SECURITY: vaa.Address is guaranteed to be 32 bytes so copy's slice into `a` is safe.
+	// The maximum value is u64 because of the incrementing ID of the emitter's type in the
+	// smart contract. Thus, this is a safe conversion.
 	var a vaa.Address
 	copy(a[24:], emitter)
 

--- a/node/pkg/watchers/aptos/watcher.go
+++ b/node/pkg/watchers/aptos/watcher.go
@@ -340,6 +340,14 @@ func (e *Watcher) processReobsBatch(logger *zap.Logger, outcomes gjson.Result, n
 	return nil
 }
 
+// normalize0x strips the optional "0x" prefix so that values from config and
+// from the chain's JSON response can be compared without prefix asymmetry
+// causing false mismatches. Applies to bare Aptos addresses and to fully-
+// qualified type strings (which embed an address as their first segment).
+func normalize0x(s string) string {
+	return strings.TrimPrefix(s, "0x")
+}
+
 // Verify that the event on the response lines up with the
 // event on the subscription URL. Defense-in-depth check.
 func (e *Watcher) verifyEventType(event gjson.Result) error {
@@ -348,8 +356,12 @@ func (e *Watcher) verifyEventType(event gjson.Result) error {
 		return fmt.Errorf("event missing 'type' field")
 	}
 
-	// Type must be an exact string match. The casing matters.
-	if t.String() != e.aptosEventType {
+	// Type must be an exact string match, modulo the optional "0x" prefix on
+	// the embedded address. Casing is intentionally significant: Aptos Move
+	// module and struct names are case-sensitive at the language level, so
+	// "WormholeMessage" and "wormholemessage" are distinct types and must not
+	// be conflated.
+	if normalize0x(t.String()) != normalize0x(e.aptosEventType) {
 		return fmt.Errorf("event type mismatch: got %q, want %q", t.String(), e.aptosEventType)
 	}
 
@@ -359,7 +371,7 @@ func (e *Watcher) verifyEventType(event gjson.Result) error {
 	if !guidAddr.Exists() {
 		return fmt.Errorf("event missing 'guid.account_address' field")
 	}
-	if !strings.EqualFold(guidAddr.String(), e.aptosAccount) {
+	if !strings.EqualFold(normalize0x(guidAddr.String()), normalize0x(e.aptosAccount)) {
 		return fmt.Errorf("event guid.account_address mismatch: got %q, want %q", guidAddr.String(), e.aptosAccount)
 	}
 

--- a/node/pkg/watchers/aptos/watcher.go
+++ b/node/pkg/watchers/aptos/watcher.go
@@ -30,10 +30,15 @@ type (
 		chainID   vaa.ChainID
 		networkID string
 
-		aptosRPC       string
-		aptosAccount   string // Wormhole contract address
-		aptosHandle    string // Event to subscribe to Aptos RPC
-		aptosEventType string // aptosEventType is derived from aptosHandle.
+		aptosRPC     string
+		aptosAccount string // Wormhole contract address
+		aptosHandle  string // Event to subscribe to Aptos RPC
+
+		// Cached canonical event values to compare against, computed at startup.
+		accountAddr     [32]byte
+		eventTypeAddr   [32]byte
+		eventTypeModule string
+		eventTypeStruct string
 
 		msgC          chan<- *common.MessagePublication
 		obsvReqC      <-chan *gossipv1.ObservationRequest
@@ -88,22 +93,33 @@ func NewWatcher(
 	}
 
 	// Validate the configured contract address. parseAptosAddr requires a valid, lowercase Aptos
-	// address so that verifyEventType can match it against the (always lowercased) event fields with
-	// an exact comparison. Fail fast on misconfiguration.
-	if _, ok := parseAptosAddr(aptosAccount); !ok {
+	// address so that verifyEventType can match it against the (always lowercased) event fields.
+	// Fail fast on misconfiguration. The canonical bytes are cached for later comparison.
+	accountAddr, ok := parseAptosAddr(aptosAccount)
+	if !ok {
 		return nil, fmt.Errorf("aptosAccount %q is not a valid lowercase Aptos address", aptosAccount)
 	}
 
+	// Cache the canonical pieces of the event type for comparison in verifyEventType.
+	eventType := strings.TrimSuffix(aptosHandle, "Handle")
+	eventTypeAddr, eventTypeModule, eventTypeStruct, ok := parseAptosEventType(eventType)
+	if !ok {
+		return nil, fmt.Errorf("derived aptosEventType %q is not a valid Move type tag", eventType)
+	}
+
 	return &Watcher{
-		chainID:        chainID,
-		networkID:      string(networkID),
-		aptosRPC:       aptosRPC,
-		aptosAccount:   aptosAccount,
-		aptosHandle:    aptosHandle,
-		aptosEventType: strings.TrimSuffix(aptosHandle, "Handle"),
-		msgC:           msgC,
-		obsvReqC:       obsvReqC,
-		readinessSync:  common.MustConvertChainIdToReadinessSyncing(chainID),
+		chainID:         chainID,
+		networkID:       string(networkID),
+		aptosRPC:        aptosRPC,
+		aptosAccount:    aptosAccount,
+		aptosHandle:     aptosHandle,
+		accountAddr:     accountAddr,
+		eventTypeAddr:   eventTypeAddr,
+		eventTypeModule: eventTypeModule,
+		eventTypeStruct: eventTypeStruct,
+		msgC:            msgC,
+		obsvReqC:        obsvReqC,
+		readinessSync:   common.MustConvertChainIdToReadinessSyncing(chainID),
 	}, nil
 }
 
@@ -315,7 +331,6 @@ func (e *Watcher) processPollingBatch(logger *zap.Logger, events gjson.Result, n
 				zap.String("eventType", event.Get("type").String()),
 				zap.String("guidAccountAddress", event.Get("guid.account_address").String()),
 				zap.String("guidCreationNumber", event.Get("guid.creation_number").String()),
-				zap.String("expectedType", e.aptosEventType),
 				zap.String("account", e.aptosAccount),
 				zap.String("handle", e.aptosHandle),
 			)
@@ -360,7 +375,6 @@ func (e *Watcher) processReobservationBatch(logger *zap.Logger, outcomes gjson.R
 				zap.String("eventType", aptosEvent.Get("type").String()),
 				zap.String("guidAccountAddress", aptosEvent.Get("guid.account_address").String()),
 				zap.String("guidCreationNumber", aptosEvent.Get("guid.creation_number").String()),
-				zap.String("expectedType", e.aptosEventType),
 				zap.String("account", e.aptosAccount),
 				zap.String("handle", e.aptosHandle),
 			)
@@ -411,12 +425,32 @@ func parseAptosAddr(addr string) ([32]byte, bool) {
 	if addr != strings.ToLower(addr) {
 		return out, false
 	}
+	// The Aptos API returns special addresses in short form on a 4-bit nibble boundary
+	// (e.g. "0x1", "0x0"), which is odd-length hex. Pad so it decodes.
+	if len(addr)%2 == 1 {
+		addr = "0" + addr
+	}
 	decoded, err := hex.DecodeString(addr)
 	if err != nil {
 		return out, false
 	}
 	copy(out[32-len(decoded):], decoded)
 	return out, true
+}
+
+// parseAptosEventType splits a Move type tag "<address>::<module>::<struct>" into its canonical
+// address bytes and its module/struct names. ok is false if the tag does not have exactly three
+// "::"-separated segments or its address segment is not a valid Aptos address.
+func parseAptosEventType(t string) (addr [32]byte, module, structName string, ok bool) {
+	parts := strings.Split(t, "::")
+	if len(parts) != 3 {
+		return addr, "", "", false
+	}
+	addr, ok = parseAptosAddr(parts[0])
+	if !ok {
+		return addr, "", "", false
+	}
+	return addr, parts[1], parts[2], true
 }
 
 // Verify that the event on the response lines up with the
@@ -427,10 +461,11 @@ func (e *Watcher) verifyEventType(event gjson.Result) error {
 		return fmt.Errorf("event missing 'type' field")
 	}
 
-	// The type must match exactly.
-	// Aptos returns the canonical type string, and Move module/struct names are case-sensitive.
-	if stripHexadecimalPrefix(t.String()) != stripHexadecimalPrefix(e.aptosEventType) {
-		return fmt.Errorf("event type mismatch: got %q, want %q", t.String(), e.aptosEventType)
+	// Compare the address segment by canonical bytes, since the API may strip leading zeros.
+	// Move module/struct names are case-sensitive and must match exactly.
+	addr, module, structName, ok := parseAptosEventType(t.String())
+	if !ok || addr != e.eventTypeAddr || module != e.eventTypeModule || structName != e.eventTypeStruct {
+		return fmt.Errorf("event type mismatch: got %q, want handle %q", t.String(), e.aptosHandle)
 	}
 
 	// The GUID identifies the on-chain EventHandle that emitted the event;
@@ -439,7 +474,8 @@ func (e *Watcher) verifyEventType(event gjson.Result) error {
 	if !guidAddr.Exists() {
 		return fmt.Errorf("event missing 'guid.account_address' field")
 	}
-	if stripHexadecimalPrefix(guidAddr.String()) != stripHexadecimalPrefix(e.aptosAccount) {
+	gAddr, ok := parseAptosAddr(guidAddr.String())
+	if !ok || gAddr != e.accountAddr {
 		return fmt.Errorf("event guid.account_address mismatch: got %q, want %q", guidAddr.String(), e.aptosAccount)
 	}
 

--- a/node/pkg/watchers/aptos/watcher.go
+++ b/node/pkg/watchers/aptos/watcher.go
@@ -83,6 +83,10 @@ func NewWatcher(
 	if !strings.HasSuffix(aptosHandle, "Handle") {
 		return nil, fmt.Errorf("aptosHandle %q does not end with 'Handle'", aptosHandle)
 	}
+	// Validate the configured contract address
+	if _, ok := parseAptosAddr(aptosAccount); !ok {
+		return nil, fmt.Errorf("aptosAccount %q is not a valid Aptos address", aptosAccount)
+	}
 	return &Watcher{
 		chainID:        chainID,
 		networkID:      string(networkID),
@@ -278,10 +282,8 @@ func (e *Watcher) retrievePayload(s string) ([]byte, error) {
 	return body, err
 }
 
-// Compares event type to the watchers event
 // processPollingBatch iterates the events returned by the polling endpoint,
-// advancing nextSequence as events are consumed. Returns a non-nil error if
-// the watcher should exit (event type mismatch).
+// advancing nextSequence as events are consumed.
 func (e *Watcher) processPollingBatch(logger *zap.Logger, events gjson.Result, nextSequence *uint64) {
 	// the endpoint returns an array of events, ordered by sequence id (ASC)
 	for _, event := range events.Array() {
@@ -290,6 +292,13 @@ func (e *Watcher) processPollingBatch(logger *zap.Logger, events gjson.Result, n
 			continue
 		}
 		eventSeq := eventSequence.Uint()
+
+		// On startup nextSequence is 0; a non-zero first event is pre-existing backlog we
+		// should not republish. Capture this before advancing, since it reads the old value.
+		isStartupBacklog := *nextSequence == 0 && eventSeq != 0
+
+		// Consume this slot regardless of outcome so a skipped event is never re-fetched.
+		*nextSequence = eventSeq + 1
 
 		if err := e.verifyEventType(event); err != nil {
 			logger.Error("aptos event failed verification",
@@ -306,15 +315,10 @@ func (e *Watcher) processPollingBatch(logger *zap.Logger, events gjson.Result, n
 			continue
 		}
 
-		if *nextSequence == 0 && eventSeq != 0 {
+		if isStartupBacklog {
 			// Avoid publishing an old observation on startup. This does not block the first message on a new chain (when eventSeq would be zero).
-			*nextSequence = eventSeq + 1
 			continue
 		}
-
-		// this is interesting in the last iteration, whereby we
-		// find the next sequence that comes after the array
-		*nextSequence = eventSeq + 1
 
 		data := event.Get("data")
 		if !data.Exists() {
@@ -328,7 +332,6 @@ func (e *Watcher) processPollingBatch(logger *zap.Logger, events gjson.Result, n
 
 // processReobsBatch handles the response to a reobservation lookup. The query
 // uses limit=1 so outcomes is expected to be a zero- or one-element array.
-// Returns a non-nil error if the watcher should exit (event type mismatch).
 func (e *Watcher) processReobsBatch(logger *zap.Logger, outcomes gjson.Result, nativeSeq uint64) {
 	for _, aptosEvent := range outcomes.Array() {
 		newSeq := aptosEvent.Get("sequence_number")
@@ -366,12 +369,36 @@ func (e *Watcher) processReobsBatch(logger *zap.Logger, outcomes gjson.Result, n
 	}
 }
 
-// normalize0x strips the optional "0x" prefix so that values from config and
-// from the chain's JSON response can be compared without prefix asymmetry
-// causing false mismatches. Applies to bare Aptos addresses and to fully-
-// qualified type strings (which embed an address as their first segment).
+// normalize0x strips an optional leading "0x" prefix so a configured value without it still
+// matches the chain's 0x-prefixed representation.
 func normalize0x(s string) string {
 	return strings.TrimPrefix(s, "0x")
+}
+
+// aptosAddrEqual reports whether two Aptos account addresses are equal. Each is decoded to its
+// canonical 32-byte form, so the "0x"/"0X" prefix, letter casing, and leading-zero padding are
+// all ignored. Returns false if either side is not a valid address.
+func aptosAddrEqual(actualAddr, expectedAddr string) bool {
+	actual, actualOK := parseAptosAddr(actualAddr)
+	expected, expectedOK := parseAptosAddr(expectedAddr)
+	return actualOK && expectedOK && actual == expected
+}
+
+// parseAptosAddr decodes a hex Aptos address into its canonical 32-byte form.
+func parseAptosAddr(addr string) ([32]byte, bool) {
+	var out [32]byte
+	if len(addr) >= 2 && addr[0] == '0' && (addr[1] == 'x' || addr[1] == 'X') {
+		addr = addr[2:]
+	}
+	if len(addr) == 0 || len(addr) > 64 {
+		return out, false
+	}
+	decoded, err := hex.DecodeString(addr)
+	if err != nil {
+		return out, false
+	}
+	copy(out[32-len(decoded):], decoded)
+	return out, true
 }
 
 // Verify that the event on the response lines up with the
@@ -382,11 +409,8 @@ func (e *Watcher) verifyEventType(event gjson.Result) error {
 		return fmt.Errorf("event missing 'type' field")
 	}
 
-	// Type must be an exact string match, modulo the optional "0x" prefix on
-	// the embedded address. Casing is intentionally significant: Aptos Move
-	// module and struct names are case-sensitive at the language level, so
-	// "WormholeMessage" and "wormholemessage" are distinct types and must not
-	// be conflated.
+	// The type must match exactly, modulo the optional leading "0x" prefix. Casing is significant:
+	// Aptos returns the canonical type string, and Move module/struct names are case-sensitive.
 	if normalize0x(t.String()) != normalize0x(e.aptosEventType) {
 		return fmt.Errorf("event type mismatch: got %q, want %q", t.String(), e.aptosEventType)
 	}
@@ -397,7 +421,7 @@ func (e *Watcher) verifyEventType(event gjson.Result) error {
 	if !guidAddr.Exists() {
 		return fmt.Errorf("event missing 'guid.account_address' field")
 	}
-	if !strings.EqualFold(normalize0x(guidAddr.String()), normalize0x(e.aptosAccount)) {
+	if !aptosAddrEqual(guidAddr.String(), e.aptosAccount) {
 		return fmt.Errorf("event guid.account_address mismatch: got %q, want %q", guidAddr.String(), e.aptosAccount)
 	}
 

--- a/node/pkg/watchers/aptos/watcher_test.go
+++ b/node/pkg/watchers/aptos/watcher_test.go
@@ -279,7 +279,7 @@ func TestVerifyEventType(t *testing.T) {
 			// compared case-insensitively.
 			name: "Happy path casing change",
 			mutate: func(m map[string]any) {
-				m["guid"].(map[string]any)["account_address"] = "0x5Bc11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625"
+				m["guid"].(map[string]any)["account_address"] = "0x5Bc11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625" //nolint:forcetypeassert // test data shape is known
 			},
 		},
 		{
@@ -307,7 +307,7 @@ func TestVerifyEventType(t *testing.T) {
 		},
 		{
 			name:        "Missing account_address",
-			mutate:      func(m map[string]any) { delete(m["guid"].(map[string]any), "account_address") },
+			mutate:      func(m map[string]any) { delete(m["guid"].(map[string]any), "account_address") }, //nolint:forcetypeassert // test data shape is known
 			expectError: "event missing 'guid.account_address'",
 		},
 		{
@@ -315,7 +315,7 @@ func TestVerifyEventType(t *testing.T) {
 			// guid.account_address. normalize0x should strip both sides.
 			name: "0x prefix stripped on guid.account_address",
 			mutate: func(m map[string]any) {
-				m["guid"].(map[string]any)["account_address"] = strings.TrimPrefix(testAptosAccount, "0x")
+				m["guid"].(map[string]any)["account_address"] = strings.TrimPrefix(testAptosAccount, "0x") //nolint:forcetypeassert // test data shape is known
 			},
 		},
 		{

--- a/node/pkg/watchers/aptos/watcher_test.go
+++ b/node/pkg/watchers/aptos/watcher_test.go
@@ -3,6 +3,7 @@ package aptos
 import (
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -266,196 +267,72 @@ func TestVerifyEventType(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		json        string
+		mutate      func(m map[string]any) // Function to mutate the event JSON
 		expectError string
 	}{
 		{
-			name: "Happy path",
-			json: `{
-				"guid": {
-					"creation_number": "2",
-					"account_address": "0x5bc11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625"
-				},
-				"type" : "0x5bc11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625::state::WormholeMessage",
-				"sequence_number": "171377",
-				"data": {
-					"sender": "1",
-					"sequence": "171377",
-					"nonce": "0",
-					"payload": "0xdeadbeef",
-					"consistency_level": "0",
-					"timestamp": "1700000000"
-				}
-			}`,
-			expectError: "",
+			name:   "Happy path",
+			mutate: nil,
 		},
 		{
+			// Casing of the address is insignificant: guid.account_address is
+			// compared case-insensitively.
 			name: "Happy path casing change",
-			json: `{
-				"guid": {
-					"creation_number": "2",
-					"account_address": "0x5Bc11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625"
-				},
-				"type" : "0x5bc11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625::state::WormholeMessage",
-				"sequence_number": "171377",
-				"data": {
-					"sender": "1",
-					"sequence": "171377",
-					"nonce": "0",
-					"payload": "0xdeadbeef",
-					"consistency_level": "0",
-					"timestamp": "1700000000"
-				}
-			}`,
-			expectError: "",
+			mutate: func(m map[string]any) {
+				m["guid"].(map[string]any)["account_address"] = "0x5Bc11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625"
+			},
 		},
 		{
-			name: "Missing 'type' in the JSON",
-			json: `{
-				"guid": {
-					"creation_number": "2",
-					"account_address": "0x5bc11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625"
-				},
-				"sequence_number": "171377",
-				"data": {
-					"sender": "1",
-					"sequence": "171377",
-					"nonce": "0",
-					"payload": "0xdeadbeef",
-					"consistency_level": "0",
-					"timestamp": "1700000000"
-				}
-			}`,
+			name:        "Missing 'type' in the JSON",
+			mutate:      func(m map[string]any) { delete(m, "type") },
 			expectError: "event missing 'type'",
 		},
 		{
+			// Different address in the package segment of the type.
 			name: "Wrong type package",
-			json: `{
-				"guid": {
-					"creation_number": "2",
-					"account_address": "0x5bc11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625"
-				},
-				"type" : "0x11c11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625::state::WormholeMessage",
-				"sequence_number": "171377",
-				"data": {
-					"sender": "1",
-					"sequence": "171377",
-					"nonce": "0",
-					"payload": "0xdeadbeef",
-					"consistency_level": "0",
-					"timestamp": "1700000000"
-				}
-			}`,
+			mutate: func(m map[string]any) {
+				m["type"] = "0x11c11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625::state::WormholeMessage"
+			},
 			expectError: "event type mismatch",
 		},
 		{
-			name: "Wrong type module",
-			json: `{
-				"guid": {
-					"creation_number": "2",
-					"account_address": "0x5bc11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625"
-				},
-				"type" : "0x5bc11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625::notstate::WormholeMessage",
-				"sequence_number": "171377",
-				"data": {
-					"sender": "1",
-					"sequence": "171377",
-					"nonce": "0",
-					"payload": "0xdeadbeef",
-					"consistency_level": "0",
-					"timestamp": "1700000000"
-				}
-			}`,
+			name:        "Wrong type module",
+			mutate:      func(m map[string]any) { m["type"] = testAptosAccount + "::notstate::WormholeMessage" },
 			expectError: "event type mismatch",
 		},
 		{
-			name: "Wrong type struct type",
-			json: `{
-				"guid": {
-					"creation_number": "2",
-					"account_address": "0x5bc11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625"
-				},
-				"type" : "0x5bc11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625::state::NotWormholeMessage",
-				"sequence_number": "171377",
-				"data": {
-					"sender": "1",
-					"sequence": "171377",
-					"nonce": "0",
-					"payload": "0xdeadbeef",
-					"consistency_level": "0",
-					"timestamp": "1700000000"
-				}
-			}`,
+			name:        "Wrong type struct type",
+			mutate:      func(m map[string]any) { m["type"] = testAptosAccount + "::state::NotWormholeMessage" },
 			expectError: "event type mismatch",
 		},
 		{
-			name: "Missing account_address",
-			json: `{
-				"guid": {
-					"creation_number": "2",
-				},
-				"type" : "0x5bc11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625::state::WormholeMessage",
-				"sequence_number": "171377",
-				"data": {
-					"sender": "1",
-					"sequence": "171377",
-					"nonce": "0",
-					"payload": "0xdeadbeef",
-					"consistency_level": "0",
-					"timestamp": "1700000000"
-				}
-			}`,
+			name:        "Missing account_address",
+			mutate:      func(m map[string]any) { delete(m["guid"].(map[string]any), "account_address") },
 			expectError: "event missing 'guid.account_address'",
 		},
 		{
 			// Config carries the "0x" prefix; this event omits it on
 			// guid.account_address. normalize0x should strip both sides.
 			name: "0x prefix stripped on guid.account_address",
-			json: `{
-				"guid": {
-					"creation_number": "2",
-					"account_address": "5bc11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625"
-				},
-				"type" : "0x5bc11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625::state::WormholeMessage",
-				"sequence_number": "171377",
-				"data": {
-					"sender": "1",
-					"sequence": "171377",
-					"nonce": "0",
-					"payload": "0xdeadbeef",
-					"consistency_level": "0",
-					"timestamp": "1700000000"
-				}
-			}`,
-			expectError: "",
+			mutate: func(m map[string]any) {
+				m["guid"].(map[string]any)["account_address"] = strings.TrimPrefix(testAptosAccount, "0x")
+			},
 		},
 		{
 			// Config carries the "0x" prefix; this event omits it on
 			// the type field. normalize0x should strip both sides.
-			name: "0x prefix stripped on type",
-			json: `{
-				"guid": {
-					"creation_number": "2",
-					"account_address": "0x5bc11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625"
-				},
-				"type" : "5bc11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625::state::WormholeMessage",
-				"sequence_number": "171377",
-				"data": {
-					"sender": "1",
-					"sequence": "171377",
-					"nonce": "0",
-					"payload": "0xdeadbeef",
-					"consistency_level": "0",
-					"timestamp": "1700000000"
-				}
-			}`,
-			expectError: "",
+			name:   "0x prefix stripped on type",
+			mutate: func(m map[string]any) { m["type"] = strings.TrimPrefix(testExpectedType, "0x") },
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			err := w.verifyEventType(gjson.Parse(tc.json))
+			e := pollEvent()
+			if tc.mutate != nil {
+				tc.mutate(e)
+			}
+			err := w.verifyEventType(gjson.Parse(marshalJSON(t, e)))
 
 			if tc.expectError == "" {
 				assert.NoError(t, err)
@@ -486,6 +363,31 @@ func pollEvent() map[string]any {
 // processPollingBatch expects via gjson.Parse.
 func encodeBatch(t *testing.T, events ...map[string]any) string {
 	return marshalJSON(t, events)
+}
+
+// assertLoggedError verifies the failure surface of the batch processors, which
+// no longer return an error but instead log it via zap and continue. The
+// haystack for each entry is its message plus its "error" context field (the
+// verifyEventType error is attached via zap.Error). When want is empty, no
+// error-level entry should have been logged at all.
+func assertLoggedError(t *testing.T, logs *observer.ObservedLogs, want string) {
+	t.Helper()
+
+	if want == "" {
+		assert.Empty(t, logs.All(), "expected no error logs")
+		return
+	}
+
+	for _, e := range logs.All() {
+		s := e.Message
+		if ev, ok := e.ContextMap()["error"]; ok {
+			s += " " + fmt.Sprint(ev)
+		}
+		if strings.Contains(s, want) {
+			return
+		}
+	}
+	assert.Failf(t, "missing expected log", "expected a logged error containing %q, got %v", want, logs.All())
 }
 
 func TestProcessPollingBatch(t *testing.T) {
@@ -583,7 +485,7 @@ func TestProcessPollingBatch(t *testing.T) {
 			initialNextSeq:   100,
 			expectedNextSeq:  100,
 			expectedMsgCount: 0,
-			expectError:      "aptos event type mismatch",
+			expectError:      "event type mismatch",
 		},
 		{
 			name:             "One valid, one invalid",
@@ -605,7 +507,7 @@ func TestProcessPollingBatch(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			core, _ := observer.New(zapcore.ErrorLevel)
+			core, logs := observer.New(zapcore.ErrorLevel)
 			logger := zap.New(core)
 			msgC := make(chan *common.MessagePublication, 16)
 			w := &Watcher{
@@ -623,14 +525,9 @@ func TestProcessPollingBatch(t *testing.T) {
 			}
 
 			nextSeq := tc.initialNextSeq
-			err := w.processPollingBatch(logger, gjson.Parse(jsonStr), &nextSeq)
+			w.processPollingBatch(logger, gjson.Parse(jsonStr), &nextSeq)
 
-			if tc.expectError == "" {
-				require.NoError(t, err)
-			} else {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tc.expectError)
-			}
+			assertLoggedError(t, logs, tc.expectError)
 			assert.Equal(t, tc.expectedNextSeq, nextSeq)
 			assert.Len(t, msgC, tc.expectedMsgCount)
 		})
@@ -671,14 +568,14 @@ func TestProcessReobs(t *testing.T) {
 			events:           []map[string]any{happyFirst},
 			nativeSeq:        99, // Wrong sequence for the message
 			expectedMsgCount: 0,
-			expectError:      "",
+			expectError:      "newSeq != nativeSeq",
 		},
 		{
 			name:             "Bad event information",
 			events:           []map[string]any{badHandle},
 			nativeSeq:        100,
 			expectedMsgCount: 0,
-			expectError:      "aptos event type mismatch",
+			expectError:      "event type mismatch",
 		},
 		{
 			name:             "One valid, one invalid",
@@ -705,7 +602,7 @@ func TestProcessReobs(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			core, _ := observer.New(zapcore.ErrorLevel)
+			core, logs := observer.New(zapcore.ErrorLevel)
 			logger := zap.New(core)
 			msgC := make(chan *common.MessagePublication, 16)
 			w := &Watcher{
@@ -722,14 +619,9 @@ func TestProcessReobs(t *testing.T) {
 				jsonStr = encodeBatch(t, tc.events...)
 			}
 
-			err := w.processReobsBatch(logger, gjson.Parse(jsonStr), tc.nativeSeq)
+			w.processReobsBatch(logger, gjson.Parse(jsonStr), tc.nativeSeq)
 
-			if tc.expectError == "" {
-				require.NoError(t, err)
-			} else {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tc.expectError)
-			}
+			assertLoggedError(t, logs, tc.expectError)
 			assert.Len(t, msgC, tc.expectedMsgCount)
 		})
 	}

--- a/node/pkg/watchers/aptos/watcher_test.go
+++ b/node/pkg/watchers/aptos/watcher_test.go
@@ -587,6 +587,63 @@ func TestParseAptosAddrLeftPads(t *testing.T) {
 	assert.False(t, ok, "uppercase 0X prefix must be rejected")
 }
 
+// TestParseAptosAddrLengths exercises the full spectrum of input lengths the RPC could
+// conceivably return, since verifyEventType feeds it untrusted address strings. Aptos addresses
+// are 32 bytes (64 hex nibbles); the parser accepts any non-empty hex string up to 64 nibbles
+// (odd or even, since the API strips leading zeros, including down to a single nibble) and rejects
+// empty input or anything longer than 64 nibbles. Every accepted value left-pads into the canonical
+// 32-byte form.
+func TestParseAptosAddrLengths(t *testing.T) {
+	// hexN returns a value of n hex nibbles (without the "0x" prefix), e.g. "1212...".
+	hexN := func(n int) string {
+		return strings.Repeat("12", n/2) + strings.Repeat("1", n%2)
+	}
+
+	tests := []struct {
+		name   string
+		addr   string
+		wantOK bool
+	}{
+		// Empty / prefix-only: nothing to decode.
+		{name: "empty string", addr: "", wantOK: false},
+		{name: "prefix only", addr: "0x", wantOK: false},
+
+		// Minimum-length short forms the API returns for special addresses (e.g. 0x0, 0x1).
+		{name: "single nibble", addr: "0x1", wantOK: true},
+		{name: "single zero nibble", addr: "0x0", wantOK: true},
+
+		// Odd-length values in range: the parser pads them to an even nibble count.
+		{name: "odd length 3", addr: "0x" + hexN(3), wantOK: true},
+		{name: "odd length 63", addr: "0x" + hexN(63), wantOK: true},
+
+		// Even-length values in range.
+		{name: "even length 2", addr: "0x" + hexN(2), wantOK: true},
+		{name: "even length 62", addr: "0x" + hexN(62), wantOK: true},
+
+		// Boundary at the 64-nibble (32-byte) maximum.
+		{name: "max length 64", addr: "0x" + hexN(64), wantOK: true},
+		{name: "one over max (65)", addr: "0x" + hexN(65), wantOK: false},
+		{name: "two over max (66)", addr: "0x" + hexN(66), wantOK: false},
+
+		// Length is measured after stripping "0x", so an unprefixed 64-nibble value is still valid.
+		{name: "max length 64 no prefix", addr: hexN(64), wantOK: true},
+
+		// Length is in range but the content is not valid hex.
+		{name: "non-hex in range", addr: "0xzz", wantOK: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			out, ok := parseAptosAddr(tc.addr)
+			require.Equal(t, tc.wantOK, ok)
+			if !ok {
+				// Rejected inputs must yield the zero value and never a partially-decoded address.
+				assert.Equal(t, [32]byte{}, out)
+			}
+		})
+	}
+}
+
 func TestProcessPollingBatch(t *testing.T) {
 	// happy path: two consecutive events. Built by mutating pollEvent() defaults.
 	happyFirst := pollEvent()

--- a/node/pkg/watchers/aptos/watcher_test.go
+++ b/node/pkg/watchers/aptos/watcher_test.go
@@ -394,7 +394,7 @@ func TestAptosAddrEqual(t *testing.T) {
 	// Prefix, casing, and leading-zero padding are all ignored.
 	assert.True(t, aptosAddrEqual("0x01", "0x0000000000000000000000000000000000000000000000000000000000000001"))
 	assert.True(t, aptosAddrEqual("0xABCD", "abcd"))
-	assert.True(t, aptosAddrEqual("0X01", "0x01"))            // "0X" prefix
+	assert.True(t, aptosAddrEqual("0X01", "0x01"))             // "0X" prefix
 	assert.True(t, aptosAddrEqual("0x00", "0x00000000000000")) // zero address, any padding
 
 	// Distinct addresses must not be equal.

--- a/node/pkg/watchers/aptos/watcher_test.go
+++ b/node/pkg/watchers/aptos/watcher_test.go
@@ -275,12 +275,13 @@ func TestVerifyEventType(t *testing.T) {
 			mutate: nil,
 		},
 		{
-			// Casing of the address is insignificant: guid.account_address is
-			// compared case-insensitively.
-			name: "Happy path casing change",
+			// Casing of the address is significant: the API always returns lowercased
+			// addresses, so an uppercased guid.account_address is a mismatch.
+			name: "Uppercased address fails",
 			mutate: func(m map[string]any) {
 				m["guid"].(map[string]any)["account_address"] = "0x5Bc11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625" //nolint:forcetypeassert // test data shape is known
 			},
+			expectError: "event guid.account_address mismatch",
 		},
 		{
 			name:        "Missing 'type' in the JSON",
@@ -390,20 +391,112 @@ func assertLoggedError(t *testing.T, logs *observer.ObservedLogs, want string) {
 	assert.Failf(t, "missing expected log", "expected a logged error containing %q, got %v", want, logs.All())
 }
 
-func TestAptosAddrEqual(t *testing.T) {
-	// Prefix, casing, and leading-zero padding are all ignored.
-	assert.True(t, aptosAddrEqual("0x01", "0x0000000000000000000000000000000000000000000000000000000000000001"))
-	assert.True(t, aptosAddrEqual("0xABCD", "abcd"))
-	assert.True(t, aptosAddrEqual("0X01", "0x01"))             // "0X" prefix
-	assert.True(t, aptosAddrEqual("0x00", "0x00000000000000")) // zero address, any padding
+func TestNewWatcher(t *testing.T) {
+	tests := []struct {
+		name        string
+		account     string
+		handle      string
+		expectError string
+	}{
+		{
+			name:    "valid lowercase",
+			account: testAptosAccount,
+			handle:  testAptosHandle,
+		},
+		{
+			name:        "uppercased account",
+			account:     "0x5Bc11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625",
+			handle:      testAptosHandle,
+			expectError: "aptosAccount",
+		},
+		{
+			name:        "uppercased address in handle",
+			account:     testAptosAccount,
+			handle:      "0x5Bc11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625::state::WormholeMessageHandle",
+			expectError: "aptosHandle address segment",
+		},
+		{
+			name:        "handle missing 'Handle' suffix",
+			account:     testAptosAccount,
+			handle:      testExpectedType,
+			expectError: "does not end with 'Handle'",
+		},
+		{
+			name:        "invalid account hex",
+			account:     "0xzz",
+			handle:      testAptosHandle,
+			expectError: "not a valid lowercase Aptos address",
+		},
+	}
 
-	// Distinct addresses must not be equal.
-	assert.False(t, aptosAddrEqual("0x1", "0x2"))
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w, err := NewWatcher(vaa.ChainIDAptos, "aptos", "http://localhost", tc.account, tc.handle, nil, nil)
 
-	// Invalid inputs are never equal: empty, non-hex, and over-32-byte (>64 hex chars).
-	assert.False(t, aptosAddrEqual("", "0x1"))
-	assert.False(t, aptosAddrEqual("0xZZ", "0x1"))
-	assert.False(t, aptosAddrEqual(strings.Repeat("a", 65), strings.Repeat("a", 65)))
+			if tc.expectError == "" {
+				require.NoError(t, err)
+				require.NotNil(t, w)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectError)
+			}
+		})
+	}
+}
+
+func TestValidateAptosHandle(t *testing.T) {
+	tests := []struct {
+		name        string
+		handle      string
+		expectError string
+	}{
+		{
+			name:   "valid handle",
+			handle: testAptosHandle,
+		},
+		{
+			name:        "too few segments",
+			handle:      "0x5bc11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625::WormholeMessageHandle",
+			expectError: "must have the form",
+		},
+		{
+			name:        "too many segments",
+			handle:      testAptosHandle + "::extra",
+			expectError: "must have the form",
+		},
+		{
+			name:        "no separators",
+			handle:      "0x5bc11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625",
+			expectError: "must have the form",
+		},
+		{
+			name:        "uppercased address segment",
+			handle:      "0x5Bc11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625::state::WormholeMessageHandle",
+			expectError: "is not a valid lowercase Aptos address",
+		},
+		{
+			name:        "invalid hex address segment",
+			handle:      "0xzz::state::WormholeMessageHandle",
+			expectError: "is not a valid lowercase Aptos address",
+		},
+		{
+			name:        "empty address segment",
+			handle:      "::state::WormholeMessageHandle",
+			expectError: "is not a valid lowercase Aptos address",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateAptosHandle(tc.handle)
+			if tc.expectError == "" {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectError)
+			}
+		})
+	}
 }
 
 func TestParseAptosAddrLeftPads(t *testing.T) {
@@ -427,6 +520,12 @@ func TestParseAptosAddrLeftPads(t *testing.T) {
 	want[30] = 0x01
 	want[31] = 0x02
 	assert.Equal(t, want, got)
+
+	// Uppercase hex and the "0X" prefix are rejected: only lowercase is valid.
+	_, ok = parseAptosAddr("0xABCD")
+	assert.False(t, ok, "uppercase hex must be rejected")
+	_, ok = parseAptosAddr("0X01")
+	assert.False(t, ok, "uppercase 0X prefix must be rejected")
 }
 
 func TestProcessPollingBatch(t *testing.T) {
@@ -658,7 +757,7 @@ func TestProcessReobs(t *testing.T) {
 				jsonStr = encodeBatch(t, tc.events...)
 			}
 
-			w.processReobsBatch(logger, gjson.Parse(jsonStr), tc.nativeSeq)
+			w.processReobservationBatch(logger, gjson.Parse(jsonStr), tc.nativeSeq)
 
 			assertLoggedError(t, logs, tc.expectError)
 			assert.Len(t, msgC, tc.expectedMsgCount)

--- a/node/pkg/watchers/aptos/watcher_test.go
+++ b/node/pkg/watchers/aptos/watcher_test.go
@@ -312,7 +312,7 @@ func TestVerifyEventType(t *testing.T) {
 		},
 		{
 			// Config carries the "0x" prefix; this event omits it on
-			// guid.account_address. normalize0x should strip both sides.
+			// guid.account_address. The address comparison ignores the prefix.
 			name: "0x prefix stripped on guid.account_address",
 			mutate: func(m map[string]any) {
 				m["guid"].(map[string]any)["account_address"] = strings.TrimPrefix(testAptosAccount, "0x") //nolint:forcetypeassert // test data shape is known
@@ -320,7 +320,7 @@ func TestVerifyEventType(t *testing.T) {
 		},
 		{
 			// Config carries the "0x" prefix; this event omits it on
-			// the type field. normalize0x should strip both sides.
+			// the type field. The embedded address comparison ignores the prefix.
 			name:   "0x prefix stripped on type",
 			mutate: func(m map[string]any) { m["type"] = strings.TrimPrefix(testExpectedType, "0x") },
 		},
@@ -390,14 +390,53 @@ func assertLoggedError(t *testing.T, logs *observer.ObservedLogs, want string) {
 	assert.Failf(t, "missing expected log", "expected a logged error containing %q, got %v", want, logs.All())
 }
 
+func TestAptosAddrEqual(t *testing.T) {
+	// Prefix, casing, and leading-zero padding are all ignored.
+	assert.True(t, aptosAddrEqual("0x01", "0x0000000000000000000000000000000000000000000000000000000000000001"))
+	assert.True(t, aptosAddrEqual("0xABCD", "abcd"))
+	assert.True(t, aptosAddrEqual("0X01", "0x01"))            // "0X" prefix
+	assert.True(t, aptosAddrEqual("0x00", "0x00000000000000")) // zero address, any padding
+
+	// Distinct addresses must not be equal.
+	assert.False(t, aptosAddrEqual("0x1", "0x2"))
+
+	// Invalid inputs are never equal: empty, non-hex, and over-32-byte (>64 hex chars).
+	assert.False(t, aptosAddrEqual("", "0x1"))
+	assert.False(t, aptosAddrEqual("0xZZ", "0x1"))
+	assert.False(t, aptosAddrEqual(strings.Repeat("a", 65), strings.Repeat("a", 65)))
+}
+
+func TestParseAptosAddrLeftPads(t *testing.T) {
+	// A short address must land in the low-order (rightmost) bytes: 0x01 -> 0x00..01,
+	// not 0x01 followed by zeros.
+	got, ok := parseAptosAddr("0x01")
+	require.True(t, ok)
+	want := [32]byte{}
+	want[31] = 0x01
+	assert.Equal(t, want, got)
+
+	// A wrongly right-padded (left-aligned) layout must NOT be produced.
+	wrong := [32]byte{}
+	wrong[0] = 0x01
+	assert.NotEqual(t, wrong, got)
+
+	// Multi-byte values stay big-endian and right-aligned.
+	got, ok = parseAptosAddr("0x0102")
+	require.True(t, ok)
+	want = [32]byte{}
+	want[30] = 0x01
+	want[31] = 0x02
+	assert.Equal(t, want, got)
+}
+
 func TestProcessPollingBatch(t *testing.T) {
 	// happy path: two consecutive events. Built by mutating pollEvent() defaults.
 	happyFirst := pollEvent()
 	happySecond := pollEvent()
 	happySecond["sequence_number"] = "101"
 
-	// Bad event information: wrong event type triggers verifyEventType, which
-	// causes processPollingBatch to return an error before touching nextSequence.
+	// Bad event information: wrong event type fails verifyEventType, so the event is
+	// skipped (not published) but its sequence slot is still consumed (nextSequence advances).
 	badHandle := pollEvent()
 	badHandle["type"] = "0x5bc11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625::state::NotAWormholeMessage"
 
@@ -483,7 +522,7 @@ func TestProcessPollingBatch(t *testing.T) {
 			name:             "Bad event information",
 			events:           []map[string]any{badHandle},
 			initialNextSeq:   100,
-			expectedNextSeq:  100,
+			expectedNextSeq:  101, // slot consumed even though the event is skipped
 			expectedMsgCount: 0,
 			expectError:      "event type mismatch",
 		},

--- a/node/pkg/watchers/aptos/watcher_test.go
+++ b/node/pkg/watchers/aptos/watcher_test.go
@@ -3,6 +3,7 @@ package aptos
 import (
 	"encoding/hex"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/certusone/wormhole/node/pkg/common"
@@ -406,6 +407,50 @@ func TestVerifyEventType(t *testing.T) {
 			}`,
 			expectError: "event missing 'guid.account_address'",
 		},
+		{
+			// Config carries the "0x" prefix; this event omits it on
+			// guid.account_address. normalize0x should strip both sides.
+			name: "0x prefix stripped on guid.account_address",
+			json: `{
+				"guid": {
+					"creation_number": "2",
+					"account_address": "5bc11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625"
+				},
+				"type" : "0x5bc11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625::state::WormholeMessage",
+				"sequence_number": "171377",
+				"data": {
+					"sender": "1",
+					"sequence": "171377",
+					"nonce": "0",
+					"payload": "0xdeadbeef",
+					"consistency_level": "0",
+					"timestamp": "1700000000"
+				}
+			}`,
+			expectError: "",
+		},
+		{
+			// Config carries the "0x" prefix; this event omits it on
+			// the type field. normalize0x should strip both sides.
+			name: "0x prefix stripped on type",
+			json: `{
+				"guid": {
+					"creation_number": "2",
+					"account_address": "0x5bc11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625"
+				},
+				"type" : "5bc11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625::state::WormholeMessage",
+				"sequence_number": "171377",
+				"data": {
+					"sender": "1",
+					"sequence": "171377",
+					"nonce": "0",
+					"payload": "0xdeadbeef",
+					"consistency_level": "0",
+					"timestamp": "1700000000"
+				}
+			}`,
+			expectError: "",
+		},
 	}
 
 	for _, tc := range tests {
@@ -462,6 +507,19 @@ func TestProcessPollingBatch(t *testing.T) {
 	// nextSequence is advanced to eventSeq+1 and observeData is never called.
 	startupSkip := pollEvent() // sequence_number defaults to "100"
 
+	// Normalization: same valid event, but with the "0x" prefix stripped from
+	// guid.account_address only. verifyEventType should normalize and accept.
+	prefixStrippedGuid := pollEvent()
+	prefixStrippedGuid["guid"] = map[string]any{
+		"creation_number": "2",
+		"account_address": strings.TrimPrefix(testAptosAccount, "0x"),
+	}
+
+	// Normalization: same valid event, but with the "0x" prefix stripped from
+	// the type field only. verifyEventType should normalize and accept.
+	prefixStrippedType := pollEvent()
+	prefixStrippedType["type"] = strings.TrimPrefix(testExpectedType, "0x")
+
 	tests := []struct {
 		name             string
 		events           []map[string]any // marshaled to a JSON array unless rawJSON is set
@@ -474,6 +532,22 @@ func TestProcessPollingBatch(t *testing.T) {
 		{
 			name:             "happy path: one event",
 			events:           []map[string]any{happyFirst},
+			initialNextSeq:   100,
+			expectedNextSeq:  101,
+			expectedMsgCount: 1,
+			expectError:      "",
+		},
+		{
+			name:             "0x prefix stripped on guid.account_address",
+			events:           []map[string]any{prefixStrippedGuid},
+			initialNextSeq:   100,
+			expectedNextSeq:  101,
+			expectedMsgCount: 1,
+			expectError:      "",
+		},
+		{
+			name:             "0x prefix stripped on type",
+			events:           []map[string]any{prefixStrippedType},
 			initialNextSeq:   100,
 			expectedNextSeq:  101,
 			expectedMsgCount: 1,

--- a/node/pkg/watchers/aptos/watcher_test.go
+++ b/node/pkg/watchers/aptos/watcher_test.go
@@ -257,13 +257,8 @@ func TestObserveDataNonceTooLargeFails(t *testing.T) {
 }
 
 func TestVerifyEventType(t *testing.T) {
-	w := &Watcher{
-		chainID:        vaa.ChainIDAptos,
-		networkID:      "aptos-test",
-		aptosAccount:   testAptosAccount,
-		aptosHandle:    testAptosHandle,
-		aptosEventType: testExpectedType,
-	}
+	w, err := NewWatcher(vaa.ChainIDAptos, "aptos-test", "http://localhost", testAptosAccount, testAptosHandle, nil, nil)
+	require.NoError(t, err)
 
 	tests := []struct {
 		name        string
@@ -325,6 +320,17 @@ func TestVerifyEventType(t *testing.T) {
 			name:   "0x prefix stripped on type",
 			mutate: func(m map[string]any) { m["type"] = strings.TrimPrefix(testExpectedType, "0x") },
 		},
+		{
+			// A type tag without exactly three "::" segments is malformed.
+			name:        "Malformed type: too few segments",
+			mutate:      func(m map[string]any) { m["type"] = testAptosAccount + "::WormholeMessage" },
+			expectError: "event type mismatch",
+		},
+		{
+			name:        "Malformed type: too many segments",
+			mutate:      func(m map[string]any) { m["type"] = testExpectedType + "::extra" },
+			expectError: "event type mismatch",
+		},
 	}
 
 	for _, tc := range tests {
@@ -341,6 +347,43 @@ func TestVerifyEventType(t *testing.T) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tc.expectError)
 			}
+		})
+	}
+}
+
+// TestVerifyEventTypeShortFormAddress confirms the byte comparison treats the Aptos API's
+// short-form addresses (leading zeros stripped) as equal to the zero-padded configured form.
+// The watcher is configured with the full 64-char address; the event uses the stripped form.
+func TestVerifyEventTypeShortFormAddress(t *testing.T) {
+	tests := []struct {
+		name      string
+		fullAddr  string // configured, zero-padded 64-char form
+		shortAddr string // form returned by the API, leading zeros stripped
+	}{
+		{
+			// Special address collapsed to a single nibble.
+			name:      "single nibble (0x1)",
+			fullAddr:  "0x0000000000000000000000000000000000000000000000000000000000000001",
+			shortAddr: "0x1",
+		},
+		{
+			// One full leading zero byte (two nibbles) stripped; remainder is even-length.
+			name:      "leading zero byte stripped",
+			fullAddr:  "0x007730cd28ee1cdc9e999336cbc430f99e7c44397c0aa77516f6f23a78559bb5",
+			shortAddr: "0x7730cd28ee1cdc9e999336cbc430f99e7c44397c0aa77516f6f23a78559bb5",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w, err := NewWatcher(vaa.ChainIDAptos, "aptos-test", "http://localhost", tc.fullAddr, tc.fullAddr+"::module::EventHandle", nil, nil)
+			require.NoError(t, err)
+
+			event := map[string]any{
+				"guid": map[string]any{"creation_number": "0", "account_address": tc.shortAddr},
+				"type": tc.shortAddr + "::module::Event",
+			}
+			require.NoError(t, w.verifyEventType(gjson.Parse(marshalJSON(t, event))))
 		})
 	}
 }
@@ -513,6 +556,22 @@ func TestParseAptosAddrLeftPads(t *testing.T) {
 	wrong[0] = 0x01
 	assert.NotEqual(t, wrong, got)
 
+	// Odd-length (single-nibble) short form, as the Aptos API returns special addresses
+	// like "0x1"/"0x0", must be padded and land in the rightmost byte.
+	got, ok = parseAptosAddr("0x1")
+	require.True(t, ok)
+	want = [32]byte{}
+	want[31] = 0x01
+	assert.Equal(t, want, got)
+
+	// A stripped leading zero byte (two nibbles) yields the same canonical bytes as the
+	// full zero-padded form.
+	stripped, ok := parseAptosAddr("0x7730cd28ee1cdc9e999336cbc430f99e7c44397c0aa77516f6f23a78559bb5")
+	require.True(t, ok)
+	padded, ok := parseAptosAddr("0x007730cd28ee1cdc9e999336cbc430f99e7c44397c0aa77516f6f23a78559bb5")
+	require.True(t, ok)
+	assert.Equal(t, padded, stripped)
+
 	// Multi-byte values stay big-endian and right-aligned.
 	got, ok = parseAptosAddr("0x0102")
 	require.True(t, ok)
@@ -648,14 +707,8 @@ func TestProcessPollingBatch(t *testing.T) {
 			core, logs := observer.New(zapcore.ErrorLevel)
 			logger := zap.New(core)
 			msgC := make(chan *common.MessagePublication, 16)
-			w := &Watcher{
-				chainID:        vaa.ChainIDAptos,
-				networkID:      "aptos-test",
-				msgC:           msgC,
-				aptosAccount:   testAptosAccount,
-				aptosHandle:    testAptosHandle,
-				aptosEventType: testExpectedType,
-			}
+			w, err := NewWatcher(vaa.ChainIDAptos, "aptos-test", "http://localhost", testAptosAccount, testAptosHandle, msgC, nil)
+			require.NoError(t, err)
 
 			jsonStr := tc.rawJSON
 			if jsonStr == "" {
@@ -743,14 +796,8 @@ func TestProcessReobs(t *testing.T) {
 			core, logs := observer.New(zapcore.ErrorLevel)
 			logger := zap.New(core)
 			msgC := make(chan *common.MessagePublication, 16)
-			w := &Watcher{
-				chainID:        vaa.ChainIDAptos,
-				networkID:      "aptos-test",
-				msgC:           msgC,
-				aptosAccount:   testAptosAccount,
-				aptosHandle:    testAptosHandle,
-				aptosEventType: testExpectedType,
-			}
+			w, err := NewWatcher(vaa.ChainIDAptos, "aptos-test", "http://localhost", testAptosAccount, testAptosHandle, msgC, nil)
+			require.NoError(t, err)
 
 			jsonStr := tc.rawJSON
 			if jsonStr == "" {

--- a/node/pkg/watchers/aptos/watcher_test.go
+++ b/node/pkg/watchers/aptos/watcher_test.go
@@ -2,7 +2,7 @@ package aptos
 
 import (
 	"encoding/hex"
-	"fmt"
+	"encoding/json"
 	"testing"
 
 	"github.com/certusone/wormhole/node/pkg/common"
@@ -15,22 +15,17 @@ import (
 	"go.uber.org/zap/zaptest/observer"
 )
 
-// validEvent returns a well-formed Aptos WormholeMessage JSON.
-func validEvent() string {
-	return `{
-		"sender": "1",
-		"payload": "0xdeadbeef",
-		"timestamp": "1000",
-		"nonce": "42",
-		"sequence": "7",
-		"consistency_level": "1"
-	}`
-}
+const (
+	testAptosAccount = "0x5bc11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625"
+	testAptosHandle  = "0x5bc11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625::state::WormholeMessageHandle"
+	testExpectedType = "0x5bc11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625::state::WormholeMessage"
+)
 
-// eventWith replaces or removes a single field in validEvent.
-// Pass value "" with remove=true to delete the field.
-func eventWith(field, value string, remove bool) string {
-	base := map[string]string{
+// eventData returns a fresh, mutable map of the inner "data" object that
+// observeData consumes. All values are strings (gjson .Uint() parses via
+// strconv). Callers can mutate or delete fields before marshaling.
+func eventData() map[string]any {
+	return map[string]any{
 		"sender":            "1",
 		"payload":           "0xdeadbeef",
 		"timestamp":         "1000",
@@ -38,22 +33,33 @@ func eventWith(field, value string, remove bool) string {
 		"sequence":          "7",
 		"consistency_level": "1",
 	}
+}
+
+// Marshal JSON to mimic Aptos API
+func marshalJSON(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return string(b)
+}
+
+// validEvent returns a well-formed Aptos WormholeMessage JSON.
+func validEvent() string {
+	b, _ := json.Marshal(eventData())
+	return string(b)
+}
+
+// eventWith replaces or removes a single field in validEvent.
+// Pass value "" with remove=true to delete the field.
+func eventWith(field, value string, remove bool) string {
+	d := eventData()
 	if remove {
-		delete(base, field)
+		delete(d, field)
 	} else {
-		base[field] = value
+		d[field] = value
 	}
-	json := "{"
-	first := true
-	for k, v := range base {
-		if !first {
-			json += ","
-		}
-		json += fmt.Sprintf("%q:%q", k, v)
-		first = false
-	}
-	json += "}"
-	return json
+	b, _ := json.Marshal(d)
+	return string(b)
 }
 
 func TestObserveData(t *testing.T) {
@@ -218,4 +224,439 @@ func TestObserveDataFields(t *testing.T) {
 	assert.Equal(t, uint8(15), msg.ConsistencyLevel)
 	assert.Equal(t, int64(1700000000), msg.Timestamp.Unix())
 	assert.True(t, msg.IsReobservation)
+}
+
+/*
+Most implementations have nonce as 32 bits. The Aptos implementation incorrectly has 64 bits.
+It's possible to send a Wormhole message with too large of a nonce. These should be rejected, not truncated.
+This test confirms that this stays true.
+*/
+func TestObserveDataNonceTooLargeFails(t *testing.T) {
+	core, _ := observer.New(zapcore.ErrorLevel)
+	logger := zap.New(core)
+	msgC := make(chan *common.MessagePublication, 1)
+	w := &Watcher{
+		chainID:   vaa.ChainIDAptos,
+		networkID: "aptos-test",
+		msgC:      msgC,
+	}
+
+	json := `{
+		"sender": "5",
+		"payload": "0xcafebabe",
+		"timestamp": "1700000000",
+		"nonce": "4294967296",
+		"sequence": "42",
+		"consistency_level": "15"
+	}`
+
+	w.observeData(logger, gjson.Parse(json), 123, true)
+	require.Len(t, msgC, 0)
+}
+
+func TestVerifyEventType(t *testing.T) {
+	w := &Watcher{
+		chainID:        vaa.ChainIDAptos,
+		networkID:      "aptos-test",
+		aptosAccount:   testAptosAccount,
+		aptosHandle:    testAptosHandle,
+		aptosEventType: testExpectedType,
+	}
+
+	tests := []struct {
+		name        string
+		json        string
+		expectError string
+	}{
+		{
+			name: "Happy path",
+			json: `{
+				"guid": {
+					"creation_number": "2",
+					"account_address": "0x5bc11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625"
+				},
+				"type" : "0x5bc11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625::state::WormholeMessage",
+				"sequence_number": "171377",
+				"data": {
+					"sender": "1",
+					"sequence": "171377",
+					"nonce": "0",
+					"payload": "0xdeadbeef",
+					"consistency_level": "0",
+					"timestamp": "1700000000"
+				}
+			}`,
+			expectError: "",
+		},
+		{
+			name: "Happy path casing change",
+			json: `{
+				"guid": {
+					"creation_number": "2",
+					"account_address": "0x5Bc11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625"
+				},
+				"type" : "0x5bc11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625::state::WormholeMessage",
+				"sequence_number": "171377",
+				"data": {
+					"sender": "1",
+					"sequence": "171377",
+					"nonce": "0",
+					"payload": "0xdeadbeef",
+					"consistency_level": "0",
+					"timestamp": "1700000000"
+				}
+			}`,
+			expectError: "",
+		},
+		{
+			name: "Missing 'type' in the JSON",
+			json: `{
+				"guid": {
+					"creation_number": "2",
+					"account_address": "0x5bc11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625"
+				},
+				"sequence_number": "171377",
+				"data": {
+					"sender": "1",
+					"sequence": "171377",
+					"nonce": "0",
+					"payload": "0xdeadbeef",
+					"consistency_level": "0",
+					"timestamp": "1700000000"
+				}
+			}`,
+			expectError: "event missing 'type'",
+		},
+		{
+			name: "Wrong type package",
+			json: `{
+				"guid": {
+					"creation_number": "2",
+					"account_address": "0x5bc11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625"
+				},
+				"type" : "0x11c11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625::state::WormholeMessage",
+				"sequence_number": "171377",
+				"data": {
+					"sender": "1",
+					"sequence": "171377",
+					"nonce": "0",
+					"payload": "0xdeadbeef",
+					"consistency_level": "0",
+					"timestamp": "1700000000"
+				}
+			}`,
+			expectError: "event type mismatch",
+		},
+		{
+			name: "Wrong type module",
+			json: `{
+				"guid": {
+					"creation_number": "2",
+					"account_address": "0x5bc11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625"
+				},
+				"type" : "0x5bc11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625::notstate::WormholeMessage",
+				"sequence_number": "171377",
+				"data": {
+					"sender": "1",
+					"sequence": "171377",
+					"nonce": "0",
+					"payload": "0xdeadbeef",
+					"consistency_level": "0",
+					"timestamp": "1700000000"
+				}
+			}`,
+			expectError: "event type mismatch",
+		},
+		{
+			name: "Wrong type struct type",
+			json: `{
+				"guid": {
+					"creation_number": "2",
+					"account_address": "0x5bc11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625"
+				},
+				"type" : "0x5bc11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625::state::NotWormholeMessage",
+				"sequence_number": "171377",
+				"data": {
+					"sender": "1",
+					"sequence": "171377",
+					"nonce": "0",
+					"payload": "0xdeadbeef",
+					"consistency_level": "0",
+					"timestamp": "1700000000"
+				}
+			}`,
+			expectError: "event type mismatch",
+		},
+		{
+			name: "Missing account_address",
+			json: `{
+				"guid": {
+					"creation_number": "2",
+				},
+				"type" : "0x5bc11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625::state::WormholeMessage",
+				"sequence_number": "171377",
+				"data": {
+					"sender": "1",
+					"sequence": "171377",
+					"nonce": "0",
+					"payload": "0xdeadbeef",
+					"consistency_level": "0",
+					"timestamp": "1700000000"
+				}
+			}`,
+			expectError: "event missing 'guid.account_address'",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := w.verifyEventType(gjson.Parse(tc.json))
+
+			if tc.expectError == "" {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectError)
+			}
+		})
+	}
+}
+
+// pollEvent returns a fresh map representing one valid polling-batch event.
+// Defaults are hardcoded; callers mutate "sequence_number" (and any other
+// field, including nested "data" fields) before passing to encodeBatch.
+func pollEvent() map[string]any {
+	return map[string]any{
+		"guid": map[string]any{
+			"creation_number": "2",
+			"account_address": testAptosAccount,
+		},
+		"type":            testExpectedType,
+		"sequence_number": "100",
+		"data":            eventData(),
+	}
+}
+
+// encodeBatch marshals events into the JSON array string that
+// processPollingBatch expects via gjson.Parse.
+func encodeBatch(t *testing.T, events ...map[string]any) string {
+	return marshalJSON(t, events)
+}
+
+func TestProcessPollingBatch(t *testing.T) {
+	// happy path: two consecutive events. Built by mutating pollEvent() defaults.
+	happyFirst := pollEvent()
+	happySecond := pollEvent()
+	happySecond["sequence_number"] = "101"
+
+	// Bad event information: wrong event type triggers verifyEventType, which
+	// causes processPollingBatch to return an error before touching nextSequence.
+	badHandle := pollEvent()
+	badHandle["type"] = "0x5bc11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625::state::NotAWormholeMessage"
+
+	invalidEvent := pollEvent()
+	delete(invalidEvent, "data")
+
+	// Startup skip: with initialNextSeq=0 and eventSeq != 0, the loop hits the
+	// "avoid publishing an old observation on startup" branch (watcher.go:283) —
+	// nextSequence is advanced to eventSeq+1 and observeData is never called.
+	startupSkip := pollEvent() // sequence_number defaults to "100"
+
+	tests := []struct {
+		name             string
+		events           []map[string]any // marshaled to a JSON array unless rawJSON is set
+		rawJSON          string           // overrides events when non-empty
+		initialNextSeq   uint64
+		expectedNextSeq  uint64
+		expectedMsgCount int
+		expectError      string // substring expected in returned error; "" means nil
+	}{
+		{
+			name:             "happy path: one event",
+			events:           []map[string]any{happyFirst},
+			initialNextSeq:   100,
+			expectedNextSeq:  101,
+			expectedMsgCount: 1,
+			expectError:      "",
+		},
+		{
+			name:             "startup skip: nextSeq=0, eventSeq!=0",
+			events:           []map[string]any{startupSkip},
+			initialNextSeq:   0,
+			expectedNextSeq:  101, // eventSeq (100) + 1
+			expectedMsgCount: 0,   // event is skipped, not published
+			expectError:      "",
+		},
+		{
+			name:             "happy path: two consecutive events",
+			events:           []map[string]any{happyFirst, happySecond},
+			initialNextSeq:   100,
+			expectedNextSeq:  102,
+			expectedMsgCount: 2,
+			expectError:      "",
+		},
+		{
+			name:             "empty",
+			events:           []map[string]any{},
+			initialNextSeq:   100,
+			expectedNextSeq:  100,
+			expectedMsgCount: 0,
+			expectError:      "",
+		},
+		{
+			name:             "Bad event information",
+			events:           []map[string]any{badHandle},
+			initialNextSeq:   100,
+			expectedNextSeq:  100,
+			expectedMsgCount: 0,
+			expectError:      "aptos event type mismatch",
+		},
+		{
+			name:             "One valid, one invalid",
+			events:           []map[string]any{happyFirst, invalidEvent},
+			initialNextSeq:   100,
+			expectedNextSeq:  101,
+			expectedMsgCount: 1,
+			expectError:      "",
+		},
+		{
+			name:             "One invalid, one valid",
+			events:           []map[string]any{invalidEvent, happyFirst},
+			initialNextSeq:   100,
+			expectedNextSeq:  101,
+			expectedMsgCount: 1,
+			expectError:      "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			core, _ := observer.New(zapcore.ErrorLevel)
+			logger := zap.New(core)
+			msgC := make(chan *common.MessagePublication, 16)
+			w := &Watcher{
+				chainID:        vaa.ChainIDAptos,
+				networkID:      "aptos-test",
+				msgC:           msgC,
+				aptosAccount:   testAptosAccount,
+				aptosHandle:    testAptosHandle,
+				aptosEventType: testExpectedType,
+			}
+
+			jsonStr := tc.rawJSON
+			if jsonStr == "" {
+				jsonStr = encodeBatch(t, tc.events...)
+			}
+
+			nextSeq := tc.initialNextSeq
+			err := w.processPollingBatch(logger, gjson.Parse(jsonStr), &nextSeq)
+
+			if tc.expectError == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectError)
+			}
+			assert.Equal(t, tc.expectedNextSeq, nextSeq)
+			assert.Len(t, msgC, tc.expectedMsgCount)
+		})
+	}
+}
+
+func TestProcessReobs(t *testing.T) {
+	// happy path: two consecutive events. Built by mutating pollEvent() defaults.
+	happyFirst := pollEvent()
+	happySecond := pollEvent()
+	happySecond["sequence_number"] = "101"
+
+	// Bad event information: wrong event type triggers verifyEventType, which
+	// causes processPollingBatch to return an error before touching nextSequence.
+	badHandle := pollEvent()
+	badHandle["type"] = "0x5bc11445584a763c1fa7ed39081f1b920954da14e04b32440cba863d03e19625::state::NotAWormholeMessage"
+
+	invalidEvent := pollEvent()
+	delete(invalidEvent, "data")
+
+	tests := []struct {
+		name             string
+		events           []map[string]any // marshaled to a JSON array unless rawJSON is set
+		rawJSON          string           // overrides events when non-empty
+		nativeSeq        uint64
+		expectedMsgCount int
+		expectError      string
+	}{
+		{
+			name:             "happy path: one event",
+			events:           []map[string]any{happyFirst},
+			nativeSeq:        100,
+			expectedMsgCount: 1,
+			expectError:      "",
+		},
+		{
+			name:             "Bad sequence",
+			events:           []map[string]any{happyFirst},
+			nativeSeq:        99, // Wrong sequence for the message
+			expectedMsgCount: 0,
+			expectError:      "",
+		},
+		{
+			name:             "Bad event information",
+			events:           []map[string]any{badHandle},
+			nativeSeq:        100,
+			expectedMsgCount: 0,
+			expectError:      "aptos event type mismatch",
+		},
+		{
+			name:             "One valid, one invalid",
+			events:           []map[string]any{happyFirst, invalidEvent},
+			nativeSeq:        100,
+			expectedMsgCount: 1,
+			expectError:      "",
+		},
+		{ // Stops after the first event
+			name:             "One invalid, one valid",
+			events:           []map[string]any{invalidEvent, happyFirst},
+			nativeSeq:        100,
+			expectedMsgCount: 0,
+			expectError:      "",
+		},
+		{
+			name:             "empty",
+			events:           []map[string]any{},
+			nativeSeq:        100,
+			expectedMsgCount: 0,
+			expectError:      "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			core, _ := observer.New(zapcore.ErrorLevel)
+			logger := zap.New(core)
+			msgC := make(chan *common.MessagePublication, 16)
+			w := &Watcher{
+				chainID:        vaa.ChainIDAptos,
+				networkID:      "aptos-test",
+				msgC:           msgC,
+				aptosAccount:   testAptosAccount,
+				aptosHandle:    testAptosHandle,
+				aptosEventType: testExpectedType,
+			}
+
+			jsonStr := tc.rawJSON
+			if jsonStr == "" {
+				jsonStr = encodeBatch(t, tc.events...)
+			}
+
+			err := w.processReobsBatch(logger, gjson.Parse(jsonStr), tc.nativeSeq)
+
+			if tc.expectError == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectError)
+			}
+			assert.Len(t, msgC, tc.expectedMsgCount)
+		})
+	}
 }


### PR DESCRIPTION
The PR does the following: 
* Separates the core processing functionality for the Aptos watcher into separate functions. This is to make the code more testable. 
* Adds an event type verification to the message handling. This required a small change to the watcher configuration. This should be the ONLY functionality change to the watcher from the refactor.
* Rewrote the JSON modification framework in the test suite to be more modular. 