### PR TITLE
node: Update coverage baseline

### DIFF
--- a/.coverage-baseline
+++ b/.coverage-baseline
@@ -22,14 +22,14 @@ github.com/certusone/wormhole/node/hack/release_verification 0.0
 github.com/certusone/wormhole/node/hack/repair_eth 0.0
 github.com/certusone/wormhole/node/hack/repair_solana 0.0
 github.com/certusone/wormhole/node/hack/solana 0.0
-github.com/certusone/wormhole/node/pkg/accountant 47.4
-github.com/certusone/wormhole/node/pkg/adminrpc 47.5
+github.com/certusone/wormhole/node/pkg/accountant 49.8
+github.com/certusone/wormhole/node/pkg/adminrpc 49.2
 github.com/certusone/wormhole/node/pkg/altpub 87.4
-github.com/certusone/wormhole/node/pkg/common 62.3
+github.com/certusone/wormhole/node/pkg/common 62.5
 github.com/certusone/wormhole/node/pkg/db 76.6
 github.com/certusone/wormhole/node/pkg/devnet 41.2
 github.com/certusone/wormhole/node/pkg/governor 49.7
-github.com/certusone/wormhole/node/pkg/guardiansigner 41.8
+github.com/certusone/wormhole/node/pkg/guardiansigner 42.3
 github.com/certusone/wormhole/node/pkg/gwrelayer 31.9
 github.com/certusone/wormhole/node/pkg/manager 23.3
 github.com/certusone/wormhole/node/pkg/manager/delegatedmanagersetabi 0.0
@@ -44,7 +44,7 @@ github.com/certusone/wormhole/node/pkg/proto/prometheus/v1 0.0
 github.com/certusone/wormhole/node/pkg/proto/publicrpc/v1 0.0
 github.com/certusone/wormhole/node/pkg/proto/spy/v1 0.0
 github.com/certusone/wormhole/node/pkg/publicrpc 12.4
-github.com/certusone/wormhole/node/pkg/query 69.9
+github.com/certusone/wormhole/node/pkg/query 70.0
 github.com/certusone/wormhole/node/pkg/random 0.0
 github.com/certusone/wormhole/node/pkg/readiness 0.0
 github.com/certusone/wormhole/node/pkg/supervisor 0.0
@@ -55,7 +55,7 @@ github.com/certusone/wormhole/node/pkg/version 0.0
 github.com/certusone/wormhole/node/pkg/watchers/algorand 30.4
 github.com/certusone/wormhole/node/pkg/watchers/aptos 29.8
 github.com/certusone/wormhole/node/pkg/watchers/cosmwasm 0.0
-github.com/certusone/wormhole/node/pkg/watchers/evm 23.4
+github.com/certusone/wormhole/node/pkg/watchers/evm 23.6
 github.com/certusone/wormhole/node/pkg/watchers/evm/connectors 43.6
 github.com/certusone/wormhole/node/pkg/watchers/evm/connectors/delegated_guardians 0.0
 github.com/certusone/wormhole/node/pkg/watchers/evm/connectors/ethabi 0.0
@@ -67,8 +67,8 @@ github.com/certusone/wormhole/node/pkg/watchers/mock 0.0
 github.com/certusone/wormhole/node/pkg/watchers/near 75.4
 github.com/certusone/wormhole/node/pkg/watchers/near/nearapi 61.8
 github.com/certusone/wormhole/node/pkg/watchers/near/nearapi/mock 0.0
-github.com/certusone/wormhole/node/pkg/watchers/solana 34.6
+github.com/certusone/wormhole/node/pkg/watchers/solana 39.9
 github.com/certusone/wormhole/node/pkg/watchers/sui 7.9
 github.com/certusone/wormhole/node/pkg/wormconn 0.0
 github.com/wormhole-foundation/wormhole/sdk 70.2
-github.com/wormhole-foundation/wormhole/sdk/vaa 59.8
+github.com/wormhole-foundation/wormhole/sdk/vaa 61.4


### PR DESCRIPTION
Coverage has improved since the previous baseline. This PR updates the coverage baseline to reflect the latest test coverage.

Review the diff in `.coverage-baseline` and merge to lock in the improvements.