### PR TITLE
Add test-fast for Go unit testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,13 @@ test-coverage:
 	@set -o pipefail && (cd node && go test -count=1 -v -timeout 5m -race -cover ./...) 2>&1 | tee coverage.txt
 	@set -o pipefail && (cd sdk && go test -count=1 -v -timeout 5m -race -cover ./...) 2>&1 | tee -a coverage.txt
 
+.PHONY: test-fast
+## Run fast tests for node and sdk, skipping tests gated by testing.Short() and fuzz smoke tests
+test-fast:
+	@echo "Running fast tests for node and sdk..."
+	@cd node && go test -short ./...
+	@cd sdk && go test -short ./...
+
 .PHONY: check-coverage
 ## Check coverage against baseline (run tests first)
 check-coverage: build-coverage-check test-coverage

--- a/node/Makefile
+++ b/node/Makefile
@@ -1,7 +1,6 @@
 .PHONY: lint
 lint:
-# Lints spelling and Go via the custom wormhole-golangci-lint
-	bash ../scripts/lint.sh lint
+	golangci-lint run -c ../.golangci.yml ./...
 
 .PHONY: test
 test: 

--- a/node/Makefile
+++ b/node/Makefile
@@ -1,11 +1,16 @@
 .PHONY: lint
-lint: 
-	golangci-lint run -c ../.golangci.yml ./...
+lint:
+# Lints spelling and Go via the custom wormhole-golangci-lint
+	bash ../scripts/lint.sh lint
 
 .PHONY: test
 test: 
 	go test -v ./...
-	timeout 10s go test -fuzz=FuzzMessagePublicationUnmarshalBinary -fuzztime=5s ./pkg/common || true
+	timeout 5s go test -fuzz=FuzzMessagePublicationUnmarshalBinary -fuzztime=3s ./pkg/common || true
+
+.PHONY: test-fast
+test-fast:
+	go test -short ./...
 
 .PHONY: test-coverage
 test-coverage:

--- a/node/pkg/db/accountant_test.go
+++ b/node/pkg/db/accountant_test.go
@@ -23,6 +23,8 @@ import (
 )
 
 func TestAcctPendingTransferMsgID(t *testing.T) {
+	t.Parallel()
+
 	tokenBridgeAddr, err := vaa.StringToAddress("0x0290fb167208af455bb137780163b7b7a9a10c16")
 	require.NoError(t, err)
 
@@ -42,6 +44,8 @@ func TestAcctPendingTransferMsgID(t *testing.T) {
 }
 
 func TestAcctIsPendingTransfer(t *testing.T) {
+	t.Parallel()
+
 	assert.Equal(t, true, acctIsPendingTransfer([]byte("ACCT:PXFER3:"+"2/0000000000000000000000000290fb167208af455bb137780163b7b7a9a10c16/789101112131415")))
 	assert.Equal(t, false, acctIsPendingTransfer([]byte("ACCT:PXFER3:")))
 	assert.Equal(t, false, acctIsPendingTransfer([]byte("ACCT:PXFER3:1")))
@@ -56,6 +60,8 @@ func TestAcctIsPendingTransfer(t *testing.T) {
 }
 
 func TestAcctStoreAndDeletePendingTransfers(t *testing.T) {
+	t.Parallel()
+
 	dbPath := t.TempDir()
 	db := OpenDb(zap.NewNop(), &dbPath)
 	defer db.Close()
@@ -119,6 +125,8 @@ func TestAcctStoreAndDeletePendingTransfers(t *testing.T) {
 }
 
 func TestAcctGetEmptyData(t *testing.T) {
+	t.Parallel()
+
 	logger := zap.NewNop()
 	dbPath := t.TempDir()
 	db := OpenDb(logger, &dbPath)
@@ -130,6 +138,8 @@ func TestAcctGetEmptyData(t *testing.T) {
 }
 
 func TestAcctGetData(t *testing.T) {
+	t.Parallel()
+
 	logger := zap.NewNop()
 	dbPath := t.TempDir()
 	db := OpenDb(logger, &dbPath)
@@ -194,6 +204,8 @@ func TestAcctGetData(t *testing.T) {
 }
 
 func TestAcctLoadingWhereOldPendingGetsUpdated(t *testing.T) {
+	t.Parallel()
+
 	dbPath := t.TempDir()
 	db := OpenDb(zap.NewNop(), &dbPath)
 	defer db.Close()
@@ -325,6 +337,8 @@ func (msg *OldMessagePublication) MessageIDString() string {
 }
 
 func TestUnmarshalOldJSON(t *testing.T) {
+	t.Parallel()
+
 	jsn := `
 	{
 	  "TxID": "SGVsbG8=",

--- a/node/pkg/db/db_test.go
+++ b/node/pkg/db/db_test.go
@@ -47,6 +47,8 @@ func getVAAWithSeqNum(seqNum uint64) vaa.VAA {
 
 // Testing the expected default behavior of a CreateGovernanceVAA
 func TestVaaIDFromString(t *testing.T) {
+	t.Parallel()
+
 	vaaIdString := "1/0000000000000000000000000000000000000000000000000000000000000004/1"
 	vaaID, _ := VaaIDFromString(vaaIdString)
 	expectAddr := vaa.Address{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4}
@@ -57,6 +59,8 @@ func TestVaaIDFromString(t *testing.T) {
 }
 
 func TestVaaIDFromVAA(t *testing.T) {
+	t.Parallel()
+
 	testVaa := getVAA()
 	vaaID := VaaIDFromVAA(&testVaa)
 	expectAddr := vaa.Address{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4}
@@ -67,6 +71,8 @@ func TestVaaIDFromVAA(t *testing.T) {
 }
 
 func TestBytes(t *testing.T) {
+	t.Parallel()
+
 	vaaIdString := "1/0000000000000000000000000000000000000000000000000000000000000004/1"
 	vaaID, _ := VaaIDFromString(vaaIdString)
 	expected := []byte{0x73, 0x69, 0x67, 0x6e, 0x65, 0x64, 0x2f, 0x31, 0x2f, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x34, 0x2f, 0x31}
@@ -75,6 +81,8 @@ func TestBytes(t *testing.T) {
 }
 
 func TestEmitterPrefixBytesWithChainIDAndAddress(t *testing.T) {
+	t.Parallel()
+
 	vaaIdString := "1/0000000000000000000000000000000000000000000000000000000000000004/1"
 	vaaID, _ := VaaIDFromString(vaaIdString)
 	expected := []byte{0x73, 0x69, 0x67, 0x6e, 0x65, 0x64, 0x2f, 0x31, 0x2f, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x34}
@@ -83,11 +91,15 @@ func TestEmitterPrefixBytesWithChainIDAndAddress(t *testing.T) {
 }
 
 func TestEmitterPrefixBytesWithOnlyChainID(t *testing.T) {
+	t.Parallel()
+
 	vaaID := VAAID{EmitterChain: vaa.ChainID(26)}
 	assert.Equal(t, []byte("signed/26"), vaaID.EmitterPrefixBytes())
 }
 
 func TestStoreSignedVAAUnsigned(t *testing.T) {
+	t.Parallel()
+
 	dbPath := t.TempDir()
 	db := OpenDb(zap.NewNop(), &dbPath)
 	defer db.Close()
@@ -100,6 +112,8 @@ func TestStoreSignedVAAUnsigned(t *testing.T) {
 }
 
 func TestStoreSignedVAASigned(t *testing.T) {
+	t.Parallel()
+
 	dbPath := t.TempDir()
 	db := OpenDb(zap.NewNop(), &dbPath)
 	defer db.Close()
@@ -115,6 +129,12 @@ func TestStoreSignedVAASigned(t *testing.T) {
 }
 
 func TestStoreSignedVAABatch(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping large signed VAA batch stress test in short mode")
+	}
+
+	t.Parallel()
+
 	dbPath := t.TempDir()
 	db := OpenDb(zap.NewNop(), &dbPath)
 	defer db.Close()
@@ -174,6 +194,8 @@ func TestStoreSignedVAABatch(t *testing.T) {
 }
 
 func TestGetSignedVAABytes(t *testing.T) {
+	t.Parallel()
+
 	dbPath := t.TempDir()
 	db := OpenDb(zap.NewNop(), &dbPath)
 	defer db.Close()
@@ -201,6 +223,8 @@ func TestGetSignedVAABytes(t *testing.T) {
 }
 
 func TestFindEmitterSequenceGap(t *testing.T) {
+	t.Parallel()
+
 	dbPath := t.TempDir()
 	db := OpenDb(zap.NewNop(), &dbPath)
 	defer db.Close()

--- a/node/pkg/db/governor_test.go
+++ b/node/pkg/db/governor_test.go
@@ -23,6 +23,8 @@ func (d *Database) rowExistsInDB(key []byte) error {
 }
 
 func TestSerializeAndDeserializeOfTransfer(t *testing.T) {
+	t.Parallel()
+
 	tokenAddr, err := vaa.StringToAddress("0x707f9118e33a9b8998bea41dd0d46f38bb963fc8")
 	require.NoError(t, err)
 
@@ -58,6 +60,8 @@ func TestSerializeAndDeserializeOfTransfer(t *testing.T) {
 }
 
 func TestPendingMsgIDV5(t *testing.T) {
+	t.Parallel()
+
 	ethereumTokenBridgeAddr, err := vaa.StringToAddress("0x0290fb167208af455bb137780163b7b7a9a10c16")
 	require.NoError(t, err)
 
@@ -76,6 +80,8 @@ func TestPendingMsgIDV5(t *testing.T) {
 }
 
 func TestTransferMsgIDV5(t *testing.T) {
+	t.Parallel()
+
 	tokenAddr, err := vaa.StringToAddress("0x707f9118e33a9b8998bea41dd0d46f38bb963fc8")
 	require.NoError(t, err)
 
@@ -103,6 +109,8 @@ func TestTransferMsgIDV5(t *testing.T) {
 
 // TestTransferMsgIDV4 tests the old transfer format prefix (now superseded by V5).
 func TestTransferMsgIDV4(t *testing.T) {
+	t.Parallel()
+
 	tokenAddr, err := vaa.StringToAddress("0x707f9118e33a9b8998bea41dd0d46f38bb963fc8")
 	require.NoError(t, err)
 
@@ -131,6 +139,8 @@ func TestTransferMsgIDV4(t *testing.T) {
 // TestIsTransferV5 tests the IsTransfer function for the current transfer format.
 // The V5 suffix matches the "GOV:XFER5:" prefix used by the current transfer implementation.
 func TestIsTransferV5(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name     string
 		input    []byte
@@ -189,7 +199,10 @@ func TestIsTransferV5(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			result := IsTransfer(tt.input)
 			assert.Equal(t, tt.expected, result)
 		})
@@ -199,6 +212,8 @@ func TestIsTransferV5(t *testing.T) {
 // TestIsTransferV4 tests the isOldTransfer function for the legacy transfer format.
 // The V4 suffix matches the "GOV:XFER4:" prefix used by the old transfer implementation.
 func TestIsTransferV4(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name     string
 		input    []byte
@@ -252,7 +267,10 @@ func TestIsTransferV4(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			result := isOldTransfer(tt.input)
 			assert.Equal(t, tt.expected, result)
 		})
@@ -262,6 +280,8 @@ func TestIsTransferV4(t *testing.T) {
 // TestIsPendingMsgV5 tests the IsPendingMsg function for the current pending message format.
 // The V5 suffix matches the "GOV:PENDING5:" prefix used by the current pending message implementation.
 func TestIsPendingMsgV5(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name     string
 		input    []byte
@@ -320,7 +340,10 @@ func TestIsPendingMsgV5(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			result := IsPendingMsg(tt.input)
 			assert.Equal(t, tt.expected, result)
 		})
@@ -330,6 +353,8 @@ func TestIsPendingMsgV5(t *testing.T) {
 // TestIsPendingMsgV4 tests the isOldPendingMsg function for the legacy pending message format.
 // The V4 suffix matches the "GOV:PENDING4:" prefix used by the legacy pending message implementation.
 func TestIsPendingMsgV4(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name     string
 		input    []byte
@@ -383,7 +408,10 @@ func TestIsPendingMsgV4(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			result := isOldPendingMsg(tt.input)
 			assert.Equal(t, tt.expected, result)
 		})
@@ -391,6 +419,8 @@ func TestIsPendingMsgV4(t *testing.T) {
 }
 
 func TestGetChainGovernorData(t *testing.T) {
+	t.Parallel()
+
 	dbPath := t.TempDir()
 	db := OpenDb(zap.NewNop(), &dbPath)
 	defer db.Close()
@@ -405,6 +435,8 @@ func TestGetChainGovernorData(t *testing.T) {
 }
 
 func TestStoreTransfer(t *testing.T) {
+	t.Parallel()
+
 	dbPath := t.TempDir()
 	db := OpenDb(zap.NewNop(), &dbPath)
 	defer db.Close()
@@ -436,6 +468,8 @@ func TestStoreTransfer(t *testing.T) {
 }
 
 func TestDeleteTransfer(t *testing.T) {
+	t.Parallel()
+
 	dbPath := t.TempDir()
 	db := OpenDb(zap.NewNop(), &dbPath)
 	defer db.Close()
@@ -476,6 +510,8 @@ func TestDeleteTransfer(t *testing.T) {
 }
 
 func TestStorePendingMsg(t *testing.T) {
+	t.Parallel()
+
 	dbPath := t.TempDir()
 	db := OpenDb(zap.NewNop(), &dbPath)
 	defer db.Close()
@@ -501,6 +537,8 @@ func TestStorePendingMsg(t *testing.T) {
 }
 
 func TestDeletePendingMsg(t *testing.T) {
+	t.Parallel()
+
 	dbPath := t.TempDir()
 	db := OpenDb(zap.NewNop(), &dbPath)
 	defer db.Close()
@@ -535,6 +573,8 @@ func TestDeletePendingMsg(t *testing.T) {
 }
 
 func TestSerializeAndDeserializeOfPendingTransfer(t *testing.T) {
+	t.Parallel()
+
 	tokenBridgeAddr, err := vaa.StringToAddress("0x0290fb167208af455bb137780163b7b7a9a10c16")
 	require.NoError(t, err)
 
@@ -570,6 +610,8 @@ func TestSerializeAndDeserializeOfPendingTransfer(t *testing.T) {
 }
 
 func TestStoreAndReloadTransfersAndPendingMessages(t *testing.T) {
+	t.Parallel()
+
 	dbPath := t.TempDir()
 	db := OpenDb(zap.NewNop(), &dbPath)
 	defer db.Close()
@@ -664,6 +706,8 @@ func TestStoreAndReloadTransfersAndPendingMessages(t *testing.T) {
 }
 
 func TestMarshalUnmarshalNoMsgIdOrHash(t *testing.T) {
+	t.Parallel()
+
 	tokenAddr, err := vaa.StringToAddress("0x707f9118e33a9b8998bea41dd0d46f38bb963fc8")
 	require.NoError(t, err)
 
@@ -696,6 +740,8 @@ func TestMarshalUnmarshalNoMsgIdOrHash(t *testing.T) {
 // Note that Transfer.Marshal can't fail, so there are no negative tests for that.
 
 func TestUnmarshalTransferFailures(t *testing.T) {
+	t.Parallel()
+
 	tokenAddr, err := vaa.StringToAddress("0x707f9118e33a9b8998bea41dd0d46f38bb963fc8")
 	require.NoError(t, err)
 
@@ -778,6 +824,8 @@ func TestUnmarshalTransferFailures(t *testing.T) {
 // Note that PendingTransfer.Marshal can't fail, so there are no negative tests for that.
 
 func TestUnmarshalPendingTransferFailures(t *testing.T) {
+	t.Parallel()
+
 	tokenBridgeAddr, err := vaa.StringToAddress("0x0290fb167208af455bb137780163b7b7a9a10c16")
 	require.NoError(t, err)
 

--- a/node/pkg/db/manager_test.go
+++ b/node/pkg/db/manager_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestAggregatedTransactionMarshalUnmarshal(t *testing.T) {
+	t.Parallel()
+
 	// Create test data
 	original := &AggregatedTransaction{
 		VAAHash:          []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
@@ -61,6 +63,8 @@ func TestAggregatedTransactionMarshalUnmarshal(t *testing.T) {
 }
 
 func TestAggregatedTransactionIsComplete(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name       string
 		required   uint8
@@ -75,7 +79,10 @@ func TestAggregatedTransactionIsComplete(t *testing.T) {
 	}
 
 	for _, tc := range tests {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			tx := &AggregatedTransaction{
 				Required:   tc.required,
 				Signatures: make(map[uint8][][]byte),
@@ -89,6 +96,8 @@ func TestAggregatedTransactionIsComplete(t *testing.T) {
 }
 
 func TestManagerDBStoreAndGet(t *testing.T) {
+	t.Parallel()
+
 	// Create in-memory database
 	opts := badger.DefaultOptions("").WithInMemory(true).WithLogger(nil)
 	badgerDB, err := badger.Open(opts)
@@ -130,6 +139,8 @@ func TestManagerDBStoreAndGet(t *testing.T) {
 }
 
 func TestManagerDBHasAggregatedTransaction(t *testing.T) {
+	t.Parallel()
+
 	opts := badger.DefaultOptions("").WithInMemory(true).WithLogger(nil)
 	badgerDB, err := badger.Open(opts)
 	require.NoError(t, err)
@@ -159,6 +170,8 @@ func TestManagerDBHasAggregatedTransaction(t *testing.T) {
 }
 
 func TestManagerDBDeleteAggregatedTransaction(t *testing.T) {
+	t.Parallel()
+
 	opts := badger.DefaultOptions("").WithInMemory(true).WithLogger(nil)
 	badgerDB, err := badger.Open(opts)
 	require.NoError(t, err)
@@ -208,6 +221,8 @@ func TestManagerDBDeleteAggregatedTransaction(t *testing.T) {
 }
 
 func TestManagerDBGetAggregatedTransactionByVAAID(t *testing.T) {
+	t.Parallel()
+
 	opts := badger.DefaultOptions("").WithInMemory(true).WithLogger(nil)
 	badgerDB, err := badger.Open(opts)
 	require.NoError(t, err)
@@ -247,6 +262,8 @@ func TestManagerDBGetAggregatedTransactionByVAAID(t *testing.T) {
 }
 
 func TestManagerDBIndexNotDeletedWhenPointingToDifferentHash(t *testing.T) {
+	t.Parallel()
+
 	opts := badger.DefaultOptions("").WithInMemory(true).WithLogger(nil)
 	badgerDB, err := badger.Open(opts)
 	require.NoError(t, err)
@@ -301,6 +318,8 @@ func TestManagerDBIndexNotDeletedWhenPointingToDifferentHash(t *testing.T) {
 }
 
 func TestManagerDBLoadAllAggregatedTransactions(t *testing.T) {
+	t.Parallel()
+
 	opts := badger.DefaultOptions("").WithInMemory(true).WithLogger(nil)
 	badgerDB, err := badger.Open(opts)
 	require.NoError(t, err)

--- a/node/pkg/db/notary_test.go
+++ b/node/pkg/db/notary_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestStoreAndReloadData(t *testing.T) {
+	t.Parallel()
+
 	// Set-up.
 	dbPath := t.TempDir()
 	database := OpenDb(zap.NewNop(), &dbPath)
@@ -44,6 +46,8 @@ func TestStoreAndReloadData(t *testing.T) {
 // TestDelete tests the deletion of a message from the notary's database.
 // It covers the deletion of both delayed and blackholed messages.
 func TestDelete(t *testing.T) {
+	t.Parallel()
+
 	// Set-up.
 	dbPath := t.TempDir()
 	database := OpenDb(zap.NewNop(), &dbPath)
@@ -93,6 +97,8 @@ func TestDelete(t *testing.T) {
 }
 
 func TestKeysForStoredMessagesV1(t *testing.T) {
+	t.Parallel()
+
 	msg1 := makeNewMsgPub(t)
 	pMsg := makeNewPendingMsg(t, msg1)
 

--- a/node/pkg/node/node_test.go
+++ b/node/pkg/node/node_test.go
@@ -559,6 +559,10 @@ func createGovernanceMsgAndVaa(t testing.TB) (*common.MessagePublication, *nodev
 
 // TestConsensus tests that a set of guardians can form consensus on certain messages and reject certain other messages
 func TestConsensus(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping slow guardian consensus integration test in short mode")
+	}
+
 	// adjust processor time intervals to make tests pass faster
 	processor.FirstRetryMinWait = time.Second * 3
 	processor.CleanupInterval = time.Second * 1

--- a/node/pkg/p2p/watermark_test.go
+++ b/node/pkg/p2p/watermark_test.go
@@ -110,6 +110,10 @@ func NewG(t *testing.T, nodeName string) *G {
 // TestWatermark runs 4 different guardians one of which does not send its P2PID in the signed part of the heartbeat.
 // The expectation is that hosts that send this information will become "protected" by the Connection Manager.
 func TestWatermark(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping slow p2p integration test in short mode")
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -174,6 +178,10 @@ func TestWatermark(t *testing.T) {
 }
 
 func TestManualProtectedPeers(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping slow p2p integration test in short mode")
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/node/pkg/query/query_test.go
+++ b/node/pkg/query/query_test.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -41,7 +42,7 @@ const (
 )
 
 var (
-	nonce = uint32(0)
+	nonce atomic.Uint32
 
 	watcherChainsForTest = []vaa.ChainID{vaa.ChainIDPolygon, vaa.ChainIDBSC, vaa.ChainIDArbitrum}
 )
@@ -139,9 +140,8 @@ func createSignedQueryRequestForTesting(
 	perChainQueries []*PerChainQueryRequest,
 ) (*gossipv1.SignedQueryRequest, *QueryRequest) {
 	t.Helper()
-	nonce += 1
 	queryRequest := &QueryRequest{
-		Nonce:           nonce,
+		Nonce:           nonce.Add(1),
 		PerChainQueries: perChainQueries,
 	}
 
@@ -259,6 +259,8 @@ func validateResponseForTest(
 }
 
 func TestParseAllowedRequestersSuccess(t *testing.T) {
+	t.Parallel()
+
 	ccqAllowedRequestersList, err := parseAllowedRequesters(testSigner)
 	require.NoError(t, err)
 	require.NotNil(t, ccqAllowedRequestersList)
@@ -281,6 +283,8 @@ func TestParseAllowedRequestersSuccess(t *testing.T) {
 }
 
 func TestParseAllowedRequestersFailsIfParameterEmpty(t *testing.T) {
+	t.Parallel()
+
 	ccqAllowedRequestersList, err := parseAllowedRequesters("")
 	require.Error(t, err)
 	require.Nil(t, ccqAllowedRequestersList)
@@ -291,6 +295,8 @@ func TestParseAllowedRequestersFailsIfParameterEmpty(t *testing.T) {
 }
 
 func TestParseAllowedRequestersFailsIfInvalidParameter(t *testing.T) {
+	t.Parallel()
+
 	ccqAllowedRequestersList, err := parseAllowedRequesters("Hello")
 	require.Error(t, err)
 	require.Nil(t, ccqAllowedRequestersList)
@@ -502,6 +508,10 @@ func (md *mockData) waitForResponse() *QueryResponsePublication {
 
 // TestInvalidQueries tests all the obvious reasons why a query may fail (aside from watcher failures).
 func TestInvalidQueries(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping async query handler negative test in short mode")
+	}
+
 	ctx := context.Background()
 	logger := zap.NewNop()
 
@@ -685,6 +695,10 @@ func TestQueryWithRetryDueToTimeoutShouldSucceed(t *testing.T) {
 }
 
 func TestQueryWithTooManyRetriesShouldFail(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping async query handler timeout test in short mode")
+	}
+
 	ctx := context.Background()
 	logger := zap.NewNop()
 
@@ -751,6 +765,10 @@ func TestQueryWithLimitedRetriesOnMultipleChainsShouldSucceed(t *testing.T) {
 }
 
 func TestFatalErrorOnPerChainQueryShouldCauseRequestToFail(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping async query handler fatal-error test in short mode")
+	}
+
 	ctx := context.Background()
 	logger := zap.NewNop()
 
@@ -812,6 +830,8 @@ func TestPublishRetrySucceeds(t *testing.T) {
 }
 
 func TestPerChainConfigValid(t *testing.T) {
+	t.Parallel()
+
 	for chainID, config := range perChainConfig {
 		if config.NumWorkers <= 0 {
 			assert.Equal(t, "", fmt.Sprintf(`perChainConfig for "%s" has an invalid NumWorkers: %d`, chainID.String(), config.NumWorkers))

--- a/node/pkg/watchers/evm/ccq_backfill_test.go
+++ b/node/pkg/watchers/evm/ccq_backfill_test.go
@@ -49,26 +49,37 @@ func (conn *mockBackfillConn) RawBatchCallContext(ctx context.Context, b []rpc.B
 // TestCcqBackFillDetermineMaxBatchSize verifies that the search for the max allowed block size converges for all values between 1 and CCQ_MAX_BATCH_SIZE + 1 inclusive.
 // It also verifies the returned set of blocks.
 func TestCcqBackFillDetermineMaxBatchSize(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping exhaustive CCQ backfill batch-size sweep in short mode")
+	}
+
+	t.Parallel()
+
 	ctx := context.Background()
 	logger := zap.NewNop()
 	latestBlockNum := int64(17533044)
 
 	for maxBatchSize := int64(1); maxBatchSize <= CCQ_MAX_BATCH_SIZE+1; maxBatchSize++ {
-		conn := &mockBackfillConn{maxBatchSize: maxBatchSize}
-		batchSize, blocks, err := ccqBackFillDetermineMaxBatchSize(ctx, logger, conn, latestBlockNum, time.Microsecond)
-		require.NoError(t, err)
-		if maxBatchSize > CCQ_MAX_BATCH_SIZE { // If the node supports more than our max size, we should cap the batch size at our max.
-			require.Equal(t, CCQ_MAX_BATCH_SIZE, batchSize)
-		} else {
-			require.Equal(t, maxBatchSize, batchSize)
-		}
-		require.Equal(t, batchSize, int64(len(blocks)))
+		maxBatchSize := maxBatchSize
+		t.Run(fmt.Sprintf("maxBatchSize=%d", maxBatchSize), func(t *testing.T) {
+			t.Parallel()
 
-		blockNum := uint64(latestBlockNum) // #nosec G115 -- This value is set above so the conversion is safe
-		for _, block := range blocks {
-			assert.Equal(t, blockNum, block.BlockNum)
-			assert.Equal(t, blockNum*10, block.Timestamp)
-			blockNum--
-		}
+			conn := &mockBackfillConn{maxBatchSize: maxBatchSize}
+			batchSize, blocks, err := ccqBackFillDetermineMaxBatchSize(ctx, logger, conn, latestBlockNum, time.Microsecond)
+			require.NoError(t, err)
+			if maxBatchSize > CCQ_MAX_BATCH_SIZE { // If the node supports more than our max size, we should cap the batch size at our max.
+				require.Equal(t, CCQ_MAX_BATCH_SIZE, batchSize)
+			} else {
+				require.Equal(t, maxBatchSize, batchSize)
+			}
+			require.Equal(t, batchSize, int64(len(blocks)))
+
+			blockNum := uint64(latestBlockNum) // #nosec G115 -- This value is set above so the conversion is safe
+			for _, block := range blocks {
+				assert.Equal(t, blockNum, block.BlockNum)
+				assert.Equal(t, blockNum*10, block.Timestamp)
+				blockNum--
+			}
+		})
 	}
 }

--- a/node/pkg/watchers/near/watcher_test.go
+++ b/node/pkg/watchers/near/watcher_test.go
@@ -65,6 +65,13 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
+func skipNearWatcherInShortMode(t *testing.T) {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("skipping async NEAR watcher test in short mode")
+	}
+}
+
 func portalEmitterAddress() vaa.Address {
 	s := "contract.portalbridge.near"
 	h := sha256.New()
@@ -213,6 +220,8 @@ func (testCase *testCase) setupAndRun(logger *zap.Logger) {
 
 // TestWatcherSimple() tests the most simple case: "final" API only retruns one block which contains a Wormhole transaction. No re-observation requests.
 func TestWatcherSimple(t *testing.T) {
+	skipNearWatcherInShortMode(t)
+
 	logger := zaptest.NewLogger(t)
 
 	pl, _ := hex.DecodeString("0100000000000000000000000000000000000000000000000000000000000f42400000000000000000000000000000000000000000000000000000000000000000000f0108bc32f7de18a5f6e1e7d6ee7aff9f5fc858d0d87ac0da94dd8d2a5d267d6b00160000000000000000000000000000000000000000000000000000000000000000")
@@ -248,6 +257,8 @@ func TestWatcherSimple(t *testing.T) {
 
 // TestWatcherSimple2() tests the case where the "final" API returns a sequence of real blocks which contain a single Wormhole transaction. No re-observation requests.
 func TestWatcherSimple2(t *testing.T) {
+	skipNearWatcherInShortMode(t)
+
 	logger := zaptest.NewLogger(t)
 
 	pl, _ := hex.DecodeString("0100000000000000000000000000000000000000000000000000000000000f42400000000000000000000000000000000000000000000000000000000000000000000f0108bc32f7de18a5f6e1e7d6ee7aff9f5fc858d0d87ac0da94dd8d2a5d267d6b00160000000000000000000000000000000000000000000000000000000000000000")
@@ -291,6 +302,8 @@ func TestWatcherSimple2(t *testing.T) {
 // TestWatcherReobservation() tests the simple re-observation case: The "final" endpoint returns
 // the same unrelated block and there is a re-observation request for past data.
 func TestWatcherReobservation(t *testing.T) {
+	skipNearWatcherInShortMode(t)
+
 	logger := zaptest.NewLogger(t)
 
 	pl, _ := hex.DecodeString("0100000000000000000000000000000000000000000000000000000000000f42400000000000000000000000000000000000000000000000000000000000000000000f0108bc32f7de18a5f6e1e7d6ee7aff9f5fc858d0d87ac0da94dd8d2a5d267d6b00160000000000000000000000000000000000000000000000000000000000000000")
@@ -334,6 +347,8 @@ func TestWatcherReobservation(t *testing.T) {
 // TestWatcherDelayedFinal() tests the case where a block cannot be finalized by a parent having it as
 // last_final_block and instead needs to be finalized by having it observed as finalized during polling
 func TestWatcherDelayedFinal(t *testing.T) {
+	skipNearWatcherInShortMode(t)
+
 	logger := zaptest.NewLogger(t)
 
 	pl, _ := hex.DecodeString("0100000000000000000000000000000000000000000000000000000000000f42400000000000000000000000000000000000000000000000000000000000000000000f0108bc32f7de18a5f6e1e7d6ee7aff9f5fc858d0d87ac0da94dd8d2a5d267d6b00160000000000000000000000000000000000000000000000000000000000000000")
@@ -379,6 +394,8 @@ func TestWatcherDelayedFinal(t *testing.T) {
 // last_final_block and instead needs to be finalized by having it observed as finalized during polling
 // additionally, there is a large gap between polls
 func TestWatcherDelayedFinalAndGaps(t *testing.T) {
+	skipNearWatcherInShortMode(t)
+
 	logger := zaptest.NewLogger(t)
 
 	pl, _ := hex.DecodeString("0100000000000000000000000000000000000000000000000000000000000f42400000000000000000000000000000000000000000000000000000000000000000000f0108bc32f7de18a5f6e1e7d6ee7aff9f5fc858d0d87ac0da94dd8d2a5d267d6b00160000000000000000000000000000000000000000000000000000000000000000")
@@ -426,6 +443,8 @@ func TestWatcherDelayedFinalAndGaps(t *testing.T) {
 "6eCgeVSC4Hwm8tAVy4qNQpnLs4S9EpzRjGtAipwZ632A", // 76538236 block 7: tx3 receipt
 */
 func TestWatcherSynthetic(t *testing.T) {
+	skipNearWatcherInShortMode(t)
+
 	logger := zaptest.NewLogger(t)
 
 	pl, _ := hex.DecodeString("0100000000000000000000000000000000000000000000000000000000000f42400000000000000000000000000000000000000000000000000000000000000000000f0108bc32f7de18a5f6e1e7d6ee7aff9f5fc858d0d87ac0da94dd8d2a5d267d6b00160000000000000000000000000000000000000000000000000000000000000000")
@@ -524,6 +543,8 @@ func TestWatcherSynthetic(t *testing.T) {
 "6eCgeVSC4Hwm8tAVy4qNQpnLs4S9EpzRjGtAipwZ632A", // 76538236 block 7: tx3 receipt
 */
 func TestWatcherUnfinalized(t *testing.T) {
+	skipNearWatcherInShortMode(t)
+
 	logger := zaptest.NewLogger(t)
 
 	pl, _ := hex.DecodeString("0100000000000000000000000000000000000000000000000000000000000f42400000000000000000000000000000000000000000000000000000000000000000000f0108bc32f7de18a5f6e1e7d6ee7aff9f5fc858d0d87ac0da94dd8d2a5d267d6b00160000000000000000000000000000000000000000000000000000000000000000")

--- a/sdk/Makefile
+++ b/sdk/Makefile
@@ -1,5 +1,6 @@
 .PHONY: go-generate
 go-generate:
 	go run chainid_generator.go
+
 go-test:
 	go test ./vaa/...

--- a/wormchain/Makefile
+++ b/wormchain/Makefile
@@ -131,4 +131,3 @@ ictest-cw-shutdown-contracts: rm-testcache
 ictest-validator-hotswap: rm-testcache
 	cd interchaintest && go test -race -v -run ^TestValidatorHotswap$$ ./...
 .PHONY: ictest-validator-hotswap
-


### PR DESCRIPTION
Speed up local human + agent unit test loops by making a new testing
target. CI is untouched so it still runs the full test suite.

- Add `test-fast` to get a much faster unit test loop in Go code. This
  passes `-short` to go test, skips fuzzing, and omits `-race`.
- Gate slow integration-style tests, stress tests, and tests relying on
  sleeps behind Go's testing.Short() configuration.
- Add t.Parallel() to certain tests where appropriate (Go tests run in
- Shortens fuzz time for a specific test since it hasn't had any issues
  since merged

LLM summary from diffing the two test times:
> make test-fast gives a fast local path: 18.43s vs main make test at 89.15s, about 79% faster.
