### PR TITLE
node: Migrate Sui watcher to use `suiclient` package

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -281,7 +281,7 @@ def build_node_yaml():
             if sui:
                 container["command"] += [
                     "--suiRPC",
-                    "http://sui:9000",
+                    "sui:443",
                     "--suiMoveEventType",
                     "0xf82ef05c95ebafcbeb1cce2b636448b8cd1c6daad201f7d04ecddcda15c19d52::publish_message::WormholeMessage",
                 ]

--- a/devnet/sui-devnet.yaml
+++ b/devnet/sui-devnet.yaml
@@ -9,6 +9,11 @@ spec:
     - name: node
       port: 9000
       targetPort: node
+    # The Sui full node serves the gRPC v2 API (used by the guardian) multiplexed on the same
+    # port as JSON-RPC. Expose it as `sui:443` so the watcher can connect via gRPC.
+    - name: grpc
+      port: 443
+      targetPort: node
     - name: prometheus
       port: 9184
       targetPort: prometheus

--- a/devnet/tx-verifier/sui/tx-verifier-sui-runner.sh
+++ b/devnet/tx-verifier/sui/tx-verifier-sui-runner.sh
@@ -7,7 +7,14 @@ sed -i '/module token_bridge::transfer_tokens/r /tmp/transfer_tokens_unsafe.move
 
 # Configurations, such as the RPC endpoint and output files for various pieces of information collected for the
 # tests to be performed.
+# RPC is the JSON-RPC endpoint. It is used here only by the `worm`/`sui` CLI for deployment and
+# transfers (the gRPC migration covers the transfer verifier, not the Sui CLI). Note that Sui's
+# JSON-RPC is deprecated upstream with full removal on 2026-07-31, so this will need revisiting
+# (the CLI's replacement interface is determined by the bundled Sui version).
 RPC=http://sui:9000
+# GRPC_RPC is the gRPC endpoint used by the transfer verifier (--suiRPC). The Sui node serves
+# gRPC multiplexed on the JSON-RPC port; it is exposed as `sui:443` by the devnet service.
+GRPC_RPC=sui:443
 SETUP_DEVNET_OUTPUT_PATH=/tmp/setup-devnet-output.txt
 EXAMPLE_COIN_TX_OUTPUT_PATH=/tmp/setup-example-coin-tx-output.txt
 
@@ -203,32 +210,23 @@ transfer_without_deposit_unsafe() {
         --gas-budget 10000000
 }
 
-echo "[*] running testcases pre-start" # these tests are aimed at the suiProcessInitialEvents flag
-# testcase 1 - do a normal token bridge transfer
-res=`mint_and_transfer_token $treasury_cap_10 $coin_package_id::coin_10::COIN_10 100_0000000000`
-sleep 1
-
-# testcase 2 - do a token bridge transfer where the deposited amount does not cover the full bridge amount
-res=`mint_and_transfer_unsafe_imbalanced $treasury_cap_10 $coin_package_id::coin_10::COIN_10 100_0000000000 200_0000000000`
-sleep 1
-
-# testcase 3 - do a token bridge transfer where the token is not deposited at all
-resp=`transfer_without_deposit_unsafe $treasury_cap_10 $coin_package_id::coin_10::COIN_10 200_0000000000`
-sleep 1
-
+# The verifier consumes events via a forward-only gRPC subscription, so it is started before any
+# test transfers are made; transfers performed afterwards are then observed live and verified.
 echo "[*] starting the sui transfer verifier"
 /guardiand transfer-verifier \
     sui \
-    --suiRPC "${RPC}" \
+    --suiRPC "${GRPC_RPC}" \
     --suiEnvironment=devnet \
     --suiCoreBridgePackageId $core_bridge_package_id \
     --suiTokenBridgeEmitter $token_bridge_emitter_cap \
     --suiTokenBridgePackageId $token_bridge_package_id \
     --logLevel=debug \
-    --suiProcessOnChainEvents \
     2> /tmp/error.log &
 
-echo "[*] running testcases post-start"
+# Give the verifier a moment to establish its subscription before generating events.
+sleep 5
+
+echo "[*] running testcases"
 
 # testcase 1 - do a normal token bridge transfer
 res=`mint_and_transfer_token $treasury_cap_10 $coin_package_id::coin_10::COIN_10 100_0000000000`
@@ -242,17 +240,17 @@ sleep 1
 res=`transfer_without_deposit_unsafe $treasury_cap_10 $coin_package_id::coin_10::COIN_10 200_0000000000`
 sleep 10
 
-# There should be two of each test - one for pre-start and one for post-start.
+# There should be one of each test, all observed live after the verifier started.
 echo "[*] verifying that tests succeeded"
 
 cat /tmp/error.log
 
-if [ $(cat /tmp/error.log | grep "bridge transfer requested for more tokens than were deposited" | wc -l) -ne 2 ]; then
+if [ $(cat /tmp/error.log | grep "bridge transfer requested for more tokens than were deposited" | wc -l) -ne 1 ]; then
     echo " [-] amount out > amount in test failed"
     exit 1
 fi
 
-if [ $(cat /tmp/error.log | grep "bridge transfer requested for tokens that were never deposited" | wc -l) -ne 2 ]; then
+if [ $(cat /tmp/error.log | grep "bridge transfer requested for tokens that were never deposited" | wc -l) -ne 1 ]; then
     echo " [-] amount in == 0 test failed"
     exit 1
 fi

--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -417,7 +417,7 @@ func init() {
 	movementAccount = NodeCmd.Flags().String("movementAccount", "", "movement account")
 	movementHandle = NodeCmd.Flags().String("movementHandle", "", "movement handle")
 
-	suiRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "suiRPC", "Sui RPC URL", "http://sui:9000", []string{"http", "https"})
+	suiRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "suiRPC", "Sui gRPC endpoint", "sui:443", []string{""})
 	suiMoveEventType = NodeCmd.Flags().String("suiMoveEventType", "", "Sui move event type for publish_message")
 
 	solanaRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "solanaRPC", "Solana RPC URL (required)", "http://solana-devnet:8899", []string{"http", "https"})

--- a/node/cmd/txverifier/sui.go
+++ b/node/cmd/txverifier/sui.go
@@ -7,10 +7,9 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"strconv"
-	"time"
 
 	"github.com/certusone/wormhole/node/pkg/common"
+	"github.com/certusone/wormhole/node/pkg/suiclient"
 	"github.com/certusone/wormhole/node/pkg/telemetry"
 	txverifier "github.com/certusone/wormhole/node/pkg/txverifier"
 	"github.com/certusone/wormhole/node/pkg/version"
@@ -20,17 +19,13 @@ import (
 	ipfslog "github.com/ipfs/go-log/v2"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
-)
-
-const (
-	InitialEventFetchLimit = 25
-	EventQueryInterval     = 2 * time.Second
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 // CLI args
 var (
 	suiRPC                       *string
-	suiProcessOnChainEvents      *bool
 	suiProcessWormholeScanEvents *bool
 	suiEnvironment               *string
 	suiDigest                    *string
@@ -49,8 +44,7 @@ var TransferVerifierCmdSui = &cobra.Command{
 
 // CLI parameters
 func init() {
-	suiRPC = TransferVerifierCmdSui.Flags().String("suiRPC", "", "Sui RPC url")
-	suiProcessOnChainEvents = TransferVerifierCmdSui.Flags().Bool("suiProcessOnChainEvents", false, "Indicate whether the Sui transfer verifier should process on-chain events")
+	suiRPC = TransferVerifierCmdSui.Flags().String("suiRPC", "", "Sui gRPC endpoint, host:port (e.g. fullnode.mainnet.sui.io:443, or sui:443 in devnet)")
 	suiProcessWormholeScanEvents = TransferVerifierCmdSui.Flags().Bool("suiProcessWormholeScanEvents", false, "Indicate whether the Sui transfer verifier should process WormholeScan events")
 	suiDigest = TransferVerifierCmdSui.Flags().String("suiDigest", "", "If provided, perform transaction verification on this single digest")
 	suiEnvironment = TransferVerifierCmdSui.Flags().String("suiEnvironment", "mainnet", "The Sui environment to connect to. Supported values: mainnet, testnet and devnet")
@@ -141,13 +135,25 @@ func runTransferVerifierSui(cmd *cobra.Command, args []string) {
 	logger.Debug("Sui core bridge package ID", zap.String("packageId", *suiCoreBridgePackageId))
 	logger.Debug("Sui token bridge package ID", zap.String("packageId", *suiTokenBridgePackageId))
 	logger.Debug("Sui token bridge emitter", zap.String("address", *suiTokenBridgeEmitter))
-	logger.Debug("process on-chain events", zap.Bool("processOnChainEvents", *suiProcessOnChainEvents))
 	logger.Debug("process WormholeScan events", zap.Bool("processWormholeScanEvents", *suiProcessWormholeScanEvents))
 
-	suiApiConnection := txverifier.NewSuiApiConnection(*suiRPC)
+	// Create the Sui gRPC client. A local devnet node serves plaintext gRPC, so disable TLS there.
+	var dialOpts []grpc.DialOption
+	if *suiEnvironment == "devnet" {
+		dialOpts = append(dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	}
+	client, err := suiclient.NewSuiGrpcClient(*suiRPC, logger, dialOpts...)
+	if err != nil {
+		logger.Fatal("Failed to create Sui gRPC client", zap.Error(err))
+	}
+	defer func() {
+		if cerr := client.Close(); cerr != nil {
+			logger.Error("Failed to close Sui gRPC client", zap.Error(cerr))
+		}
+	}()
 
 	// Create a new SuiTransferVerifier
-	suiTransferVerifier := txverifier.NewSuiTransferVerifier(*suiCoreBridgePackageId, *suiTokenBridgeEmitter, *suiTokenBridgePackageId, suiApiConnection)
+	suiTransferVerifier := txverifier.NewSuiTransferVerifier(*suiCoreBridgePackageId, *suiTokenBridgeEmitter, *suiTokenBridgePackageId, client)
 
 	// Process a single digest and exit
 	if *suiDigest != "" {
@@ -178,100 +184,35 @@ func runTransferVerifierSui(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	// Get the event filter
-	eventFilter := suiTransferVerifier.GetEventFilter()
-
-	// Initial event fetching
-	resp, err := suiApiConnection.QueryEvents(ctx, eventFilter, "null", InitialEventFetchLimit, true)
+	// Live processing: subscribe to WormholeMessage events emitted by the core bridge and
+	// verify each transaction as its events arrive. The gRPC subscription streams events
+	// going forward, replacing the previous JSON-RPC poll-and-diff-by-timestamp approach.
+	const eventChannelBufferSize = 64
+	eventChan := make(chan suiclient.SuiTransactionEvent, eventChannelBufferSize)
+	subscription, err := client.SubscribeToTransactionEvent(ctx, suiTransferVerifier.GetEventType(), eventChan)
 	if err != nil {
-		logger.Fatal("Error in querying initial events", zap.Error(err))
+		logger.Fatal("Error subscribing to events", zap.Error(err))
 	}
+	defer subscription.Unsubscribe()
 
-	initialEvents := resp.Result.Data
-
-	// Use the latest timestamp to determine the starting point for live processing
-	var latestTimestamp int
-	for _, event := range initialEvents {
-		if event.Timestamp != nil {
-			timestampInt, atoiErr := strconv.Atoi(*event.Timestamp)
-			if atoiErr != nil {
-				logger.Error("Error converting timestamp to int", zap.Error(atoiErr))
-				continue
-			}
-			if timestampInt > latestTimestamp {
-				latestTimestamp = timestampInt
-			}
-		}
-	}
-	logger.Info("Initial events fetched", zap.Int("number of initial events", len(initialEvents)), zap.Int("latestTimestamp", latestTimestamp))
-
-	// If specified, process the initial events. This is useful for running a number of digests
-	// through the verifier before starting live processing.
-	if *suiProcessOnChainEvents {
-		logger.Info("Processing on-chain events")
-		for _, event := range initialEvents {
-			if event.ID.TxDigest != nil {
-				_, err = suiTransferVerifier.ProcessDigest(ctx, *event.ID.TxDigest, "", logger)
-				if err != nil {
-					logger.Error(err.Error())
-				}
-			}
-		}
-		logger.Info("Finished processing initial events")
-	}
-
-	// Ticker for live processing
-	ticker := time.NewTicker(EventQueryInterval)
-	defer ticker.Stop()
+	logger.Info("Subscribed to WormholeMessage events", zap.String("eventType", suiTransferVerifier.GetEventType()))
 
 	for {
 		select {
 		case <-ctx.Done():
 			logger.Info("Context cancelled")
-		case <-ticker.C:
-			// Fetch new events
-			resp, err := suiApiConnection.QueryEvents(ctx, eventFilter, "null", InitialEventFetchLimit, true)
-			if err != nil {
-				logger.Error("Error in querying new events", zap.Error(err))
+			return
+		case subErr := <-subscription.Err():
+			logger.Fatal("Subscription error", zap.Error(subErr))
+		case txEvent := <-eventChan:
+			if txEvent.TxDigest == "" {
 				continue
 			}
 
-			newEvents := resp.Result.Data
-
-			// List of transaction digests for transactions in which the WormholeMessage
-			// event was emitted.
-			var txDigests []string
-
-			// Iterate over all events and get the transaction digests for events younger
-			// than latestTimestamp. Also update latestTimestamp.
-			for _, event := range newEvents {
-				if event.Timestamp != nil {
-					timestampInt, err := strconv.Atoi(*event.Timestamp)
-					if err != nil {
-						logger.Error("Error converting timestamp to int", zap.Error(err))
-						continue
-					}
-					if timestampInt > latestTimestamp {
-						latestTimestamp = timestampInt
-						if event.ID.TxDigest != nil {
-							txDigests = append(txDigests, *event.ID.TxDigest)
-						}
-					}
-				}
+			if _, err := suiTransferVerifier.ProcessDigest(ctx, txEvent.TxDigest, "", logger); err != nil {
+				logger.Error(err.Error())
 			}
-
-			for _, txDigest := range txDigests {
-				_, err := suiTransferVerifier.ProcessDigest(ctx, txDigest, "", logger)
-				if err != nil {
-					logger.Error(err.Error())
-				}
-				logger.Info("Processed new event", zap.String("txDigest", txDigest))
-			}
-
-			if len(txDigests) > 0 {
-				logger.Info("New events processed", zap.Int("latestTimestamp", latestTimestamp), zap.Int("txDigestCount", len(txDigests)))
-			}
-
+			logger.Info("Processed new event", zap.String("txDigest", txEvent.TxDigest))
 		}
 	}
 }

--- a/node/pkg/suiclient/suiclient.go
+++ b/node/pkg/suiclient/suiclient.go
@@ -106,7 +106,7 @@ type SuiObjectChange struct {
 // Callers MUST nil-check every field they read. The Get* methods do not
 // enforce per-field presence — that responsibility belongs to the caller.
 type SuiTransaction struct {
-	Digest        *string
+	TxDigest      *string
 	Events        []SuiEvent
 	Checkpoint    *uint64
 	Timestamp     *time.Time

--- a/node/pkg/suiclient/suiclient.go
+++ b/node/pkg/suiclient/suiclient.go
@@ -23,6 +23,7 @@ const (
 	TransactionFieldCheckpoint     = "checkpoint"
 	TransactionFieldTimestamp      = "timestamp"
 	TransactionFieldChangedObjects = "effects.changed_objects"
+	TransactionFieldStatus         = "effects.status"
 )
 
 const (
@@ -180,6 +181,10 @@ type SuiClient interface {
 	// SuiTransaction; see the TransactionField* constants. At least one field
 	// is required.
 	//
+	// The execution status is always fetched in addition to the requested
+	// fields, and an error is returned unless the transaction executed
+	// successfully — callers never see data from failed transactions.
+	//
 	// Fields not requested (and fields requested but missing from the upstream
 	// response) come back nil/empty. Callers MUST nil-check every field they
 	// read — this method does not enforce per-field presence.
@@ -187,7 +192,7 @@ type SuiClient interface {
 
 	// Subscribe to transaction events of type `eventType`. Each matching event is delivered
 	// on the channel as a SuiTransactionEvent, pairing it with the digest of the transaction
-	// that emitted it.
+	// that emitted it. Events from transactions that did not execute successfully are dropped.
 	SubscribeToTransactionEvent(ctx context.Context, eventType string, eventWriteChannel chan<- SuiTransactionEvent) (SuiSubscription, error)
 	SubscribeToTransactionEvents(ctx context.Context, eventTypes []string, eventWriteChannel chan<- SuiTransactionEvent) (SuiSubscription, error)
 

--- a/node/pkg/suiclient/suiclient.go
+++ b/node/pkg/suiclient/suiclient.go
@@ -82,9 +82,9 @@ type SuiTransactionEvent struct {
 	Event    SuiEvent
 }
 
-// SuiObjectChange holds the subset of a transaction effect's changed-object
-// information needed to look up an object's state before and after a
-// transaction. It is populated from effects.changed_objects; request
+// SuiObjectChange holds basic metadata of an object that changed during the
+// execution of a transaction, such as it's ID, type and versions before and
+// after transaction execution. It is populated from effects.changed_objects; request
 // TransactionFieldChangedObjects to have it populated on SuiTransaction.
 //
 // Callers MUST nil-check every field they read.

--- a/node/pkg/suiclient/suiclient.go
+++ b/node/pkg/suiclient/suiclient.go
@@ -18,10 +18,11 @@ const (
 // any string, so callers needing a sub-message path (e.g. "contents.value")
 // can pass the literal directly.
 const (
-	TransactionFieldDigest     = "digest"
-	TransactionFieldEvents     = "events"
-	TransactionFieldCheckpoint = "checkpoint"
-	TransactionFieldTimestamp  = "timestamp"
+	TransactionFieldDigest         = "digest"
+	TransactionFieldEvents         = "events"
+	TransactionFieldCheckpoint     = "checkpoint"
+	TransactionFieldTimestamp      = "timestamp"
+	TransactionFieldChangedObjects = "effects.changed_objects"
 )
 
 const (
@@ -70,6 +71,33 @@ type SuiEvent struct {
 	BcsBytes          []byte
 }
 
+// SuiTransactionEvent pairs an event with the digest of the transaction that emitted it.
+// It is produced by the subscription, where events are delivered individually and would
+// otherwise lose their transaction context — the bare gRPC Event carries no digest, so the
+// digest is taken from the parent ExecutedTransaction. Events obtained via GetTransaction do
+// not need this wrapper, since the caller already knows the digest.
+type SuiTransactionEvent struct {
+	TxDigest string
+	Event    SuiEvent
+}
+
+// SuiObjectChange holds the subset of a transaction effect's changed-object
+// information needed to look up an object's state before and after a
+// transaction. It is populated from effects.changed_objects; request
+// TransactionFieldChangedObjects to have it populated on SuiTransaction.
+//
+// Callers MUST nil-check every field they read.
+type SuiObjectChange struct {
+	ObjectID   *string
+	ObjectType *string
+	// InputVersion is the object's version before this transaction executed
+	// (i.e. the previous version).
+	InputVersion *uint64
+	// OutputVersion is the object's version after this transaction executed
+	// (i.e. the current version).
+	OutputVersion *uint64
+}
+
 // SuiTransaction holds the flat-primitive fields of an executed transaction.
 // A field is populated only when the caller requested it via the field mask
 // AND the upstream node returned it; otherwise the field is nil/empty.
@@ -77,10 +105,11 @@ type SuiEvent struct {
 // Callers MUST nil-check every field they read. The Get* methods do not
 // enforce per-field presence — that responsibility belongs to the caller.
 type SuiTransaction struct {
-	Digest     *string
-	Events     []SuiEvent
-	Checkpoint *uint64
-	Timestamp  *time.Time
+	Digest        *string
+	Events        []SuiEvent
+	Checkpoint    *uint64
+	Timestamp     *time.Time
+	ObjectChanges []SuiObjectChange
 }
 
 // SuiCheckpoint holds the flat-primitive fields of a checkpoint. A field is
@@ -156,9 +185,11 @@ type SuiClient interface {
 	// read — this method does not enforce per-field presence.
 	GetTransaction(ctx context.Context, digest string, fields []string) (SuiTransaction, error)
 
-	// Subscribe to transaction events of type `eventType`
-	SubscribeToTransactionEvent(ctx context.Context, eventType string, eventWriteChannel chan<- SuiEvent) (SuiSubscription, error)
-	SubscribeToTransactionEvents(ctx context.Context, eventTypes []string, eventWriteChannel chan<- SuiEvent) (SuiSubscription, error)
+	// Subscribe to transaction events of type `eventType`. Each matching event is delivered
+	// on the channel as a SuiTransactionEvent, pairing it with the digest of the transaction
+	// that emitted it.
+	SubscribeToTransactionEvent(ctx context.Context, eventType string, eventWriteChannel chan<- SuiTransactionEvent) (SuiSubscription, error)
+	SubscribeToTransactionEvents(ctx context.Context, eventTypes []string, eventWriteChannel chan<- SuiTransactionEvent) (SuiSubscription, error)
 
 	// Close the client
 	Close() error

--- a/node/pkg/suiclient/suigrpc.go
+++ b/node/pkg/suiclient/suigrpc.go
@@ -168,7 +168,7 @@ func (s *SuiGrpcClient) createCheckpointStream(ctx context.Context, fields []str
 	return stream, err
 }
 
-func (s *SuiGrpcClient) SubscribeToTransactionEvent(ctx context.Context, event string, eventWriteChannel chan<- SuiEvent) (SuiSubscription, error) {
+func (s *SuiGrpcClient) SubscribeToTransactionEvent(ctx context.Context, event string, eventWriteChannel chan<- SuiTransactionEvent) (SuiSubscription, error) {
 	eventTypes := []string{
 		event,
 	}
@@ -176,7 +176,7 @@ func (s *SuiGrpcClient) SubscribeToTransactionEvent(ctx context.Context, event s
 	return s.SubscribeToTransactionEvents(ctx, eventTypes, eventWriteChannel)
 }
 
-func (s *SuiGrpcClient) SubscribeToTransactionEvents(ctx context.Context, eventTypes []string, eventWriteChannel chan<- SuiEvent) (SuiSubscription, error) {
+func (s *SuiGrpcClient) SubscribeToTransactionEvents(ctx context.Context, eventTypes []string, eventWriteChannel chan<- SuiTransactionEvent) (SuiSubscription, error) {
 	if len(eventTypes) == 0 {
 		return SuiSubscription{}, fmt.Errorf("sui gRPC SubscribeToTransactionEvents requires at least one event type")
 	}
@@ -184,8 +184,10 @@ func (s *SuiGrpcClient) SubscribeToTransactionEvents(ctx context.Context, eventT
 		return SuiSubscription{}, fmt.Errorf("sui gRPC SubscribeToTransactionEvents requires a non-nil eventWriteChannel")
 	}
 
-	// This stream is only concerned with transaction events
+	// This stream is concerned with transaction events plus the digest of the transaction
+	// that emitted them, which is paired with each event as a SuiTransactionEvent below.
 	fields := []string{
+		"transactions.digest",
 		"transactions.events",
 	}
 
@@ -273,10 +275,17 @@ func (s *SuiGrpcClient) SubscribeToTransactionEvents(ctx context.Context, eventT
 						continue
 					}
 
+					// Pair the event with the digest of the transaction that emitted it; the
+					// bare gRPC Event carries no digest of its own.
+					txDigest := ""
+					if tx.Digest != nil {
+						txDigest = *tx.Digest
+					}
+
 					// Writing to eventWriteChannel could be blocking if there are no readers. Use a select to include
 					// a simultaneous check to bail out if the context is cancelled.
 					select {
-					case eventWriteChannel <- *suiEvent:
+					case eventWriteChannel <- SuiTransactionEvent{TxDigest: txDigest, Event: *suiEvent}:
 					case <-ctx.Done():
 						return
 					}
@@ -298,9 +307,11 @@ func (s *SuiGrpcClient) Close() error {
 	return nil
 }
 
-// Create a new SuiClient, with the gRPC service as implementation. Additional gRPC dial options
-// (e.g. for custom transport credentials, interceptors, or per-RPC metadata via interceptors) may
-// be supplied; they are appended after the defaults so callers can override them.
+// Create a new SuiClient, with the gRPC service as implementation. The default transport is TLS.
+// Additional gRPC dial options (e.g. for custom transport credentials, interceptors, or per-RPC
+// metadata via interceptors) may be supplied; they are appended after the defaults so callers can
+// override them. In particular, passing grpc.WithTransportCredentials(insecure.NewCredentials())
+// overrides the default TLS transport with a plaintext one, as needed for a local dev-mode node.
 func NewSuiGrpcClient(rpcURL string, logger *zap.Logger, extraOpts ...grpc.DialOption) (SuiClient, error) {
 	if logger == nil {
 		logger = zap.NewNop()
@@ -403,6 +414,20 @@ func grpcExecutedTransactionToSuiTransaction(grpcTransaction *pb.ExecutedTransac
 			if suiEventPtr := grpcEventToSuiEvent(event); suiEventPtr != nil {
 				out.Events = append(out.Events, *suiEventPtr)
 			}
+		}
+	}
+
+	if grpcTransaction.Effects != nil {
+		for _, changedObject := range grpcTransaction.Effects.ChangedObjects {
+			if changedObject == nil {
+				continue
+			}
+			out.ObjectChanges = append(out.ObjectChanges, SuiObjectChange{
+				ObjectID:      changedObject.ObjectId,
+				ObjectType:    changedObject.ObjectType,
+				InputVersion:  changedObject.InputVersion,
+				OutputVersion: changedObject.OutputVersion,
+			})
 		}
 	}
 

--- a/node/pkg/suiclient/suigrpc.go
+++ b/node/pkg/suiclient/suigrpc.go
@@ -130,12 +130,23 @@ func (s *SuiGrpcClient) GetLatestCheckpoint(ctx context.Context, fields []string
 // Replaces `sui_getTransactionBlock`.
 // Docs: https://www.quicknode.com/docs/sui/sui-grpc/ledger/get-transaction
 //
+// The execution status is always fetched in addition to the requested fields, and an error is
+// returned unless the transaction carries an explicit successful status. Wormhole only ever
+// cares about successful transactions, so enforcing this here guarantees callers never act on
+// data from a failed (or status-less) transaction.
+//
 // Returned-field nil-checking is the caller's responsibility — any field
 // not requested OR not returned by the upstream node comes back nil/empty,
 // and this method does not enforce per-field presence.
 func (s *SuiGrpcClient) GetTransaction(ctx context.Context, digest string, fields []string) (SuiTransaction, error) {
 	if len(fields) == 0 {
 		return SuiTransaction{}, fmt.Errorf("sui gRPC GetTransaction requires at least one field for digest=%s", digest)
+	}
+
+	if !slices.Contains(fields, TransactionFieldStatus) {
+		// Clone before appending so the caller's slice is never mutated through a shared
+		// backing array.
+		fields = append(slices.Clone(fields), TransactionFieldStatus)
 	}
 
 	getTransactionRequest := pb.GetTransactionRequest{
@@ -153,7 +164,21 @@ func (s *SuiGrpcClient) GetTransaction(ctx context.Context, digest string, field
 		return SuiTransaction{}, fmt.Errorf("sui gRPC GetTransaction returned nil top-level properties for digest=%s fields=%v", digest, fields)
 	}
 
+	if !transactionSucceeded(resp.Transaction) {
+		return SuiTransaction{}, fmt.Errorf("sui gRPC GetTransaction: transaction did not execute successfully (or its execution status is missing) for digest=%s", digest)
+	}
+
 	return grpcExecutedTransactionToSuiTransaction(resp.Transaction), nil
+}
+
+// transactionSucceeded reports whether the executed transaction carries an explicit successful
+// execution status. A missing effects/status/success field counts as failure (fail closed).
+func transactionSucceeded(tx *pb.ExecutedTransaction) bool {
+	return tx != nil &&
+		tx.Effects != nil &&
+		tx.Effects.Status != nil &&
+		tx.Effects.Status.Success != nil &&
+		*tx.Effects.Status.Success
 }
 
 func (s *SuiGrpcClient) createCheckpointStream(ctx context.Context, fields []string) (pb.SubscriptionService_SubscribeCheckpointsClient, error) {
@@ -186,9 +211,12 @@ func (s *SuiGrpcClient) SubscribeToTransactionEvents(ctx context.Context, eventT
 
 	// This stream is concerned with transaction events plus the digest of the transaction
 	// that emitted them, which is paired with each event as a SuiTransactionEvent below.
+	// The execution status is fetched as well so that events from failed transactions can
+	// be dropped.
 	fields := []string{
 		"transactions.digest",
 		"transactions.events",
+		"transactions.effects.status",
 	}
 
 	// Create a cancel context for use in the subscription
@@ -249,6 +277,16 @@ func (s *SuiGrpcClient) SubscribeToTransactionEvents(ctx context.Context, eventT
 
 				// If there are no events, proceed to next transaction
 				if tx.Events == nil || len(tx.Events.Events) == 0 {
+					continue
+				}
+
+				// Sui only commits events for successful transactions, so a transaction that
+				// carries events without an explicit successful status is anomalous. Drop its
+				// events (fail closed).
+				if !transactionSucceeded(tx) {
+					s.logger.Warn("Sui gRPC subscription: dropping events from a transaction without a successful execution status",
+						zap.Stringp("digest", tx.Digest),
+					)
 					continue
 				}
 

--- a/node/pkg/suiclient/suigrpc.go
+++ b/node/pkg/suiclient/suigrpc.go
@@ -439,7 +439,7 @@ func grpcExecutedTransactionToSuiTransaction(grpcTransaction *pb.ExecutedTransac
 		return out
 	}
 
-	out.Digest = grpcTransaction.Digest
+	out.TxDigest = grpcTransaction.Digest
 	out.Checkpoint = grpcTransaction.Checkpoint
 
 	if grpcTransaction.Timestamp != nil {

--- a/node/pkg/suiclient/suigrpc_live_test.go
+++ b/node/pkg/suiclient/suigrpc_live_test.go
@@ -177,7 +177,7 @@ func TestGrpcClientSubscribeToTransactionEvents(t *testing.T) {
 		"0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a::publish_message::WormholeMessage",
 	}
 
-	suiEventChan := make(chan SuiEvent)
+	suiEventChan := make(chan SuiTransactionEvent)
 	subscription, err := client.SubscribeToTransactionEvents(ctx, eventTypes, suiEventChan)
 	require.NoError(t, err)
 	defer subscription.Unsubscribe()
@@ -209,8 +209,10 @@ func TestGrpcClientSubscribeToTransactionEvents(t *testing.T) {
 				<-subscription.Done()
 				return
 			}
-		case ev := <-suiEventChan:
+		case txEvent := <-suiEventChan:
 			{
+				ev := txEvent.Event
+				fmt.Printf("\tTxDigest=%s\n", txEvent.TxDigest)
 				fmt.Printf("\tEventType=%s\n", ev.EventType)
 				fmt.Println("\t\tPackageID:", ev.PackageID)
 				fmt.Println("\t\tModule:", ev.TransactionModule)

--- a/node/pkg/suiclient/suigrpc_live_test.go
+++ b/node/pkg/suiclient/suigrpc_live_test.go
@@ -1,3 +1,13 @@
+//go:build integration
+
+// The tests in this file run against a live Sui mainnet gRPC endpoint and are only compiled
+// with the `integration` build tag:
+//
+//	go test -tags integration ./pkg/suiclient -v
+//
+// The subscription test additionally requires SUI_GRPC_TEST_SUBSCRIPTION to be set, since it
+// depends on live event traffic.
+
 package suiclient
 
 import (
@@ -12,25 +22,6 @@ import (
 	"go.uber.org/zap"
 )
 
-// To enable live tests, set the environmental variable SUI_GRPC_TEST_LIVE=ANYTHING.
-// Set it to INCLUDE_SUBSCRIPTION_TEST specifically to enable the subscription test.
-func suiGrpcClientLiveTestEnabled() (bool, bool) {
-	val := os.Getenv("SUI_GRPC_TEST_LIVE")
-
-	runNormalTests := false
-	runSubscriptionTest := false
-
-	if len(val) > 0 {
-		runNormalTests = true
-	}
-
-	if val == "INCLUDE_SUBSCRIPTION_TEST" {
-		runSubscriptionTest = true
-	}
-
-	return runNormalTests, runSubscriptionTest
-}
-
 // Definition converted from the Sui module's definition. Field order and types must match the
 // on-chain Move struct exactly so BCS decoding succeeds. To derive these by hand, run
 // `sui move summary --bytecode <package-id>` against the published package and translate each
@@ -42,11 +33,6 @@ type WormholeState struct {
 }
 
 func TestGrpcClientGetObject(t *testing.T) {
-	runNormalTests, _ := suiGrpcClientLiveTestEnabled()
-	if !runNormalTests {
-		return
-	}
-
 	testLogger := zap.NewNop()
 	ctx := context.Background()
 	client, err := NewSuiGrpcClient(SuiRPCMainnet, testLogger)
@@ -96,11 +82,6 @@ type WormholeMessage struct {
 }
 
 func TestGrpcClientGetTransaction(t *testing.T) {
-	runNormalTests, _ := suiGrpcClientLiveTestEnabled()
-	if !runNormalTests {
-		return
-	}
-
 	testLogger := zap.NewNop()
 	ctx := context.Background()
 	client, err := NewSuiGrpcClient(SuiRPCMainnet, testLogger)
@@ -143,11 +124,6 @@ func TestGrpcClientGetTransaction(t *testing.T) {
 }
 
 func TestGrpcClientGetCheckpointSN(t *testing.T) {
-	runNormalTests, _ := suiGrpcClientLiveTestEnabled()
-	if !runNormalTests {
-		return
-	}
-
 	testLogger := zap.NewNop()
 	ctx := context.Background()
 	client, err := NewSuiGrpcClient(SuiRPCMainnet, testLogger)
@@ -161,9 +137,8 @@ func TestGrpcClientGetCheckpointSN(t *testing.T) {
 }
 
 func TestGrpcClientSubscribeToTransactionEvents(t *testing.T) {
-	_, runSubscriptionTest := suiGrpcClientLiveTestEnabled()
-	if !runSubscriptionTest {
-		return
+	if os.Getenv("SUI_GRPC_TEST_SUBSCRIPTION") == "" {
+		t.Skip("set SUI_GRPC_TEST_SUBSCRIPTION=1 to run the live subscription test")
 	}
 
 	testLogger := zap.NewNop()

--- a/node/pkg/suiclient/suigrpc_test.go
+++ b/node/pkg/suiclient/suigrpc_test.go
@@ -560,7 +560,7 @@ func TestGetTransactionEnforcesExecutionStatus(t *testing.T) {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
-				require.NotNil(t, tx.Digest)
+				require.NotNil(t, tx.TxDigest)
 			}
 		})
 	}

--- a/node/pkg/suiclient/suigrpc_test.go
+++ b/node/pkg/suiclient/suigrpc_test.go
@@ -7,9 +7,17 @@ import (
 	"testing"
 
 	pb "github.com/block-vision/sui-go-sdk/pb/sui/rpc/v2"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/metadata"
 )
+
+// successfulEffects returns transaction effects carrying an explicit successful execution
+// status, as expected by the status checks in GetTransaction and the event subscription.
+func successfulEffects() *pb.TransactionEffects {
+	success := true
+	return &pb.TransactionEffects{Status: &pb.ExecutionStatus{Success: &success}}
+}
 
 // A mock LedgerService client for testing. Each of the requests (GetObject, GetCheckpoint, GetTransaction) can
 // be simulated by calling the appropriate `SetNext*Response` function, to return a prepared response.
@@ -226,7 +234,9 @@ func FuzzSuiGrpcClientGetTransactionNoEvents(f *testing.F) {
 			if transactionNilOrNot {
 				resp.Transaction = nil
 			} else {
-				resp.Transaction = &pb.ExecutedTransaction{}
+				// The successful status keeps the post-status-check conversion path
+				// exercised; the status check itself is covered by unit tests.
+				resp.Transaction = &pb.ExecutedTransaction{Effects: successfulEffects()}
 
 				if !transaction_digestNilOrNot {
 					resp.Transaction.Digest = &transaction_digest
@@ -426,6 +436,9 @@ func FuzzSuiGrpcClientSubscribeToEvents(f *testing.F) {
 					grpcTx := &pb.ExecutedTransaction{
 						Digest: &txDigest,
 						Events: &pb.TransactionEvents{},
+						// The successful status keeps the event-matching path exercised;
+						// the status check itself is covered by unit tests.
+						Effects: successfulEffects(),
 					}
 					for idx := range entries {
 						grpcEvent := &pb.Event{}
@@ -508,6 +521,119 @@ func FuzzSuiGrpcClientSubscribeToEvents(f *testing.F) {
 		// Unsubscribe again to confirm it is safe to call after the goroutine has exited.
 		subscription.Unsubscribe()
 	})
+}
+
+// TestGetTransactionEnforcesExecutionStatus verifies that GetTransaction returns an error for
+// any transaction that does not carry an explicit successful execution status, including all
+// the partially-populated status shapes (fail closed).
+func TestGetTransactionEnforcesExecutionStatus(t *testing.T) {
+	digest := "0xDigest"
+	successFalse := false
+
+	cases := []struct {
+		name    string
+		effects *pb.TransactionEffects
+		wantErr bool
+	}{
+		{name: "success", effects: successfulEffects(), wantErr: false},
+		{name: "failed", effects: &pb.TransactionEffects{Status: &pb.ExecutionStatus{Success: &successFalse}}, wantErr: true},
+		{name: "success field missing", effects: &pb.TransactionEffects{Status: &pb.ExecutionStatus{}}, wantErr: true},
+		{name: "status missing", effects: &pb.TransactionEffects{}, wantErr: true},
+		{name: "effects missing", effects: nil, wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ledgerService := &MockLedgerServiceClient{}
+			grpcClient := newSuiGrpcClientWithServices(zap.NewNop(), nil, ledgerService, nil)
+
+			ledgerService.SetNextGetTransactionResponse(&pb.GetTransactionResponse{
+				Transaction: &pb.ExecutedTransaction{
+					Digest:  &digest,
+					Effects: tc.effects,
+				},
+			})
+
+			tx, err := grpcClient.GetTransaction(context.Background(), digest, []string{TransactionFieldDigest})
+
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, tx.Digest)
+			}
+		})
+	}
+}
+
+// TestSubscribeDropsEventsFromFailedTransactions verifies that the event subscription only
+// forwards events from transactions with an explicit successful execution status. The streamed
+// checkpoint contains one successful and one failed transaction, each carrying an otherwise
+// identical matching event; only the successful transaction's event must be delivered.
+func TestSubscribeDropsEventsFromFailedTransactions(t *testing.T) {
+	successDigest := "0xSuccess"
+	failedDigest := "0xFailed"
+	packageId := "PackageId"
+	module := "Module"
+	sender := "Sender"
+	eventType := "EventType"
+	contentsName := "Contents.Name"
+	contentsValue := []byte{0x13, 0x37}
+	successFalse := false
+
+	makeEvent := func() *pb.Event {
+		return &pb.Event{
+			PackageId: &packageId,
+			Module:    &module,
+			Sender:    &sender,
+			EventType: &eventType,
+			Contents: &pb.Bcs{
+				Name:  &contentsName,
+				Value: contentsValue,
+			},
+		}
+	}
+
+	resp := &pb.SubscribeCheckpointsResponse{
+		Checkpoint: &pb.Checkpoint{
+			Transactions: []*pb.ExecutedTransaction{
+				{
+					Digest:  &successDigest,
+					Events:  &pb.TransactionEvents{Events: []*pb.Event{makeEvent()}},
+					Effects: successfulEffects(),
+				},
+				{
+					Digest:  &failedDigest,
+					Events:  &pb.TransactionEvents{Events: []*pb.Event{makeEvent()}},
+					Effects: &pb.TransactionEffects{Status: &pb.ExecutionStatus{Success: &successFalse}},
+				},
+			},
+		},
+	}
+
+	subscriptionService := &MockSubscriptionServiceClient{
+		nextStream: &MockSubscribeCheckpointsStream{
+			responses: []*pb.SubscribeCheckpointsResponse{resp},
+			recvErr:   io.EOF,
+		},
+	}
+	grpcClient := newSuiGrpcClientWithServices(zap.NewNop(), nil, nil, subscriptionService)
+
+	eventChan := make(chan SuiTransactionEvent, 4)
+	subscription, err := grpcClient.SubscribeToTransactionEvent(context.Background(), eventType, eventChan)
+	require.NoError(t, err)
+	defer subscription.Unsubscribe()
+
+	// Wait for the subscription goroutine to process the single response and exit.
+	<-subscription.Done()
+
+	var received []SuiTransactionEvent
+	for len(eventChan) > 0 {
+		received = append(received, <-eventChan)
+	}
+
+	require.Len(t, received, 1)
+	require.Equal(t, successDigest, received[0].TxDigest)
 }
 
 func FuzzNewSuiGrpcClient(f *testing.F) {

--- a/node/pkg/suiclient/suigrpc_test.go
+++ b/node/pkg/suiclient/suigrpc_test.go
@@ -477,7 +477,7 @@ func FuzzSuiGrpcClientSubscribeToEvents(f *testing.F) {
 
 		// Buffer the channel generously so the subscription goroutine never blocks while
 		// writing events. At most maxTransactions*maxEventsPerTx events can be produced.
-		eventChan := make(chan SuiEvent, maxTransactions*maxEventsPerTx+1)
+		eventChan := make(chan SuiTransactionEvent, maxTransactions*maxEventsPerTx+1)
 
 		eventTypes := []string{"non-matching-event-type"}
 		if matchEventType {

--- a/node/pkg/txverifier/sui.go
+++ b/node/pkg/txverifier/sui.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"strings"
 
 	"github.com/certusone/wormhole/node/pkg/common"
 	"github.com/certusone/wormhole/node/pkg/suiclient"
@@ -96,10 +95,11 @@ func (s *SuiTransferVerifier) extractBridgeRequestsFromEvents(events []suiclient
 
 		// The on-chain sender is a 32-byte address. The message ID format and the configured
 		// token bridge emitter both use a hex encoding with a "0x" prefix.
-		sender := "0x" + hex.EncodeToString(wormholeMessage.Sender[:])
+		sender := hex.EncodeToString(wormholeMessage.Sender[:])
+		senderWith0x := "0x" + sender
 
 		// Only process the event if it was emitted by the token bridge emitter.
-		if sender != s.suiTokenBridgeEmitter {
+		if senderWith0x != s.suiTokenBridgeEmitter {
 			logger.Debug("Event does not match the criteria",
 				zap.String("event type", event.EventType),
 				zap.String("event sender", sender),
@@ -119,10 +119,7 @@ func (s *SuiTransferVerifier) extractBridgeRequestsFromEvents(events []suiclient
 			continue
 		}
 
-		// The sender address is prefixed with "0x", but the message ID format does not include that prefix.
-		senderWithout0x := strings.TrimPrefix(sender, "0x")
-
-		msgIDStr := fmt.Sprintf("%d/%s/%d", vaa.ChainIDSui, senderWithout0x, wormholeMessage.Sequence)
+		msgIDStr := fmt.Sprintf("%d/%s/%d", vaa.ChainIDSui, sender, wormholeMessage.Sequence)
 		assetKey := fmt.Sprintf(KEY_FORMAT, hdr.OriginAddress.String(), hdr.OriginChain)
 
 		logger.Debug("Found request out of bridge",

--- a/node/pkg/txverifier/sui.go
+++ b/node/pkg/txverifier/sui.go
@@ -89,7 +89,8 @@ func (s *SuiTransferVerifier) extractBridgeRequestsFromEvents(events []suiclient
 		// instances. If the contents cannot be decoded, the event is simply skipped.
 		wormholeMessage, err := suiclient.DecodeBcs[WormholeMessage](event.BcsBytes)
 		if err != nil {
-			logger.Debug("Failed to BCS-decode WormholeMessage event", zap.Error(err))
+			// We expect that all events of the correct type can be decoded successfully so error loudly
+			logger.Error("Failed to BCS-decode WormholeMessage event", zap.Error(err))
 			continue
 		}
 
@@ -115,7 +116,6 @@ func (s *SuiTransferVerifier) extractBridgeRequestsFromEvents(events []suiclient
 		// If there is an error decoding the payload, skip the event. One reason for a potential
 		// failure in decoding is that an attestation of a token was requested.
 		if err != nil {
-			logger.Debug("Error decoding payload", zap.Error(err))
 			continue
 		}
 

--- a/node/pkg/txverifier/sui.go
+++ b/node/pkg/txverifier/sui.go
@@ -2,14 +2,14 @@ package txverifier
 
 import (
 	"context"
-	"encoding/json"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"math/big"
-	"net/http"
 	"strings"
 
 	"github.com/certusone/wormhole/node/pkg/common"
+	"github.com/certusone/wormhole/node/pkg/suiclient"
 	"github.com/wormhole-foundation/wormhole/sdk/vaa"
 	"go.uber.org/zap"
 )
@@ -48,16 +48,17 @@ type SuiTransferVerifier struct {
 	// Used to match the owning package of native and wrapped asset types.
 	suiTokenBridgePackageId string
 	suiEventType            string
-	suiApiConnection        SuiApiInterface
+	// gRPC client used to fetch transactions and objects.
+	client suiclient.SuiClient
 }
 
-func NewSuiTransferVerifier(suiCoreBridgePackageId, suiTokenBridgeEmitter, suiTokenBridgePackageId string, suiApiConnection SuiApiInterface) *SuiTransferVerifier {
+func NewSuiTransferVerifier(suiCoreBridgePackageId, suiTokenBridgeEmitter, suiTokenBridgePackageId string, client suiclient.SuiClient) *SuiTransferVerifier {
 	return &SuiTransferVerifier{
 		suiCoreBridgePackageId:  suiCoreBridgePackageId,
 		suiTokenBridgeEmitter:   suiTokenBridgeEmitter,
 		suiTokenBridgePackageId: suiTokenBridgePackageId,
 		suiEventType:            fmt.Sprintf("%s::%s::%s", suiCoreBridgePackageId, suiModule, suiEventName),
-		suiApiConnection:        suiApiConnection,
+		client:                  client,
 	}
 }
 
@@ -65,155 +66,163 @@ func (s *SuiTransferVerifier) GetTokenBridgeEmitter() string {
 	return s.suiTokenBridgeEmitter
 }
 
-// Filter to be used for querying events
-// The `MoveEventType` filter doesn't seem to be available in the documentation. However, there is an example
-// showing the inclusion of `type` in the `MoveModule` filter.
-// Reference: https://docs.sui.io/guides/developer/sui-101/using-events#query-events-with-rpc
-func (s *SuiTransferVerifier) GetEventFilter() string {
-	return fmt.Sprintf(`
-	{
-		"MoveModule":{
-			"package":"%s",
-			"module":"%s",
-			"type":"%s"
-		}
-	}`, s.suiCoreBridgePackageId, suiModule, s.suiEventType)
+// GetEventType returns the fully-qualified `WormholeMessage` event type emitted by the core
+// bridge. It can be used to subscribe to the relevant events over gRPC.
+func (s *SuiTransferVerifier) GetEventType() string {
+	return s.suiEventType
 }
 
 // extractBridgeRequestsFromEvents iterates through all events, and tries to identify `WormholeMessage` events emitted by the token bridge.
 // These events are parsed and collected in a `MsgIdToRequestOutOfBridge` object, mapping message IDs to requests out of the bridge. This
 // function does not return errors, as any issues encountered during processing of individual events result in those events being skipped.
-func (s *SuiTransferVerifier) extractBridgeRequestsFromEvents(events []SuiEvent, logger *zap.Logger) MsgIdToRequestOutOfBridge {
+func (s *SuiTransferVerifier) extractBridgeRequestsFromEvents(events []suiclient.SuiEvent, logger *zap.Logger) MsgIdToRequestOutOfBridge {
 	requests := make(MsgIdToRequestOutOfBridge)
 
 	for _, event := range events {
-		var wormholeMessage WormholeMessage
-
-		// Parse the ParsedJson field into a WormholeMessage. This is done explicitly to avoid any unnecessary
-		// error logging for events that can't be deserialized into `WormholeMessage` instances. If an event's
-		// ParsedJson cannot be unmarshaled into a WormholeMessage, it is simply skipped.
-		if event.ParsedJson != nil {
-			err := json.Unmarshal(*event.ParsedJson, &wormholeMessage)
-			if err != nil {
-				// If an error ocurrs, the ParsedJson is rejected as an event that is not emitted by the bridge
-				continue
-			}
-		}
-
-		// If any of these event parameters are nil, skip the event
-		if wormholeMessage.Sender == nil || wormholeMessage.Sequence == nil || event.Type == nil {
+		// Only process `WormholeMessage` events emitted by the core bridge.
+		if event.EventType != s.suiEventType {
 			continue
 		}
 
-		// Only process the event if it is a WormholeMessage event from the token bridge emitter
-		if *event.Type == s.suiEventType && *wormholeMessage.Sender == s.suiTokenBridgeEmitter {
+		// BCS-decode the event contents into a WormholeMessage. This is done explicitly to avoid any
+		// unnecessary error logging for events that can't be deserialized into `WormholeMessage`
+		// instances. If the contents cannot be decoded, the event is simply skipped.
+		wormholeMessage, err := suiclient.DecodeBcs[WormholeMessage](event.BcsBytes)
+		if err != nil {
+			logger.Debug("Failed to BCS-decode WormholeMessage event", zap.Error(err))
+			continue
+		}
 
-			// Parse the wormhole message. vaa.IsTransfer can be omitted, since this is done
-			// inside `DecodeTransferPayloadHdr` already.
-			hdr, err := vaa.DecodeTransferPayloadHdr(wormholeMessage.Payload)
+		// The on-chain sender is a 32-byte address. The message ID format and the configured
+		// token bridge emitter both use a hex encoding with a "0x" prefix.
+		sender := "0x" + hex.EncodeToString(wormholeMessage.Sender[:])
 
-			// If there is an error decoding the payload, skip the event. One reason for a potential
-			// failure in decoding is that an attestation of a token was requested.
-			if err != nil {
-				logger.Debug("Error decoding payload", zap.Error(err))
-				continue
-			}
-
-			// The sender address is prefixed with "0x", but the message ID format does not include that prefix.
-			senderWithout0x := strings.TrimPrefix(*wormholeMessage.Sender, "0x")
-
-			msgIDStr := fmt.Sprintf("%d/%s/%s", vaa.ChainIDSui, senderWithout0x, *wormholeMessage.Sequence)
-			assetKey := fmt.Sprintf(KEY_FORMAT, hdr.OriginAddress.String(), hdr.OriginChain)
-
-			logger.Debug("Found request out of bridge",
-				zap.String("msgID", msgIDStr),
-				zap.String("assetKey", assetKey),
-				zap.String("amount", hdr.Amount.String()),
-			)
-
-			requests[msgIDStr] = &RequestOutOfBridge{
-				AssetKey:       assetKey,
-				Amount:         hdr.Amount,
-				DepositMade:    false,
-				DepositSolvent: false,
-			}
-		} else {
+		// Only process the event if it was emitted by the token bridge emitter.
+		if sender != s.suiTokenBridgeEmitter {
 			logger.Debug("Event does not match the criteria",
-				zap.String("event type", *event.Type),
-				zap.String("event sender", *wormholeMessage.Sender),
+				zap.String("event type", event.EventType),
+				zap.String("event sender", sender),
 				zap.String("expected event type", s.suiEventType),
 				zap.String("expected event sender", s.suiTokenBridgeEmitter),
 			)
+			continue
+		}
+
+		// Parse the wormhole message. vaa.IsTransfer can be omitted, since this is done
+		// inside `DecodeTransferPayloadHdr` already.
+		hdr, err := vaa.DecodeTransferPayloadHdr(wormholeMessage.Payload)
+
+		// If there is an error decoding the payload, skip the event. One reason for a potential
+		// failure in decoding is that an attestation of a token was requested.
+		if err != nil {
+			logger.Debug("Error decoding payload", zap.Error(err))
+			continue
+		}
+
+		// The sender address is prefixed with "0x", but the message ID format does not include that prefix.
+		senderWithout0x := strings.TrimPrefix(sender, "0x")
+
+		msgIDStr := fmt.Sprintf("%d/%s/%d", vaa.ChainIDSui, senderWithout0x, wormholeMessage.Sequence)
+		assetKey := fmt.Sprintf(KEY_FORMAT, hdr.OriginAddress.String(), hdr.OriginChain)
+
+		logger.Debug("Found request out of bridge",
+			zap.String("msgID", msgIDStr),
+			zap.String("assetKey", assetKey),
+			zap.String("amount", hdr.Amount.String()),
+		)
+
+		requests[msgIDStr] = &RequestOutOfBridge{
+			AssetKey:       assetKey,
+			Amount:         hdr.Amount,
+			DepositMade:    false,
+			DepositSolvent: false,
 		}
 	}
 
 	return requests
 }
 
-// extractTransfersIntoBridgeFromChanges iterates through all object changes, and tries to identify token transfers into the bridge.
+// extractTransfersIntoBridgeFromObjectChanges iterates through all object changes, and tries to identify token transfers into the bridge.
 // These transfers are accumulated in an `AssetKeyToTransferIntoBridge` object, which is returned to the caller. The default behaviour
 // of this function is to fail-close, meaning that any errors that occur during processing result in the offending object change being ignored.
-func (s *SuiTransferVerifier) extractTransfersIntoBridgeFromObjectChanges(ctx context.Context, objectChanges []ObjectChange, logger *zap.Logger) AssetKeyToTransferIntoBridge {
+func (s *SuiTransferVerifier) extractTransfersIntoBridgeFromObjectChanges(ctx context.Context, objectChanges []suiclient.SuiObjectChange, logger *zap.Logger) AssetKeyToTransferIntoBridge {
 	transfers := make(AssetKeyToTransferIntoBridge)
 
 	for _, objectChange := range objectChanges {
+		// All of these fields are required to look up and decode the object at both versions.
+		if objectChange.ObjectID == nil || objectChange.ObjectType == nil || objectChange.InputVersion == nil || objectChange.OutputVersion == nil {
+			continue
+		}
+
+		objectType := *objectChange.ObjectType
+
 		// Check that the type information is correct. Doing it here means it's not necessary to do it
-		// again, even in the case where `GetObject` is used for a single object instead of getting past
-		// objects.
-		if !objectChange.ValidateTypeInformation(s.suiTokenBridgePackageId) {
+		// again after decoding the object contents.
+		if !validateSuiAssetType(objectType, s.suiTokenBridgePackageId) {
 			continue
 		}
 
-		if objectChange.PreviousVersion == "" {
-			logger.Warn("No previous version of asset available",
-				zap.String("objectId", objectChange.ObjectId),
-				zap.String("currentVersion", objectChange.Version))
-			continue
-		}
-
-		// Get the previous version of the object. This makes a call to the Sui API.
-		resp, err := s.suiApiConnection.TryMultiGetPastObjects(ctx, objectChange.ObjectId, objectChange.Version, objectChange.PreviousVersion)
+		// Fetch the object at the version after this transaction executed (the current version)
+		// and at the version before it executed (the previous version). These calls go to the Sui API.
+		currentObject, err := s.client.GetObjectAtVersion(ctx, *objectChange.ObjectID, objectChange.OutputVersion, []string{suiclient.ObjectFieldContents})
 		if err != nil {
-			logger.Error("Error getting past objects",
-				zap.String("objectId", objectChange.ObjectId),
-				zap.String("currentVersion", objectChange.Version),
-				zap.String("previousVersion", objectChange.PreviousVersion),
+			logger.Error("Error getting current object version",
+				zap.String("objectId", *objectChange.ObjectID),
+				zap.Uint64("version", *objectChange.OutputVersion),
 				zap.Error(err))
 			continue
 		}
 
-		decimals, err := resp.GetDecimals()
+		previousObject, err := s.client.GetObjectAtVersion(ctx, *objectChange.ObjectID, objectChange.InputVersion, []string{suiclient.ObjectFieldContents})
 		if err != nil {
-			logger.Error("Error getting decimals", zap.Error(err))
+			logger.Error("Error getting previous object version",
+				zap.String("objectId", *objectChange.ObjectID),
+				zap.Uint64("version", *objectChange.InputVersion),
+				zap.Error(err))
 			continue
 		}
 
-		address, err := resp.GetTokenAddress()
+		currentInfo, err := decodeSuiAssetObject(objectType, currentObject.ContentsBytes)
 		if err != nil {
-			logger.Error("Error getting token address", zap.Error(err))
+			logger.Error("Error decoding current asset object", zap.String("objectId", *objectChange.ObjectID), zap.Error(err))
 			continue
 		}
 
-		chain, err := resp.GetTokenChain()
+		previousInfo, err := decodeSuiAssetObject(objectType, previousObject.ContentsBytes)
 		if err != nil {
-			logger.Error("Error getting token chain", zap.Error(err))
+			logger.Error("Error decoding previous asset object", zap.String("objectId", *objectChange.ObjectID), zap.Error(err))
 			continue
 		}
 
-		// Get the change in balance
-		balanceChange, err := resp.GetBalanceChange()
-		if err != nil {
-			logger.Error("Error getting balance difference", zap.Error(err))
+		// The decimals, token address, and token chain are immutable properties of an asset and
+		// must not change across versions. A mismatch indicates malformed or unexpected data.
+		if currentInfo.decimals != previousInfo.decimals {
+			logger.Error("decimals do not match between object versions", zap.String("objectId", *objectChange.ObjectID))
+			continue
+		}
+		if currentInfo.tokenAddress != previousInfo.tokenAddress {
+			logger.Error("token addresses do not match between object versions", zap.String("objectId", *objectChange.ObjectID))
+			continue
+		}
+		if currentInfo.tokenChain != previousInfo.tokenChain {
+			logger.Error("token chains do not match between object versions", zap.String("objectId", *objectChange.ObjectID))
 			continue
 		}
 
-		normalized := normalize(balanceChange, decimals)
+		// Compute the change in balance between the previous and current versions. For wrapped
+		// assets the supply is burned (decreases) when tokens are sent into the bridge, so the
+		// sign is inverted to represent the deposit as a positive amount.
+		balanceChange := new(big.Int).Sub(currentInfo.balance, previousInfo.balance)
+		if currentInfo.isWrapped {
+			balanceChange.Neg(balanceChange)
+		}
+
+		normalized := normalize(balanceChange, currentInfo.decimals)
 
 		// Add the key if it does not exist yet
-		assetKey := fmt.Sprintf(KEY_FORMAT, address, chain)
+		assetKey := fmt.Sprintf(KEY_FORMAT, currentInfo.tokenAddress, currentInfo.tokenChain)
 
 		if _, exists := transfers[assetKey]; !exists {
-			// logger.Debug("First time seeing transfer into bridge for asset", zap.String("assetKey", assetKey))
 			transfers[assetKey] = &TransferIntoBridge{
 				Amount:  big.NewInt(0),
 				Solvent: false,
@@ -251,11 +260,14 @@ func (s *SuiTransferVerifier) ProcessDigest(ctx context.Context, digest string, 
 func (s *SuiTransferVerifier) processDigestInternal(ctx context.Context, digest string, msgIdStr string, logger *zap.Logger) (bool, error) {
 	logger.Debug("processing digest", zap.String("txDigest", digest), zap.String("msgId", msgIdStr))
 
-	// Get the transaction block
-	txBlock, err := s.suiApiConnection.GetTransactionBlock(ctx, digest)
+	// Get the transaction, including its events and the objects changed by its effects.
+	txn, err := s.client.GetTransaction(ctx, digest, []string{
+		suiclient.TransactionFieldEvents,
+		suiclient.TransactionFieldChangedObjects,
+	})
 
 	if err != nil {
-		logger.Error("failed to retrieve transaction block",
+		logger.Error("failed to retrieve transaction",
 			zap.String("txDigest", digest),
 			zap.Error(err),
 		)
@@ -263,7 +275,7 @@ func (s *SuiTransferVerifier) processDigestInternal(ctx context.Context, digest 
 	}
 
 	// Extract bridge requests from events
-	bridgeOutRequests := s.extractBridgeRequestsFromEvents(txBlock.Result.Events, logger)
+	bridgeOutRequests := s.extractBridgeRequestsFromEvents(txn.Events, logger)
 
 	if len(bridgeOutRequests) == 0 {
 		logger.Debug("No relevant events found in transaction block", zap.String("txDigest", digest))
@@ -272,7 +284,7 @@ func (s *SuiTransferVerifier) processDigestInternal(ctx context.Context, digest 
 	}
 
 	// Process all object changes, specifically looking for transfers into the token bridge
-	transfersIntoBridge := s.extractTransfersIntoBridgeFromObjectChanges(ctx, txBlock.Result.ObjectChanges, logger)
+	transfersIntoBridge := s.extractTransfersIntoBridgeFromObjectChanges(ctx, txn.ObjectChanges, logger)
 
 	// Validate solvency using the requests out of the bridge vs the transfers into the bridge.
 	resolved, err := validateSolvency(bridgeOutRequests, transfersIntoBridge)
@@ -335,92 +347,4 @@ func (s *SuiTransferVerifier) processDigestInternal(ctx context.Context, digest 
 	}
 
 	return true, nil
-}
-
-type SuiApiResponse interface {
-	GetError() error
-}
-
-func suiApiRequest[T SuiApiResponse](ctx context.Context, rpc string, method string, params string) (T, error) {
-	var defaultT T
-
-	// Create the request
-	requestBody := fmt.Sprintf(`{"jsonrpc":"2.0", "id": 1, "method": "%s", "params": %s}`, method, params)
-
-	req, err := http.NewRequestWithContext(ctx, "POST", rpc, strings.NewReader(requestBody))
-	if err != nil {
-		return defaultT, fmt.Errorf("cannot create request: %w", err)
-	}
-
-	// Add headers
-	req.Header.Set("Content-Type", "application/json")
-
-	// Send the request
-	client := &http.Client{}
-	resp, err := client.Do(req)
-	if err != nil {
-		return defaultT, fmt.Errorf("cannot send request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	// Read the response
-	body, err := common.SafeRead(resp.Body)
-	if err != nil {
-		return defaultT, fmt.Errorf("cannot read response: %w", err)
-	}
-
-	// Parse the response
-	var res T
-	err = json.Unmarshal(body, &res)
-	if err != nil {
-		return defaultT, fmt.Errorf("cannot parse response: %w", err)
-	}
-
-	// Check if the API returned an error
-	if res.GetError() != nil {
-		return defaultT, fmt.Errorf("error from Sui RPC: %w", res.GetError())
-	}
-
-	return res, nil
-}
-
-type SuiApiConnection struct {
-	rpc string
-}
-
-func NewSuiApiConnection(rpc string) SuiApiInterface {
-	return &SuiApiConnection{rpc: rpc}
-}
-
-func (s *SuiApiConnection) GetTransactionBlock(ctx context.Context, txDigest string) (SuiGetTransactionBlockResponse, error) {
-	method := "sui_getTransactionBlock"
-	params := fmt.Sprintf(`[
-				"%s", 
-				{
-					"showObjectChanges":true,
-					"showEvents": true
-				}
-			]`, txDigest)
-
-	return suiApiRequest[SuiGetTransactionBlockResponse](ctx, s.rpc, method, params)
-}
-
-func (s *SuiApiConnection) QueryEvents(ctx context.Context, filter string, cursor string, limit int, descending bool) (SuiQueryEventsResponse, error) {
-	method := "suix_queryEvents"
-	params := fmt.Sprintf(`[%s, %s, %d, %t]`, filter, cursor, limit, descending)
-
-	return suiApiRequest[SuiQueryEventsResponse](ctx, s.rpc, method, params)
-}
-
-func (s *SuiApiConnection) TryMultiGetPastObjects(ctx context.Context, objectId string, version string, previousVersion string) (SuiTryMultiGetPastObjectsResponse, error) {
-	method := "sui_tryMultiGetPastObjects"
-	params := fmt.Sprintf(`[
-			[
-				{"objectId" : "%s", "version" : "%s"},
-				{"objectId" : "%s", "version" : "%s"}
-			],
-			{"showContent": true}
-		]`, objectId, version, objectId, previousVersion)
-
-	return suiApiRequest[SuiTryMultiGetPastObjectsResponse](ctx, s.rpc, method, params)
 }

--- a/node/pkg/txverifier/sui.go
+++ b/node/pkg/txverifier/sui.go
@@ -172,7 +172,7 @@ func (s *SuiTransferVerifier) extractTransfersIntoBridgeFromObjectChanges(ctx co
 
 		previousObject, err := s.client.GetObjectAtVersion(ctx, *objectChange.ObjectID, objectChange.InputVersion, []string{suiclient.ObjectFieldContents})
 		if err != nil {
-			logger.Error("Error getting previous object version",
+			logger.Error("Error getting object at previous version",
 				zap.String("objectId", *objectChange.ObjectID),
 				zap.Uint64("version", *objectChange.InputVersion),
 				zap.Error(err))

--- a/node/pkg/txverifier/sui_test.go
+++ b/node/pkg/txverifier/sui_test.go
@@ -113,7 +113,7 @@ func (m *mockSuiClient) registerObject(change ObjectChange, result ResultTestCas
 
 	var currentContents, previousContents []byte
 	if result.wrapped {
-		tokenChain := mustU16(result.tokenChain)
+		tokenChain := vaa.ChainID(mustU16(result.tokenChain))
 		currentContents = bcsWrappedObject(mustU64(result.newBalance), tokenAddress, tokenChain, result.decimals)
 		previousContents = bcsWrappedObject(mustU64(result.oldBalance), tokenAddress, tokenChain, result.decimals)
 	} else {
@@ -148,7 +148,7 @@ func parseByteCSV(s string) []byte {
 	parts := strings.Split(s, ",")
 	out := make([]byte, len(parts))
 	for i, p := range parts {
-		v, err := strconv.Atoi(strings.TrimSpace(p))
+		v, err := strconv.ParseUint(strings.TrimSpace(p), 10, 8)
 		if err != nil {
 			panic(fmt.Sprintf("invalid byte %q: %v", p, err))
 		}
@@ -179,7 +179,7 @@ func bcsNativeObject(balance uint64, tokenAddress []byte, decimals uint8) []byte
 	})
 }
 
-func bcsWrappedObject(supply uint64, tokenAddress []byte, tokenChain uint16, decimals uint8) []byte {
+func bcsWrappedObject(supply uint64, tokenAddress []byte, tokenChain vaa.ChainID, decimals uint8) []byte {
 	return mystenbcs.MustMarshal(suiWrappedAssetField{
 		Value: suiWrappedAsset{
 			Info: suiForeignInfo{

--- a/node/pkg/txverifier/sui_test.go
+++ b/node/pkg/txverifier/sui_test.go
@@ -3,11 +3,14 @@ package txverifier
 import (
 	"context"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"math/big"
+	"strconv"
+	"strings"
 	"testing"
 
+	mystenbcs "github.com/block-vision/sui-go-sdk/mystenbcs"
+	"github.com/certusone/wormhole/node/pkg/suiclient"
 	"github.com/stretchr/testify/assert"
 	"github.com/wormhole-foundation/wormhole/sdk/vaa"
 	"go.uber.org/zap"
@@ -19,18 +22,22 @@ const (
 	SuiUsdcAddress      = "5d4b302506645c37ff133b98c4b50a5ae14841659738d6d733d59d0d217a93bf"
 )
 
-func newTestSuiTransferVerifier(connection SuiApiInterface) *SuiTransferVerifier {
+func newTestSuiTransferVerifier(client suiclient.SuiClient) *SuiTransferVerifier {
 	suiCoreContract := "0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a"
 	suiTokenBridgeContract := "0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d"
 	suiTokenBridgeEmitter := "0xccceeb29348f71bdd22ffef43a2a19c1f5b5e17c5cca5411529120182672ade5"
 
-	return NewSuiTransferVerifier(suiCoreContract, suiTokenBridgeEmitter, suiTokenBridgeContract, connection)
+	return NewSuiTransferVerifier(suiCoreContract, suiTokenBridgeEmitter, suiTokenBridgeContract, client)
 }
 
-type MockSuiApiConnection struct {
-	// The events to be returned by QueryEvents
-	Events           []SuiEvent
-	ObjectsResponses []SuiTryMultiGetPastObjectsResponse
+// ObjectChange is a test-local representation of a changed object. It keeps the string fields
+// used by the test tables; it is converted into a suiclient.SuiObjectChange when exercising the
+// verifier, and used to register the corresponding BCS-encoded object versions on the mock.
+type ObjectChange struct {
+	ObjectType      string
+	ObjectId        string
+	Version         string
+	PreviousVersion string
 }
 
 type ResultTestCase struct {
@@ -43,992 +50,183 @@ type ResultTestCase struct {
 	drop         bool
 }
 
-func NewMockSuiApiConnection(events []SuiEvent) *MockSuiApiConnection {
-	return &MockSuiApiConnection{
-		Events:           events,
-		ObjectsResponses: nil,
+// mockSuiClient is a suiclient.SuiClient that serves a single prepared transaction and a set of
+// BCS-encoded object versions keyed by (objectId, version). Only the methods exercised by the
+// verifier are meaningfully implemented.
+type mockSuiClient struct {
+	transaction suiclient.SuiTransaction
+	objects     map[string][]byte
+}
+
+func newMockSuiClient() *mockSuiClient {
+	return &mockSuiClient{objects: make(map[string][]byte)}
+}
+
+func objKey(objectId string, version uint64) string {
+	return fmt.Sprintf("%s@%d", objectId, version)
+}
+
+func (m *mockSuiClient) GetTransaction(ctx context.Context, digest string, fields []string) (suiclient.SuiTransaction, error) {
+	return m.transaction, nil
+}
+
+func (m *mockSuiClient) GetObjectAtVersion(ctx context.Context, objectID string, version *uint64, fields []string) (suiclient.SuiObject, error) {
+	if version == nil {
+		return suiclient.SuiObject{}, fmt.Errorf("nil version for object %s", objectID)
 	}
-}
-
-func (mock *MockSuiApiConnection) SetEvents(events []SuiEvent) {
-	mock.Events = events
-}
-
-func (mock *MockSuiApiConnection) SetObjectsResponse(ObjectResponse SuiTryMultiGetPastObjectsResponse) {
-	mock.ObjectsResponses = append(mock.ObjectsResponses, ObjectResponse)
-}
-
-func (mock *MockSuiApiConnection) ClearObjectResponses() {
-	mock.ObjectsResponses = []SuiTryMultiGetPastObjectsResponse{}
-}
-
-func (mock *MockSuiApiConnection) QueryEvents(ctx context.Context, filter string, cursor string, limit int, descending bool) (SuiQueryEventsResponse, error) {
-	return SuiQueryEventsResponse{}, nil
-}
-
-func (mock *MockSuiApiConnection) GetTransactionBlock(ctx context.Context, txDigest string) (SuiGetTransactionBlockResponse, error) {
-
-	objectChanges := []ObjectChange{}
-
-	// Create new nested object that unwraps some of it
-	for _, objectResponse := range mock.ObjectsResponses {
-		objectType, _ := objectResponse.GetObjectType()
-		objectId, _ := objectResponse.GetObjectId()
-		version, _ := objectResponse.GetVersion()
-		previousVersion, _ := objectResponse.GetPreviousVersion()
-
-		obj := ObjectChange{
-			ObjectType:      objectType,
-			ObjectId:        objectId,
-			Version:         version,
-			PreviousVersion: previousVersion,
-		}
-		objectChanges = append(objectChanges, obj)
+	contents, ok := m.objects[objKey(objectID, *version)]
+	if !ok {
+		return suiclient.SuiObject{}, fmt.Errorf("object %s@%d not found", objectID, *version)
 	}
-
-	return SuiGetTransactionBlockResponse{Result: SuiGetTransactionBlockResult{Events: mock.Events, ObjectChanges: objectChanges}}, nil
+	return suiclient.SuiObject{ContentsBytes: contents}, nil
 }
-func (mock *MockSuiApiConnection) TryMultiGetPastObjects(ctx context.Context, objectId string, version string, previousVersion string) (SuiTryMultiGetPastObjectsResponse, error) {
 
-	for _, response := range mock.ObjectsResponses {
-		keyIn := fmt.Sprintf("%s-%s-%s", objectId, version, previousVersion)
-		objectId, err0 := response.GetObjectId()
-		version, err1 := response.GetVersion()
-		previousVersion, err2 := response.GetPreviousVersion()
-		if err0 != nil || err1 != nil || err2 != nil {
-			return SuiTryMultiGetPastObjectsResponse{}, fmt.Errorf("Error processing version data")
-		}
+func (m *mockSuiClient) GetObject(ctx context.Context, objectID string, fields []string) (suiclient.SuiObject, error) {
+	return m.GetObjectAtVersion(ctx, objectID, nil, fields)
+}
 
-		keyCur := fmt.Sprintf("%s-%s-%s", objectId, version, previousVersion)
-		if keyIn == keyCur {
-			return response, nil
-		}
+func (m *mockSuiClient) GetLatestCheckpoint(ctx context.Context, fields []string) (suiclient.SuiCheckpoint, error) {
+	return suiclient.SuiCheckpoint{}, nil
+}
+
+func (m *mockSuiClient) SubscribeToTransactionEvent(ctx context.Context, eventType string, eventWriteChannel chan<- suiclient.SuiTransactionEvent) (suiclient.SuiSubscription, error) {
+	return suiclient.SuiSubscription{}, nil
+}
+
+func (m *mockSuiClient) SubscribeToTransactionEvents(ctx context.Context, eventTypes []string, eventWriteChannel chan<- suiclient.SuiTransactionEvent) (suiclient.SuiSubscription, error) {
+	return suiclient.SuiSubscription{}, nil
+}
+
+func (m *mockSuiClient) Close() error {
+	return nil
+}
+
+// registerObject registers the BCS-encoded contents for both the current (output) and previous
+// (input) versions of an object change, unless the result case is marked to be dropped (in which
+// case the object is left unregistered so lookups fail, mirroring a missing object).
+func (m *mockSuiClient) registerObject(change ObjectChange, result ResultTestCase) {
+	if result.drop {
+		return
 	}
 
-	return SuiTryMultiGetPastObjectsResponse{}, fmt.Errorf("Can't find entry")
-}
+	tokenAddress := parseByteCSV(result.tokenAddress)
 
-func TestNewSuiApiConnection(t *testing.T) {
-	sampleUrl := "http://localhost:8080"
-
-	api := NewSuiApiConnection(sampleUrl)
-	if rpc, ok := api.(*SuiApiConnection); ok {
-		assert.Equal(t, sampleUrl, rpc.rpc)
+	var currentContents, previousContents []byte
+	if result.wrapped {
+		tokenChain := mustU16(result.tokenChain)
+		currentContents = bcsWrappedObject(mustU64(result.newBalance), tokenAddress, tokenChain, result.decimals)
+		previousContents = bcsWrappedObject(mustU64(result.oldBalance), tokenAddress, tokenChain, result.decimals)
 	} else {
-		t.Errorf("Unable to get RPC from SuiApiConnection")
+		currentContents = bcsNativeObject(mustU64(result.newBalance), tokenAddress, result.decimals)
+		previousContents = bcsNativeObject(mustU64(result.oldBalance), tokenAddress, result.decimals)
+	}
+
+	m.objects[objKey(change.ObjectId, mustU64(change.Version))] = currentContents
+	m.objects[objKey(change.ObjectId, mustU64(change.PreviousVersion))] = previousContents
+}
+
+// --- test helpers ---
+
+func mustU64(s string) uint64 {
+	v, err := strconv.ParseUint(s, 10, 64)
+	if err != nil {
+		panic(fmt.Sprintf("invalid uint64 %q: %v", s, err))
+	}
+	return v
+}
+
+func mustU16(s string) uint16 {
+	v, err := strconv.ParseUint(s, 10, 16)
+	if err != nil {
+		panic(fmt.Sprintf("invalid uint16 %q: %v", s, err))
+	}
+	return uint16(v)
+}
+
+// parseByteCSV parses a comma-separated list of decimal byte values (e.g. "0,1,255") into a []byte.
+func parseByteCSV(s string) []byte {
+	parts := strings.Split(s, ",")
+	out := make([]byte, len(parts))
+	for i, p := range parts {
+		v, err := strconv.Atoi(strings.TrimSpace(p))
+		if err != nil {
+			panic(fmt.Sprintf("invalid byte %q: %v", p, err))
+		}
+		out[i] = byte(v)
+	}
+	return out
+}
+
+// senderBytes converts a hex sender/emitter string (with or without a 0x prefix) into the 32-byte
+// representation used by the on-chain WormholeMessage event.
+func senderBytes(sender string) [32]byte {
+	raw, err := hex.DecodeString(strings.TrimPrefix(sender, "0x"))
+	if err != nil {
+		panic(fmt.Sprintf("invalid sender %q: %v", sender, err))
+	}
+	var out [32]byte
+	copy(out[:], raw)
+	return out
+}
+
+func bcsNativeObject(balance uint64, tokenAddress []byte, decimals uint8) []byte {
+	return mystenbcs.MustMarshal(suiNativeAssetField{
+		Value: suiNativeAsset{
+			Custody:      balance,
+			TokenAddress: suiExternalAddress{Value: suiBytes32{Data: tokenAddress}},
+			Decimals:     decimals,
+		},
+	})
+}
+
+func bcsWrappedObject(supply uint64, tokenAddress []byte, tokenChain uint16, decimals uint8) []byte {
+	return mystenbcs.MustMarshal(suiWrappedAssetField{
+		Value: suiWrappedAsset{
+			Info: suiForeignInfo{
+				TokenChain:     tokenChain,
+				TokenAddress:   suiExternalAddress{Value: suiBytes32{Data: tokenAddress}},
+				NativeDecimals: decimals,
+				Symbol:         []byte("TEST"),
+			},
+			TreasuryCap: suiTreasuryCap{TotalSupply: supply},
+			Decimals:    decimals,
+		},
+	})
+}
+
+// makeWormholeEvent builds a suiclient.SuiEvent whose BCS contents are a WormholeMessage with the
+// given sender, sequence and payload.
+func makeWormholeEvent(eventType string, sender string, payload []byte, sequence uint64) suiclient.SuiEvent {
+	return suiclient.SuiEvent{
+		EventType: eventType,
+		BcsBytes: mystenbcs.MustMarshal(WormholeMessage{
+			Sender:   senderBytes(sender),
+			Sequence: sequence,
+			Payload:  payload,
+		}),
 	}
 }
 
-func nextSequenceNumber(seq *uint64) *string {
-	(*seq)++
-	seqStr := fmt.Sprintf("%d", *seq)
-	return &seqStr
-}
-
-func TestProcessEvents(t *testing.T) {
-	connection := NewMockSuiApiConnection([]SuiEvent{})
-	suiTxVerifier := newTestSuiTransferVerifier(connection)
-
-	arbitraryEventType := "arbitrary::EventType"
-	arbitraryEmitter := "0x3117"
-
-	sequenceNumber := uint64(0)
-
-	logger := zap.NewNop()
-
-	// Constants used throughout the tests
-	suiEventType := suiTxVerifier.suiEventType
-	suiTokenBridgeEmitter := suiTxVerifier.suiTokenBridgeEmitter
-
-	// Define test cases
-	tests := []struct {
-		name           string
-		events         []SuiEvent
-		expectedResult map[string]*big.Int
-		expectedCount  int
-	}{
-		{
-			name:           "TestNoEvents",
-			events:         []SuiEvent{},
-			expectedResult: map[string]*big.Int{},
-			expectedCount:  0,
-		},
-		{
-			name: "TestSingleEthereumUSDCEvent",
-			events: []SuiEvent{
-				{
-					Type: &suiEventType,
-					ParsedJson: uncheckedJsonMarshal(&WormholeMessage{
-						Sender:   &suiTokenBridgeEmitter,
-						Payload:  generatePayload(1, big.NewInt(100), EthereumUsdcAddress, 2),
-						Sequence: nextSequenceNumber(&sequenceNumber),
-					}),
-				},
-			},
-			expectedResult: map[string]*big.Int{
-				fmt.Sprintf(KEY_FORMAT, EthereumUsdcAddress, vaa.ChainIDEthereum): big.NewInt(100),
-			},
-			expectedCount: 1,
-		},
-		{
-			name: "TestMultipleEthereumUSDCEvents",
-			events: []SuiEvent{
-				{
-					Type: &suiEventType,
-					ParsedJson: uncheckedJsonMarshal(&WormholeMessage{
-						Sender:   &suiTokenBridgeEmitter,
-						Payload:  generatePayload(1, big.NewInt(100), EthereumUsdcAddress, uint16(vaa.ChainIDEthereum)),
-						Sequence: nextSequenceNumber(&sequenceNumber),
-					}),
-				},
-				{
-					Type: &suiEventType,
-					ParsedJson: uncheckedJsonMarshal(&WormholeMessage{
-						Sender:   &suiTokenBridgeEmitter,
-						Payload:  generatePayload(1, big.NewInt(100), EthereumUsdcAddress, uint16(vaa.ChainIDEthereum)),
-						Sequence: nextSequenceNumber(&sequenceNumber),
-					}),
-				},
-			},
-			expectedResult: map[string]*big.Int{
-				fmt.Sprintf(KEY_FORMAT, EthereumUsdcAddress, vaa.ChainIDEthereum): big.NewInt(200),
-			},
-			expectedCount: 2,
-		},
-		{
-			name: "TestMixedEthereumAndSuiUSDCEvents",
-			events: []SuiEvent{
-				{
-					Type: &suiEventType,
-					ParsedJson: uncheckedJsonMarshal(&WormholeMessage{
-						Sender:   &suiTokenBridgeEmitter,
-						Payload:  generatePayload(1, big.NewInt(100), EthereumUsdcAddress, uint16(vaa.ChainIDEthereum)),
-						Sequence: nextSequenceNumber(&sequenceNumber),
-					}),
-				},
-				{
-					Type: &suiEventType,
-					ParsedJson: uncheckedJsonMarshal(&WormholeMessage{
-						Sender:   &suiTokenBridgeEmitter,
-						Payload:  generatePayload(1, big.NewInt(100), SuiUsdcAddress, uint16(vaa.ChainIDSui)),
-						Sequence: nextSequenceNumber(&sequenceNumber),
-					}),
-				},
-			},
-			expectedResult: map[string]*big.Int{
-				fmt.Sprintf(KEY_FORMAT, EthereumUsdcAddress, vaa.ChainIDEthereum): big.NewInt(100),
-				fmt.Sprintf(KEY_FORMAT, SuiUsdcAddress, vaa.ChainIDSui):           big.NewInt(100),
-			},
-			expectedCount: 2,
-		},
-		{
-			name: "TestIncorrectSender",
-			events: []SuiEvent{
-				{
-					Type: &suiEventType,
-					ParsedJson: uncheckedJsonMarshal(&WormholeMessage{
-						Sender:   &arbitraryEmitter,
-						Payload:  generatePayload(1, big.NewInt(100), EthereumUsdcAddress, uint16(vaa.ChainIDEthereum)),
-						Sequence: nextSequenceNumber(&sequenceNumber),
-					}),
-				},
-			},
-			expectedResult: map[string]*big.Int{},
-			expectedCount:  0,
-		},
-		{
-			name: "TestSkipNonWormholeEvents",
-			events: []SuiEvent{
-				{
-					Type: &suiEventType,
-					ParsedJson: uncheckedJsonMarshal(&WormholeMessage{
-						Sender:   &suiTokenBridgeEmitter,
-						Payload:  generatePayload(1, big.NewInt(100), EthereumUsdcAddress, uint16(vaa.ChainIDEthereum)),
-						Sequence: nextSequenceNumber(&sequenceNumber),
-					}),
-				},
-				{
-					Type: &arbitraryEventType,
-					ParsedJson: uncheckedJsonMarshal(&WormholeMessage{
-						Sender:   &suiTokenBridgeEmitter,
-						Payload:  generatePayload(1, big.NewInt(100), SuiUsdcAddress, uint16(vaa.ChainIDSui)),
-						Sequence: nextSequenceNumber(&sequenceNumber),
-					}),
-				},
-			},
-			expectedResult: map[string]*big.Int{
-				fmt.Sprintf(KEY_FORMAT, EthereumUsdcAddress, vaa.ChainIDEthereum): big.NewInt(100),
-			},
-			expectedCount: 1,
-		},
-		{
-			name: "TestInvalidWormholePayloads",
-			events: []SuiEvent{
-				{ // Invalid payload type
-					Type: &suiEventType,
-					ParsedJson: uncheckedJsonMarshal(&WormholeMessage{
-						Sender:   &suiTokenBridgeEmitter,
-						Payload:  generatePayload(0, big.NewInt(100), EthereumUsdcAddress, uint16(vaa.ChainIDEthereum)),
-						Sequence: nextSequenceNumber(&sequenceNumber),
-					}),
-				},
-				{ // Empty payload
-					Type: &suiEventType,
-					ParsedJson: uncheckedJsonMarshal(&WormholeMessage{
-						Sender:   &suiTokenBridgeEmitter,
-						Payload:  []byte{},
-						Sequence: nextSequenceNumber(&sequenceNumber),
-					}),
-				},
-			},
-			expectedResult: map[string]*big.Int{},
-			expectedCount:  0,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-
-			requests := suiTxVerifier.extractBridgeRequestsFromEvents(tt.events, logger)
-
-			assert.Equal(t, tt.expectedCount, len(requests))
-			// assert.Equal(t, tt.expectedResult, result)
-			// assert.Equal(t, tt.expectedCount, count)
-		})
+// toSuiObjectChange converts a test-local ObjectChange into a suiclient.SuiObjectChange.
+func toSuiObjectChange(change ObjectChange) suiclient.SuiObjectChange {
+	objectType := change.ObjectType
+	objectId := change.ObjectId
+	outputVersion := mustU64(change.Version)
+	inputVersion := mustU64(change.PreviousVersion)
+	return suiclient.SuiObjectChange{
+		ObjectID:      &objectId,
+		ObjectType:    &objectType,
+		OutputVersion: &outputVersion,
+		InputVersion:  &inputVersion,
 	}
 }
 
-func TestProcessObjectUpdates(t *testing.T) {
-	suiTxVerifier := newTestSuiTransferVerifier(nil)
-	ctx := context.TODO()
-
-	logger := zap.NewNop() // zap.Must(zap.NewDevelopment())
-
-	// Constants used throughout the tests
-	normalObjectNativeType := "0x2::dynamic_field::Field<0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0x2::sui::SUI>, 0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::native_asset::NativeAsset<0x2::sui::SUI>>"
-	normalObjectForeignType := "0x2::dynamic_field::Field<0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0x5d4b302506645c37ff133b98c4b50a5ae14841659738d6d733d59d0d217a93bf::coin::COIN>, 0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::wrapped_asset::WrappedAsset<0x5d4b302506645c37ff133b98c4b50a5ae14841659738d6d733d59d0d217a93bf::coin::COIN>>"
-	normalVersion := "6565"
-	normalPreviousVersion := "4040"
-	normalObjectNativeId := "0x831c45a8d512c9cf46e7a8a947f7cbbb5e0a59829aa72450ff26fb1873fd0e94"
-	normalObjectForeignId := "0xf8f80c0d569fb076adb5fdc3a717dcb9ac14f7fd7512dc17efbf0f80a8b7fa8a"
-
-	normalTokenAddressForeign := "0,0,0,0,0,0,0,0,0,0,0,0,160,184,105,145,198,33,139,54,193,209,157,74,46,158,176,206,54,6,235,72"
-	normalTokenAddressNative := "146,88,24,31,92,234,200,219,255,183,3,8,144,36,60,174,214,154,149,153,210,136,109,149,122,156,183,101,106,243,189,179"
-	normalChainIdNative := "21"
-	normalChainIdForeign := "2"
-
-	oneToken := new(big.Int)
-	oneToken.SetString("1000000000000000000", 10)
-
-	// Decimals, token chain, token address, wrapped or not, balance/custody
-	tests := []struct {
-		name           string
-		objectChanges  []ObjectChange
-		resultList     []ResultTestCase
-		expectedResult map[string]TransferIntoBridge
-		expectedCount  uint
-	}{
-		{
-			name: "TestProcessObjectNativeBase",
-			objectChanges: []ObjectChange{
-				{
-					ObjectType:      normalObjectNativeType,
-					Version:         normalVersion,
-					PreviousVersion: normalPreviousVersion,
-					ObjectId:        normalObjectNativeId,
-				},
-			},
-			resultList: []ResultTestCase{
-				{
-					tokenChain:   normalChainIdNative,
-					tokenAddress: normalTokenAddressNative,
-					wrapped:      false,
-					newBalance:   "1000",
-					oldBalance:   "10",
-					decimals:     8,
-				},
-			},
-			expectedResult: map[string]TransferIntoBridge{
-				"9258181f5ceac8dbffb7030890243caed69a9599d2886d957a9cb7656af3bdb3-21": {Amount: big.NewInt(990)},
-			},
-			expectedCount: 1,
-		},
-		{
-			name: "TestProcessObjectForeignBase",
-			objectChanges: []ObjectChange{
-				{
-					ObjectType:      normalObjectForeignType,
-					Version:         normalVersion,
-					PreviousVersion: normalPreviousVersion,
-					ObjectId:        normalObjectForeignId,
-				},
-			},
-			resultList: []ResultTestCase{
-				{
-					tokenChain:   normalChainIdForeign,
-					tokenAddress: normalTokenAddressForeign,
-					wrapped:      true,
-					newBalance:   "10",
-					oldBalance:   "1000",
-					decimals:     8,
-				},
-			},
-			expectedResult: map[string]TransferIntoBridge{
-				"000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48-2": {Amount: big.NewInt(990)},
-			},
-			expectedCount: 1,
-		},
-		{
-			name: "TestProcessObjectNativeNegative",
-			objectChanges: []ObjectChange{
-				{
-					ObjectType:      normalObjectNativeType,
-					Version:         normalVersion,
-					PreviousVersion: normalPreviousVersion,
-					ObjectId:        normalObjectNativeId,
-				},
-			},
-			resultList: []ResultTestCase{
-				{
-					tokenChain:   normalChainIdNative,
-					tokenAddress: normalTokenAddressNative,
-					wrapped:      false,
-					newBalance:   "10",
-					oldBalance:   "1000",
-					decimals:     8,
-				},
-			},
-			expectedResult: map[string]TransferIntoBridge{
-				"9258181f5ceac8dbffb7030890243caed69a9599d2886d957a9cb7656af3bdb3-21": {Amount: big.NewInt(-990)},
-			},
-			expectedCount: 1,
-		},
-		{
-			name: "TestProcessObjectForeignNegative", // Unsure if this test case is possible from Sui API
-			objectChanges: []ObjectChange{
-				{
-					ObjectType:      normalObjectForeignType,
-					Version:         normalVersion,
-					PreviousVersion: normalPreviousVersion,
-					ObjectId:        normalObjectForeignId,
-				},
-			},
-			resultList: []ResultTestCase{
-				{
-					tokenChain:   normalChainIdForeign,
-					tokenAddress: normalTokenAddressForeign,
-					wrapped:      true,
-					newBalance:   "1000",
-					oldBalance:   "10",
-					decimals:     8,
-				},
-			},
-			expectedResult: map[string]TransferIntoBridge{
-				"000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48-2": {Amount: big.NewInt(-990)},
-			},
-			expectedCount: 1,
-		},
-		{
-			name: "TestProcessObjectNativeMultiple",
-			objectChanges: []ObjectChange{
-				{
-					ObjectType:      normalObjectNativeType,
-					Version:         normalVersion,
-					PreviousVersion: normalPreviousVersion,
-					ObjectId:        normalObjectNativeId,
-				},
-				{
-					ObjectType:      "0x2::dynamic_field::Field<0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0xb779486cfd6c19e9218cc7dc17c453014d2d9ba12d2ee4dbb0ec4e1e02ae1cca::spt::SPT>, 0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::native_asset::NativeAsset<0xb779486cfd6c19e9218cc7dc17c453014d2d9ba12d2ee4dbb0ec4e1e02ae1cca::spt::SPT>>",
-					Version:         normalVersion,
-					PreviousVersion: normalPreviousVersion,
-					ObjectId:        "0x0063d37cdce648a7c6f72f69a75a114fbcc81ef23300e4ace60c7941521163db",
-				},
-			},
-			resultList: []ResultTestCase{
-				{
-					tokenChain:   normalChainIdNative,
-					tokenAddress: normalTokenAddressNative,
-					wrapped:      false,
-					newBalance:   "1000",
-					oldBalance:   "10",
-					decimals:     8,
-				},
-				{
-					tokenChain:   normalChainIdNative,
-					tokenAddress: "80,117,89,76,1,212,111,59,203,196,167,239,20,98,5,130,115,190,206,119,147,238,189,4,100,150,53,151,201,253,9,53",
-					wrapped:      false,
-					newBalance:   "5000",
-					oldBalance:   "50",
-					decimals:     8,
-				},
-			},
-			expectedResult: map[string]TransferIntoBridge{
-				"9258181f5ceac8dbffb7030890243caed69a9599d2886d957a9cb7656af3bdb3-21": {Amount: big.NewInt(990)},
-				"5075594c01d46f3bcbc4a7ef1462058273bece7793eebd0464963597c9fd0935-21": {Amount: big.NewInt(4950)},
-			},
-			expectedCount: 2,
-		},
-		{
-			name: "TestProcessObjectNativeAndForeign",
-			objectChanges: []ObjectChange{
-				{
-					ObjectType:      normalObjectNativeType,
-					Version:         normalVersion,
-					PreviousVersion: normalPreviousVersion,
-					ObjectId:        normalObjectNativeId,
-				},
-				{
-					ObjectType:      normalObjectForeignType,
-					Version:         normalVersion,
-					PreviousVersion: normalPreviousVersion,
-					ObjectId:        normalObjectForeignId,
-				},
-			},
-			resultList: []ResultTestCase{
-				{
-					tokenChain:   normalChainIdNative,
-					tokenAddress: normalTokenAddressNative,
-					wrapped:      false,
-					newBalance:   "1000",
-					oldBalance:   "10",
-					decimals:     8,
-				},
-				{
-					tokenChain:   normalChainIdForeign,
-					tokenAddress: normalTokenAddressForeign,
-					wrapped:      true,
-					newBalance:   "50",
-					oldBalance:   "5000",
-					decimals:     8,
-				},
-			},
-			expectedResult: map[string]TransferIntoBridge{
-				"9258181f5ceac8dbffb7030890243caed69a9599d2886d957a9cb7656af3bdb3-21": {Amount: big.NewInt(990)},
-				"000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48-2":  {Amount: big.NewInt(4950)},
-			},
-			expectedCount: 2,
-		},
-		{
-			name: "TestProcessObjectWrongPackageIdType",
-			objectChanges: []ObjectChange{
-				{
-					ObjectType:      "0x2::dynamic_field::Field<0xa340e3db1332c21f20f5c08bef0fa459e733575f9a7e2f5faca64f72cd5a54f2::token_registry::Key<0x2::sui::SUI>, 0xa340e3db1332c21f20f5c08bef0fa459e733575f9a7e2f5faca64f72cd5a54f2::native_asset::NativeAsset<0x2::sui::SUI>",
-					Version:         normalVersion,
-					PreviousVersion: normalPreviousVersion,
-					ObjectId:        normalObjectNativeId,
-				},
-			},
-			resultList: []ResultTestCase{
-				{
-					tokenChain:   normalChainIdNative,
-					tokenAddress: normalTokenAddressNative,
-					wrapped:      false,
-					newBalance:   "1000",
-					oldBalance:   "10",
-					decimals:     8,
-				},
-			},
-			expectedResult: map[string]TransferIntoBridge{},
-			expectedCount:  0,
-		},
-		{
-			name: "TestProcessObjectNotDynamicField",
-			objectChanges: []ObjectChange{
-				{
-					ObjectType:      "0x11111111111111111111::dynamic_field::Field<0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0x2::sui::SUI>, 0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::native_asset::NativeAsset<0x2::sui::SUI>",
-					Version:         normalVersion,
-					PreviousVersion: normalPreviousVersion,
-					ObjectId:        normalObjectNativeId,
-				},
-			},
-			resultList: []ResultTestCase{
-				{
-					tokenChain:   normalChainIdNative,
-					tokenAddress: normalTokenAddressNative,
-					wrapped:      false,
-					newBalance:   "1000",
-					oldBalance:   "10",
-					decimals:     8,
-				},
-			},
-			expectedResult: map[string]TransferIntoBridge{},
-			expectedCount:  0,
-		},
-		{
-			name: "TestProcessObjectMismatchedCoinTypes",
-			objectChanges: []ObjectChange{
-				{
-					ObjectType:      "0x2::dynamic_field::Field<0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0x2::sui::SUI>, 0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::native_asset::NativeAsset<0x11111111111111111111::sui::SUI>",
-					Version:         normalVersion,
-					PreviousVersion: normalPreviousVersion,
-					ObjectId:        normalObjectNativeId,
-				},
-			},
-			resultList: []ResultTestCase{
-				{
-					tokenChain:   normalChainIdNative,
-					tokenAddress: normalTokenAddressNative,
-					wrapped:      false,
-					newBalance:   "1000",
-					oldBalance:   "10",
-					decimals:     8,
-				},
-			},
-			expectedResult: map[string]TransferIntoBridge{},
-			expectedCount:  0,
-		},
-		{
-			name: "TestProcessObjectNotAssetType",
-			objectChanges: []ObjectChange{
-				{
-					ObjectType:      "0x2::dynamic_field::Field<0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0x2::sui::SUI>, 0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::not_native_asset::NativeAsset<0x2::sui::SUI>",
-					Version:         normalVersion,
-					PreviousVersion: normalPreviousVersion,
-					ObjectId:        normalObjectNativeId,
-				},
-			},
-			resultList: []ResultTestCase{
-				{
-					tokenChain:   normalChainIdNative,
-					tokenAddress: normalTokenAddressNative,
-					wrapped:      false,
-					newBalance:   "1000",
-					oldBalance:   "10",
-					decimals:     8,
-				},
-			},
-			expectedResult: map[string]TransferIntoBridge{},
-			expectedCount:  0,
-		},
-		{
-			name: "TestProcessObjectOneGoodOneBad",
-			objectChanges: []ObjectChange{
-				{
-					ObjectType:      normalObjectForeignType,
-					Version:         normalVersion,
-					PreviousVersion: normalPreviousVersion,
-					ObjectId:        normalObjectForeignId,
-				},
-				{
-					ObjectType:      "0x2::dynamic_field::Field<0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0x2::sui::SUI>, 0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::not_native_asset::NativeAsset<0x2::sui::SUI>",
-					Version:         fmt.Sprintf("%s111", normalVersion),
-					PreviousVersion: normalPreviousVersion,
-					ObjectId:        normalObjectNativeId,
-				},
-			},
-			resultList: []ResultTestCase{
-				{
-					tokenChain:   normalChainIdForeign,
-					tokenAddress: normalTokenAddressForeign,
-					wrapped:      true,
-					newBalance:   "10",
-					oldBalance:   "1000",
-					decimals:     8,
-				},
-				{
-					tokenChain:   normalChainIdNative,
-					tokenAddress: normalTokenAddressNative,
-					wrapped:      false,
-					newBalance:   "1000",
-					oldBalance:   "10",
-					decimals:     8,
-				},
-			},
-			expectedResult: map[string]TransferIntoBridge{
-				"000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48-2": {Amount: big.NewInt(990)},
-			},
-			expectedCount: 1,
-		},
-		{
-			name: "TestProcessObjectRealNumbers",
-			objectChanges: []ObjectChange{
-				{
-					ObjectType:      normalObjectNativeType,
-					Version:         normalVersion,
-					PreviousVersion: normalPreviousVersion,
-					ObjectId:        normalObjectNativeId,
-				},
-			},
-			resultList: []ResultTestCase{
-				{
-					tokenChain:   normalChainIdNative,
-					tokenAddress: normalTokenAddressNative,
-					wrapped:      false,
-					newBalance:   "1000000000000000",
-					oldBalance:   "999999000000000",
-					decimals:     8,
-				},
-			},
-			expectedResult: map[string]TransferIntoBridge{
-				"9258181f5ceac8dbffb7030890243caed69a9599d2886d957a9cb7656af3bdb3-21": {Amount: big.NewInt(1000000000)},
-			},
-			expectedCount: 1,
-		},
-		{
-			name: "TestProcessObjectNormalize",
-			objectChanges: []ObjectChange{
-				{
-					ObjectType:      normalObjectNativeType,
-					Version:         normalVersion,
-					PreviousVersion: normalPreviousVersion,
-					ObjectId:        normalObjectNativeId,
-				},
-			},
-			resultList: []ResultTestCase{
-				{
-					tokenChain:   normalChainIdNative,
-					tokenAddress: normalTokenAddressNative,
-					wrapped:      false,
-					newBalance:   "101000000000000000000",
-					oldBalance:   "100000000000000000000",
-					decimals:     18,
-				},
-			},
-			expectedResult: map[string]TransferIntoBridge{
-				"9258181f5ceac8dbffb7030890243caed69a9599d2886d957a9cb7656af3bdb3-21": {Amount: big.NewInt(100000000)},
-			},
-			expectedCount: 1,
-		},
-		{
-			name: "TestProcessObjectMissingVersion",
-			objectChanges: []ObjectChange{
-				{
-					ObjectType:      normalObjectNativeType,
-					Version:         normalVersion,
-					PreviousVersion: normalPreviousVersion,
-					ObjectId:        normalObjectNativeId,
-				},
-			},
-			resultList: []ResultTestCase{
-				{
-					tokenChain:   normalChainIdNative,
-					tokenAddress: normalTokenAddressNative,
-					wrapped:      false,
-					newBalance:   "1000",
-					oldBalance:   "10",
-					decimals:     8,
-					drop:         true,
-				},
-			},
-			expectedResult: map[string]TransferIntoBridge{},
-			expectedCount:  0,
-		},
+func toSuiObjectChanges(changes []ObjectChange) []suiclient.SuiObjectChange {
+	out := make([]suiclient.SuiObjectChange, 0, len(changes))
+	for _, c := range changes {
+		out = append(out, toSuiObjectChange(c))
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			connection := NewMockSuiApiConnection([]SuiEvent{})
-			suiTxVerifier.suiApiConnection = connection
-
-			assert.Equal(t, len(tt.objectChanges), len(tt.resultList))
-
-			// Add all changes to the mock Sui API for future lookups
-			for index := 0; index < len(tt.objectChanges); index++ {
-				change := tt.objectChanges[index]
-				queryResult := tt.resultList[index]
-
-				if !queryResult.drop {
-					responseObject := generateResponsesObject(change.ObjectId, change.Version, change.ObjectType, change.PreviousVersion, queryResult.newBalance, queryResult.oldBalance, queryResult.tokenAddress, queryResult.tokenChain, queryResult.decimals, queryResult.wrapped)
-					connection.SetObjectsResponse(responseObject)
-				}
-			}
-
-			// Run function and check results
-			transfers := suiTxVerifier.extractTransfersIntoBridgeFromObjectChanges(ctx, tt.objectChanges, logger)
-
-			// Check that expectedResult and transfers have same number of keys
-			assert.Equal(t, uint(len(tt.expectedResult)), uint(len(transfers)))
-
-			// Check that each key in expectedResult exists in transfers and has the expected amount
-			for key, expectedValue := range tt.expectedResult {
-				actualValue, exists := transfers[key]
-				if !exists {
-					t.Errorf("Expected key %s not found in result", key)
-				} else if actualValue.Amount.Cmp(expectedValue.Amount) != 0 {
-					t.Errorf("For key %s, expected amount %s but got %s", key, expectedValue.Amount.String(), actualValue.Amount.String())
-				}
-			}
-		})
-	}
-}
-
-func TestProcessDigest(t *testing.T) {
-	suiTxVerifier := newTestSuiTransferVerifier(nil)
-
-	// Constants used throughout the tests
-	normalObjectNativeType := "0x2::dynamic_field::Field<0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0x2::sui::SUI>, 0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::native_asset::NativeAsset<0x2::sui::SUI>>"
-	normalObjectForeignType := "0x2::dynamic_field::Field<0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0x5d4b302506645c37ff133b98c4b50a5ae14841659738d6d733d59d0d217a93bf::coin::COIN>, 0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::wrapped_asset::WrappedAsset<0x5d4b302506645c37ff133b98c4b50a5ae14841659738d6d733d59d0d217a93bf::coin::COIN>>"
-	normalVersion := "6565"
-	normalPreviousVersion := "4040"
-	normalObjectNativeId := "0x831c45a8d512c9cf46e7a8a947f7cbbb5e0a59829aa72450ff26fb1873fd0e94"
-	normalObjectForeignId := "0xf8f80c0d569fb076adb5fdc3a717dcb9ac14f7fd7512dc17efbf0f80a8b7fa8a"
-
-	normalTokenAddressForeign := "0,0,0,0,0,0,0,0,0,0,0,0,160,184,105,145,198,33,139,54,193,209,157,74,46,158,176,206,54,6,235,72"
-	normalTokenAddressNative := "93,75,48,37,6,100,92,55,255,19,59,152,196,181,10,90,225,72,65,101,151,56,214,215,51,213,157,13,33,122,147,191"
-	normalChainIdNative := "21"
-	normalChainIdForeign := "2"
-
-	suiEventType := suiTxVerifier.suiEventType
-	suiTokenBridgeEmitter := suiTxVerifier.suiTokenBridgeEmitter
-
-	sequenceNumber := uint64(0)
-
-	logger := zap.Must(zap.NewDevelopment())
-
-	// func processDigest(digest string, suiApiConnection SuiApiInterface, logger *zap.Logger) error {
-	// Needs BOTH events and ObjectChange information to be updated
-	tests := []struct {
-		name          string
-		objectChanges []ObjectChange
-		resultList    []ResultTestCase
-		suiEvents     []SuiEvent
-		expectedError error
-		expectedCount uint
-	}{
-		{
-			name: "TestProcessDigestNativeBase",
-			objectChanges: []ObjectChange{
-				{
-					ObjectType:      normalObjectNativeType,
-					Version:         normalVersion,
-					PreviousVersion: normalPreviousVersion,
-					ObjectId:        normalObjectNativeId,
-				},
-			},
-			resultList: []ResultTestCase{
-				{
-					tokenChain:   normalChainIdNative,
-					tokenAddress: normalTokenAddressNative,
-					wrapped:      false,
-					newBalance:   "1000",
-					oldBalance:   "10",
-					decimals:     8,
-				},
-			},
-			suiEvents: []SuiEvent{
-				{
-					Type: &suiEventType,
-					ParsedJson: uncheckedJsonMarshal(&WormholeMessage{
-						Sender:  &suiTokenBridgeEmitter,
-						Payload: generatePayload(1, big.NewInt(990), SuiUsdcAddress, uint16(vaa.ChainIDSui)),
-					}),
-				},
-			},
-			expectedError: nil,
-			expectedCount: 1,
-		},
-		{
-			name: "TestProcessDigestTakingMoreThanPuttingIn",
-			objectChanges: []ObjectChange{
-				{
-					ObjectType:      normalObjectNativeType,
-					Version:         normalVersion,
-					PreviousVersion: normalPreviousVersion,
-					ObjectId:        normalObjectNativeId,
-				},
-			},
-			resultList: []ResultTestCase{
-				{
-					tokenChain:   normalChainIdNative,
-					tokenAddress: normalTokenAddressNative,
-					wrapped:      false,
-					newBalance:   "100000",
-					oldBalance:   "100000",
-					decimals:     8,
-				},
-			},
-			suiEvents: []SuiEvent{
-				{
-					Type: &suiEventType,
-					ParsedJson: uncheckedJsonMarshal(&WormholeMessage{
-						Sender:   &suiTokenBridgeEmitter,
-						Payload:  generatePayload(1, big.NewInt(100000), SuiUsdcAddress, uint16(vaa.ChainIDSui)),
-						Sequence: nextSequenceNumber(&sequenceNumber),
-					}),
-				},
-			},
-			expectedError: &InvariantError{Msg: INVARIANT_INSUFFICIENT_DEPOSIT},
-			expectedCount: 0,
-		},
-		{
-			name:          "TestProcessDigestNoEvents",
-			objectChanges: []ObjectChange{},
-			resultList:    []ResultTestCase{},
-			suiEvents: []SuiEvent{
-				{
-					Type: &suiEventType,
-					ParsedJson: uncheckedJsonMarshal(&WormholeMessage{
-						Sender:   &suiTokenBridgeEmitter,
-						Payload:  generatePayload(1, big.NewInt(100000), SuiUsdcAddress, uint16(vaa.ChainIDSui)),
-						Sequence: nextSequenceNumber(&sequenceNumber),
-					}),
-				},
-			},
-			expectedError: &InvariantError{Msg: INVARIANT_NO_DEPOSIT},
-			expectedCount: 0,
-		},
-		{
-			name: "TestProcessDigestForeignBase",
-			objectChanges: []ObjectChange{
-				{
-					ObjectType:      normalObjectForeignType,
-					Version:         normalVersion,
-					PreviousVersion: normalPreviousVersion,
-					ObjectId:        normalObjectForeignId,
-				},
-			},
-			resultList: []ResultTestCase{
-				{
-					tokenChain:   normalChainIdForeign,
-					tokenAddress: normalTokenAddressForeign,
-					wrapped:      true,
-					newBalance:   "10",
-					oldBalance:   "1000",
-					decimals:     8,
-				},
-			},
-			suiEvents: []SuiEvent{
-				{
-					Type: &suiEventType,
-					ParsedJson: uncheckedJsonMarshal(&WormholeMessage{
-						Sender:   &suiTokenBridgeEmitter,
-						Payload:  generatePayload(1, big.NewInt(990), EthereumUsdcAddress, uint16(vaa.ChainIDEthereum)),
-						Sequence: nextSequenceNumber(&sequenceNumber),
-					}),
-				},
-			},
-			expectedError: nil,
-			expectedCount: 1,
-		},
-		{
-			name:          "TestProcessDigestNoEvents",
-			objectChanges: []ObjectChange{},
-			resultList:    []ResultTestCase{},
-			suiEvents: []SuiEvent{
-				{
-					Type: &suiEventType,
-					ParsedJson: uncheckedJsonMarshal(&WormholeMessage{
-						Sender:   &suiTokenBridgeEmitter,
-						Payload:  generatePayload(1, big.NewInt(100000), SuiUsdcAddress, uint16(vaa.ChainIDSui)),
-						Sequence: nextSequenceNumber(&sequenceNumber),
-					}),
-				},
-			},
-			expectedError: &InvariantError{Msg: INVARIANT_NO_DEPOSIT},
-			expectedCount: 0,
-		},
-		{
-			name: "TestProcessDigestMultipleEvents",
-			objectChanges: []ObjectChange{
-				{
-					ObjectType:      normalObjectForeignType,
-					Version:         normalVersion,
-					PreviousVersion: normalPreviousVersion,
-					ObjectId:        normalObjectForeignId,
-				},
-			},
-			resultList: []ResultTestCase{
-				{
-					tokenChain:   normalChainIdForeign,
-					tokenAddress: normalTokenAddressForeign,
-					wrapped:      true,
-					newBalance:   "10",
-					oldBalance:   "2000",
-					decimals:     8,
-				},
-			},
-			suiEvents: []SuiEvent{
-				{
-					Type: &suiEventType,
-					ParsedJson: uncheckedJsonMarshal(&WormholeMessage{
-						Sender:   &suiTokenBridgeEmitter,
-						Payload:  generatePayload(1, big.NewInt(990), EthereumUsdcAddress, uint16(vaa.ChainIDEthereum)),
-						Sequence: nextSequenceNumber(&sequenceNumber),
-					}),
-				},
-				{
-					Type: &suiEventType,
-					ParsedJson: uncheckedJsonMarshal(&WormholeMessage{
-						Sender:  &suiTokenBridgeEmitter,
-						Payload: generatePayload(1, big.NewInt(1000), EthereumUsdcAddress, uint16(vaa.ChainIDEthereum)),
-					}),
-				},
-			},
-			expectedError: nil,
-			expectedCount: 2,
-		},
-		{
-			name: "TestProcessDigestMultipleEventsOverWithdraw",
-			objectChanges: []ObjectChange{
-				{
-					ObjectType:      normalObjectForeignType,
-					Version:         normalVersion,
-					PreviousVersion: normalPreviousVersion,
-					ObjectId:        normalObjectForeignId,
-				},
-			},
-			resultList: []ResultTestCase{
-				{
-					tokenChain:   normalChainIdForeign,
-					tokenAddress: normalTokenAddressForeign,
-					wrapped:      true,
-					newBalance:   "10",
-					oldBalance:   "2000",
-					decimals:     8,
-				},
-			},
-			suiEvents: []SuiEvent{
-				{
-					Type: &suiEventType,
-					ParsedJson: uncheckedJsonMarshal(&WormholeMessage{
-						Sender:   &suiTokenBridgeEmitter,
-						Payload:  generatePayload(1, big.NewInt(990), EthereumUsdcAddress, uint16(vaa.ChainIDEthereum)),
-						Sequence: nextSequenceNumber(&sequenceNumber),
-					}),
-				},
-				{
-					Type: &suiEventType,
-					ParsedJson: uncheckedJsonMarshal(&WormholeMessage{
-						Sender:   &suiTokenBridgeEmitter,
-						Payload:  generatePayload(1, big.NewInt(1001), EthereumUsdcAddress, uint16(vaa.ChainIDEthereum)),
-						Sequence: nextSequenceNumber(&sequenceNumber),
-					}),
-				},
-			},
-			expectedError: &InvariantError{Msg: INVARIANT_INSUFFICIENT_DEPOSIT},
-			expectedCount: 0,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.TODO()
-			assert.Equal(t, len(tt.objectChanges), len(tt.resultList))
-			connection := NewMockSuiApiConnection(tt.suiEvents) // Set events for connection
-			suiTxVerifier.suiApiConnection = connection
-
-			// Add Object Response data for Sui connections
-			for index := 0; index < len(tt.objectChanges); index++ {
-				change := tt.objectChanges[index]
-				queryResult := tt.resultList[index]
-
-				responseObject := generateResponsesObject(change.ObjectId, change.Version, change.ObjectType, change.PreviousVersion, queryResult.newBalance, queryResult.oldBalance, queryResult.tokenAddress, queryResult.tokenChain, queryResult.decimals, queryResult.wrapped)
-
-				connection.SetObjectsResponse(responseObject)
-			}
-
-			_, err := suiTxVerifier.processDigestInternal(ctx, "HASH", "", logger)
-
-			assert.Equal(t, true, tt.expectedError == nil && err == nil || err != nil && err.Error() == tt.expectedError.Error())
-			// assert.Equal(t, tt.expectedCount, numProcessed)
-		})
-	}
-}
-
-// Marshal the input to a json.RawMessage, and ignore the error message.
-func uncheckedJsonMarshal(v any) *json.RawMessage {
-	data, _ := json.Marshal(v)
-	return (*json.RawMessage)(&data)
+	return out
 }
 
 // Generate WormholeMessage payload.
@@ -1063,162 +261,575 @@ func generatePayload(payloadType byte, amount *big.Int, originAddressHex string,
 	return payload
 }
 
-/*
-JSON data
+func TestProcessEvents(t *testing.T) {
+	suiTxVerifier := newTestSuiTransferVerifier(nil)
 
-Decimals, token chain, token address, wrapped or not, balance/custody
-*/
+	arbitraryEventType := "arbitrary::EventType"
+	arbitraryEmitter := "0x3117"
 
-func generateResponsesObject(objectId string, version string, objectType string, previousVersion string, balanceAfter string, balanceBefore string, tokenAddress string, tokenChain string, decimals uint8, isWrapped bool) SuiTryMultiGetPastObjectsResponse {
+	logger := zap.NewNop()
 
-	var newVersion string
-	var oldVersion string
+	// Constants used throughout the tests
+	suiEventType := suiTxVerifier.suiEventType
+	suiTokenBridgeEmitter := suiTxVerifier.suiTokenBridgeEmitter
 
-	if isWrapped == false {
-		newVersion = generateResponseObjectNative(objectId, version, objectType, balanceAfter, tokenAddress, decimals)
-		oldVersion = generateResponseObjectNative(objectId, previousVersion, objectType, balanceBefore, tokenAddress, decimals)
-	} else {
-		newVersion = generateResponseObjectForeign(objectId, version, objectType, balanceAfter, tokenAddress, tokenChain, decimals)
-		oldVersion = generateResponseObjectForeign(objectId, previousVersion, objectType, balanceBefore, tokenAddress, tokenChain, decimals)
+	// Define test cases. Each event is given a unique sequence number so that distinct events
+	// produce distinct message IDs (and therefore distinct bridge-out requests).
+	tests := []struct {
+		name           string
+		events         []suiclient.SuiEvent
+		expectedResult map[string]*big.Int
+		expectedCount  int
+	}{
+		{
+			name:           "TestNoEvents",
+			events:         []suiclient.SuiEvent{},
+			expectedResult: map[string]*big.Int{},
+			expectedCount:  0,
+		},
+		{
+			name: "TestSingleEthereumUSDCEvent",
+			events: []suiclient.SuiEvent{
+				makeWormholeEvent(suiEventType, suiTokenBridgeEmitter, generatePayload(1, big.NewInt(100), EthereumUsdcAddress, 2), 1),
+			},
+			expectedResult: map[string]*big.Int{
+				fmt.Sprintf(KEY_FORMAT, EthereumUsdcAddress, vaa.ChainIDEthereum): big.NewInt(100),
+			},
+			expectedCount: 1,
+		},
+		{
+			name: "TestMultipleEthereumUSDCEvents",
+			events: []suiclient.SuiEvent{
+				makeWormholeEvent(suiEventType, suiTokenBridgeEmitter, generatePayload(1, big.NewInt(100), EthereumUsdcAddress, uint16(vaa.ChainIDEthereum)), 2),
+				makeWormholeEvent(suiEventType, suiTokenBridgeEmitter, generatePayload(1, big.NewInt(100), EthereumUsdcAddress, uint16(vaa.ChainIDEthereum)), 3),
+			},
+			expectedResult: map[string]*big.Int{
+				fmt.Sprintf(KEY_FORMAT, EthereumUsdcAddress, vaa.ChainIDEthereum): big.NewInt(200),
+			},
+			expectedCount: 2,
+		},
+		{
+			name: "TestMixedEthereumAndSuiUSDCEvents",
+			events: []suiclient.SuiEvent{
+				makeWormholeEvent(suiEventType, suiTokenBridgeEmitter, generatePayload(1, big.NewInt(100), EthereumUsdcAddress, uint16(vaa.ChainIDEthereum)), 4),
+				makeWormholeEvent(suiEventType, suiTokenBridgeEmitter, generatePayload(1, big.NewInt(100), SuiUsdcAddress, uint16(vaa.ChainIDSui)), 5),
+			},
+			expectedResult: map[string]*big.Int{
+				fmt.Sprintf(KEY_FORMAT, EthereumUsdcAddress, vaa.ChainIDEthereum): big.NewInt(100),
+				fmt.Sprintf(KEY_FORMAT, SuiUsdcAddress, vaa.ChainIDSui):           big.NewInt(100),
+			},
+			expectedCount: 2,
+		},
+		{
+			name: "TestIncorrectSender",
+			events: []suiclient.SuiEvent{
+				makeWormholeEvent(suiEventType, arbitraryEmitter, generatePayload(1, big.NewInt(100), EthereumUsdcAddress, uint16(vaa.ChainIDEthereum)), 6),
+			},
+			expectedResult: map[string]*big.Int{},
+			expectedCount:  0,
+		},
+		{
+			name: "TestSkipNonWormholeEvents",
+			events: []suiclient.SuiEvent{
+				makeWormholeEvent(suiEventType, suiTokenBridgeEmitter, generatePayload(1, big.NewInt(100), EthereumUsdcAddress, uint16(vaa.ChainIDEthereum)), 7),
+				makeWormholeEvent(arbitraryEventType, suiTokenBridgeEmitter, generatePayload(1, big.NewInt(100), SuiUsdcAddress, uint16(vaa.ChainIDSui)), 8),
+			},
+			expectedResult: map[string]*big.Int{
+				fmt.Sprintf(KEY_FORMAT, EthereumUsdcAddress, vaa.ChainIDEthereum): big.NewInt(100),
+			},
+			expectedCount: 1,
+		},
+		{
+			name: "TestInvalidWormholePayloads",
+			events: []suiclient.SuiEvent{
+				// Invalid payload type
+				makeWormholeEvent(suiEventType, suiTokenBridgeEmitter, generatePayload(0, big.NewInt(100), EthereumUsdcAddress, uint16(vaa.ChainIDEthereum)), 9),
+				// Empty payload
+				makeWormholeEvent(suiEventType, suiTokenBridgeEmitter, []byte{}, 10),
+			},
+			expectedResult: map[string]*big.Int{},
+			expectedCount:  0,
+		},
 	}
 
-	// Complete the rest of the response data
-	responseString := fmt.Sprintf(`{"result": [{"details" : %s}, {"details" : %s}]}`, newVersion, oldVersion)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			requests := suiTxVerifier.extractBridgeRequestsFromEvents(tt.events, logger)
+			assert.Equal(t, tt.expectedCount, len(requests))
+		})
+	}
+}
 
-	data := SuiTryMultiGetPastObjectsResponse{}
-	err := json.Unmarshal([]byte(responseString), &data)
-	if err != nil {
-		fmt.Println("Error in JSON parsing...")
+func TestProcessObjectUpdates(t *testing.T) {
+	ctx := context.TODO()
+	logger := zap.NewNop()
+
+	// Constants used throughout the tests
+	normalObjectNativeType := "0x2::dynamic_field::Field<0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0x2::sui::SUI>, 0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::native_asset::NativeAsset<0x2::sui::SUI>>"
+	normalObjectForeignType := "0x2::dynamic_field::Field<0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0x5d4b302506645c37ff133b98c4b50a5ae14841659738d6d733d59d0d217a93bf::coin::COIN>, 0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::wrapped_asset::WrappedAsset<0x5d4b302506645c37ff133b98c4b50a5ae14841659738d6d733d59d0d217a93bf::coin::COIN>>"
+	normalVersion := "6565"
+	normalPreviousVersion := "4040"
+	normalObjectNativeId := "0x831c45a8d512c9cf46e7a8a947f7cbbb5e0a59829aa72450ff26fb1873fd0e94"
+	normalObjectForeignId := "0xf8f80c0d569fb076adb5fdc3a717dcb9ac14f7fd7512dc17efbf0f80a8b7fa8a"
+
+	normalTokenAddressForeign := "0,0,0,0,0,0,0,0,0,0,0,0,160,184,105,145,198,33,139,54,193,209,157,74,46,158,176,206,54,6,235,72"
+	normalTokenAddressNative := "146,88,24,31,92,234,200,219,255,183,3,8,144,36,60,174,214,154,149,153,210,136,109,149,122,156,183,101,106,243,189,179"
+	normalChainIdNative := "21"
+	normalChainIdForeign := "2"
+
+	// Decimals, token chain, token address, wrapped or not, balance/custody
+	tests := []struct {
+		name           string
+		objectChanges  []ObjectChange
+		resultList     []ResultTestCase
+		expectedResult map[string]TransferIntoBridge
+		expectedCount  uint
+	}{
+		{
+			name: "TestProcessObjectNativeBase",
+			objectChanges: []ObjectChange{
+				{ObjectType: normalObjectNativeType, Version: normalVersion, PreviousVersion: normalPreviousVersion, ObjectId: normalObjectNativeId},
+			},
+			resultList: []ResultTestCase{
+				{tokenChain: normalChainIdNative, tokenAddress: normalTokenAddressNative, wrapped: false, newBalance: "1000", oldBalance: "10", decimals: 8},
+			},
+			expectedResult: map[string]TransferIntoBridge{
+				"9258181f5ceac8dbffb7030890243caed69a9599d2886d957a9cb7656af3bdb3-21": {Amount: big.NewInt(990)},
+			},
+			expectedCount: 1,
+		},
+		{
+			name: "TestProcessObjectForeignBase",
+			objectChanges: []ObjectChange{
+				{ObjectType: normalObjectForeignType, Version: normalVersion, PreviousVersion: normalPreviousVersion, ObjectId: normalObjectForeignId},
+			},
+			resultList: []ResultTestCase{
+				{tokenChain: normalChainIdForeign, tokenAddress: normalTokenAddressForeign, wrapped: true, newBalance: "10", oldBalance: "1000", decimals: 8},
+			},
+			expectedResult: map[string]TransferIntoBridge{
+				"000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48-2": {Amount: big.NewInt(990)},
+			},
+			expectedCount: 1,
+		},
+		{
+			name: "TestProcessObjectNativeNegative",
+			objectChanges: []ObjectChange{
+				{ObjectType: normalObjectNativeType, Version: normalVersion, PreviousVersion: normalPreviousVersion, ObjectId: normalObjectNativeId},
+			},
+			resultList: []ResultTestCase{
+				{tokenChain: normalChainIdNative, tokenAddress: normalTokenAddressNative, wrapped: false, newBalance: "10", oldBalance: "1000", decimals: 8},
+			},
+			expectedResult: map[string]TransferIntoBridge{
+				"9258181f5ceac8dbffb7030890243caed69a9599d2886d957a9cb7656af3bdb3-21": {Amount: big.NewInt(-990)},
+			},
+			expectedCount: 1,
+		},
+		{
+			name: "TestProcessObjectForeignNegative", // Unsure if this test case is possible from Sui API
+			objectChanges: []ObjectChange{
+				{ObjectType: normalObjectForeignType, Version: normalVersion, PreviousVersion: normalPreviousVersion, ObjectId: normalObjectForeignId},
+			},
+			resultList: []ResultTestCase{
+				{tokenChain: normalChainIdForeign, tokenAddress: normalTokenAddressForeign, wrapped: true, newBalance: "1000", oldBalance: "10", decimals: 8},
+			},
+			expectedResult: map[string]TransferIntoBridge{
+				"000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48-2": {Amount: big.NewInt(-990)},
+			},
+			expectedCount: 1,
+		},
+		{
+			name: "TestProcessObjectNativeMultiple",
+			objectChanges: []ObjectChange{
+				{ObjectType: normalObjectNativeType, Version: normalVersion, PreviousVersion: normalPreviousVersion, ObjectId: normalObjectNativeId},
+				{
+					ObjectType:      "0x2::dynamic_field::Field<0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0xb779486cfd6c19e9218cc7dc17c453014d2d9ba12d2ee4dbb0ec4e1e02ae1cca::spt::SPT>, 0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::native_asset::NativeAsset<0xb779486cfd6c19e9218cc7dc17c453014d2d9ba12d2ee4dbb0ec4e1e02ae1cca::spt::SPT>>",
+					Version:         normalVersion,
+					PreviousVersion: normalPreviousVersion,
+					ObjectId:        "0x0063d37cdce648a7c6f72f69a75a114fbcc81ef23300e4ace60c7941521163db",
+				},
+			},
+			resultList: []ResultTestCase{
+				{tokenChain: normalChainIdNative, tokenAddress: normalTokenAddressNative, wrapped: false, newBalance: "1000", oldBalance: "10", decimals: 8},
+				{tokenChain: normalChainIdNative, tokenAddress: "80,117,89,76,1,212,111,59,203,196,167,239,20,98,5,130,115,190,206,119,147,238,189,4,100,150,53,151,201,253,9,53", wrapped: false, newBalance: "5000", oldBalance: "50", decimals: 8},
+			},
+			expectedResult: map[string]TransferIntoBridge{
+				"9258181f5ceac8dbffb7030890243caed69a9599d2886d957a9cb7656af3bdb3-21": {Amount: big.NewInt(990)},
+				"5075594c01d46f3bcbc4a7ef1462058273bece7793eebd0464963597c9fd0935-21": {Amount: big.NewInt(4950)},
+			},
+			expectedCount: 2,
+		},
+		{
+			name: "TestProcessObjectNativeAndForeign",
+			objectChanges: []ObjectChange{
+				{ObjectType: normalObjectNativeType, Version: normalVersion, PreviousVersion: normalPreviousVersion, ObjectId: normalObjectNativeId},
+				{ObjectType: normalObjectForeignType, Version: normalVersion, PreviousVersion: normalPreviousVersion, ObjectId: normalObjectForeignId},
+			},
+			resultList: []ResultTestCase{
+				{tokenChain: normalChainIdNative, tokenAddress: normalTokenAddressNative, wrapped: false, newBalance: "1000", oldBalance: "10", decimals: 8},
+				{tokenChain: normalChainIdForeign, tokenAddress: normalTokenAddressForeign, wrapped: true, newBalance: "50", oldBalance: "5000", decimals: 8},
+			},
+			expectedResult: map[string]TransferIntoBridge{
+				"9258181f5ceac8dbffb7030890243caed69a9599d2886d957a9cb7656af3bdb3-21": {Amount: big.NewInt(990)},
+				"000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48-2":  {Amount: big.NewInt(4950)},
+			},
+			expectedCount: 2,
+		},
+		{
+			name: "TestProcessObjectWrongPackageIdType",
+			objectChanges: []ObjectChange{
+				{
+					ObjectType:      "0x2::dynamic_field::Field<0xa340e3db1332c21f20f5c08bef0fa459e733575f9a7e2f5faca64f72cd5a54f2::token_registry::Key<0x2::sui::SUI>, 0xa340e3db1332c21f20f5c08bef0fa459e733575f9a7e2f5faca64f72cd5a54f2::native_asset::NativeAsset<0x2::sui::SUI>",
+					Version:         normalVersion,
+					PreviousVersion: normalPreviousVersion,
+					ObjectId:        normalObjectNativeId,
+				},
+			},
+			resultList: []ResultTestCase{
+				{tokenChain: normalChainIdNative, tokenAddress: normalTokenAddressNative, wrapped: false, newBalance: "1000", oldBalance: "10", decimals: 8},
+			},
+			expectedResult: map[string]TransferIntoBridge{},
+			expectedCount:  0,
+		},
+		{
+			name: "TestProcessObjectNotDynamicField",
+			objectChanges: []ObjectChange{
+				{
+					ObjectType:      "0x11111111111111111111::dynamic_field::Field<0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0x2::sui::SUI>, 0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::native_asset::NativeAsset<0x2::sui::SUI>",
+					Version:         normalVersion,
+					PreviousVersion: normalPreviousVersion,
+					ObjectId:        normalObjectNativeId,
+				},
+			},
+			resultList: []ResultTestCase{
+				{tokenChain: normalChainIdNative, tokenAddress: normalTokenAddressNative, wrapped: false, newBalance: "1000", oldBalance: "10", decimals: 8},
+			},
+			expectedResult: map[string]TransferIntoBridge{},
+			expectedCount:  0,
+		},
+		{
+			name: "TestProcessObjectMismatchedCoinTypes",
+			objectChanges: []ObjectChange{
+				{
+					ObjectType:      "0x2::dynamic_field::Field<0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0x2::sui::SUI>, 0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::native_asset::NativeAsset<0x11111111111111111111::sui::SUI>",
+					Version:         normalVersion,
+					PreviousVersion: normalPreviousVersion,
+					ObjectId:        normalObjectNativeId,
+				},
+			},
+			resultList: []ResultTestCase{
+				{tokenChain: normalChainIdNative, tokenAddress: normalTokenAddressNative, wrapped: false, newBalance: "1000", oldBalance: "10", decimals: 8},
+			},
+			expectedResult: map[string]TransferIntoBridge{},
+			expectedCount:  0,
+		},
+		{
+			name: "TestProcessObjectNotAssetType",
+			objectChanges: []ObjectChange{
+				{
+					ObjectType:      "0x2::dynamic_field::Field<0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0x2::sui::SUI>, 0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::not_native_asset::NativeAsset<0x2::sui::SUI>",
+					Version:         normalVersion,
+					PreviousVersion: normalPreviousVersion,
+					ObjectId:        normalObjectNativeId,
+				},
+			},
+			resultList: []ResultTestCase{
+				{tokenChain: normalChainIdNative, tokenAddress: normalTokenAddressNative, wrapped: false, newBalance: "1000", oldBalance: "10", decimals: 8},
+			},
+			expectedResult: map[string]TransferIntoBridge{},
+			expectedCount:  0,
+		},
+		{
+			name: "TestProcessObjectOneGoodOneBad",
+			objectChanges: []ObjectChange{
+				{ObjectType: normalObjectForeignType, Version: normalVersion, PreviousVersion: normalPreviousVersion, ObjectId: normalObjectForeignId},
+				{
+					ObjectType:      "0x2::dynamic_field::Field<0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0x2::sui::SUI>, 0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::not_native_asset::NativeAsset<0x2::sui::SUI>",
+					Version:         fmt.Sprintf("%s111", normalVersion),
+					PreviousVersion: normalPreviousVersion,
+					ObjectId:        normalObjectNativeId,
+				},
+			},
+			resultList: []ResultTestCase{
+				{tokenChain: normalChainIdForeign, tokenAddress: normalTokenAddressForeign, wrapped: true, newBalance: "10", oldBalance: "1000", decimals: 8},
+				{tokenChain: normalChainIdNative, tokenAddress: normalTokenAddressNative, wrapped: false, newBalance: "1000", oldBalance: "10", decimals: 8},
+			},
+			expectedResult: map[string]TransferIntoBridge{
+				"000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48-2": {Amount: big.NewInt(990)},
+			},
+			expectedCount: 1,
+		},
+		{
+			name: "TestProcessObjectRealNumbers",
+			objectChanges: []ObjectChange{
+				{ObjectType: normalObjectNativeType, Version: normalVersion, PreviousVersion: normalPreviousVersion, ObjectId: normalObjectNativeId},
+			},
+			resultList: []ResultTestCase{
+				{tokenChain: normalChainIdNative, tokenAddress: normalTokenAddressNative, wrapped: false, newBalance: "1000000000000000", oldBalance: "999999000000000", decimals: 8},
+			},
+			expectedResult: map[string]TransferIntoBridge{
+				"9258181f5ceac8dbffb7030890243caed69a9599d2886d957a9cb7656af3bdb3-21": {Amount: big.NewInt(1000000000)},
+			},
+			expectedCount: 1,
+		},
+		{
+			// Balances are kept within uint64 (the on-chain Balance/Supply type) while still
+			// exercising the >8-decimals normalization: a change of 1e18 at 18 decimals
+			// normalizes to 1e8.
+			name: "TestProcessObjectNormalize",
+			objectChanges: []ObjectChange{
+				{ObjectType: normalObjectNativeType, Version: normalVersion, PreviousVersion: normalPreviousVersion, ObjectId: normalObjectNativeId},
+			},
+			resultList: []ResultTestCase{
+				{tokenChain: normalChainIdNative, tokenAddress: normalTokenAddressNative, wrapped: false, newBalance: "2000000000000000000", oldBalance: "1000000000000000000", decimals: 18},
+			},
+			expectedResult: map[string]TransferIntoBridge{
+				"9258181f5ceac8dbffb7030890243caed69a9599d2886d957a9cb7656af3bdb3-21": {Amount: big.NewInt(100000000)},
+			},
+			expectedCount: 1,
+		},
+		{
+			name: "TestProcessObjectMissingVersion",
+			objectChanges: []ObjectChange{
+				{ObjectType: normalObjectNativeType, Version: normalVersion, PreviousVersion: normalPreviousVersion, ObjectId: normalObjectNativeId},
+			},
+			resultList: []ResultTestCase{
+				{tokenChain: normalChainIdNative, tokenAddress: normalTokenAddressNative, wrapped: false, newBalance: "1000", oldBalance: "10", decimals: 8, drop: true},
+			},
+			expectedResult: map[string]TransferIntoBridge{},
+			expectedCount:  0,
+		},
 	}
 
-	return data
-}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, len(tt.objectChanges), len(tt.resultList))
 
-func generateResponseObjectNative(objectId string, version string, objectType string, balance string, tokenAddress string, decimals uint8) string {
-	json_string_per_object := fmt.Sprintf(`{
-		"objectId": "%s",
-		"version": "%s",
-		"digest": "4ne8fjG16hAXP8GxuXzoA5hBwuHz6C4D7cyf4TZza4Pa",
-		"type": "%s",
-		"owner": {
-			"ObjectOwner": "0x334881831bd89287554a6121087e498fa023ce52c037001b53a4563a00a281a5"
-		},
-		"previousTransaction": "FRx1iHA3Wq2ybDe3hhMSkS5yqsKJ4wUDUWY3Xp8K6g18",
-		"storageRebate": "3146400",
-		"content": {
-			"type": "%s",
-			"fields": {
-			"id": {
-				"id": "0x831c45a8d512c9cf46e7a8a947f7cbbb5e0a59829aa72450ff26fb1873fd0e94"
-			},
-			"name": {
-				"type": "0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0x2::sui::SUI>",
-				"fields": {
-				"dummy_field": false
-				}
-			},
-			"value": {
-				"type": "0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::native_asset::NativeAsset<0x2::sui::SUI>",
-				"fields": {
-				"custody": "%s",
-				"decimals": %d,
-				"token_address": {
-					"type": "0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a::external_address::ExternalAddress",
-					"fields": {
-					"value": {
-						"type": "0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a::bytes32::Bytes32",
-						"fields": {
-						"data": [
-							%s
-						]
-						}
-					}
-					}
-				}
+			mock := newMockSuiClient()
+			suiTxVerifier := newTestSuiTransferVerifier(mock)
+
+			// Register all object versions on the mock for future lookups
+			for index := range tt.objectChanges {
+				mock.registerObject(tt.objectChanges[index], tt.resultList[index])
+			}
+
+			// Run function and check results
+			transfers := suiTxVerifier.extractTransfersIntoBridgeFromObjectChanges(ctx, toSuiObjectChanges(tt.objectChanges), logger)
+
+			// Check that expectedResult and transfers have same number of keys
+			assert.Equal(t, uint(len(tt.expectedResult)), uint(len(transfers)))
+
+			// Check that each key in expectedResult exists in transfers and has the expected amount
+			for key, expectedValue := range tt.expectedResult {
+				actualValue, exists := transfers[key]
+				if !exists {
+					t.Errorf("Expected key %s not found in result", key)
+				} else if actualValue.Amount.Cmp(expectedValue.Amount) != 0 {
+					t.Errorf("For key %s, expected amount %s but got %s", key, expectedValue.Amount.String(), actualValue.Amount.String())
 				}
 			}
-    }}}`, objectId, version, objectType, objectType, balance, decimals, tokenAddress)
-
-	return json_string_per_object
+		})
+	}
 }
 
-func generateResponseObjectForeign(objectId string, version string, objectType string, balance string, tokenAddress string, tokenChain string, decimals uint8) string {
-	json_string_per_object := fmt.Sprintf(`{
-		"objectId": "%s",
-		"version": "%s",
-		"digest": "CWXv7KJrNawMqREtVYCRT9PVF2H8cogW1WCLMd5iQchr",
-		"type": "%s",
-		"owner": {
-		  "ObjectOwner": "0x334881831bd89287554a6121087e498fa023ce52c037001b53a4563a00a281a5"
+func TestProcessDigest(t *testing.T) {
+	// Constants used throughout the tests
+	normalObjectNativeType := "0x2::dynamic_field::Field<0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0x2::sui::SUI>, 0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::native_asset::NativeAsset<0x2::sui::SUI>>"
+	normalObjectForeignType := "0x2::dynamic_field::Field<0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0x5d4b302506645c37ff133b98c4b50a5ae14841659738d6d733d59d0d217a93bf::coin::COIN>, 0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::wrapped_asset::WrappedAsset<0x5d4b302506645c37ff133b98c4b50a5ae14841659738d6d733d59d0d217a93bf::coin::COIN>>"
+	normalVersion := "6565"
+	normalPreviousVersion := "4040"
+	normalObjectNativeId := "0x831c45a8d512c9cf46e7a8a947f7cbbb5e0a59829aa72450ff26fb1873fd0e94"
+	normalObjectForeignId := "0xf8f80c0d569fb076adb5fdc3a717dcb9ac14f7fd7512dc17efbf0f80a8b7fa8a"
+
+	normalTokenAddressForeign := "0,0,0,0,0,0,0,0,0,0,0,0,160,184,105,145,198,33,139,54,193,209,157,74,46,158,176,206,54,6,235,72"
+	normalTokenAddressNative := "93,75,48,37,6,100,92,55,255,19,59,152,196,181,10,90,225,72,65,101,151,56,214,215,51,213,157,13,33,122,147,191"
+	normalChainIdNative := "21"
+	normalChainIdForeign := "2"
+
+	suiTxVerifier := newTestSuiTransferVerifier(nil)
+	suiEventType := suiTxVerifier.suiEventType
+	suiTokenBridgeEmitter := suiTxVerifier.suiTokenBridgeEmitter
+
+	logger := zap.Must(zap.NewDevelopment())
+
+	// Needs BOTH events and ObjectChange information to be set on the mocked transaction.
+	tests := []struct {
+		name          string
+		objectChanges []ObjectChange
+		resultList    []ResultTestCase
+		suiEvents     []suiclient.SuiEvent
+		expectedError error
+	}{
+		{
+			name: "TestProcessDigestNativeBase",
+			objectChanges: []ObjectChange{
+				{ObjectType: normalObjectNativeType, Version: normalVersion, PreviousVersion: normalPreviousVersion, ObjectId: normalObjectNativeId},
+			},
+			resultList: []ResultTestCase{
+				{tokenChain: normalChainIdNative, tokenAddress: normalTokenAddressNative, wrapped: false, newBalance: "1000", oldBalance: "10", decimals: 8},
+			},
+			suiEvents: []suiclient.SuiEvent{
+				makeWormholeEvent(suiEventType, suiTokenBridgeEmitter, generatePayload(1, big.NewInt(990), SuiUsdcAddress, uint16(vaa.ChainIDSui)), 101),
+			},
+			expectedError: nil,
 		},
-		"previousTransaction": "EaqLzHQTeiPq2FjYCRobDH5E91DAVZgKgZzwQUJ5FaNU",
-		"storageRebate": "4050800",
-		"content": {
-		  "dataType": "moveObject",
-		  "type": "%s",
-		  "hasPublicTransfer": false,
-		  "fields": {
-			"id": {
-			  "id": "0xf8f80c0d569fb076adb5fdc3a717dcb9ac14f7fd7512dc17efbf0f80a8b7fa8a"
+		{
+			name: "TestProcessDigestTakingMoreThanPuttingIn",
+			objectChanges: []ObjectChange{
+				{ObjectType: normalObjectNativeType, Version: normalVersion, PreviousVersion: normalPreviousVersion, ObjectId: normalObjectNativeId},
 			},
-			"name": {
-			  "type": "0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0x5d4b302506645c37ff133b98c4b50a5ae14841659738d6d733d59d0d217a93bf::coin::COIN>",
-			  "fields": {
-				"dummy_field": false
-			  }
+			resultList: []ResultTestCase{
+				{tokenChain: normalChainIdNative, tokenAddress: normalTokenAddressNative, wrapped: false, newBalance: "100000", oldBalance: "100000", decimals: 8},
 			},
-			"value": {
-			  "type": "0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::wrapped_asset::WrappedAsset<0x5d4b302506645c37ff133b98c4b50a5ae14841659738d6d733d59d0d217a93bf::coin::COIN>",
-			  "fields": {
-				"decimals": 6,
-				"info": {
-				  "type": "0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::wrapped_asset::ForeignInfo<0x5d4b302506645c37ff133b98c4b50a5ae14841659738d6d733d59d0d217a93bf::coin::COIN>",
-				  "fields": {
-					"native_decimals": %d,
-					"symbol": "USDC",
-					"token_address": {
-					  "type": "0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a::external_address::ExternalAddress",
-					  "fields": {
-						"value": {
-						  "type": "0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a::bytes32::Bytes32",
-						  "fields": {"data": [%s]
-						  }
-						}
-					  }
-					},
-					"token_chain": %s
-				  }
-				},
-				"treasury_cap": {
-				  "type": "0x2::coin::TreasuryCap<0x5d4b302506645c37ff133b98c4b50a5ae14841659738d6d733d59d0d217a93bf::coin::COIN>",
-				  "fields": {
-					"id": {
-					  "id": "0xa5085139fdeae133cf6ca58f1f1cee138f24ad6fc54d8e24a519dc24f3b2b974"
-					},
-					"total_supply": {
-					  "type": "0x2::balance::Supply<0x5d4b302506645c37ff133b98c4b50a5ae14841659738d6d733d59d0d217a93bf::coin::COIN>",
-					  "fields": {
-						"value": "%s"
-					  }
-					}
-				  }
-				},
-				"upgrade_cap": {
-				  "type": "0x2::package::UpgradeCap",
-				  "fields": {
-					"id": {
-					  "id": "0x86ebd31cc715928671ac05e29e85b68ae1d96db02565b5413084fcb5afb695b1"
-					},
-					"package": "0x5d4b302506645c37ff133b98c4b50a5ae14841659738d6d733d59d0d217a93bf",
-					"policy": 0,
-					"version": "1"
-				  }
-				}
-			  }
+			suiEvents: []suiclient.SuiEvent{
+				makeWormholeEvent(suiEventType, suiTokenBridgeEmitter, generatePayload(1, big.NewInt(100000), SuiUsdcAddress, uint16(vaa.ChainIDSui)), 102),
+			},
+			expectedError: &InvariantError{Msg: INVARIANT_INSUFFICIENT_DEPOSIT},
+		},
+		{
+			name:          "TestProcessDigestNoEventsNative",
+			objectChanges: []ObjectChange{},
+			resultList:    []ResultTestCase{},
+			suiEvents: []suiclient.SuiEvent{
+				makeWormholeEvent(suiEventType, suiTokenBridgeEmitter, generatePayload(1, big.NewInt(100000), SuiUsdcAddress, uint16(vaa.ChainIDSui)), 103),
+			},
+			expectedError: &InvariantError{Msg: INVARIANT_NO_DEPOSIT},
+		},
+		{
+			name: "TestProcessDigestForeignBase",
+			objectChanges: []ObjectChange{
+				{ObjectType: normalObjectForeignType, Version: normalVersion, PreviousVersion: normalPreviousVersion, ObjectId: normalObjectForeignId},
+			},
+			resultList: []ResultTestCase{
+				{tokenChain: normalChainIdForeign, tokenAddress: normalTokenAddressForeign, wrapped: true, newBalance: "10", oldBalance: "1000", decimals: 8},
+			},
+			suiEvents: []suiclient.SuiEvent{
+				makeWormholeEvent(suiEventType, suiTokenBridgeEmitter, generatePayload(1, big.NewInt(990), EthereumUsdcAddress, uint16(vaa.ChainIDEthereum)), 104),
+			},
+			expectedError: nil,
+		},
+		{
+			name:          "TestProcessDigestNoEventsForeign",
+			objectChanges: []ObjectChange{},
+			resultList:    []ResultTestCase{},
+			suiEvents: []suiclient.SuiEvent{
+				makeWormholeEvent(suiEventType, suiTokenBridgeEmitter, generatePayload(1, big.NewInt(100000), SuiUsdcAddress, uint16(vaa.ChainIDSui)), 105),
+			},
+			expectedError: &InvariantError{Msg: INVARIANT_NO_DEPOSIT},
+		},
+		{
+			name: "TestProcessDigestMultipleEvents",
+			objectChanges: []ObjectChange{
+				{ObjectType: normalObjectForeignType, Version: normalVersion, PreviousVersion: normalPreviousVersion, ObjectId: normalObjectForeignId},
+			},
+			resultList: []ResultTestCase{
+				{tokenChain: normalChainIdForeign, tokenAddress: normalTokenAddressForeign, wrapped: true, newBalance: "10", oldBalance: "2000", decimals: 8},
+			},
+			suiEvents: []suiclient.SuiEvent{
+				makeWormholeEvent(suiEventType, suiTokenBridgeEmitter, generatePayload(1, big.NewInt(990), EthereumUsdcAddress, uint16(vaa.ChainIDEthereum)), 106),
+				makeWormholeEvent(suiEventType, suiTokenBridgeEmitter, generatePayload(1, big.NewInt(1000), EthereumUsdcAddress, uint16(vaa.ChainIDEthereum)), 107),
+			},
+			expectedError: nil,
+		},
+		{
+			name: "TestProcessDigestMultipleEventsOverWithdraw",
+			objectChanges: []ObjectChange{
+				{ObjectType: normalObjectForeignType, Version: normalVersion, PreviousVersion: normalPreviousVersion, ObjectId: normalObjectForeignId},
+			},
+			resultList: []ResultTestCase{
+				{tokenChain: normalChainIdForeign, tokenAddress: normalTokenAddressForeign, wrapped: true, newBalance: "10", oldBalance: "2000", decimals: 8},
+			},
+			suiEvents: []suiclient.SuiEvent{
+				makeWormholeEvent(suiEventType, suiTokenBridgeEmitter, generatePayload(1, big.NewInt(990), EthereumUsdcAddress, uint16(vaa.ChainIDEthereum)), 108),
+				makeWormholeEvent(suiEventType, suiTokenBridgeEmitter, generatePayload(1, big.NewInt(1001), EthereumUsdcAddress, uint16(vaa.ChainIDEthereum)), 109),
+			},
+			expectedError: &InvariantError{Msg: INVARIANT_INSUFFICIENT_DEPOSIT},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.TODO()
+			assert.Equal(t, len(tt.objectChanges), len(tt.resultList))
+
+			mock := newMockSuiClient()
+			mock.transaction = suiclient.SuiTransaction{
+				Events:        tt.suiEvents,
+				ObjectChanges: toSuiObjectChanges(tt.objectChanges),
 			}
-		  }
+
+			// Register object version data on the mock
+			for index := range tt.objectChanges {
+				mock.registerObject(tt.objectChanges[index], tt.resultList[index])
+			}
+
+			suiTxVerifier := newTestSuiTransferVerifier(mock)
+
+			_, err := suiTxVerifier.processDigestInternal(ctx, "HASH", "", logger)
+
+			assert.Equal(t, true, tt.expectedError == nil && err == nil || err != nil && err.Error() == tt.expectedError.Error())
+		})
+	}
+}
+
+func TestSuiVerifierGetters(t *testing.T) {
+	v := newTestSuiTransferVerifier(nil)
+	assert.Equal(t, "0xccceeb29348f71bdd22ffef43a2a19c1f5b5e17c5cca5411529120182672ade5", v.GetTokenBridgeEmitter())
+	assert.Equal(t, "0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a::publish_message::WormholeMessage", v.GetEventType())
+}
+
+func TestDecodeSuiAssetObject(t *testing.T) {
+	addr := parseByteCSV("0,0,0,0,0,0,0,0,0,0,0,0,160,184,105,145,198,33,139,54,193,209,157,74,46,158,176,206,54,6,235,72")
+
+	// Unknown asset type -> error.
+	_, err := decodeSuiAssetObject("0x2::dynamic_field::Field<x::token_registry::Key<c>, y::other::Other<c>>", bcsNativeObject(1, addr, 8))
+	assert.Error(t, err)
+
+	// Native type but undecodable (truncated) bytes -> error.
+	_, err = decodeSuiAssetObject("a::native_asset::NativeAsset<c>", []byte{0x01, 0x02})
+	assert.Error(t, err)
+
+	// Wrapped asset with an unknown token chain -> KnownChainIDFromNumber error.
+	_, err = decodeSuiAssetObject("a::wrapped_asset::WrappedAsset<c>", bcsWrappedObject(1, addr, 60000, 8))
+	assert.Error(t, err)
+
+	// Wrapped asset happy path.
+	info, err := decodeSuiAssetObject("a::wrapped_asset::WrappedAsset<c>", bcsWrappedObject(990, addr, 2, 8))
+	assert.NoError(t, err)
+	assert.True(t, info.isWrapped)
+	assert.Equal(t, uint64(990), info.balance.Uint64())
+	assert.Equal(t, vaa.ChainIDEthereum, info.tokenChain)
+}
+
+// TestProcessDigestPublic exercises the public ProcessDigest wrapper, including its handling of
+// invariant violations (which it converts to a (false, nil) result).
+func TestProcessDigestPublic(t *testing.T) {
+	normalObjectNativeType := "0x2::dynamic_field::Field<0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0x2::sui::SUI>, 0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::native_asset::NativeAsset<0x2::sui::SUI>>"
+	normalTokenAddressNative := "93,75,48,37,6,100,92,55,255,19,59,152,196,181,10,90,225,72,65,101,151,56,214,215,51,213,157,13,33,122,147,191"
+	objectId := "0x831c45a8d512c9cf46e7a8a947f7cbbb5e0a59829aa72450ff26fb1873fd0e94"
+	logger := zap.NewNop()
+	ctx := context.TODO()
+
+	build := func(newBalance, oldBalance string, amount *big.Int) *SuiTransferVerifier {
+		change := ObjectChange{ObjectType: normalObjectNativeType, Version: "6565", PreviousVersion: "4040", ObjectId: objectId}
+		result := ResultTestCase{tokenChain: "21", tokenAddress: normalTokenAddressNative, wrapped: false, newBalance: newBalance, oldBalance: oldBalance, decimals: 8}
+		mock := newMockSuiClient()
+		v := newTestSuiTransferVerifier(mock)
+		mock.transaction = suiclient.SuiTransaction{
+			Events:        []suiclient.SuiEvent{makeWormholeEvent(v.suiEventType, v.suiTokenBridgeEmitter, generatePayload(1, amount, SuiUsdcAddress, uint16(vaa.ChainIDSui)), 1)},
+			ObjectChanges: toSuiObjectChanges([]ObjectChange{change}),
 		}
-	  }`, objectId, version, objectType, objectType, decimals, tokenAddress, tokenChain, balance)
-	return json_string_per_object
+		mock.registerObject(change, result)
+		return v
+	}
 
+	// Solvent: a deposit of 990 covers the 990 requested out of the bridge.
+	ok, err := build("1000", "10", big.NewInt(990)).ProcessDigest(ctx, "HASH", "", logger)
+	assert.NoError(t, err)
+	assert.True(t, ok)
+
+	// Insolvent: nothing deposited for the 100000 requested -> ProcessDigest converts the
+	// invariant violation into (false, nil).
+	ok, err = build("100000", "100000", big.NewInt(100000)).ProcessDigest(ctx, "HASH", "", logger)
+	assert.NoError(t, err)
+	assert.False(t, ok)
 }

--- a/node/pkg/txverifier/suitypes.go
+++ b/node/pkg/txverifier/suitypes.go
@@ -1,451 +1,208 @@
 package txverifier
 
 import (
-	"context"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"math/big"
 	"regexp"
 	"strings"
 
+	"github.com/certusone/wormhole/node/pkg/suiclient"
 	"github.com/wormhole-foundation/wormhole/sdk/vaa"
 )
 
-// The SuiApi interface defines the functions that are required to interact with the Sui RPC.
-type SuiApiInterface interface {
-	QueryEvents(ctx context.Context, filter string, cursor string, limit int, descending bool) (SuiQueryEventsResponse, error)
-	GetTransactionBlock(ctx context.Context, txDigest string) (SuiGetTransactionBlockResponse, error)
-	TryMultiGetPastObjects(ctx context.Context, objectId string, version string, previousVersion string) (SuiTryMultiGetPastObjectsResponse, error)
+// The following structs mirror the on-chain Move types emitted/stored by the Sui core
+// and token bridges. Their field order and types must match the Move definitions exactly
+// so that BCS decoding of the gRPC-provided bytes succeeds. The layouts were validated
+// against live mainnet objects.
+//
+// BCS notes:
+//   - A Move `Balance<T>`/`Supply<T>` wraps a single `u64` and serializes as a bare u64.
+//   - `wormhole::bytes32::Bytes32 { data: vector<u8> }` is a length-prefixed vector, NOT a
+//     fixed array, so it decodes into a Go []byte (the length is always 32).
+//   - A Move `UID`/`ID`/`address` serializes as a fixed 32-byte value (no length prefix).
+//   - `token_registry::Key<C>` is an empty Move struct, which Sui serializes as a single
+//     `dummy_field: bool` (1 byte).
+
+// wormhole::bytes32::Bytes32 { data: vector<u8> }
+type suiBytes32 struct {
+	Data []byte
 }
 
-// This struct defines the standard properties that get returned from the RPC.
-// It includes the ErrorMessage and Error fields as well, with a standard implementation
-// of a `GetError()` function. `suiApiRequest` requires `GetError()` for standard
-// API error handling.
-type SuiApiStandardResponse struct {
-	Jsonrpc string `json:"jsonrpc"`
-	ID      int    `json:"id"`
-	// error_msg is typically populated when a non-api-related error occurs (like ratelimiting)
-	ErrorMessage *string `json:"error_msg"`
-	// error is typically populated when an api-related error occurs
-	Error *struct {
-		Code    int    `json:"code"`
-		Message string `json:"message"`
-	} `json:"error"`
+// wormhole::external_address::ExternalAddress { value: Bytes32 }
+type suiExternalAddress struct {
+	Value suiBytes32
 }
 
-func (e SuiApiStandardResponse) GetError() error {
-	if e.ErrorMessage != nil {
-		return fmt.Errorf("error from Sui RPC: %s", *e.ErrorMessage)
-	}
-
-	if e.Error != nil {
-		return fmt.Errorf("error from Sui RPC: %s", e.Error.Message)
-	}
-
-	return nil
+//	token_bridge::native_asset::NativeAsset<C> {
+//		custody: Balance<C>,            // serialized as u64
+//		token_address: ExternalAddress,
+//		decimals: u8,
+//	}
+type suiNativeAsset struct {
+	Custody      uint64
+	TokenAddress suiExternalAddress
+	Decimals     uint8
 }
 
-// The response object for suix_queryEvents
-type SuiQueryEventsResponse struct {
-	SuiApiStandardResponse
-	Result SuiQueryEventsResult `json:"result"`
+//	token_bridge::wrapped_asset::ForeignInfo<C> {
+//		token_chain: u16,
+//		token_address: ExternalAddress,
+//		native_decimals: u8,
+//		symbol: String,                // serialized as vector<u8>
+//	}
+type suiForeignInfo struct {
+	TokenChain     uint16
+	TokenAddress   suiExternalAddress
+	NativeDecimals uint8
+	Symbol         []byte
 }
 
-type SuiQueryEventsResult struct {
-	Data []SuiEvent `json:"data"`
+// 0x2::coin::TreasuryCap<C> { id: UID, total_supply: Supply<C> }.
+// UID serializes as a 32-byte address and Supply<C> as a u64.
+type suiTreasuryCap struct {
+	ID          [32]byte
+	TotalSupply uint64
 }
 
-type SuiEvent struct {
-	ID struct {
-		TxDigest *string `json:"txDigest"`
-		EventSeq *string `json:"eventSeq"`
-	} `json:"id"`
-	PackageID         *string `json:"packageId"`
-	TransactionModule *string `json:"transactionModule"`
-	Sender            *string `json:"sender"`
-	Type              *string `json:"type"`
-	// Bcs               *string          `json:"bcs"`
-	Timestamp  *string          `json:"timestampMs"`
-	ParsedJson *json.RawMessage `json:"parsedJson"`
+//	token_bridge::wrapped_asset::WrappedAsset<C> {
+//		info: ForeignInfo<C>,
+//		treasury_cap: TreasuryCap<C>,
+//		decimals: u8,
+//		upgrade_cap: UpgradeCap,        // trailing; not needed and left undecoded
+//	}
+type suiWrappedAsset struct {
+	Info        suiForeignInfo
+	TreasuryCap suiTreasuryCap
+	Decimals    uint8
 }
 
-// The response object for sui_GetTransactionBlock
-type SuiGetTransactionBlockResponse struct {
-	SuiApiStandardResponse
-	Result SuiGetTransactionBlockResult `json:"result"`
+//	0x2::dynamic_field::Field<Name, Value> {
+//		id: UID,        // 32-byte address
+//		name: Name,     // token_registry::Key<C>, an empty struct -> 1-byte dummy bool
+//		value: Value,
+//	}
+type suiNativeAssetField struct {
+	ID    [32]byte
+	Name  bool
+	Value suiNativeAsset
 }
 
-type SuiGetTransactionBlockResult struct {
-	ObjectChanges []ObjectChange `json:"objectChanges"`
-	Events        []SuiEvent     `json:"events"`
+type suiWrappedAssetField struct {
+	ID    [32]byte
+	Name  bool
+	Value suiWrappedAsset
 }
 
-type ObjectChange struct {
-	ObjectType      string `json:"objectType"`
-	ObjectId        string `json:"objectId"`
-	Version         string `json:"version"`
-	PreviousVersion string `json:"previousVersion"`
-}
-
-// Validate the type information of the object change. The following checks are performed:
-//   - pass the object through a regex that extracts the package ID, coin type, and asset type
-//   - ensure that the asset type is wrapped or native
-//   - ensure that the package IDs match the expected package ID
-//   - ensure that the coin types match
-func (o ObjectChange) ValidateTypeInformation(expectedPackageId string) (success bool) {
-	// AI generated regex
-	re := regexp.MustCompile(`^0x2::dynamic_field::Field<([^:]+)::token_registry::Key<([^>]+)>, ([^:]+)::([^<]+)<([^>]+)>>$`)
-	matches := re.FindStringSubmatch(o.ObjectType)
-
-	if len(matches) == 6 {
-		scanPackage1 := matches[1]
-		scanCoinType1 := matches[2]
-		scanPackage2 := matches[3]
-		scanAssetType := matches[4]
-		scanCoinType2 := matches[5]
-
-		// Ensure that the asset type is wrapped or native
-		if scanAssetType != "wrapped_asset::WrappedAsset" && scanAssetType != "native_asset::NativeAsset" {
-			return false
-		}
-
-		// Ensure that the package IDs match the expected package ID
-		if scanPackage1 != expectedPackageId || scanPackage2 != expectedPackageId {
-			return false
-		}
-
-		// Ensure that the coin types match
-		if scanCoinType1 != scanCoinType2 {
-			return false
-		}
-
-		return true
-	}
-
-	// No matches were found
-	return false
-}
-
-// The response object for suix_tryMultiGetPastObjects
-type SuiTryMultiGetPastObjectsResponse struct {
-	SuiApiStandardResponse
-	Result [2]SuiTryMultiGetPastObjectsResult `json:"result"`
-}
-
-// Gets the balance difference of the two result objects.
-func (r SuiTryMultiGetPastObjectsResponse) GetBalanceChange() (*big.Int, error) {
-
-	if len(r.Result) != 2 {
-		return nil, fmt.Errorf("incorrect number of objects in Result")
-	}
-
-	// Determine if the asset is wrapped or native. It's only necessary to check if one asset
-	// is wrapped, since `TryMultiGetPastObjects` queries only a single object ID.
-	isWrapped, err := r.Result[0].IsWrapped()
-	if err != nil {
-		return nil, fmt.Errorf("Error checking if object is wrapped: %w", err)
-	}
-
-	oldBalance, err := r.Result[1].GetVersionBalance(isWrapped)
-	if err != nil {
-		return nil, fmt.Errorf("Error getting old balance: %w", err)
-	}
-
-	newBalance, err := r.Result[0].GetVersionBalance(isWrapped)
-	if err != nil {
-		return nil, fmt.Errorf("Error getting new balance: %w", err)
-	}
-
-	// NOTE: newBalance is also modified by this operation, so care should be taken if future changes
-	// relies on the original value of newBalance.
-	difference := newBalance.Sub(newBalance, oldBalance)
-
-	// If the asset is wrapped, it means that the balance should have been burned, implying a reduction
-	// in total supply. Hence, the difference is negative and the sign needs to be inverted.
-	if isWrapped {
-		difference.Neg(difference)
-	}
-
-	return difference, nil
-}
-
-// Gets the decimals
-func (r SuiTryMultiGetPastObjectsResponse) GetDecimals() (uint8, error) {
-	decimals0, err0 := r.Result[0].GetDecimals()
-	decimals1, err1 := r.Result[1].GetDecimals()
-
-	if err0 != nil {
-		return 0, fmt.Errorf("Error getting decimals: %w", err0)
-	} else if err1 != nil {
-		return 0, fmt.Errorf("Error getting decimals: %w", err1)
-	} else if decimals0 != decimals1 {
-		return 0, fmt.Errorf("decimals do not match")
-	}
-
-	return decimals0, nil
-}
-
-func (r SuiTryMultiGetPastObjectsResponse) GetTokenAddress() (string, error) {
-	tokenAddress0, err0 := r.Result[0].GetTokenAddress()
-	tokenAddress1, err1 := r.Result[1].GetTokenAddress()
-
-	if err0 != nil {
-		return "", fmt.Errorf("Error getting token address: %w", err0)
-	} else if err1 != nil {
-		return "", fmt.Errorf("Error getting token address: %w", err1)
-	} else if tokenAddress0 != tokenAddress1 {
-		return "", fmt.Errorf("token addresses do not match")
-	}
-
-	return tokenAddress0, nil
-}
-
-func (r SuiTryMultiGetPastObjectsResponse) GetTokenChain() (vaa.ChainID, error) {
-	chain0, err0 := r.Result[0].GetTokenChain()
-	chain1, err1 := r.Result[1].GetTokenChain()
-
-	if err0 != nil {
-		return 0, fmt.Errorf("Error getting token chain: %w", err0)
-	} else if err1 != nil {
-		return 0, fmt.Errorf("Error getting token chain: %w", err1)
-	} else if chain0 != chain1 {
-		return 0, fmt.Errorf("token chain ids do not match")
-	}
-
-	return chain0, nil
-}
-
-func (r SuiTryMultiGetPastObjectsResponse) GetObjectId() (string, error) {
-	objectId, err := r.Result[0].GetObjectId()
-	if err != nil {
-		return "", fmt.Errorf("could not get object id")
-	}
-
-	return objectId, nil
-}
-
-func (r SuiTryMultiGetPastObjectsResponse) GetVersion() (string, error) {
-	version, err := r.Result[0].GetVersion()
-	if err != nil {
-		return "", fmt.Errorf("could not get object id")
-	}
-
-	return version, nil
-}
-
-func (r SuiTryMultiGetPastObjectsResponse) GetPreviousVersion() (string, error) {
-	previousVersion, err := r.Result[1].GetVersion()
-	if err != nil {
-		return "", fmt.Errorf("could not get object id")
-	}
-
-	return previousVersion, nil
-}
-
-func (r SuiTryMultiGetPastObjectsResponse) GetObjectType() (string, error) {
-	type0, err0 := r.Result[0].GetObjectType()
-	type1, err1 := r.Result[1].GetObjectType()
-
-	if err0 != nil {
-		return "", fmt.Errorf("Error getting token chain: %w", err0)
-	} else if err1 != nil {
-		return "", fmt.Errorf("Error getting token chain: %w", err1)
-	} else if type0 != type1 {
-		return "", fmt.Errorf("token chain ids do not match")
-	}
-
-	return type0, nil
-}
-
-// The result object for suix_tryMultiGetPastObjects.
-type SuiTryMultiGetPastObjectsResult struct {
-	Status  string          `json:"status"`
-	Details json.RawMessage `json:"details"`
-}
-
-// Check if the result object is wrapped.
-func (r SuiTryMultiGetPastObjectsResult) IsWrapped() (bool, error) {
-	path := "content.type"
-	objectType, err := extractFromJsonPath[string](r.Details, path)
-
-	if err != nil {
-		return false, fmt.Errorf("Error extracting object type: %w", err)
-	}
-
-	return strings.Contains(objectType, "wrapped_asset::WrappedAsset"), nil
-}
-
-// Get the balance of the result object.
-func (r SuiTryMultiGetPastObjectsResult) GetVersionBalance(isWrapped bool) (*big.Int, error) {
-
-	var path string
-	supplyInt := big.NewInt(0)
-
-	// The path to use for a native asset
-	pathNative := "content.fields.value.fields.custody"
-
-	// The path to use for a wrapped asset
-	pathWrapped := "content.fields.value.fields.treasury_cap.fields.total_supply.fields.value"
-
-	if isWrapped {
-		path = pathWrapped
-	} else {
-		path = pathNative
-	}
-
-	supply, err := extractFromJsonPath[string](r.Details, path)
-
-	if err != nil {
-		return supplyInt, fmt.Errorf("Error extracting wormhole balance: %w", err)
-	}
-
-	supplyInt, success := supplyInt.SetString(supply, 10)
-
-	if !success {
-		return supplyInt, fmt.Errorf("error converting supply to int: %w", err)
-	}
-
-	return supplyInt, nil
-}
-
-// Get the result object's decimals.
-func (r SuiTryMultiGetPastObjectsResult) GetDecimals() (uint8, error) {
-	// token_bridge::wrapped_asset::decimals() and token_bridge::native_asset::decimals()
-	// both store the decimals used for truncation in the NativeAsset or WrappedAsset's `decimals()` field
-	path := "content.fields.value.fields.decimals"
-
-	decimals, err := extractFromJsonPath[float64](r.Details, path)
-
-	if err != nil {
-		return 0, fmt.Errorf("Error extracting decimals: %w", err)
-	}
-
-	return uint8(decimals), nil
-}
-
-// Get the result object's token address. This will be the address of the token
-// on its origin chain.
-func (r SuiTryMultiGetPastObjectsResult) GetTokenAddress() (tokenAddress string, err error) {
-	var path string
-
-	// The path to use for a native asset
-	pathNative := "content.fields.value.fields.token_address.fields.value.fields.data"
-
-	// The path to use for a wrapped asset
-	pathWrapped := "content.fields.value.fields.info.fields.token_address.fields.value.fields.data"
-
-	wrapped, err := r.IsWrapped()
-
-	if err != nil {
-		return "", fmt.Errorf("Error checking if object is wrapped: %w", err)
-	}
-
-	if wrapped {
-		path = pathWrapped
-	} else {
-		path = pathNative
-	}
-
-	data, err := extractFromJsonPath[[]interface{}](r.Details, path)
-
-	if err != nil {
-		return "", fmt.Errorf("Error extracting token address: %w", err)
-	}
-
-	// data is of type []interface{}, and each element is of type float64.
-	// We need to convert each element to a byte, and then convert the []byte to a hex string.
-	addrBytes := make([]byte, len(data))
-
-	for i, v := range data {
-		if f, ok := v.(float64); ok {
-			addrBytes[i] = byte(f)
-		} else {
-			return "", fmt.Errorf("Error converting token data to float type")
-		}
-	}
-
-	return hex.EncodeToString(addrBytes), nil
-}
-
-// Get the token's chain ID. This will be the chain ID of the network the token
-// originated from.
-func (r SuiTryMultiGetPastObjectsResult) GetTokenChain() (vaa.ChainID, error) {
-
-	wrapped, err := r.IsWrapped()
-
-	if err != nil {
-		return 0, fmt.Errorf("Error checking if object is wrapped: %w", err)
-	}
-
-	if !wrapped {
-		return vaa.ChainIDSui, nil
-	}
-
-	path := "content.fields.value.fields.info.fields.token_chain"
-
-	chain, err := extractFromJsonPath[float64](r.Details, path)
-
-	if err != nil {
-		return 0, fmt.Errorf("Error extracting chain: %w", err)
-	}
-
-	if float64(uint16(chain)) != chain {
-		return 0, fmt.Errorf("failed to cast chain ID: %f", chain)
-	}
-
-	chainId, err := vaa.KnownChainIDFromNumber(uint16(chain))
-
-	if err != nil {
-		return 0, fmt.Errorf("Error converting chain to known chain id: %w", err)
-	}
-
-	return chainId, nil
-}
-
-func (r SuiTryMultiGetPastObjectsResult) GetObjectId() (string, error) {
-	path := "objectId"
-
-	objectId, err := extractFromJsonPath[string](r.Details, path)
-
-	if err != nil {
-		return "", fmt.Errorf("Error extracting objectId: %w", err)
-	}
-
-	return objectId, nil
-}
-
-func (r SuiTryMultiGetPastObjectsResult) GetVersion() (string, error) {
-	path := "version"
-
-	version, err := extractFromJsonPath[string](r.Details, path)
-
-	if err != nil {
-		return "", fmt.Errorf("Error extracting version: %w", err)
-	}
-
-	return version, nil
-}
-
-func (r SuiTryMultiGetPastObjectsResult) GetObjectType() (string, error) {
-	path := "type"
-
-	objectType, err := extractFromJsonPath[string](r.Details, path)
-
-	if err != nil {
-		return "", fmt.Errorf("Error extracting type: %w", err)
-	}
-
-	return objectType, nil
-}
-
-// Definition of the WormholeMessage event
+// WormholeMessage mirrors the on-chain `publish_message::WormholeMessage` event emitted by
+// the Sui core bridge. Field order and types must match the Move struct exactly so that BCS
+// decoding of the gRPC event contents succeeds.
 type WormholeMessage struct {
-	ConsistencyLevel *uint8  `json:"consistency_level"`
-	Nonce            *uint32 `json:"nonce"`
-	Payload          []byte  `json:"payload"`
-	Sender           *string `json:"sender"`
-	Sequence         *string `json:"sequence"`
-	Timestamp        *string `json:"timestamp"`
+	Sender           [32]byte
+	Sequence         uint64
+	Nonce            uint32
+	Payload          []byte
+	ConsistencyLevel uint8
+	Timestamp        uint64
+}
+
+// suiAssetInfo is the normalized token-registry asset data extracted from an object's BCS
+// contents. The balance is the custodied amount for native assets, or the wrapped token's
+// total supply for wrapped assets.
+type suiAssetInfo struct {
+	isWrapped    bool
+	decimals     uint8
+	tokenAddress string // hex-encoded, without a 0x prefix
+	tokenChain   vaa.ChainID
+	balance      *big.Int
+}
+
+// suiDynamicFieldTypeRegex matches a token-registry dynamic field object type of the form
+//
+//	0x...2::dynamic_field::Field<<pkg>::token_registry::Key<<coin>>,<pkg>::<asset>::<Asset><<coin>>>
+//
+// The framework address may be abbreviated (0x2) or fully padded (0x000...0002), and the
+// comma separating the two type arguments may or may not be followed by whitespace; the gRPC
+// API uses the padded address and no space, whereas the legacy JSON-RPC API used the short
+// form and a trailing space.
+var suiDynamicFieldTypeRegex = regexp.MustCompile(`^0x0*2::dynamic_field::Field<([^:]+)::token_registry::Key<([^>]+)>,\s*([^:]+)::([^<]+)<([^>]+)>>$`)
+
+// validateSuiAssetType validates the type information of a token-registry dynamic field object.
+// The following checks are performed:
+//   - the type matches the token-registry dynamic field shape
+//   - the asset type is a wrapped or native token-bridge asset
+//   - both package IDs match the expected token bridge package ID
+//   - the coin type referenced by the field key matches the coin type of the asset value
+func validateSuiAssetType(objectType string, expectedPackageId string) bool {
+	matches := suiDynamicFieldTypeRegex.FindStringSubmatch(objectType)
+
+	if len(matches) != 6 {
+		return false
+	}
+
+	scanPackage1 := matches[1]
+	scanCoinType1 := matches[2]
+	scanPackage2 := matches[3]
+	scanAssetType := matches[4]
+	scanCoinType2 := matches[5]
+
+	// Ensure that the asset type is wrapped or native
+	if scanAssetType != "wrapped_asset::WrappedAsset" && scanAssetType != "native_asset::NativeAsset" {
+		return false
+	}
+
+	// Ensure that the package IDs match the expected package ID
+	if scanPackage1 != expectedPackageId || scanPackage2 != expectedPackageId {
+		return false
+	}
+
+	// Ensure that the coin types match
+	if scanCoinType1 != scanCoinType2 {
+		return false
+	}
+
+	return true
+}
+
+// decodeSuiAssetObject decodes a token-registry dynamic field object's BCS contents into
+// normalized asset info. `objectType` is used to decide whether the field value is a native
+// or wrapped asset.
+func decodeSuiAssetObject(objectType string, contents []byte) (*suiAssetInfo, error) {
+	switch {
+	case strings.Contains(objectType, "wrapped_asset::WrappedAsset"):
+		field, err := suiclient.DecodeBcs[suiWrappedAssetField](contents)
+		if err != nil {
+			return nil, fmt.Errorf("failed to BCS-decode WrappedAsset: %w", err)
+		}
+
+		chain, err := vaa.KnownChainIDFromNumber(field.Value.Info.TokenChain)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert token chain %d to a known chain id: %w", field.Value.Info.TokenChain, err)
+		}
+
+		return &suiAssetInfo{
+			isWrapped:    true,
+			decimals:     field.Value.Decimals,
+			tokenAddress: hex.EncodeToString(field.Value.Info.TokenAddress.Value.Data),
+			tokenChain:   chain,
+			balance:      new(big.Int).SetUint64(field.Value.TreasuryCap.TotalSupply),
+		}, nil
+
+	case strings.Contains(objectType, "native_asset::NativeAsset"):
+		field, err := suiclient.DecodeBcs[suiNativeAssetField](contents)
+		if err != nil {
+			return nil, fmt.Errorf("failed to BCS-decode NativeAsset: %w", err)
+		}
+
+		return &suiAssetInfo{
+			isWrapped:    false,
+			decimals:     field.Value.Decimals,
+			tokenAddress: hex.EncodeToString(field.Value.TokenAddress.Value.Data),
+			tokenChain:   vaa.ChainIDSui,
+			balance:      new(big.Int).SetUint64(field.Value.Custody),
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("object type is neither a native nor wrapped token-bridge asset: %s", objectType)
+	}
 }

--- a/node/pkg/txverifier/suitypes.go
+++ b/node/pkg/txverifier/suitypes.go
@@ -52,7 +52,7 @@ type suiNativeAsset struct {
 //		symbol: String,                // serialized as vector<u8>
 //	}
 type suiForeignInfo struct {
-	TokenChain     uint16
+	TokenChain     vaa.ChainID
 	TokenAddress   suiExternalAddress
 	NativeDecimals uint8
 	Symbol         []byte
@@ -83,15 +83,15 @@ type suiWrappedAsset struct {
 //		value: Value,
 //	}
 type suiNativeAssetField struct {
-	ID    [32]byte
-	Name  bool
-	Value suiNativeAsset
+	ID        [32]byte
+	DummyName bool
+	Value     suiNativeAsset
 }
 
 type suiWrappedAssetField struct {
-	ID    [32]byte
-	Name  bool
-	Value suiWrappedAsset
+	ID        [32]byte
+	DummyName bool
+	Value     suiWrappedAsset
 }
 
 // WormholeMessage mirrors the on-chain `publish_message::WormholeMessage` event emitted by

--- a/node/pkg/watchers/sui/watcher.go
+++ b/node/pkg/watchers/sui/watcher.go
@@ -54,6 +54,7 @@ type (
 		obsvReqC      <-chan *gossipv1.ObservationRequest
 		readinessSync readiness.Component
 
+		// Note: suiclient.SuiClient is an interface. A `nil` check is therefore fine for checking initialization.
 		suiClient suiclient.SuiClient
 
 		// Sui transaction verifier

--- a/node/pkg/watchers/sui/watcher.go
+++ b/node/pkg/watchers/sui/watcher.go
@@ -169,7 +169,7 @@ func (e *Watcher) processEvent(ctx context.Context, logger *zap.Logger, event su
 	msg, err := suiclient.DecodeBcs[txverifier.WormholeMessage](event.BcsBytes)
 	if err != nil {
 		p2p.DefaultRegistry.AddErrorCount(vaa.ChainIDSui, 1)
-		return fmt.Errorf("processEvent failed to BCS-decode WormholeMessage: %w", err)
+		return fmt.Errorf("processEvent failed to decode WormholeMessage BCS bytes: %w", err)
 	}
 
 	txHashBytes, err := base58.Decode(txDigest)
@@ -374,7 +374,7 @@ func (e *Watcher) Run(ctx context.Context) error {
 				} else if checkpoint.SequenceNumber == nil {
 					logger.Error("latest checkpoint response missing sequence number")
 				} else {
-					height := int64(*checkpoint.SequenceNumber) // #nosec G115 -- Sui checkpoint sequence numbers will not exceed int64 for the foreseeable future
+					height := int64(*checkpoint.SequenceNumber) // #nosec G115 -- Sui checkpoint sequence numbers will not exceed math.MaxInt64 for the foreseeable future
 					currentSuiHeight.Set(float64(*checkpoint.SequenceNumber))
 					logger.Debug("sui_getLatestCheckpointSequenceNumber", zap.Int64("result", height))
 

--- a/node/pkg/watchers/sui/watcher.go
+++ b/node/pkg/watchers/sui/watcher.go
@@ -5,24 +5,24 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"net/http"
-	"strconv"
 	"strings"
 	"time"
 
 	"encoding/hex"
-	"encoding/json"
 
 	"github.com/certusone/wormhole/node/pkg/common"
 	"github.com/certusone/wormhole/node/pkg/p2p"
 	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
 	"github.com/certusone/wormhole/node/pkg/readiness"
+	"github.com/certusone/wormhole/node/pkg/suiclient"
 	"github.com/certusone/wormhole/node/pkg/supervisor"
 	"github.com/certusone/wormhole/node/pkg/watchers"
 
 	eth_common "github.com/ethereum/go-ethereum/common"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/mr-tron/base58"
 	"github.com/wormhole-foundation/wormhole/sdk"
@@ -32,6 +32,16 @@ import (
 	txverifier "github.com/certusone/wormhole/node/pkg/txverifier"
 )
 
+// suiGrpcDialOpts returns the gRPC dial options for connecting to the Sui endpoint. In unsafe
+// dev mode the local Sui node serves plaintext gRPC, so TLS is disabled; otherwise the default
+// (TLS) transport configured by suiclient.NewSuiGrpcClient is used.
+func suiGrpcDialOpts(unsafeDevMode bool) []grpc.DialOption {
+	if unsafeDevMode {
+		return []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
+	}
+	return nil
+}
+
 type (
 	// Watcher is responsible for looking over Sui blockchain and reporting new transactions to the wormhole contract
 	Watcher struct {
@@ -40,128 +50,15 @@ type (
 
 		unsafeDevMode bool
 
-		msgChan                   chan<- *common.MessagePublication
-		obsvReqC                  <-chan *gossipv1.ObservationRequest
-		readinessSync             readiness.Component
-		latestProcessedCheckpoint int64
-		maximumBatchSize          int
-		descendingOrder           bool
-		loopDelay                 time.Duration
-		queryEventsCmd            string
-		postTimeout               time.Duration
+		msgChan       chan<- *common.MessagePublication
+		obsvReqC      <-chan *gossipv1.ObservationRequest
+		readinessSync readiness.Component
+
+		suiClient suiclient.SuiClient
 
 		// Sui transaction verifier
 		suiTxVerifier     *txverifier.SuiTransferVerifier
 		txVerifierEnabled bool
-	}
-
-	SuiEventResponse struct {
-		Jsonrpc string               `json:"jsonrpc"`
-		Result  SuiEventResponseData `json:"result"`
-		ID      int                  `json:"id"`
-	}
-	SuiEventResponseData struct {
-		Data       []SuiResult `json:"data"`
-		NextCursor struct {
-			TxDigest string `json:"txDigest"`
-			EventSeq string `json:"eventSeq"`
-		} `json:"nextCursor"`
-		HasNextPage bool `json:"hasNextPage"`
-	}
-
-	SuiResultInfo struct {
-		result     SuiResult
-		checkpoint int64
-	}
-
-	FieldsData struct {
-		ConsistencyLevel *uint8  `json:"consistency_level"`
-		Nonce            *uint32 `json:"nonce"`
-		Payload          []byte  `json:"payload"`
-		Sender           *string `json:"sender"`
-		// Sui's JSON-RPC encodes this on-chain u64 as a quoted decimal string in parsedJson.
-		Sequence *uint64 `json:"sequence,string"`
-		// Sui's JSON-RPC encodes this on-chain u64 as a quoted decimal string in parsedJson.
-		Timestamp *uint64 `json:"timestamp,string"`
-	}
-
-	SuiResult struct {
-		ID struct {
-			TxDigest *string `json:"txDigest"`
-			EventSeq *string `json:"eventSeq"`
-		} `json:"id"`
-		PackageID         *string          `json:"packageId"`
-		TransactionModule *string          `json:"transactionModule"`
-		Sender            *string          `json:"sender"`
-		Type              *string          `json:"type"`
-		Bcs               *string          `json:"bcs"`
-		Timestamp         *string          `json:"timestampMs"`
-		Fields            *json.RawMessage `json:"parsedJson"`
-	}
-
-	SuiEventError struct {
-		Code    int64  `json:"code"`
-		Message string `json:"message"`
-	}
-
-	SuiEventMsg struct {
-		Jsonrpc string         `json:"jsonrpc"`
-		Method  *string        `json:"method"`
-		ID      *int64         `json:"id"`
-		Error   *SuiEventError `json:"error"`
-		Params  *struct {
-			Subscription int64      `json:"subscription"`
-			Result       *SuiResult `json:"result"`
-		} `json:"params"`
-	}
-
-	SuiTxnQueryError struct {
-		Jsonrpc string `json:"jsonrpc"`
-		Error   struct {
-			Code    int     `json:"code"`
-			Message *string `json:"message"`
-		} `json:"error"`
-		ID int `json:"id"`
-	}
-
-	SuiTxnQuery struct {
-		Jsonrpc string      `json:"jsonrpc"`
-		Result  []SuiResult `json:"result"`
-		ID      int         `json:"id"`
-	}
-
-	SuiCheckpointSN struct {
-		Jsonrpc string `json:"jsonrpc"`
-		Result  string `json:"result"`
-		ID      int    `json:"id"`
-	}
-
-	GetCheckpointResponse struct {
-		Jsonrpc string `json:"jsonrpc"`
-		Result  struct {
-			Digest      string `json:"digest"`
-			TimestampMs string `json:"timestampMs"`
-			Checkpoint  string `json:"checkpoint"`
-		} `json:"result"`
-		ID int `json:"id"`
-	}
-
-	RequestPayload struct {
-		JSONRPC string     `json:"jsonrpc"`
-		ID      int        `json:"id"`
-		Method  string     `json:"method"`
-		Params  [][]string `json:"params"`
-	}
-
-	TxBlockResult struct {
-		Digest      string `json:"digest"`
-		TimestampMs string `json:"timestampMs"`
-		Checkpoint  string `json:"checkpoint"`
-	}
-
-	MultipleBlockResult struct {
-		Jsonrpc string          `json:"jsonrpc"`
-		Result  []TxBlockResult `json:"result"`
 	}
 )
 
@@ -193,9 +90,6 @@ func NewWatcher(
 	env common.Environment,
 	txVerifierEnabled bool,
 ) (*Watcher, error) {
-	maxBatchSize := 10
-	descOrder := true
-
 	var suiTxVerifier *txverifier.SuiTransferVerifier
 
 	if txVerifierEnabled {
@@ -232,85 +126,54 @@ func NewWatcher(
 			suiTokenBridgeEmitter = "0x" + hex.EncodeToString(sdk.KnownTokenbridgeEmitters[vaa.ChainIDSui])
 		}
 
-		// Create the Sui Api connection, and query the state object to get the token bridge address and emitter.
-		suiApiConnection := txverifier.NewSuiApiConnection(suiRPC)
+		// Create the Sui gRPC client used by the transfer verifier to query transactions and objects.
+		suiClient, err := suiclient.NewSuiGrpcClient(suiRPC, nil, suiGrpcDialOpts(unsafeDevMode)...)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create Sui gRPC client for transfer verifier: %w", err)
+		}
 
 		// Create the new suiTxVerifier
 		suiTxVerifier = txverifier.NewSuiTransferVerifier(
 			suiCoreBridgePackageId,
 			suiTokenBridgeEmitter,
 			suiTokenBridgePackageId,
-			suiApiConnection,
+			suiClient,
 		)
 
 	}
 
 	return &Watcher{
-		suiRPC:                    suiRPC,
-		suiMoveEventType:          suiMoveEventType,
-		unsafeDevMode:             unsafeDevMode,
-		msgChan:                   messageEvents,
-		obsvReqC:                  obsvReqC,
-		readinessSync:             common.MustConvertChainIdToReadinessSyncing(vaa.ChainIDSui),
-		latestProcessedCheckpoint: 0,
-		maximumBatchSize:          maxBatchSize,
-		descendingOrder:           descOrder,   // Retrieve newest events first
-		loopDelay:                 time.Second, // SUI produces a checkpoint every ~3 seconds
-		queryEventsCmd: fmt.Sprintf(`{"jsonrpc":"2.0", "id": 1, "method": "suix_queryEvents", "params": [{ "MoveEventType": "%s" }, null, %d, %t]}`,
-			suiMoveEventType, maxBatchSize, descOrder),
-		postTimeout:       time.Second * 5,
+		suiRPC:            suiRPC,
+		suiMoveEventType:  suiMoveEventType,
+		unsafeDevMode:     unsafeDevMode,
+		msgChan:           messageEvents,
+		obsvReqC:          obsvReqC,
+		readinessSync:     common.MustConvertChainIdToReadinessSyncing(vaa.ChainIDSui),
 		suiTxVerifier:     suiTxVerifier,
 		txVerifierEnabled: txVerifierEnabled,
 	}, nil
 }
 
-func (e *Watcher) inspectBody(ctx context.Context, logger *zap.Logger, body SuiResult, isReobservation bool) error {
-	if body.ID.TxDigest == nil {
-		return errors.New("missing TxDigest field")
-	}
-	if body.Type == nil {
-		return errors.New("missing Type field")
-	}
-
-	// There may be moveEvents caught without these params.
-	// So, not necessarily an error.
-	if body.Fields == nil {
+// processEvent decodes a single Sui gRPC event into a Wormhole MessagePublication and,
+// after optional transfer verification, publishes it to the message channel. `txDigest`
+// is the base58-encoded Sui transaction digest the event belongs to; it is supplied
+// explicitly because gRPC events fetched via GetTransaction do not carry it.
+func (e *Watcher) processEvent(ctx context.Context, logger *zap.Logger, event suiclient.SuiEvent, txDigest string, isReobservation bool) error {
+	// The subscription is already filtered by event type, but reobservation returns every
+	// event in the transaction, so re-check the type here before decoding.
+	if event.EventType != e.suiMoveEventType {
 		return nil
 	}
 
-	if e.suiMoveEventType != *body.Type {
-		logger.Info("type mismatch", zap.String("e.suiMoveEventType", e.suiMoveEventType), zap.String("type", *body.Type))
-		return nil
-	}
-
-	// Now that we know this is a wormhole event, we can unmarshal the specifics.
-	var fields FieldsData
-	err := json.Unmarshal(*body.Fields, &fields)
+	msg, err := suiclient.DecodeBcs[txverifier.WormholeMessage](event.BcsBytes)
 	if err != nil {
-		logger.Error("failed to unmarshal FieldsData", zap.String("SuiResult.Fields", string(*body.Fields)), zap.Error(err))
 		p2p.DefaultRegistry.AddErrorCount(vaa.ChainIDSui, 1)
-		return fmt.Errorf("inspectBody failed to unmarshal FieldsData: %w", err)
+		return fmt.Errorf("processEvent failed to BCS-decode WormholeMessage: %w", err)
 	}
 
-	// Check if all required fields exist
-	if fields.ConsistencyLevel == nil ||
-		fields.Nonce == nil ||
-		fields.Payload == nil ||
-		fields.Sender == nil ||
-		fields.Sequence == nil ||
-		fields.Timestamp == nil {
-		logger.Info("Missing required fields in event.")
-		return nil
-	}
-
-	emitter, err := vaa.StringToAddress(*fields.Sender)
+	txHashBytes, err := base58.Decode(txDigest)
 	if err != nil {
-		return err
-	}
-
-	txHashBytes, err := base58.Decode(*body.ID.TxDigest)
-	if err != nil {
-		return err
+		return fmt.Errorf("processEvent failed to base58-decode txDigest %s: %w", txDigest, err)
 	}
 
 	if len(txHashBytes) != 32 {
@@ -318,7 +181,7 @@ func (e *Watcher) inspectBody(ctx context.Context, logger *zap.Logger, body SuiR
 			"Transaction hash is not 32 bytes",
 			zap.String("error_type", "malformed_wormhole_event"),
 			zap.String("log_msg_type", "tx_processing_error"),
-			zap.String("txHash", *body.ID.TxDigest),
+			zap.String("txHash", txDigest),
 		)
 		return errors.New("transaction hash is not 32 bytes")
 	}
@@ -327,25 +190,23 @@ func (e *Watcher) inspectBody(ctx context.Context, logger *zap.Logger, body SuiR
 
 	observation := &common.MessagePublication{
 		TxID:             txHashEthFormat.Bytes(),
-		Timestamp:        time.Unix(int64(*fields.Timestamp), 0), // #nosec G115 -- This conversion is safe indefinitely
-		Nonce:            *fields.Nonce,
-		Sequence:         *fields.Sequence,
+		Timestamp:        time.Unix(int64(msg.Timestamp), 0), // #nosec G115 -- This conversion is safe indefinitely
+		Nonce:            msg.Nonce,
+		Sequence:         msg.Sequence,
 		EmitterChain:     vaa.ChainIDSui,
-		EmitterAddress:   emitter,
-		Payload:          fields.Payload,
-		ConsistencyLevel: *fields.ConsistencyLevel,
+		EmitterAddress:   vaa.Address(msg.Sender),
+		Payload:          msg.Payload,
+		ConsistencyLevel: msg.ConsistencyLevel,
 		IsReobservation:  isReobservation,
 		Unreliable:       false,
 	}
 
 	// Verifies the observation through the Sui transaction verifier, if enabled, followed
 	// by publishing the observation to the message channel.
-	err = e.verifyAndPublish(ctx, observation, *body.ID.TxDigest, logger)
-
-	if err != nil {
+	if err := e.verifyAndPublish(ctx, observation, txDigest, logger); err != nil {
 		suiTransferVerifierFailures.Inc()
 		logger.Error("Message publication error",
-			zap.String("TxDigest", *body.ID.TxDigest),
+			zap.String("TxDigest", txDigest),
 			zap.Error(err))
 	}
 
@@ -386,6 +247,37 @@ func (e *Watcher) verifyAndPublish(
 	return nil
 }
 
+// handleReobservation fetches the transaction identified by a re-observation request and
+// re-processes each of its Wormhole message events.
+func (e *Watcher) handleReobservation(ctx context.Context, logger *zap.Logger, client suiclient.SuiClient, r *gossipv1.ObservationRequest) {
+	// node/pkg/node/reobserve.go already enforces the chain id is a valid uint16
+	// and only writes to the channel for this chain id.
+	// If either of the below cases are true, something has gone wrong.
+	if r.ChainId > math.MaxUint16 || vaa.ChainID(r.ChainId) != vaa.ChainIDSui {
+		panic("invalid chain ID")
+	}
+
+	tx58 := base58.Encode(r.TxHash)
+
+	txn, err := client.GetTransaction(ctx, tx58, []string{
+		suiclient.TransactionFieldDigest,
+		suiclient.TransactionFieldEvents,
+	})
+	if err != nil {
+		logger.Error("sui_fetch_obvs_req failed", zap.String("txhash", tx58), zap.Error(err))
+		p2p.DefaultRegistry.AddErrorCount(vaa.ChainIDSui, 1)
+		return
+	}
+
+	for i, event := range txn.Events {
+		// Events returned by GetTransaction do not carry their transaction digest, so it is
+		// supplied explicitly here.
+		if err := e.processEvent(ctx, logger, event, tx58, true); err != nil {
+			logger.Info("sui_fetch_obvs_req skipping event data in result", zap.String("txhash", tx58), zap.Int("index", i), zap.Error(err))
+		}
+	}
+}
+
 func (e *Watcher) Run(ctx context.Context) error {
 	p2p.DefaultRegistry.SetNetworkStats(vaa.ChainIDSui, &gossipv1.Heartbeat_Network{
 		ContractAddress: e.suiMoveEventType,
@@ -400,54 +292,69 @@ func (e *Watcher) Run(ctx context.Context) error {
 		zap.Bool("unsafeDevMode", e.unsafeDevMode),
 	)
 
-	// Get the node version for troubleshooting
-	e.logVersion(ctx, logger)
+	// Use an injected client (e.g. from tests) if present, otherwise create one for the
+	// lifetime of this Run. The client is kept local rather than stored on the Watcher so
+	// that each supervisor-driven restart of Run establishes a fresh connection and the
+	// concurrent goroutines below cannot observe a closed or nil client during shutdown.
+	client := e.suiClient
+	if client == nil {
+		grpcClient, err := suiclient.NewSuiGrpcClient(e.suiRPC, logger, suiGrpcDialOpts(e.unsafeDevMode)...)
+		if err != nil {
+			return fmt.Errorf("failed to create Sui gRPC client: %w", err)
+		}
+		client = grpcClient
+		defer func() {
+			if cerr := client.Close(); cerr != nil {
+				logger.Error("failed to close Sui gRPC client", zap.Error(cerr))
+			}
+		}()
+	}
 
-	// Get the latest checkpoint sequence number.  This will be the starting point for the watcher.
-	latest, err := e.getLatestCheckpointSN(ctx, logger)
+	// Get the latest checkpoint sequence number to confirm connectivity before reporting healthy.
+	initialCheckpoint, err := client.GetLatestCheckpoint(ctx, []string{suiclient.CheckpointFieldSequenceNumber})
 	if err != nil {
 		return fmt.Errorf("failed to get latest checkpoint sequence number: %w", err)
+	} else if initialCheckpoint.SequenceNumber == nil {
+		return fmt.Errorf("latest checkpoint response missing sequence number")
 	}
-	e.latestProcessedCheckpoint = latest
+
+	currentSuiHeight.Set(float64(*initialCheckpoint.SequenceNumber))
 
 	timer := time.NewTicker(time.Second * 5)
 	defer timer.Stop()
 
 	errC := make(chan error)
-	pumpData := make(chan []byte)
-	defer close(pumpData)
 
 	supervisor.Signal(ctx, supervisor.SignalHealthy)
 	readiness.SetReady(e.readinessSync)
 
 	common.RunWithScissors(ctx, errC, "sui_data_pump", func(ctx context.Context) error {
+		eventChan := make(chan suiclient.SuiTransactionEvent, 64)
+
+		subscription, err := client.SubscribeToTransactionEvent(ctx, e.suiMoveEventType, eventChan)
+		if err != nil {
+			return fmt.Errorf("sui_data_pump failed to subscribe to events: %w", err)
+		}
+		defer subscription.Unsubscribe()
+
 		for {
 			select {
 			case <-ctx.Done():
 				logger.Error("sui_data_pump context done")
 				return ctx.Err()
 
-			default:
-				dataWithEvents, err := e.getEvents(ctx)
-				if err != nil {
-					logger.Error("sui_data_pump Error", zap.Error(err))
+			case subErr := <-subscription.Err():
+				return fmt.Errorf("sui_data_pump subscription error: %w", subErr)
+
+			case txEvent := <-eventChan:
+				if txEvent.TxDigest == "" {
+					logger.Warn("sui_data_pump received event with empty TxDigest, skipping")
 					continue
 				}
-				// dataWithEvents is in descending order, so we need to process it in reverse order.
-				if len(dataWithEvents) > 0 {
-					for idx := len(dataWithEvents) - 1; idx >= 0; idx-- {
-						event := dataWithEvents[idx]
-						err = e.inspectBody(ctx, logger, event.result, false)
-						if err != nil {
-							logger.Error("inspectBody Error", zap.Error(err))
-							continue
-						}
-						if event.checkpoint > e.latestProcessedCheckpoint {
-							e.latestProcessedCheckpoint = event.checkpoint
-						}
-					}
+
+				if err := e.processEvent(ctx, logger, txEvent.Event, txEvent.TxDigest, false); err != nil {
+					logger.Error("sui_data_pump processEvent error", zap.Error(err))
 				}
-				time.Sleep(e.loopDelay) //nolint:forbidigo // TODO: This code should be refactored to not use time.Sleep
 			}
 		}
 	})
@@ -460,11 +367,14 @@ func (e *Watcher) Run(ctx context.Context) error {
 				return ctx.Err()
 
 			case <-timer.C:
-				height, err := e.getLatestCheckpointSN(ctx, logger)
+				checkpoint, err := client.GetLatestCheckpoint(ctx, []string{suiclient.CheckpointFieldSequenceNumber})
 				if err != nil {
 					logger.Error("Failed to get latest checkpoint sequence number", zap.Error(err))
+				} else if checkpoint.SequenceNumber == nil {
+					logger.Error("latest checkpoint response missing sequence number")
 				} else {
-					currentSuiHeight.Set(float64(height))
+					height := int64(*checkpoint.SequenceNumber) // #nosec G115 -- Sui checkpoint sequence numbers will not exceed int64 for the foreseeable future
+					currentSuiHeight.Set(float64(*checkpoint.SequenceNumber))
 					logger.Debug("sui_getLatestCheckpointSequenceNumber", zap.Int64("result", height))
 
 					p2p.DefaultRegistry.SetNetworkStats(vaa.ChainIDSui, &gossipv1.Heartbeat_Network{
@@ -485,56 +395,7 @@ func (e *Watcher) Run(ctx context.Context) error {
 				logger.Error("sui_fetch_obvs_req context done")
 				return ctx.Err()
 			case r := <-e.obsvReqC:
-				// node/pkg/node/reobserve.go already enforces the chain id is a valid uint16
-				// and only writes to the channel for this chain id.
-				// If either of the below cases are true, something has gone wrong
-				if r.ChainId > math.MaxUint16 || vaa.ChainID(r.ChainId) != vaa.ChainIDSui {
-					panic("invalid chain ID")
-				}
-
-				tx58 := base58.Encode(r.TxHash)
-
-				payload := fmt.Sprintf(`{"jsonrpc":"2.0", "id": 1, "method": "sui_getEvents", "params": ["%s"]}`, tx58)
-
-				body, err := e.createAndExecReq(ctx, payload)
-				if err != nil {
-					logger.Error("sui_fetch_obvs_req failed", zap.Error(err))
-					p2p.DefaultRegistry.AddErrorCount(vaa.ChainIDSui, 1)
-					return fmt.Errorf("sui_fetch_obvs_req failed to create and execute request: %w", err)
-				}
-
-				logger.Debug("receive", zap.String("body", string(body)))
-
-				// Do we have an error?
-				var err_res SuiTxnQueryError
-				err = json.Unmarshal(body, &err_res)
-				if err != nil {
-					logger.Error("sui_fetch_obvs_req failed to unmarshal event error message", zap.String("Result", string(body)))
-					p2p.DefaultRegistry.AddErrorCount(vaa.ChainIDSui, 1)
-					return err
-				}
-
-				if err_res.Error.Message != nil {
-					logger.Error("sui_fetch_obvs_req failed to get events for re-observation request, detected error", zap.String("Result", string(body)))
-					p2p.DefaultRegistry.AddErrorCount(vaa.ChainIDSui, 1)
-					// Don't need to kill the watcher on this error. So, just continue.
-					continue
-				}
-				var res SuiTxnQuery
-				err = json.Unmarshal(body, &res)
-				if err != nil {
-					logger.Error("failed to unmarshal event message", zap.String("body", string(body)), zap.Error(err))
-					p2p.DefaultRegistry.AddErrorCount(vaa.ChainIDSui, 1)
-					return fmt.Errorf("sui_fetch_obvs_req failed to unmarshal: %w", err)
-
-				}
-
-				for i, chunk := range res.Result {
-					err := e.inspectBody(ctx, logger, chunk, true)
-					if err != nil {
-						logger.Info("sui_fetch_obvs_req skipping event data in result", zap.String("txhash", tx58), zap.Int("index", i), zap.Error(err))
-					}
-				}
+				e.handleReobservation(ctx, logger, client, r)
 			}
 		}
 	})
@@ -545,239 +406,4 @@ func (e *Watcher) Run(ctx context.Context) error {
 	case err := <-errC:
 		return err
 	}
-}
-
-func (w *Watcher) getEvents(ctx context.Context) ([]SuiResultInfo, error) {
-	// Only get events newer than the last processed height
-	var retVal []SuiResultInfo
-	var results []SuiResult
-	var txs []string
-	var nextCursor struct {
-		TxDigest string
-		EventSeq string
-	}
-	firstTime := true
-	for {
-		var payload string
-		if firstTime {
-			payload = w.queryEventsCmd
-			firstTime = false
-		} else {
-			payload = fmt.Sprintf(`{"jsonrpc":"2.0", "id": 1, "method": "suix_queryEvents", "params": [{ "MoveEventType": "%s" }, { "txDigest": "%s", "eventSeq": "%s" }, %d, %t]}`,
-				w.suiMoveEventType, nextCursor.TxDigest, nextCursor.EventSeq, w.maximumBatchSize, w.descendingOrder)
-		}
-		res, err := w.suiQueryEvents(ctx, payload)
-		if err != nil {
-			return retVal, err
-		}
-		for _, datum := range res.Result.Data {
-			txs = append(txs, *datum.ID.TxDigest)
-			results = append(results, datum)
-		}
-		if (len(res.Result.Data) == 0) || (len(txs) == 0) {
-			// In devnet (tilt) the core contract may not have any events and we don't want to flood the logs.
-			if w.unsafeDevMode {
-				return retVal, nil
-			}
-			return retVal, errors.New("getEvents was unable to get any events")
-		}
-		// Get and check the checkpoint for the last event against the lastProcessedHeight to see if we are done.
-		height, hErr := w.getCheckpointForDigest(ctx, txs[len(txs)-1])
-		if hErr != nil {
-			return retVal, hErr
-		}
-		if height <= w.latestProcessedCheckpoint || !res.Result.HasNextPage {
-			break
-		}
-		nextCursor.TxDigest = res.Result.NextCursor.TxDigest
-		nextCursor.EventSeq = res.Result.NextCursor.EventSeq
-	}
-	// At this point we have events but no checkpoints.
-	// Also, we probably have more events than we need.
-	// Need to do a bulk query to get all the checkpoints and then filter out the ones we don't need.
-	mbRes, err := w.getMultipleBlocks(ctx, txs)
-	if err != nil {
-		return retVal, err
-	}
-	if (len(mbRes) == 0) || (len(mbRes) != len(txs)) {
-		return retVal, errors.New("getEvents error getting multiple blocks")
-	}
-	for idx, block := range mbRes {
-		cp, err := strconv.ParseInt(block.Checkpoint, 10, 64)
-		if err != nil {
-			return retVal, fmt.Errorf("getEvents failed to ParseInt: %w", err)
-		}
-		if cp > w.latestProcessedCheckpoint {
-			// Double check the digest here
-			if txs[idx] != block.Digest {
-				return retVal, fmt.Errorf("getEvents digest mismatch: [%s] [%s]", txs[idx], block.Digest)
-			}
-			sri := SuiResultInfo{result: results[idx], checkpoint: cp}
-			retVal = append(retVal, sri)
-		} else {
-			// We can break here because the blocks are in order.
-			break
-		}
-	}
-
-	return retVal, nil
-}
-
-func (w *Watcher) getMultipleBlocks(ctx context.Context, txs []string) ([]TxBlockResult, error) {
-	retVal := []TxBlockResult{}
-	payload := RequestPayload{
-		JSONRPC: "2.0",
-		ID:      1,
-		Method:  "sui_multiGetTransactionBlocks",
-		Params:  [][]string{txs},
-	}
-
-	payloadBytes, err := json.Marshal(payload)
-	if err != nil {
-		return retVal, fmt.Errorf("getMultipleBlocks failed to marshal payload: %w", err)
-	}
-
-	body, err := w.createAndExecReq(ctx, string(payloadBytes))
-	if err != nil {
-		return retVal, fmt.Errorf("getMultipleBlocks failed to create and execute request: %w", err)
-	}
-
-	var res MultipleBlockResult
-	err = json.Unmarshal(body, &res)
-	if err != nil {
-		return retVal, fmt.Errorf("getMultipleBlocks failed to unmarshal body: %s, error: %w", string(body), err)
-	}
-	retVal = res.Result
-
-	return retVal, nil
-}
-
-func (e *Watcher) getLatestCheckpointSN(ctx context.Context, logger *zap.Logger) (int64, error) {
-	payload := `{"jsonrpc":"2.0", "id": 1, "method": "sui_getLatestCheckpointSequenceNumber", "params": []}`
-
-	body, err := e.createAndExecReq(ctx, payload)
-	if err != nil {
-		logger.Error("sui_getLatestCheckpointSequenceNumber failed", zap.Error(err))
-		p2p.DefaultRegistry.AddErrorCount(vaa.ChainIDSui, 1)
-		return 0, fmt.Errorf("sui_getLatestCheckpointSequenceNumber failed to create and execute request: %w", err)
-	}
-
-	var res SuiCheckpointSN
-	err = json.Unmarshal(body, &res)
-	if err != nil {
-		logger.Error("unmarshal failed into uint64", zap.String("body", string(body)), zap.Error(err))
-		p2p.DefaultRegistry.AddErrorCount(vaa.ChainIDSui, 1)
-		return 0, fmt.Errorf("sui_getLatestCheckpointSequenceNumber failed to unmarshal body: %s, error: %w", string(body), err)
-	}
-
-	height, pErr := strconv.ParseInt(res.Result, 0, 64)
-	if pErr != nil {
-		logger.Error("Failed to ParseInt")
-		p2p.DefaultRegistry.AddErrorCount(vaa.ChainIDSui, 1)
-		return 0, fmt.Errorf("sui_getLatestCheckpointSequenceNumber failed to ParseInt, error: %w", pErr)
-	}
-	return height, nil
-}
-
-func (e *Watcher) getCheckpointForDigest(ctx context.Context, tx string) (int64, error) {
-	retVal := int64(0)
-	payload := fmt.Sprintf(`{"jsonrpc":"2.0", "id": 1, "method": "sui_getTransactionBlock", "params": [ "%s" ]}`, tx)
-
-	body, err := e.createAndExecReq(ctx, payload)
-	if err != nil {
-		return retVal, fmt.Errorf("getCheckpointForDigest failed to create and execute request: %w", err)
-	}
-
-	var res GetCheckpointResponse
-	err = json.Unmarshal(body, &res)
-	if err != nil {
-		return retVal, fmt.Errorf("getCheckpointForDigest failed to unmarshal body: %s, error: %w", string(body), err)
-	}
-	retVal, err = strconv.ParseInt(res.Result.Checkpoint, 10, 64)
-	if err != nil {
-		return retVal, fmt.Errorf("getCheckpointForDigest failed to ParseInt: %w", err)
-	}
-
-	return retVal, nil
-}
-
-func (w *Watcher) suiQueryEvents(ctx context.Context, payload string) (SuiEventResponse, error) {
-	retVal := SuiEventResponse{}
-
-	body, err := w.createAndExecReq(ctx, payload)
-	if err != nil {
-		return retVal, fmt.Errorf("suix_queryEvents failed to create and execute request: %w", err)
-	}
-
-	err = json.Unmarshal(body, &retVal)
-	if err != nil {
-		return retVal, fmt.Errorf("suix_queryEvents failed to unmarshal body: %s, error: %w", string(body), err)
-	}
-	return retVal, nil
-}
-
-func (w *Watcher) createAndExecReq(ctx context.Context, payload string) ([]byte, error) {
-	var retVal []byte
-	timeoutCtx, cancel := context.WithTimeout(ctx, w.postTimeout)
-	defer cancel()
-	// Create a new request with the context
-	req, err := http.NewRequestWithContext(timeoutCtx, "POST", w.suiRPC, strings.NewReader(payload))
-	if err != nil {
-		return retVal, fmt.Errorf("createAndExecReq failed to create request: %w, payload: %s", err, payload)
-	}
-
-	// Set the Content-Type header
-	req.Header.Set("Content-Type", "application/json")
-
-	// Send the request using DefaultClient
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return retVal, fmt.Errorf("createAndExecReq failed to post: %w", err)
-	}
-	body, err := common.SafeRead(resp.Body)
-	if err != nil {
-		return retVal, fmt.Errorf("createAndExecReq failed to read: %w", err)
-	}
-	resp.Body.Close()
-	return body, nil
-}
-
-// logVersion retrieves the Sui protocol version and logs it
-func (w *Watcher) logVersion(ctx context.Context, logger *zap.Logger) {
-	// We can't get the exact build, but we can get the protocol version.
-	// From: https://www.quicknode.com/docs/sui/suix_getLatestSuiSystemState
-	networkName := "sui"
-	payload := `{"jsonrpc":"2.0", "id": 1, "method": "suix_getLatestSuiSystemState", "params": []}`
-
-	type getLatestSuiSystemStateResponse struct {
-		Jsonrpc string `json:"jsonrpc"`
-		Result  struct {
-			ProtocolVersion string `json:"protocolVersion"`
-		} `json:"result"`
-		ID int `json:"id"`
-	}
-	var result getLatestSuiSystemStateResponse
-
-	body, err := w.createAndExecReq(ctx, payload)
-	if err != nil {
-		logger.Error("problem retrieving node version",
-			zap.Error(err),
-			zap.String("network", networkName),
-		)
-		return
-	}
-
-	err = json.Unmarshal(body, &result)
-	if err != nil {
-		logger.Error("problem retrieving node version",
-			zap.Error(err),
-			zap.String("network", networkName),
-		)
-		return
-	}
-
-	logger.Info("node version",
-		zap.String("version", result.Result.ProtocolVersion),
-		zap.String("network", "sui"),
-	)
 }

--- a/node/pkg/watchers/sui/watcher_live_test.go
+++ b/node/pkg/watchers/sui/watcher_live_test.go
@@ -1,0 +1,252 @@
+package sui
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/certusone/wormhole/node/pkg/common"
+	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
+	"github.com/certusone/wormhole/node/pkg/suiclient"
+	"github.com/certusone/wormhole/node/pkg/supervisor"
+	"github.com/mr-tron/base58"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// TestLiveSuiWatcher runs the real Sui watcher against a live gRPC endpoint (mainnet by
+// default) and, for every observed Wormhole message, cross-checks the gRPC/BCS-decoded fields
+// against the node's own JSON-RPC `parsedJson` rendering of the same event. A field mismatch
+// fails the test. It is skipped unless SUI_WATCHER_LIVE is set.
+//
+// Run it (streams logs; Ctrl-C to stop early):
+//
+//	SUI_WATCHER_LIVE=1 go test ./pkg/watchers/sui -run TestLiveSuiWatcher -v -timeout 0
+//
+// Optional environment variables:
+//
+//	SUI_WATCHER_RPC         gRPC endpoint host:port      (default fullnode.mainnet.sui.io:443)
+//	SUI_WATCHER_JSONRPC     JSON-RPC URL for cross-check (default https://fullnode.mainnet.sui.io)
+//	SUI_WATCHER_EVENT_TYPE  core bridge WormholeMessage  (default mainnet core bridge type)
+//	SUI_WATCHER_SECONDS     how long to observe          (default 120)
+//	SUI_WATCHER_TXVERIFIER  set to any value to enable the transfer verifier
+func TestLiveSuiWatcher(t *testing.T) {
+	if os.Getenv("SUI_WATCHER_LIVE") == "" {
+		t.Skip("set SUI_WATCHER_LIVE=1 to run the live Sui watcher test")
+	}
+
+	rpc := liveEnv("SUI_WATCHER_RPC", suiclient.SuiRPCMainnet)
+	jsonRPC := liveEnv("SUI_WATCHER_JSONRPC", "https://fullnode.mainnet.sui.io")
+	eventType := liveEnv("SUI_WATCHER_EVENT_TYPE", "0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a::publish_message::WormholeMessage")
+
+	seconds := 120
+	if s := os.Getenv("SUI_WATCHER_SECONDS"); s != "" {
+		parsed, err := strconv.Atoi(s)
+		require.NoError(t, err)
+		seconds = parsed
+	}
+	txVerifierEnabled := os.Getenv("SUI_WATCHER_TXVERIFIER") != ""
+
+	logger, err := zap.NewDevelopment()
+	require.NoError(t, err)
+
+	logger.Info("starting live Sui watcher",
+		zap.String("rpc", rpc),
+		zap.String("jsonRPC", jsonRPC),
+		zap.String("eventType", eventType),
+		zap.Int("seconds", seconds),
+		zap.Bool("txVerifierEnabled", txVerifierEnabled),
+	)
+
+	// Buffered so the watcher never blocks publishing while we verify; we drain it below.
+	msgChan := make(chan *common.MessagePublication, 100)
+	obsvReqC := make(chan *gossipv1.ObservationRequest, 10)
+
+	watcher, err := NewWatcher(rpc, eventType, false, msgChan, obsvReqC, common.MainNet, txVerifierEnabled)
+	require.NoError(t, err)
+
+	rootCtx, cancel := context.WithTimeout(context.Background(), time.Duration(seconds)*time.Second)
+	defer cancel()
+
+	observed := 0
+	verified := 0
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	supervisor.New(rootCtx, logger, func(ctx context.Context) error {
+		// Drain the message channel; log and cross-check every observation.
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case msg := <-msgChan:
+					observed++
+					logger.Info("OBSERVED WORMHOLE MESSAGE",
+						append([]zap.Field{
+							zap.Int("n", observed),
+							zap.String("txIDHex", hex.EncodeToString(msg.TxID)),
+							zap.String("verificationState", msg.VerificationState().String()),
+						}, msg.ZapFields()...)...,
+					)
+					if verifyMessageAgainstJSONRPC(ctx, t, logger, jsonRPC, eventType, msg) {
+						verified++
+					}
+				}
+			}
+		}()
+
+		if rerr := supervisor.Run(ctx, "sui", watcher.Run); rerr != nil {
+			return rerr
+		}
+
+		<-ctx.Done()
+		return nil
+	}, supervisor.WithPropagatePanic)
+
+	<-rootCtx.Done()
+	// Wait for the drain goroutine to finish any in-flight verification before the test returns,
+	// so it never calls t.Errorf after the test function has returned.
+	wg.Wait()
+	logger.Info("live Sui watcher finished", zap.Int("messagesObserved", observed), zap.Int("messagesVerified", verified))
+}
+
+// suiParsedJson mirrors the `parsedJson` of a WormholeMessage event as rendered by the Sui
+// JSON-RPC node — the independent decode the watcher's gRPC/BCS result is checked against.
+type suiParsedJson struct {
+	ConsistencyLevel uint8  `json:"consistency_level"`
+	Nonce            uint32 `json:"nonce"`
+	Payload          []byte `json:"payload"`
+	Sender           string `json:"sender"`
+	Sequence         uint64 `json:"sequence,string"`
+	Timestamp        int64  `json:"timestamp,string"`
+}
+
+// fetchParsedJSONEvent queries `sui_getEvents` for `digest` and returns the parsedJson of the
+// WormholeMessage event with the given sequence. It returns (nil, nil) when the matching event
+// is not present yet (e.g. the queried node has not indexed the just-produced transaction), and
+// (nil, err) on a transport/decode error — both of which the caller treats as retryable.
+func fetchParsedJSONEvent(ctx context.Context, jsonRPC, digest, eventType string, sequence uint64) (*suiParsedJson, error) {
+	reqBody := fmt.Sprintf(`{"jsonrpc":"2.0","id":1,"method":"sui_getEvents","params":["%s"]}`, digest)
+	reqCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, jsonRPC, strings.NewReader(reqBody))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := common.SafeRead(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var parsed struct {
+		Result []struct {
+			Type       string          `json:"type"`
+			ParsedJson json.RawMessage `json:"parsedJson"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return nil, fmt.Errorf("unmarshal JSON-RPC response: %w (body=%s)", err, string(body))
+	}
+
+	// Only decode the parsedJson of WormholeMessage events. A transaction can bundle unrelated
+	// events (e.g. a CCTP DepositForBurn, whose `nonce` is a quoted string) whose fields would
+	// otherwise collide with the strongly-typed suiParsedJson and fail the whole decode.
+	for i := range parsed.Result {
+		if parsed.Result[i].Type != eventType {
+			continue
+		}
+		var pj suiParsedJson
+		if err := json.Unmarshal(parsed.Result[i].ParsedJson, &pj); err != nil {
+			return nil, fmt.Errorf("unmarshal WormholeMessage parsedJson: %w", err)
+		}
+		if pj.Sequence == sequence {
+			return &pj, nil
+		}
+	}
+	return nil, nil
+}
+
+// verifyMessageAgainstJSONRPC fetches the events for the message's transaction over JSON-RPC and
+// asserts that the node's independently-decoded `parsedJson` fields match the gRPC/BCS-decoded
+// MessagePublication. It returns true only if a matching event was found and every field matched.
+// Lookup failures are logged and skipped (return false); an actual field mismatch fails the test
+// via t.Errorf.
+func verifyMessageAgainstJSONRPC(ctx context.Context, t *testing.T, logger *zap.Logger, jsonRPC, eventType string, msg *common.MessagePublication) bool {
+	digest := base58.Encode(msg.TxID)
+
+	pj, err := fetchParsedJSONEvent(ctx, jsonRPC, digest, eventType, msg.Sequence)
+	if err != nil {
+		logger.Warn("verify: JSON-RPC lookup failed (skipping)", zap.String("digest", digest), zap.Error(err))
+		return false
+	}
+	if pj == nil {
+		logger.Warn("verify: no matching WormholeMessage event found in JSON-RPC response (skipping)",
+			zap.String("digest", digest),
+			zap.Uint64("sequence", msg.Sequence),
+		)
+		return false
+	}
+
+	ok := true
+	mismatch := func(field string, expected, actual any) {
+		ok = false
+		t.Errorf("FIELD MISMATCH [%s] tx=%s seq=%d: jsonrpc=%v watcher=%v", field, digest, msg.Sequence, expected, actual)
+	}
+
+	// Sequence already matched by fetchParsedJSONEvent.
+	if pj.Nonce != msg.Nonce {
+		mismatch("nonce", pj.Nonce, msg.Nonce)
+	}
+	if pj.ConsistencyLevel != msg.ConsistencyLevel {
+		mismatch("consistency_level", pj.ConsistencyLevel, msg.ConsistencyLevel)
+	}
+	// parsedJson sender carries a 0x prefix; vaa.Address.String() does not.
+	if strings.TrimPrefix(pj.Sender, "0x") != msg.EmitterAddress.String() {
+		mismatch("sender/emitter", pj.Sender, msg.EmitterAddress.String())
+	}
+	if !bytes.Equal(pj.Payload, msg.Payload) {
+		mismatch("payload", hex.EncodeToString(pj.Payload), hex.EncodeToString(msg.Payload))
+	}
+	// parsedJson timestamp is in seconds; the watcher stores time.Unix(seconds, 0).
+	if !time.Unix(pj.Timestamp, 0).Equal(msg.Timestamp) {
+		mismatch("timestamp", pj.Timestamp, msg.Timestamp.Unix())
+	}
+
+	if ok {
+		logger.Info("VERIFIED against JSON-RPC parsedJson",
+			zap.String("digest", digest),
+			zap.Uint64("sequence", msg.Sequence),
+			zap.Uint32("nonce", msg.Nonce),
+			zap.Uint8("consistencyLevel", msg.ConsistencyLevel),
+			zap.String("emitter", msg.EmitterAddress.String()),
+			zap.Int("payloadLen", len(msg.Payload)),
+		)
+	}
+	return ok
+}
+
+func liveEnv(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}

--- a/node/pkg/watchers/sui/watcher_live_test.go
+++ b/node/pkg/watchers/sui/watcher_live_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package sui
 
 import (
@@ -26,11 +28,11 @@ import (
 // TestLiveSuiWatcher runs the real Sui watcher against a live gRPC endpoint (mainnet by
 // default) and, for every observed Wormhole message, cross-checks the gRPC/BCS-decoded fields
 // against the node's own JSON-RPC `parsedJson` rendering of the same event. A field mismatch
-// fails the test. It is skipped unless SUI_WATCHER_LIVE is set.
+// fails the test. It is only compiled with the `integration` build tag.
 //
 // Run it (streams logs; Ctrl-C to stop early):
 //
-//	SUI_WATCHER_LIVE=1 go test ./pkg/watchers/sui -run TestLiveSuiWatcher -v -timeout 0
+//	go test -tags integration ./pkg/watchers/sui -run TestLiveSuiWatcher -v -timeout 0
 //
 // Optional environment variables:
 //
@@ -40,10 +42,6 @@ import (
 //	SUI_WATCHER_SECONDS     how long to observe          (default 120)
 //	SUI_WATCHER_TXVERIFIER  set to any value to enable the transfer verifier
 func TestLiveSuiWatcher(t *testing.T) {
-	if os.Getenv("SUI_WATCHER_LIVE") == "" {
-		t.Skip("set SUI_WATCHER_LIVE=1 to run the live Sui watcher test")
-	}
-
 	rpc := liveEnv("SUI_WATCHER_RPC", suiclient.SuiRPCMainnet)
 	jsonRPC := liveEnv("SUI_WATCHER_JSONRPC", "https://fullnode.mainnet.sui.io")
 	eventType := liveEnv("SUI_WATCHER_EVENT_TYPE", "0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a::publish_message::WormholeMessage")

--- a/node/pkg/watchers/sui/watcher_test.go
+++ b/node/pkg/watchers/sui/watcher_test.go
@@ -2,20 +2,102 @@ package sui
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
+	"math/big"
+	"strings"
 	"testing"
 	"time"
 
+	mystenbcs "github.com/block-vision/sui-go-sdk/mystenbcs"
 	"github.com/certusone/wormhole/node/pkg/common"
+	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
+	"github.com/certusone/wormhole/node/pkg/suiclient"
 	txverifier "github.com/certusone/wormhole/node/pkg/txverifier"
-	"github.com/stretchr/testify/assert"
+	"github.com/mr-tron/base58"
 	"github.com/stretchr/testify/require"
 	"github.com/wormhole-foundation/wormhole/sdk/vaa"
 	"go.uber.org/zap"
 )
+
+// A `WormholeMessage` event captured from mainnet transaction
+// 3dFwinvN8cxotrbHmisT1zMnFiFeR5nowo9zzZw7akin. The base64 string is the BCS-serialized
+// event contents (the `contents` of the gRPC event), and the remaining constants are the
+// values it decodes to, taken from the JSON-RPC `parsedJson` rendering of the same event.
+const (
+	sampleWormholeMessageBcsB64 = "zM7rKTSPcb3SL/70OioZwfW14XxcylQRUpEgGCZyreW/OAMAAAAAAEyGAQCFAQEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACjm6FyXsyJ/MIvDRPeNoi5T6FtZKIgeRhqlBkUKAxnEB/3VCY8ABUAAAAAAAAAAAAAAABlqPB72ahZjhtbbAqI9HedvAd2dQAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMmMkaAAAAAA="
+	sampleTxDigest              = "3dFwinvN8cxotrbHmisT1zMnFiFeR5nowo9zzZw7akin"
+	sampleSenderHex             = "ccceeb29348f71bdd22ffef43a2a19c1f5b5e17c5cca5411529120182672ade5"
+	samplePayloadHex            = "01000000000000000000000000000000000000000000000000000000a39ba1725ecc89fcc22f0d13de3688b94fa16d64a22079186a941914280c67101ff754263c001500000000000000000000000065a8f07bd9a8598e1b5b6c0a88f4779dbc07767500040000000000000000000000000000000000000000000000000000000000000000"
+	sampleSequence              = uint64(211135)
+	sampleNonce                 = uint32(99916)
+	sampleConsistencyLevel      = uint8(0)
+	sampleTimestamp             = uint64(1747215154)
+)
+
+// sampleWormholeMessageBcs is the BCS-serialized contents of the sample WormholeMessage event,
+// decoded once from sampleWormholeMessageBcsB64.
+var sampleWormholeMessageBcs = func() []byte {
+	b, err := base64.StdEncoding.DecodeString(sampleWormholeMessageBcsB64)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}()
+
+// mockSuiClient is a minimal suiclient.SuiClient implementation for exercising the watcher's
+// gRPC-facing logic. Only the methods used by the tests return meaningful data. Object versions
+// are served from `objects`, keyed by "objectId@version".
+type mockSuiClient struct {
+	transactions map[string]suiclient.SuiTransaction
+	objects      map[string][]byte
+}
+
+func mockObjectKey(objectID string, version uint64) string {
+	return fmt.Sprintf("%s@%d", objectID, version)
+}
+
+func (m *mockSuiClient) GetObject(ctx context.Context, objectID string, fields []string) (suiclient.SuiObject, error) {
+	return m.GetObjectAtVersion(ctx, objectID, nil, fields)
+}
+
+func (m *mockSuiClient) GetObjectAtVersion(ctx context.Context, objectID string, version *uint64, fields []string) (suiclient.SuiObject, error) {
+	if version == nil {
+		return suiclient.SuiObject{}, errors.New("nil version")
+	}
+	contents, ok := m.objects[mockObjectKey(objectID, *version)]
+	if !ok {
+		return suiclient.SuiObject{}, fmt.Errorf("object %s@%d not found", objectID, *version)
+	}
+	return suiclient.SuiObject{ContentsBytes: contents}, nil
+}
+
+func (m *mockSuiClient) GetLatestCheckpoint(ctx context.Context, fields []string) (suiclient.SuiCheckpoint, error) {
+	sn := uint64(145024142)
+	return suiclient.SuiCheckpoint{SequenceNumber: &sn}, nil
+}
+
+func (m *mockSuiClient) GetTransaction(ctx context.Context, digest string, fields []string) (suiclient.SuiTransaction, error) {
+	txn, ok := m.transactions[digest]
+	if !ok {
+		return suiclient.SuiTransaction{}, fmt.Errorf("transaction not found: %s", digest)
+	}
+	return txn, nil
+}
+
+func (m *mockSuiClient) SubscribeToTransactionEvent(ctx context.Context, eventType string, eventWriteChannel chan<- suiclient.SuiTransactionEvent) (suiclient.SuiSubscription, error) {
+	return suiclient.SuiSubscription{}, nil
+}
+
+func (m *mockSuiClient) SubscribeToTransactionEvents(ctx context.Context, eventTypes []string, eventWriteChannel chan<- suiclient.SuiTransactionEvent) (suiclient.SuiSubscription, error) {
+	return suiclient.SuiSubscription{}, nil
+}
+
+func (m *mockSuiClient) Close() error {
+	return nil
+}
 
 func NewSuiWatcherForTest(msgChan chan *common.MessagePublication, suiTxVerifier *txverifier.SuiTransferVerifier, suiEventType string) *Watcher {
 	return &Watcher{
@@ -26,92 +108,115 @@ func NewSuiWatcherForTest(msgChan chan *common.MessagePublication, suiTxVerifier
 	}
 }
 
-type MockSuiApiConnection struct {
-	transactionBlockResponses      map[string]txverifier.SuiGetTransactionBlockResponse
-	tryMultiGetPastObjectsResponse map[string]txverifier.SuiTryMultiGetPastObjectsResponse
-}
+// Test_DecodeWormholeMessage checks that the BCS-serialized contents of a `WormholeMessage`
+// gRPC event decode into the expected fields.
+func Test_DecodeWormholeMessage(t *testing.T) {
+	bcsBytes := sampleWormholeMessageBcs
 
-func (m *MockSuiApiConnection) QueryEvents(ctx context.Context, filter string, cursor string, limit int, descending bool) (txverifier.SuiQueryEventsResponse, error) {
-	return txverifier.SuiQueryEventsResponse{}, errors.New("Not supported")
-}
-
-func (m *MockSuiApiConnection) SetTransactionBlock(txDigest string, transactionBlockResponse txverifier.SuiGetTransactionBlockResponse) {
-	m.transactionBlockResponses[txDigest] = transactionBlockResponse
-}
-
-func (m *MockSuiApiConnection) GetTransactionBlock(ctx context.Context, txDigest string) (txverifier.SuiGetTransactionBlockResponse, error) {
-	if _, exists := m.transactionBlockResponses[txDigest]; !exists {
-		return txverifier.SuiGetTransactionBlockResponse{}, errors.New("Could not find transaction block")
-	}
-
-	return m.transactionBlockResponses[txDigest], nil
-}
-
-func (m *MockSuiApiConnection) SetPastObjects(objectId string, version string, previousVersion string, pastObjectsResponse txverifier.SuiTryMultiGetPastObjectsResponse) {
-	key := fmt.Sprintf("%s-%s-%s", objectId, version, previousVersion)
-	m.tryMultiGetPastObjectsResponse[key] = pastObjectsResponse
-}
-
-func (m *MockSuiApiConnection) TryMultiGetPastObjects(ctx context.Context, objectId string, version string, previousVersion string) (txverifier.SuiTryMultiGetPastObjectsResponse, error) {
-	key := fmt.Sprintf("%s-%s-%s", objectId, version, previousVersion)
-
-	if _, exists := m.tryMultiGetPastObjectsResponse[key]; !exists {
-		return txverifier.SuiTryMultiGetPastObjectsResponse{}, errors.New("Could not find past objects")
-	}
-
-	return m.tryMultiGetPastObjectsResponse[key], nil
-}
-
-func Test_JSONParseOneWHMSg(t *testing.T) {
-	// JSON with only the first result (contains all of the fields in `FieldsData` - parses successfully)
-	msg := []byte("{\"jsonrpc\":\"2.0\",\"result\":[{\"id\":{\"txDigest\":\"2Z4A1ND5JL8c5ma9WMzFXUvpVqnwoQdYuaX4RwnLyMXU\",\"eventSeq\":\"0\"},\"packageId\":\"0x826915f8ca6d11597dfe6599b8aa02a4c08bd8d39674855254a06ee83fe7220e\",\"transactionModule\":\"lending_portal_v2\",\"sender\":\"0xccce7bbffaf1b9e9e8ca88a68a08fec11f568a697023f475f99efb7bcee951cf\",\"type\":\"0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a::publish_message::WormholeMessage\",\"parsedJson\":{\"consistency_level\":0,\"nonce\":0,\"payload\":[0,1,0,34,0,0,204,206,123,191,250,241,185,233,232,202,136,166,138,8,254,193,31,86,138,105,112,35,244,117,249,158,251,123,206,233,81,207,2,0,133,0,0,0,0,0,0,0,0,10,202,0,0,0,10,122,53,130,0,0,76,0,0,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,50,58,58,115,117,105,58,58,83,85,73,0,34,0,0,204,206,123,191,250,241,185,233,232,202,136,166,138,8,254,193,31,86,138,105,112,35,244,117,249,158,251,123,206,233,81,207,2],\"sender\":\"0xdd1ca0bd0b9e449ff55259e5bcf7e0fc1b8b7ab49aabad218681ccce7b202bd6\",\"sequence\":\"2768\",\"timestamp\":\"1693091880\"},\"bcs\":\"J8cfJrtMWT2kg6uBgWQmd8T9k9cSibQg65ufpgxugVM2ghgC8bb1vvqoXmETiMvfb9DJLEDKy2pnvAYivyWJfz8zKSn5u7EfDbMntpszG7D4gsNNu9cU2rMUi4aF7DXnv6QAp5hoaHvJymehRwXkncHfjZ7zKsZ8cUtSKJh6S6YjHMRZ67s1PPwGEVwUdQt5S3WhQdag3tuySe8FDrUWgJfbBawyUKLdbNcR1aXFtBiPu6jQ51BF7sv13x9hp2nbs5EUMYjnN1ykK4YQaKx55eY7TQcxVCRzPrEARSkMjB8VgqefLNpwiCRdq\"}],\"id\":1}")
-	expectedPayload := []byte{0, 1, 0, 34, 0, 0, 204, 206, 123, 191, 250, 241, 185, 233, 232, 202, 136, 166, 138, 8, 254, 193, 31, 86, 138, 105, 112, 35, 244, 117, 249, 158, 251, 123, 206, 233, 81, 207, 2, 0, 133, 0, 0, 0, 0, 0, 0, 0, 0, 10, 202, 0, 0, 0, 10, 122, 53, 130, 0, 0, 76, 0, 0, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 50, 58, 58, 115, 117, 105, 58, 58, 83, 85, 73, 0, 34, 0, 0, 204, 206, 123, 191, 250, 241, 185, 233, 232, 202, 136, 166, 138, 8, 254, 193, 31, 86, 138, 105, 112, 35, 244, 117, 249, 158, 251, 123, 206, 233, 81, 207, 2}
-
-	var res SuiTxnQuery
-	err := json.Unmarshal(msg, &res)
+	msg, err := suiclient.DecodeBcs[txverifier.WormholeMessage](bcsBytes)
 	require.NoError(t, err)
-	for _, chunk := range res.Result {
-		// chunk is a SuiResult
-		// fmt.Println("body.Type", *chunk.Type)
-		assert.Equal(t, "0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a::publish_message::WormholeMessage", *chunk.Type)
-		var fields FieldsData
-		err := json.Unmarshal(*chunk.Fields, &fields)
-		require.NoError(t, err)
+	require.NotNil(t, msg)
 
-		assert.Equal(t, uint8(0), *fields.ConsistencyLevel)
-		assert.Equal(t, uint32(0), *fields.Nonce)
-		assert.Equal(t, expectedPayload, fields.Payload)
-		assert.Equal(t, "0xdd1ca0bd0b9e449ff55259e5bcf7e0fc1b8b7ab49aabad218681ccce7b202bd6", *fields.Sender)
-		assert.Equal(t, uint64(2768), *fields.Sequence)
-		assert.Equal(t, uint64(1693091880), *fields.Timestamp)
-	}
+	require.Equal(t, sampleSenderHex, hex.EncodeToString(msg.Sender[:]))
+	require.Equal(t, sampleSequence, msg.Sequence)
+	require.Equal(t, sampleNonce, msg.Nonce)
+	require.Equal(t, decodeStringNoError(samplePayloadHex), msg.Payload)
+	require.Equal(t, sampleConsistencyLevel, msg.ConsistencyLevel)
+	require.Equal(t, sampleTimestamp, msg.Timestamp)
 }
 
-func Test_JSONParseMultipleMsgs(t *testing.T) {
-	// Original JSON (fails to parse)
-	msg := []byte("{\"jsonrpc\":\"2.0\",\"result\":[{\"id\":{\"txDigest\":\"2Z4A1ND5JL8c5ma9WMzFXUvpVqnwoQdYuaX4RwnLyMXU\",\"eventSeq\":\"0\"},\"packageId\":\"0x826915f8ca6d11597dfe6599b8aa02a4c08bd8d39674855254a06ee83fe7220e\",\"transactionModule\":\"lending_portal_v2\",\"sender\":\"0xccce7bbffaf1b9e9e8ca88a68a08fec11f568a697023f475f99efb7bcee951cf\",\"type\":\"0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a::publish_message::WormholeMessage\",\"parsedJson\":{\"consistency_level\":0,\"nonce\":0,\"payload\":[0,1,0,34,0,0,204,206,123,191,250,241,185,233,232,202,136,166,138,8,254,193,31,86,138,105,112,35,244,117,249,158,251,123,206,233,81,207,2,0,133,0,0,0,0,0,0,0,0,10,202,0,0,0,10,122,53,130,0,0,76,0,0,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,50,58,58,115,117,105,58,58,83,85,73,0,34,0,0,204,206,123,191,250,241,185,233,232,202,136,166,138,8,254,193,31,86,138,105,112,35,244,117,249,158,251,123,206,233,81,207,2],\"sender\":\"0xdd1ca0bd0b9e449ff55259e5bcf7e0fc1b8b7ab49aabad218681ccce7b202bd6\",\"sequence\":\"2768\",\"timestamp\":\"1693091880\"},\"bcs\":\"J8cfJrtMWT2kg6uBgWQmd8T9k9cSibQg65ufpgxugVM2ghgC8bb1vvqoXmETiMvfb9DJLEDKy2pnvAYivyWJfz8zKSn5u7EfDbMntpszG7D4gsNNu9cU2rMUi4aF7DXnv6QAp5hoaHvJymehRwXkncHfjZ7zKsZ8cUtSKJh6S6YjHMRZ67s1PPwGEVwUdQt5S3WhQdag3tuySe8FDrUWgJfbBawyUKLdbNcR1aXFtBiPu6jQ51BF7sv13x9hp2nbs5EUMYjnN1ykK4YQaKx55eY7TQcxVCRzPrEARSkMjB8VgqefLNpwiCRdq\"},{\"id\":{\"txDigest\":\"2Z4A1ND5JL8c5ma9WMzFXUvpVqnwoQdYuaX4RwnLyMXU\",\"eventSeq\":\"1\"},\"packageId\":\"0x826915f8ca6d11597dfe6599b8aa02a4c08bd8d39674855254a06ee83fe7220e\",\"transactionModule\":\"lending_portal_v2\",\"sender\":\"0xccce7bbffaf1b9e9e8ca88a68a08fec11f568a697023f475f99efb7bcee951cf\",\"type\":\"0x826915f8ca6d11597dfe6599b8aa02a4c08bd8d39674855254a06ee83fe7220e::wormhole_adapter_pool::RelayEvent\",\"parsedJson\":{\"app_id\":1,\"call_type\":2,\"fee_amount\":\"57821069\",\"nonce\":\"2762\",\"sequence\":\"2768\"},\"bcs\":\"V7pAXEvqBvtV5ps2fetket9wYhsoQT1Y8X6bT\"},{\"id\":{\"txDigest\":\"2Z4A1ND5JL8c5ma9WMzFXUvpVqnwoQdYuaX4RwnLyMXU\",\"eventSeq\":\"2\"},\"packageId\":\"0x826915f8ca6d11597dfe6599b8aa02a4c08bd8d39674855254a06ee83fe7220e\",\"transactionModule\":\"lending_portal_v2\",\"sender\":\"0xccce7bbffaf1b9e9e8ca88a68a08fec11f568a697023f475f99efb7bcee951cf\",\"type\":\"0x826915f8ca6d11597dfe6599b8aa02a4c08bd8d39674855254a06ee83fe7220e::lending_portal_v2::LendingPortalEvent\",\"parsedJson\":{\"amount\":\"45000000000\",\"call_type\":2,\"dola_pool_address\":[48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,50,58,58,115,117,105,58,58,83,85,73],\"dst_chain_id\":0,\"nonce\":\"2762\",\"receiver\":[204,206,123,191,250,241,185,233,232,202,136,166,138,8,254,193,31,86,138,105,112,35,244,117,249,158,251,123,206,233,81,207],\"sender\":\"0xccce7bbffaf1b9e9e8ca88a68a08fec11f568a697023f475f99efb7bcee951cf\",\"source_chain_id\":0},\"bcs\":\"U7Gg8eey15TjPBGfZcKPCnYHJ84s3pL2BYUaw4r3NjK8AcWfzgKqsgW9F27yhPBtQdytETbAVqfx6b2Xsw7Ypprnbym5UEzyLHzuS79PMaAbGrXtVmdDYeHnoQ3DjfCSVZ5fZEaENLmmhe5m4iEYdkrjjaujoVQtuoFqjzaXYbMj89oksCE3E19PWsKzP7DVDcC99JjphepJgtGjQhCvdtzLd8kR\"}],\"id\":1}")
-	expectedPayload := []byte{0, 1, 0, 34, 0, 0, 204, 206, 123, 191, 250, 241, 185, 233, 232, 202, 136, 166, 138, 8, 254, 193, 31, 86, 138, 105, 112, 35, 244, 117, 249, 158, 251, 123, 206, 233, 81, 207, 2, 0, 133, 0, 0, 0, 0, 0, 0, 0, 0, 10, 202, 0, 0, 0, 10, 122, 53, 130, 0, 0, 76, 0, 0, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 50, 58, 58, 115, 117, 105, 58, 58, 83, 85, 73, 0, 34, 0, 0, 204, 206, 123, 191, 250, 241, 185, 233, 232, 202, 136, 166, 138, 8, 254, 193, 31, 86, 138, 105, 112, 35, 244, 117, 249, 158, 251, 123, 206, 233, 81, 207, 2}
+// Test_processEvent checks that a `WormholeMessage` gRPC event is decoded and published as a
+// MessagePublication with the expected fields when no transfer verifier is configured.
+func Test_processEvent(t *testing.T) {
+	eventType := "0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a::publish_message::WormholeMessage"
 
-	var res SuiTxnQuery
-	err := json.Unmarshal(msg, &res)
+	msgChan := make(chan *common.MessagePublication, 1)
+	// No verifier configured, so processEvent should publish the message directly.
+	watcher := &Watcher{
+		msgChan:          msgChan,
+		suiMoveEventType: eventType,
+	}
+
+	event := suiclient.SuiEvent{
+		EventType: eventType,
+		BcsBytes:  sampleWormholeMessageBcs,
+	}
+
+	err := watcher.processEvent(context.TODO(), zap.NewNop(), event, sampleTxDigest, false)
 	require.NoError(t, err)
 
-	for _, chunk := range res.Result {
-		// chunk is a SuiResult
-		if *chunk.Type != "0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a::publish_message::WormholeMessage" {
-			continue
-		}
-		var fields FieldsData
-		err := json.Unmarshal(*chunk.Fields, &fields)
-		require.NoError(t, err)
+	published := <-msgChan
+	expectedTxID, err := base58.Decode(sampleTxDigest)
+	require.NoError(t, err)
+	require.Len(t, expectedTxID, 32)
 
-		assert.Equal(t, uint8(0), *fields.ConsistencyLevel)
-		assert.Equal(t, uint32(0), *fields.Nonce)
-		assert.Equal(t, expectedPayload, fields.Payload)
-		assert.Equal(t, "0xdd1ca0bd0b9e449ff55259e5bcf7e0fc1b8b7ab49aabad218681ccce7b202bd6", *fields.Sender)
-		assert.Equal(t, uint64(2768), *fields.Sequence)
-		assert.Equal(t, uint64(1693091880), *fields.Timestamp)
+	require.Equal(t, expectedTxID, published.TxID)
+	require.Equal(t, vaa.ChainIDSui, published.EmitterChain)
+	require.Equal(t, sampleSenderHex, published.EmitterAddress.String())
+	require.Equal(t, sampleSequence, published.Sequence)
+	require.Equal(t, sampleNonce, published.Nonce)
+	require.Equal(t, decodeStringNoError(samplePayloadHex), published.Payload)
+	require.Equal(t, sampleConsistencyLevel, published.ConsistencyLevel)
+	require.Equal(t, time.Unix(int64(sampleTimestamp), 0), published.Timestamp)
+	require.False(t, published.IsReobservation)
+}
+
+// Test_processEvent_IgnoresOtherEventTypes checks that events whose type does not match the
+// configured Wormhole message event type are skipped without publishing.
+func Test_processEvent_IgnoresOtherEventTypes(t *testing.T) {
+	msgChan := make(chan *common.MessagePublication, 1)
+	watcher := &Watcher{
+		msgChan:          msgChan,
+		suiMoveEventType: "0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a::publish_message::WormholeMessage",
 	}
+
+	event := suiclient.SuiEvent{
+		EventType: "0xabc::some_module::SomeOtherEvent",
+		BcsBytes:  sampleWormholeMessageBcs,
+	}
+
+	err := watcher.processEvent(context.TODO(), zap.NewNop(), event, sampleTxDigest, false)
+	require.NoError(t, err)
+	require.Empty(t, msgChan)
+}
+
+// Test_handleReobservation checks that a re-observation request fetches the transaction via the
+// gRPC client and publishes its Wormhole message events with IsReobservation set.
+func Test_handleReobservation(t *testing.T) {
+	eventType := "0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a::publish_message::WormholeMessage"
+
+	txHash, err := base58.Decode(sampleTxDigest)
+	require.NoError(t, err)
+
+	mockClient := &mockSuiClient{
+		transactions: map[string]suiclient.SuiTransaction{
+			sampleTxDigest: {
+				Events: []suiclient.SuiEvent{
+					{
+						EventType: eventType,
+						BcsBytes:  sampleWormholeMessageBcs,
+					},
+				},
+			},
+		},
+	}
+
+	msgChan := make(chan *common.MessagePublication, 1)
+	watcher := &Watcher{
+		msgChan:          msgChan,
+		suiMoveEventType: eventType,
+		suiClient:        mockClient,
+	}
+
+	watcher.handleReobservation(context.TODO(), zap.NewNop(), mockClient, &gossipv1.ObservationRequest{
+		ChainId: uint32(vaa.ChainIDSui),
+		TxHash:  txHash,
+	})
+
+	published := <-msgChan
+	require.Equal(t, txHash, published.TxID)
+	require.Equal(t, sampleSequence, published.Sequence)
+	require.True(t, published.IsReobservation)
 }
 
 func decodeStringNoError(s string) []byte {
@@ -119,178 +224,134 @@ func decodeStringNoError(s string) []byte {
 	return b
 }
 
-var (
-	Samples = []struct {
-		description        string
-		expectedState      common.VerificationState
-		txDigest           string
-		transactionBlock   []byte
-		pastObjects        []byte
-		messagePublication common.MessagePublication
-	}{
-		// native
-		{
-			description:      "NativeStandard",
-			expectedState:    common.Valid,
-			txDigest:         "3dFwinvN8cxotrbHmisT1zMnFiFeR5nowo9zzZw7akin",
-			transactionBlock: []byte(`{"jsonrpc":"2.0","id":1,"result":{"digest":"3dFwinvN8cxotrbHmisT1zMnFiFeR5nowo9zzZw7akin","events":[{"id":{"txDigest":"3dFwinvN8cxotrbHmisT1zMnFiFeR5nowo9zzZw7akin","eventSeq":"0"},"packageId":"0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a","transactionModule":"publish_message","sender":"0x53221ea79a11e3a6046282e7a246ef8472fdb31727018cb048d72e541d67e6f1","type":"0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a::publish_message::WormholeMessage","parsedJson":{"consistency_level":0,"nonce":99916,"payload":[1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,163,155,161,114,94,204,137,252,194,47,13,19,222,54,136,185,79,161,109,100,162,32,121,24,106,148,25,20,40,12,103,16,31,247,84,38,60,0,21,0,0,0,0,0,0,0,0,0,0,0,0,101,168,240,123,217,168,89,142,27,91,108,10,136,244,119,157,188,7,118,117,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"sender":"0xccceeb29348f71bdd22ffef43a2a19c1f5b5e17c5cca5411529120182672ade5","sequence":"211135","timestamp":"1747215154"},"bcsEncoding":"base64","bcs":"zM7rKTSPcb3SL/70OioZwfW14XxcylQRUpEgGCZyreW/OAMAAAAAAEyGAQCFAQEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACjm6FyXsyJ/MIvDRPeNoi5T6FtZKIgeRhqlBkUKAxnEB/3VCY8ABUAAAAAAAAAAAAAAABlqPB72ahZjhtbbAqI9HedvAd2dQAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMmMkaAAAAAA="}],"objectChanges":[{"type":"mutated","sender":"0x53221ea79a11e3a6046282e7a246ef8472fdb31727018cb048d72e541d67e6f1","owner":{"AddressOwner":"0x53221ea79a11e3a6046282e7a246ef8472fdb31727018cb048d72e541d67e6f1"},"objectType":"0x2::coin::Coin<0x2::sui::SUI>","objectId":"0x06c1e8523e69f625f4fc1482dd42f8db436ec7607197e0671f5baa39684d4370","version":"556965531","previousVersion":"556965171","digest":"99BZLA3UVxr9XqmTQzakQ8uTmk35R6JyWBa1eiCgpJgx"},{"type":"mutated","sender":"0x53221ea79a11e3a6046282e7a246ef8472fdb31727018cb048d72e541d67e6f1","owner":{"AddressOwner":"0x53221ea79a11e3a6046282e7a246ef8472fdb31727018cb048d72e541d67e6f1"},"objectType":"0x2::coin::Coin<0x3a304c7feba2d819ea57c3542d68439ca2c386ba02159c740f7b406e592c62ea::haedal::HAEDAL>","objectId":"0x147df1a75dff16a5e7ee966d41b966e718cc27177e67855a876fb780fde7d43e","version":"556965531","previousVersion":"556965171","digest":"Gp6qVFxHzTc8rm5TCQPxhCpBoWprPh2StLHfH1NTG3es"},{"type":"mutated","sender":"0x53221ea79a11e3a6046282e7a246ef8472fdb31727018cb048d72e541d67e6f1","owner":{"ObjectOwner":"0x334881831bd89287554a6121087e498fa023ce52c037001b53a4563a00a281a5"},"objectType":"0x2::dynamic_field::Field<0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0x3a304c7feba2d819ea57c3542d68439ca2c386ba02159c740f7b406e592c62ea::haedal::HAEDAL>, 0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::native_asset::NativeAsset<0x3a304c7feba2d819ea57c3542d68439ca2c386ba02159c740f7b406e592c62ea::haedal::HAEDAL>>","objectId":"0x42b272eb5cf166861245cb82c0adc98fc9982c496cc8869a141031d3c4fe3b12","version":"556965531","previousVersion":"556963430","digest":"3tAkXi77Dui24ShRNvzSdjnfk4HabjQpfYKvEDrnm5JQ"},{"type":"mutated","sender":"0x53221ea79a11e3a6046282e7a246ef8472fdb31727018cb048d72e541d67e6f1","owner":{"Shared":{"initial_shared_version":64}},"objectType":"0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a::state::State","objectId":"0xaeab97f96cf9877fee2883315d459552b2b921edc16d7ceac6eab944dd88919c","version":"556965531","previousVersion":"556965530","digest":"FYtqG5uY7ymFB3BYn9jGArQ6xppEsC4VfhQxR6qGAT3s"},{"type":"mutated","sender":"0x53221ea79a11e3a6046282e7a246ef8472fdb31727018cb048d72e541d67e6f1","owner":{"Shared":{"initial_shared_version":66}},"objectType":"0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::state::State","objectId":"0xc57508ee0d4595e5a8728974a4a93a787d38f339757230d441e895422c07aba9","version":"556965531","previousVersion":"556964077","digest":"MoQndo45yEjj1bQeDXUyCnC75Sd4SGoaMhuZRR4XpCF"},{"type":"created","sender":"0x53221ea79a11e3a6046282e7a246ef8472fdb31727018cb048d72e541d67e6f1","owner":{"AddressOwner":"0x53221ea79a11e3a6046282e7a246ef8472fdb31727018cb048d72e541d67e6f1"},"objectType":"0x2::coin::Coin<0x3a304c7feba2d819ea57c3542d68439ca2c386ba02159c740f7b406e592c62ea::haedal::HAEDAL>","objectId":"0xc0339b6a32e521cd689f5b74a8d2b1b9fad1f72c292c0ed81ef18c20b1847541","version":"556965531","digest":"AHQAsewynGkrB3iNmaaN7uCYeRnFXagKWucXKhcv5pEC"}],"timestampMs":"1747215154277","checkpoint":"145024142"}}`),
-			pastObjects:      []byte(`{"jsonrpc":"2.0","id":1,"result":[{"status":"VersionFound","details":{"objectId":"0x42b272eb5cf166861245cb82c0adc98fc9982c496cc8869a141031d3c4fe3b12","version":"556965531","digest":"3tAkXi77Dui24ShRNvzSdjnfk4HabjQpfYKvEDrnm5JQ","content":{"dataType":"moveObject","type":"0x2::dynamic_field::Field<0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0x3a304c7feba2d819ea57c3542d68439ca2c386ba02159c740f7b406e592c62ea::haedal::HAEDAL>, 0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::native_asset::NativeAsset<0x3a304c7feba2d819ea57c3542d68439ca2c386ba02159c740f7b406e592c62ea::haedal::HAEDAL>>","hasPublicTransfer":false,"fields":{"id":{"id":"0x42b272eb5cf166861245cb82c0adc98fc9982c496cc8869a141031d3c4fe3b12"},"name":{"type":"0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0x3a304c7feba2d819ea57c3542d68439ca2c386ba02159c740f7b406e592c62ea::haedal::HAEDAL>","fields":{"dummy_field":false}},"value":{"type":"0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::native_asset::NativeAsset<0x3a304c7feba2d819ea57c3542d68439ca2c386ba02159c740f7b406e592c62ea::haedal::HAEDAL>","fields":{"custody":"49570703852513680","decimals":9,"token_address":{"type":"0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a::external_address::ExternalAddress","fields":{"value":{"type":"0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a::bytes32::Bytes32","fields":{"data":[204,137,252,194,47,13,19,222,54,136,185,79,161,109,100,162,32,121,24,106,148,25,20,40,12,103,16,31,247,84,38,60]}}}}}}}}}},{"status":"VersionFound","details":{"objectId":"0x42b272eb5cf166861245cb82c0adc98fc9982c496cc8869a141031d3c4fe3b12","version":"556963430","digest":"CTtUsqT2kGCFJ9AWYkKEYSLxN1J68Hj1M92iaX2bS4sm","content":{"dataType":"moveObject","type":"0x2::dynamic_field::Field<0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0x3a304c7feba2d819ea57c3542d68439ca2c386ba02159c740f7b406e592c62ea::haedal::HAEDAL>, 0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::native_asset::NativeAsset<0x3a304c7feba2d819ea57c3542d68439ca2c386ba02159c740f7b406e592c62ea::haedal::HAEDAL>>","hasPublicTransfer":false,"fields":{"id":{"id":"0x42b272eb5cf166861245cb82c0adc98fc9982c496cc8869a141031d3c4fe3b12"},"name":{"type":"0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0x3a304c7feba2d819ea57c3542d68439ca2c386ba02159c740f7b406e592c62ea::haedal::HAEDAL>","fields":{"dummy_field":false}},"value":{"type":"0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::native_asset::NativeAsset<0x3a304c7feba2d819ea57c3542d68439ca2c386ba02159c740f7b406e592c62ea::haedal::HAEDAL>","fields":{"custody":"49563676945330660","decimals":9,"token_address":{"type":"0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a::external_address::ExternalAddress","fields":{"value":{"type":"0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a::bytes32::Bytes32","fields":{"data":[204,137,252,194,47,13,19,222,54,136,185,79,161,109,100,162,32,121,24,106,148,25,20,40,12,103,16,31,247,84,38,60]}}}}}}}}}}]}`),
-			messagePublication: common.MessagePublication{
-				TxID:             []byte("3dFwinvN8cxotrbHmisT1zMnFiFeR5nowo9zzZw7akin"),
-				Timestamp:        time.UnixMilli(1747215154),
-				Nonce:            99916,
-				Sequence:         211135,
-				ConsistencyLevel: 0,
-				EmitterChain:     21,
-				EmitterAddress:   vaa.Address(decodeStringNoError("ccceeb29348f71bdd22ffef43a2a19c1f5b5e17c5cca5411529120182672ade5")),
-				Payload:          decodeStringNoError("01000000000000000000000000000000000000000000000000000000a39ba1725ecc89fcc22f0d13de3688b94fa16d64a22079186a941914280c67101ff754263c001500000000000000000000000065a8f07bd9a8598e1b5b6c0a88f4779dbc07767500040000000000000000000000000000000000000000000000000000000000000000"),
-			},
-		},
-		{
-			description:      "NativeLowerDepositThanRequired",
-			expectedState:    common.Anomalous,
-			txDigest:         "3dFwinvN8cxotrbHmisT1zMnFiFeR5nowo9zzZw7akin",
-			transactionBlock: []byte(`{"jsonrpc":"2.0","id":1,"result":{"digest":"3dFwinvN8cxotrbHmisT1zMnFiFeR5nowo9zzZw7akin","events":[{"id":{"txDigest":"3dFwinvN8cxotrbHmisT1zMnFiFeR5nowo9zzZw7akin","eventSeq":"0"},"packageId":"0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a","transactionModule":"publish_message","sender":"0x53221ea79a11e3a6046282e7a246ef8472fdb31727018cb048d72e541d67e6f1","type":"0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a::publish_message::WormholeMessage","parsedJson":{"consistency_level":0,"nonce":99916,"payload":[1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,163,155,161,114,94,204,137,252,194,47,13,19,222,54,136,185,79,161,109,100,162,32,121,24,106,148,25,20,40,12,103,16,31,247,84,38,60,0,21,0,0,0,0,0,0,0,0,0,0,0,0,101,168,240,123,217,168,89,142,27,91,108,10,136,244,119,157,188,7,118,117,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"sender":"0xccceeb29348f71bdd22ffef43a2a19c1f5b5e17c5cca5411529120182672ade5","sequence":"211135","timestamp":"1747215154"},"bcsEncoding":"base64","bcs":"zM7rKTSPcb3SL/70OioZwfW14XxcylQRUpEgGCZyreW/OAMAAAAAAEyGAQCFAQEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACjm6FyXsyJ/MIvDRPeNoi5T6FtZKIgeRhqlBkUKAxnEB/3VCY8ABUAAAAAAAAAAAAAAABlqPB72ahZjhtbbAqI9HedvAd2dQAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMmMkaAAAAAA="}],"objectChanges":[{"type":"mutated","sender":"0x53221ea79a11e3a6046282e7a246ef8472fdb31727018cb048d72e541d67e6f1","owner":{"AddressOwner":"0x53221ea79a11e3a6046282e7a246ef8472fdb31727018cb048d72e541d67e6f1"},"objectType":"0x2::coin::Coin<0x2::sui::SUI>","objectId":"0x06c1e8523e69f625f4fc1482dd42f8db436ec7607197e0671f5baa39684d4370","version":"556965531","previousVersion":"556965171","digest":"99BZLA3UVxr9XqmTQzakQ8uTmk35R6JyWBa1eiCgpJgx"},{"type":"mutated","sender":"0x53221ea79a11e3a6046282e7a246ef8472fdb31727018cb048d72e541d67e6f1","owner":{"AddressOwner":"0x53221ea79a11e3a6046282e7a246ef8472fdb31727018cb048d72e541d67e6f1"},"objectType":"0x2::coin::Coin<0x3a304c7feba2d819ea57c3542d68439ca2c386ba02159c740f7b406e592c62ea::haedal::HAEDAL>","objectId":"0x147df1a75dff16a5e7ee966d41b966e718cc27177e67855a876fb780fde7d43e","version":"556965531","previousVersion":"556965171","digest":"Gp6qVFxHzTc8rm5TCQPxhCpBoWprPh2StLHfH1NTG3es"},{"type":"mutated","sender":"0x53221ea79a11e3a6046282e7a246ef8472fdb31727018cb048d72e541d67e6f1","owner":{"ObjectOwner":"0x334881831bd89287554a6121087e498fa023ce52c037001b53a4563a00a281a5"},"objectType":"0x2::dynamic_field::Field<0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0x3a304c7feba2d819ea57c3542d68439ca2c386ba02159c740f7b406e592c62ea::haedal::HAEDAL>, 0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::native_asset::NativeAsset<0x3a304c7feba2d819ea57c3542d68439ca2c386ba02159c740f7b406e592c62ea::haedal::HAEDAL>>","objectId":"0x42b272eb5cf166861245cb82c0adc98fc9982c496cc8869a141031d3c4fe3b12","version":"556965531","previousVersion":"556963430","digest":"3tAkXi77Dui24ShRNvzSdjnfk4HabjQpfYKvEDrnm5JQ"},{"type":"mutated","sender":"0x53221ea79a11e3a6046282e7a246ef8472fdb31727018cb048d72e541d67e6f1","owner":{"Shared":{"initial_shared_version":64}},"objectType":"0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a::state::State","objectId":"0xaeab97f96cf9877fee2883315d459552b2b921edc16d7ceac6eab944dd88919c","version":"556965531","previousVersion":"556965530","digest":"FYtqG5uY7ymFB3BYn9jGArQ6xppEsC4VfhQxR6qGAT3s"},{"type":"mutated","sender":"0x53221ea79a11e3a6046282e7a246ef8472fdb31727018cb048d72e541d67e6f1","owner":{"Shared":{"initial_shared_version":66}},"objectType":"0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::state::State","objectId":"0xc57508ee0d4595e5a8728974a4a93a787d38f339757230d441e895422c07aba9","version":"556965531","previousVersion":"556964077","digest":"MoQndo45yEjj1bQeDXUyCnC75Sd4SGoaMhuZRR4XpCF"},{"type":"created","sender":"0x53221ea79a11e3a6046282e7a246ef8472fdb31727018cb048d72e541d67e6f1","owner":{"AddressOwner":"0x53221ea79a11e3a6046282e7a246ef8472fdb31727018cb048d72e541d67e6f1"},"objectType":"0x2::coin::Coin<0x3a304c7feba2d819ea57c3542d68439ca2c386ba02159c740f7b406e592c62ea::haedal::HAEDAL>","objectId":"0xc0339b6a32e521cd689f5b74a8d2b1b9fad1f72c292c0ed81ef18c20b1847541","version":"556965531","digest":"AHQAsewynGkrB3iNmaaN7uCYeRnFXagKWucXKhcv5pEC"}],"timestampMs":"1747215154277","checkpoint":"145024142"}}`),
-			pastObjects:      []byte(`{"jsonrpc":"2.0","id":1,"result":[{"status":"VersionFound","details":{"objectId":"0x42b272eb5cf166861245cb82c0adc98fc9982c496cc8869a141031d3c4fe3b12","version":"556965531","digest":"3tAkXi77Dui24ShRNvzSdjnfk4HabjQpfYKvEDrnm5JQ","content":{"dataType":"moveObject","type":"0x2::dynamic_field::Field<0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0x3a304c7feba2d819ea57c3542d68439ca2c386ba02159c740f7b406e592c62ea::haedal::HAEDAL>, 0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::native_asset::NativeAsset<0x3a304c7feba2d819ea57c3542d68439ca2c386ba02159c740f7b406e592c62ea::haedal::HAEDAL>>","hasPublicTransfer":false,"fields":{"id":{"id":"0x42b272eb5cf166861245cb82c0adc98fc9982c496cc8869a141031d3c4fe3b12"},"name":{"type":"0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0x3a304c7feba2d819ea57c3542d68439ca2c386ba02159c740f7b406e592c62ea::haedal::HAEDAL>","fields":{"dummy_field":false}},"value":{"type":"0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::native_asset::NativeAsset<0x3a304c7feba2d819ea57c3542d68439ca2c386ba02159c740f7b406e592c62ea::haedal::HAEDAL>","fields":{"custody":"49570703852513680","decimals":9,"token_address":{"type":"0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a::external_address::ExternalAddress","fields":{"value":{"type":"0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a::bytes32::Bytes32","fields":{"data":[204,137,252,194,47,13,19,222,54,136,185,79,161,109,100,162,32,121,24,106,148,25,20,40,12,103,16,31,247,84,38,60]}}}}}}}}}},{"status":"VersionFound","details":{"objectId":"0x42b272eb5cf166861245cb82c0adc98fc9982c496cc8869a141031d3c4fe3b12","version":"556963430","digest":"CTtUsqT2kGCFJ9AWYkKEYSLxN1J68Hj1M92iaX2bS4sm","content":{"dataType":"moveObject","type":"0x2::dynamic_field::Field<0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0x3a304c7feba2d819ea57c3542d68439ca2c386ba02159c740f7b406e592c62ea::haedal::HAEDAL>, 0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::native_asset::NativeAsset<0x3a304c7feba2d819ea57c3542d68439ca2c386ba02159c740f7b406e592c62ea::haedal::HAEDAL>>","hasPublicTransfer":false,"fields":{"id":{"id":"0x42b272eb5cf166861245cb82c0adc98fc9982c496cc8869a141031d3c4fe3b12"},"name":{"type":"0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0x3a304c7feba2d819ea57c3542d68439ca2c386ba02159c740f7b406e592c62ea::haedal::HAEDAL>","fields":{"dummy_field":false}},"value":{"type":"0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::native_asset::NativeAsset<0x3a304c7feba2d819ea57c3542d68439ca2c386ba02159c740f7b406e592c62ea::haedal::HAEDAL>","fields":{"custody":"49563676945331660","decimals":9,"token_address":{"type":"0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a::external_address::ExternalAddress","fields":{"value":{"type":"0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a::bytes32::Bytes32","fields":{"data":[204,137,252,194,47,13,19,222,54,136,185,79,161,109,100,162,32,121,24,106,148,25,20,40,12,103,16,31,247,84,38,60]}}}}}}}}}}]}`),
-			messagePublication: common.MessagePublication{
-				TxID:             []byte("3dFwinvN8cxotrbHmisT1zMnFiFeR5nowo9zzZw7akin"),
-				Timestamp:        time.UnixMilli(1747215154),
-				Nonce:            99916,
-				Sequence:         211135,
-				ConsistencyLevel: 0,
-				EmitterChain:     21,
-				EmitterAddress:   vaa.Address(decodeStringNoError("ccceeb29348f71bdd22ffef43a2a19c1f5b5e17c5cca5411529120182672ade5")),
-				Payload:          decodeStringNoError("01000000000000000000000000000000000000000000000000000000a39ba1725ecc89fcc22f0d13de3688b94fa16d64a22079186a941914280c67101ff754263c001500000000000000000000000065a8f07bd9a8598e1b5b6c0a88f4779dbc07767500040000000000000000000000000000000000000000000000000000000000000000"),
-			},
-		},
-		{
-			description:      "NativeHigherDepositThanRequired",
-			expectedState:    common.Valid,
-			txDigest:         "3dFwinvN8cxotrbHmisT1zMnFiFeR5nowo9zzZw7akin",
-			transactionBlock: []byte(`{"jsonrpc":"2.0","id":1,"result":{"digest":"3dFwinvN8cxotrbHmisT1zMnFiFeR5nowo9zzZw7akin","events":[{"id":{"txDigest":"3dFwinvN8cxotrbHmisT1zMnFiFeR5nowo9zzZw7akin","eventSeq":"0"},"packageId":"0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a","transactionModule":"publish_message","sender":"0x53221ea79a11e3a6046282e7a246ef8472fdb31727018cb048d72e541d67e6f1","type":"0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a::publish_message::WormholeMessage","parsedJson":{"consistency_level":0,"nonce":99916,"payload":[1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,163,155,161,114,94,204,137,252,194,47,13,19,222,54,136,185,79,161,109,100,162,32,121,24,106,148,25,20,40,12,103,16,31,247,84,38,60,0,21,0,0,0,0,0,0,0,0,0,0,0,0,101,168,240,123,217,168,89,142,27,91,108,10,136,244,119,157,188,7,118,117,0,4,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"sender":"0xccceeb29348f71bdd22ffef43a2a19c1f5b5e17c5cca5411529120182672ade5","sequence":"211135","timestamp":"1747215154"},"bcsEncoding":"base64","bcs":"zM7rKTSPcb3SL/70OioZwfW14XxcylQRUpEgGCZyreW/OAMAAAAAAEyGAQCFAQEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACjm6FyXsyJ/MIvDRPeNoi5T6FtZKIgeRhqlBkUKAxnEB/3VCY8ABUAAAAAAAAAAAAAAABlqPB72ahZjhtbbAqI9HedvAd2dQAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMmMkaAAAAAA="}],"objectChanges":[{"type":"mutated","sender":"0x53221ea79a11e3a6046282e7a246ef8472fdb31727018cb048d72e541d67e6f1","owner":{"AddressOwner":"0x53221ea79a11e3a6046282e7a246ef8472fdb31727018cb048d72e541d67e6f1"},"objectType":"0x2::coin::Coin<0x2::sui::SUI>","objectId":"0x06c1e8523e69f625f4fc1482dd42f8db436ec7607197e0671f5baa39684d4370","version":"556965531","previousVersion":"556965171","digest":"99BZLA3UVxr9XqmTQzakQ8uTmk35R6JyWBa1eiCgpJgx"},{"type":"mutated","sender":"0x53221ea79a11e3a6046282e7a246ef8472fdb31727018cb048d72e541d67e6f1","owner":{"AddressOwner":"0x53221ea79a11e3a6046282e7a246ef8472fdb31727018cb048d72e541d67e6f1"},"objectType":"0x2::coin::Coin<0x3a304c7feba2d819ea57c3542d68439ca2c386ba02159c740f7b406e592c62ea::haedal::HAEDAL>","objectId":"0x147df1a75dff16a5e7ee966d41b966e718cc27177e67855a876fb780fde7d43e","version":"556965531","previousVersion":"556965171","digest":"Gp6qVFxHzTc8rm5TCQPxhCpBoWprPh2StLHfH1NTG3es"},{"type":"mutated","sender":"0x53221ea79a11e3a6046282e7a246ef8472fdb31727018cb048d72e541d67e6f1","owner":{"ObjectOwner":"0x334881831bd89287554a6121087e498fa023ce52c037001b53a4563a00a281a5"},"objectType":"0x2::dynamic_field::Field<0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0x3a304c7feba2d819ea57c3542d68439ca2c386ba02159c740f7b406e592c62ea::haedal::HAEDAL>, 0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::native_asset::NativeAsset<0x3a304c7feba2d819ea57c3542d68439ca2c386ba02159c740f7b406e592c62ea::haedal::HAEDAL>>","objectId":"0x42b272eb5cf166861245cb82c0adc98fc9982c496cc8869a141031d3c4fe3b12","version":"556965531","previousVersion":"556963430","digest":"3tAkXi77Dui24ShRNvzSdjnfk4HabjQpfYKvEDrnm5JQ"},{"type":"mutated","sender":"0x53221ea79a11e3a6046282e7a246ef8472fdb31727018cb048d72e541d67e6f1","owner":{"Shared":{"initial_shared_version":64}},"objectType":"0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a::state::State","objectId":"0xaeab97f96cf9877fee2883315d459552b2b921edc16d7ceac6eab944dd88919c","version":"556965531","previousVersion":"556965530","digest":"FYtqG5uY7ymFB3BYn9jGArQ6xppEsC4VfhQxR6qGAT3s"},{"type":"mutated","sender":"0x53221ea79a11e3a6046282e7a246ef8472fdb31727018cb048d72e541d67e6f1","owner":{"Shared":{"initial_shared_version":66}},"objectType":"0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::state::State","objectId":"0xc57508ee0d4595e5a8728974a4a93a787d38f339757230d441e895422c07aba9","version":"556965531","previousVersion":"556964077","digest":"MoQndo45yEjj1bQeDXUyCnC75Sd4SGoaMhuZRR4XpCF"},{"type":"created","sender":"0x53221ea79a11e3a6046282e7a246ef8472fdb31727018cb048d72e541d67e6f1","owner":{"AddressOwner":"0x53221ea79a11e3a6046282e7a246ef8472fdb31727018cb048d72e541d67e6f1"},"objectType":"0x2::coin::Coin<0x3a304c7feba2d819ea57c3542d68439ca2c386ba02159c740f7b406e592c62ea::haedal::HAEDAL>","objectId":"0xc0339b6a32e521cd689f5b74a8d2b1b9fad1f72c292c0ed81ef18c20b1847541","version":"556965531","digest":"AHQAsewynGkrB3iNmaaN7uCYeRnFXagKWucXKhcv5pEC"}],"timestampMs":"1747215154277","checkpoint":"145024142"}}`),
-			pastObjects:      []byte(`{"jsonrpc":"2.0","id":1,"result":[{"status":"VersionFound","details":{"objectId":"0x42b272eb5cf166861245cb82c0adc98fc9982c496cc8869a141031d3c4fe3b12","version":"556965531","digest":"3tAkXi77Dui24ShRNvzSdjnfk4HabjQpfYKvEDrnm5JQ","content":{"dataType":"moveObject","type":"0x2::dynamic_field::Field<0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0x3a304c7feba2d819ea57c3542d68439ca2c386ba02159c740f7b406e592c62ea::haedal::HAEDAL>, 0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::native_asset::NativeAsset<0x3a304c7feba2d819ea57c3542d68439ca2c386ba02159c740f7b406e592c62ea::haedal::HAEDAL>>","hasPublicTransfer":false,"fields":{"id":{"id":"0x42b272eb5cf166861245cb82c0adc98fc9982c496cc8869a141031d3c4fe3b12"},"name":{"type":"0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0x3a304c7feba2d819ea57c3542d68439ca2c386ba02159c740f7b406e592c62ea::haedal::HAEDAL>","fields":{"dummy_field":false}},"value":{"type":"0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::native_asset::NativeAsset<0x3a304c7feba2d819ea57c3542d68439ca2c386ba02159c740f7b406e592c62ea::haedal::HAEDAL>","fields":{"custody":"49570703852513680","decimals":9,"token_address":{"type":"0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a::external_address::ExternalAddress","fields":{"value":{"type":"0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a::bytes32::Bytes32","fields":{"data":[204,137,252,194,47,13,19,222,54,136,185,79,161,109,100,162,32,121,24,106,148,25,20,40,12,103,16,31,247,84,38,60]}}}}}}}}}},{"status":"VersionFound","details":{"objectId":"0x42b272eb5cf166861245cb82c0adc98fc9982c496cc8869a141031d3c4fe3b12","version":"556963430","digest":"CTtUsqT2kGCFJ9AWYkKEYSLxN1J68Hj1M92iaX2bS4sm","content":{"dataType":"moveObject","type":"0x2::dynamic_field::Field<0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0x3a304c7feba2d819ea57c3542d68439ca2c386ba02159c740f7b406e592c62ea::haedal::HAEDAL>, 0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::native_asset::NativeAsset<0x3a304c7feba2d819ea57c3542d68439ca2c386ba02159c740f7b406e592c62ea::haedal::HAEDAL>>","hasPublicTransfer":false,"fields":{"id":{"id":"0x42b272eb5cf166861245cb82c0adc98fc9982c496cc8869a141031d3c4fe3b12"},"name":{"type":"0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0x3a304c7feba2d819ea57c3542d68439ca2c386ba02159c740f7b406e592c62ea::haedal::HAEDAL>","fields":{"dummy_field":false}},"value":{"type":"0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::native_asset::NativeAsset<0x3a304c7feba2d819ea57c3542d68439ca2c386ba02159c740f7b406e592c62ea::haedal::HAEDAL>","fields":{"custody":"49563676945320660","decimals":9,"token_address":{"type":"0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a::external_address::ExternalAddress","fields":{"value":{"type":"0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a::bytes32::Bytes32","fields":{"data":[204,137,252,194,47,13,19,222,54,136,185,79,161,109,100,162,32,121,24,106,148,25,20,40,12,103,16,31,247,84,38,60]}}}}}}}}}}]}`),
-			messagePublication: common.MessagePublication{
-				TxID:             []byte("3dFwinvN8cxotrbHmisT1zMnFiFeR5nowo9zzZw7akin"),
-				Timestamp:        time.UnixMilli(1747215154),
-				Nonce:            99916,
-				Sequence:         211135,
-				ConsistencyLevel: 0,
-				EmitterChain:     21,
-				EmitterAddress:   vaa.Address(decodeStringNoError("ccceeb29348f71bdd22ffef43a2a19c1f5b5e17c5cca5411529120182672ade5")),
-				Payload:          decodeStringNoError("01000000000000000000000000000000000000000000000000000000a39ba1725ecc89fcc22f0d13de3688b94fa16d64a22079186a941914280c67101ff754263c001500000000000000000000000065a8f07bd9a8598e1b5b6c0a88f4779dbc07767500040000000000000000000000000000000000000000000000000000000000000000"),
-			},
-		},
-		// wrapped
-		{
-			description:      "WwrappedStandard",
-			expectedState:    common.Valid,
-			txDigest:         "3YTfDnRtnLTx1wKR669jjFHznAxCXLHQZkshwk7K2oTw",
-			transactionBlock: []byte(`{"jsonrpc":"2.0","id":1,"result":{"digest":"3YTfDnRtnLTx1wKR669jjFHznAxCXLHQZkshwk7K2oTw","events":[{"id":{"txDigest":"3YTfDnRtnLTx1wKR669jjFHznAxCXLHQZkshwk7K2oTw","eventSeq":"0"},"packageId":"0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a","transactionModule":"publish_message","sender":"0x6a0055cef8a44840cea847ca53bfa269194dc1ec6739383e431822617f95bc01","type":"0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a::publish_message::WormholeMessage","parsedJson":{"consistency_level":0,"nonce":0,"payload":[1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,246,192,201,139,206,1,14,96,175,237,178,39,23,189,99,25,47,84,20,90,63,150,90,51,187,130,210,199,2,158,178,206,30,32,130,100,0,1,47,30,154,29,89,37,174,13,50,143,132,52,155,181,179,234,150,230,32,17,198,224,209,83,147,55,227,252,25,113,159,134,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"sender":"0xccceeb29348f71bdd22ffef43a2a19c1f5b5e17c5cca5411529120182672ade5","sequence":"211162","timestamp":"1747278630"},"bcsEncoding":"base64","bcs":"zM7rKTSPcb3SL/70OioZwfW14XxcylQRUpEgGCZyreXaOAMAAAAAAAAAAACFAQEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA9sDJi84BDmCv7bInF71jGS9UFFo/llozu4LSxwKess4eIIJkAAEvHpodWSWuDTKPhDSbtbPqluYgEcbg0VOTN+P8GXGfhgABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJlslaAAAAAA="}],"objectChanges":[{"type":"mutated","sender":"0x6a0055cef8a44840cea847ca53bfa269194dc1ec6739383e431822617f95bc01","owner":{"AddressOwner":"0x6a0055cef8a44840cea847ca53bfa269194dc1ec6739383e431822617f95bc01"},"objectType":"0x2::coin::Coin<0x2::sui::SUI>","objectId":"0x58e20782ae501807df528e19d43b8c5a1838cfd1f48a33597be4619c18c24f80","version":"557493695","previousVersion":"557350969","digest":"2vNHn2448gNgHWWzsKz1bZ7K4SfgWd4s7zRfCCVSdMM1"},{"type":"mutated","sender":"0x6a0055cef8a44840cea847ca53bfa269194dc1ec6739383e431822617f95bc01","owner":{"Shared":{"initial_shared_version":64}},"objectType":"0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a::state::State","objectId":"0xaeab97f96cf9877fee2883315d459552b2b921edc16d7ceac6eab944dd88919c","version":"557493695","previousVersion":"557493694","digest":"7JB9FuS1jJcP79PmwQhFu3s78JmJ1XPCj6CbXJhwziQk"},{"type":"mutated","sender":"0x6a0055cef8a44840cea847ca53bfa269194dc1ec6739383e431822617f95bc01","owner":{"ObjectOwner":"0x334881831bd89287554a6121087e498fa023ce52c037001b53a4563a00a281a5"},"objectType":"0x2::dynamic_field::Field<0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651::coin::COIN>, 0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::wrapped_asset::WrappedAsset<0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651::coin::COIN>>","objectId":"0xb4a85646ee0f7c22d54c57a06329c67f46e17420bf3654de7dec30ef9a7f18fd","version":"557493695","previousVersion":"557350964","digest":"62XV5uQbzZgGvxp9tD5TdVLSaMetnksTcuxnZzxqSxF1"},{"type":"mutated","sender":"0x6a0055cef8a44840cea847ca53bfa269194dc1ec6739383e431822617f95bc01","owner":{"Shared":{"initial_shared_version":66}},"objectType":"0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::state::State","objectId":"0xc57508ee0d4595e5a8728974a4a93a787d38f339757230d441e895422c07aba9","version":"557493695","previousVersion":"557486576","digest":"3khyLTP7S2Qp5pUnvuPPsWSjcRu2TAPWFycSAq47Jp9o"},{"type":"mutated","sender":"0x6a0055cef8a44840cea847ca53bfa269194dc1ec6739383e431822617f95bc01","owner":{"AddressOwner":"0x6a0055cef8a44840cea847ca53bfa269194dc1ec6739383e431822617f95bc01"},"objectType":"0x2::coin::Coin<0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651::coin::COIN>","objectId":"0xef5b706f1fe9e2c6b42a43dc03daa741599a6d79f1e8ea030a8747ee3c6ba7e6","version":"557493695","previousVersion":"557350969","digest":"3ayiNB8sRCACWTVsnHp8efiPvZz22ZBhk1U7a1MbvvFt"}],"timestampMs":"1747278630259","checkpoint":"145311248"}}`),
-			pastObjects:      []byte(`{"jsonrpc":"2.0","id":1,"result":[{"status":"VersionFound","details":{"objectId":"0xb4a85646ee0f7c22d54c57a06329c67f46e17420bf3654de7dec30ef9a7f18fd","version":"557493695","digest":"62XV5uQbzZgGvxp9tD5TdVLSaMetnksTcuxnZzxqSxF1","content":{"dataType":"moveObject","type":"0x2::dynamic_field::Field<0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651::coin::COIN>, 0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::wrapped_asset::WrappedAsset<0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651::coin::COIN>>","hasPublicTransfer":false,"fields":{"id":{"id":"0xb4a85646ee0f7c22d54c57a06329c67f46e17420bf3654de7dec30ef9a7f18fd"},"name":{"type":"0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651::coin::COIN>","fields":{"dummy_field":false}},"value":{"type":"0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::wrapped_asset::WrappedAsset<0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651::coin::COIN>","fields":{"decimals":6,"info":{"type":"0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::wrapped_asset::ForeignInfo<0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651::coin::COIN>","fields":{"native_decimals":6,"symbol":"USDT","token_address":{"type":"0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a::external_address::ExternalAddress","fields":{"value":{"type":"0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a::bytes32::Bytes32","fields":{"data":[206,1,14,96,175,237,178,39,23,189,99,25,47,84,20,90,63,150,90,51,187,130,210,199,2,158,178,206,30,32,130,100]}}}},"token_chain":1}},"treasury_cap":{"type":"0x2::coin::TreasuryCap<0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651::coin::COIN>","fields":{"id":{"id":"0x220c42d8c6a2b1f9d2cd8a265607d07ecf1858f55d07cfca7ebeabe51fc7298a"},"total_supply":{"type":"0x2::balance::Supply<0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651::coin::COIN>","fields":{"value":"5477949690"}}}},"upgrade_cap":{"type":"0x2::package::UpgradeCap","fields":{"id":{"id":"0x4231bc583a7768d1886f437b805da3b3178fd5ca8918c09eb36a46d4d2809c5d"},"package":"0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651","policy":0,"version":"1"}}}}}}}},{"status":"VersionFound","details":{"objectId":"0xb4a85646ee0f7c22d54c57a06329c67f46e17420bf3654de7dec30ef9a7f18fd","version":"557350964","digest":"DLeLDr1cu6M1rxWuMbhiv2uGTGYDHm7JuPztbQyqQrsM","content":{"dataType":"moveObject","type":"0x2::dynamic_field::Field<0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651::coin::COIN>, 0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::wrapped_asset::WrappedAsset<0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651::coin::COIN>>","hasPublicTransfer":false,"fields":{"id":{"id":"0xb4a85646ee0f7c22d54c57a06329c67f46e17420bf3654de7dec30ef9a7f18fd"},"name":{"type":"0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651::coin::COIN>","fields":{"dummy_field":false}},"value":{"type":"0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::wrapped_asset::WrappedAsset<0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651::coin::COIN>","fields":{"decimals":6,"info":{"type":"0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::wrapped_asset::ForeignInfo<0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651::coin::COIN>","fields":{"native_decimals":6,"symbol":"USDT","token_address":{"type":"0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a::external_address::ExternalAddress","fields":{"value":{"type":"0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a::bytes32::Bytes32","fields":{"data":[206,1,14,96,175,237,178,39,23,189,99,25,47,84,20,90,63,150,90,51,187,130,210,199,2,158,178,206,30,32,130,100]}}}},"token_chain":1}},"treasury_cap":{"type":"0x2::coin::TreasuryCap<0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651::coin::COIN>","fields":{"id":{"id":"0x220c42d8c6a2b1f9d2cd8a265607d07ecf1858f55d07cfca7ebeabe51fc7298a"},"total_supply":{"type":"0x2::balance::Supply<0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651::coin::COIN>","fields":{"value":"9617779333"}}}},"upgrade_cap":{"type":"0x2::package::UpgradeCap","fields":{"id":{"id":"0x4231bc583a7768d1886f437b805da3b3178fd5ca8918c09eb36a46d4d2809c5d"},"package":"0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651","policy":0,"version":"1"}}}}}}}}]}`),
-			messagePublication: common.MessagePublication{
-				TxID:             []byte("3YTfDnRtnLTx1wKR669jjFHznAxCXLHQZkshwk7K2oTw"),
-				Timestamp:        time.UnixMilli(1747278630),
-				Nonce:            0,
-				Sequence:         211162,
-				ConsistencyLevel: 0,
-				EmitterChain:     21,
-				EmitterAddress:   vaa.Address(decodeStringNoError("ccceeb29348f71bdd22ffef43a2a19c1f5b5e17c5cca5411529120182672ade5")),
-				Payload:          decodeStringNoError("0100000000000000000000000000000000000000000000000000000000f6c0c98bce010e60afedb22717bd63192f54145a3f965a33bb82d2c7029eb2ce1e20826400012f1e9a1d5925ae0d328f84349bb5b3ea96e62011c6e0d1539337e3fc19719f8600010000000000000000000000000000000000000000000000000000000000000000"),
-			},
-		},
-		{
-			description:      "WrappedLowerDepositThanRequired",
-			expectedState:    common.Anomalous,
-			txDigest:         "3YTfDnRtnLTx1wKR669jjFHznAxCXLHQZkshwk7K2oTw",
-			transactionBlock: []byte(`{"jsonrpc":"2.0","id":1,"result":{"digest":"3YTfDnRtnLTx1wKR669jjFHznAxCXLHQZkshwk7K2oTw","events":[{"id":{"txDigest":"3YTfDnRtnLTx1wKR669jjFHznAxCXLHQZkshwk7K2oTw","eventSeq":"0"},"packageId":"0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a","transactionModule":"publish_message","sender":"0x6a0055cef8a44840cea847ca53bfa269194dc1ec6739383e431822617f95bc01","type":"0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a::publish_message::WormholeMessage","parsedJson":{"consistency_level":0,"nonce":0,"payload":[1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,246,192,201,139,206,1,14,96,175,237,178,39,23,189,99,25,47,84,20,90,63,150,90,51,187,130,210,199,2,158,178,206,30,32,130,100,0,1,47,30,154,29,89,37,174,13,50,143,132,52,155,181,179,234,150,230,32,17,198,224,209,83,147,55,227,252,25,113,159,134,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"sender":"0xccceeb29348f71bdd22ffef43a2a19c1f5b5e17c5cca5411529120182672ade5","sequence":"211162","timestamp":"1747278630"},"bcsEncoding":"base64","bcs":"zM7rKTSPcb3SL/70OioZwfW14XxcylQRUpEgGCZyreXaOAMAAAAAAAAAAACFAQEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA9sDJi84BDmCv7bInF71jGS9UFFo/llozu4LSxwKess4eIIJkAAEvHpodWSWuDTKPhDSbtbPqluYgEcbg0VOTN+P8GXGfhgABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJlslaAAAAAA="}],"objectChanges":[{"type":"mutated","sender":"0x6a0055cef8a44840cea847ca53bfa269194dc1ec6739383e431822617f95bc01","owner":{"AddressOwner":"0x6a0055cef8a44840cea847ca53bfa269194dc1ec6739383e431822617f95bc01"},"objectType":"0x2::coin::Coin<0x2::sui::SUI>","objectId":"0x58e20782ae501807df528e19d43b8c5a1838cfd1f48a33597be4619c18c24f80","version":"557493695","previousVersion":"557350969","digest":"2vNHn2448gNgHWWzsKz1bZ7K4SfgWd4s7zRfCCVSdMM1"},{"type":"mutated","sender":"0x6a0055cef8a44840cea847ca53bfa269194dc1ec6739383e431822617f95bc01","owner":{"Shared":{"initial_shared_version":64}},"objectType":"0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a::state::State","objectId":"0xaeab97f96cf9877fee2883315d459552b2b921edc16d7ceac6eab944dd88919c","version":"557493695","previousVersion":"557493694","digest":"7JB9FuS1jJcP79PmwQhFu3s78JmJ1XPCj6CbXJhwziQk"},{"type":"mutated","sender":"0x6a0055cef8a44840cea847ca53bfa269194dc1ec6739383e431822617f95bc01","owner":{"ObjectOwner":"0x334881831bd89287554a6121087e498fa023ce52c037001b53a4563a00a281a5"},"objectType":"0x2::dynamic_field::Field<0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651::coin::COIN>, 0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::wrapped_asset::WrappedAsset<0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651::coin::COIN>>","objectId":"0xb4a85646ee0f7c22d54c57a06329c67f46e17420bf3654de7dec30ef9a7f18fd","version":"557493695","previousVersion":"557350964","digest":"62XV5uQbzZgGvxp9tD5TdVLSaMetnksTcuxnZzxqSxF1"},{"type":"mutated","sender":"0x6a0055cef8a44840cea847ca53bfa269194dc1ec6739383e431822617f95bc01","owner":{"Shared":{"initial_shared_version":66}},"objectType":"0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::state::State","objectId":"0xc57508ee0d4595e5a8728974a4a93a787d38f339757230d441e895422c07aba9","version":"557493695","previousVersion":"557486576","digest":"3khyLTP7S2Qp5pUnvuPPsWSjcRu2TAPWFycSAq47Jp9o"},{"type":"mutated","sender":"0x6a0055cef8a44840cea847ca53bfa269194dc1ec6739383e431822617f95bc01","owner":{"AddressOwner":"0x6a0055cef8a44840cea847ca53bfa269194dc1ec6739383e431822617f95bc01"},"objectType":"0x2::coin::Coin<0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651::coin::COIN>","objectId":"0xef5b706f1fe9e2c6b42a43dc03daa741599a6d79f1e8ea030a8747ee3c6ba7e6","version":"557493695","previousVersion":"557350969","digest":"3ayiNB8sRCACWTVsnHp8efiPvZz22ZBhk1U7a1MbvvFt"}],"timestampMs":"1747278630259","checkpoint":"145311248"}}`),
-			pastObjects:      []byte(`{"jsonrpc":"2.0","id":1,"result":[{"status":"VersionFound","details":{"objectId":"0xb4a85646ee0f7c22d54c57a06329c67f46e17420bf3654de7dec30ef9a7f18fd","version":"557493695","digest":"62XV5uQbzZgGvxp9tD5TdVLSaMetnksTcuxnZzxqSxF1","content":{"dataType":"moveObject","type":"0x2::dynamic_field::Field<0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651::coin::COIN>, 0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::wrapped_asset::WrappedAsset<0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651::coin::COIN>>","hasPublicTransfer":false,"fields":{"id":{"id":"0xb4a85646ee0f7c22d54c57a06329c67f46e17420bf3654de7dec30ef9a7f18fd"},"name":{"type":"0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651::coin::COIN>","fields":{"dummy_field":false}},"value":{"type":"0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::wrapped_asset::WrappedAsset<0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651::coin::COIN>","fields":{"decimals":6,"info":{"type":"0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::wrapped_asset::ForeignInfo<0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651::coin::COIN>","fields":{"native_decimals":6,"symbol":"USDT","token_address":{"type":"0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a::external_address::ExternalAddress","fields":{"value":{"type":"0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a::bytes32::Bytes32","fields":{"data":[206,1,14,96,175,237,178,39,23,189,99,25,47,84,20,90,63,150,90,51,187,130,210,199,2,158,178,206,30,32,130,100]}}}},"token_chain":1}},"treasury_cap":{"type":"0x2::coin::TreasuryCap<0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651::coin::COIN>","fields":{"id":{"id":"0x220c42d8c6a2b1f9d2cd8a265607d07ecf1858f55d07cfca7ebeabe51fc7298a"},"total_supply":{"type":"0x2::balance::Supply<0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651::coin::COIN>","fields":{"value":"5477949690"}}}},"upgrade_cap":{"type":"0x2::package::UpgradeCap","fields":{"id":{"id":"0x4231bc583a7768d1886f437b805da3b3178fd5ca8918c09eb36a46d4d2809c5d"},"package":"0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651","policy":0,"version":"1"}}}}}}}},{"status":"VersionFound","details":{"objectId":"0xb4a85646ee0f7c22d54c57a06329c67f46e17420bf3654de7dec30ef9a7f18fd","version":"557350964","digest":"DLeLDr1cu6M1rxWuMbhiv2uGTGYDHm7JuPztbQyqQrsM","content":{"dataType":"moveObject","type":"0x2::dynamic_field::Field<0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651::coin::COIN>, 0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::wrapped_asset::WrappedAsset<0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651::coin::COIN>>","hasPublicTransfer":false,"fields":{"id":{"id":"0xb4a85646ee0f7c22d54c57a06329c67f46e17420bf3654de7dec30ef9a7f18fd"},"name":{"type":"0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651::coin::COIN>","fields":{"dummy_field":false}},"value":{"type":"0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::wrapped_asset::WrappedAsset<0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651::coin::COIN>","fields":{"decimals":6,"info":{"type":"0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::wrapped_asset::ForeignInfo<0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651::coin::COIN>","fields":{"native_decimals":6,"symbol":"USDT","token_address":{"type":"0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a::external_address::ExternalAddress","fields":{"value":{"type":"0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a::bytes32::Bytes32","fields":{"data":[206,1,14,96,175,237,178,39,23,189,99,25,47,84,20,90,63,150,90,51,187,130,210,199,2,158,178,206,30,32,130,100]}}}},"token_chain":1}},"treasury_cap":{"type":"0x2::coin::TreasuryCap<0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651::coin::COIN>","fields":{"id":{"id":"0x220c42d8c6a2b1f9d2cd8a265607d07ecf1858f55d07cfca7ebeabe51fc7298a"},"total_supply":{"type":"0x2::balance::Supply<0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651::coin::COIN>","fields":{"value":"9617779233"}}}},"upgrade_cap":{"type":"0x2::package::UpgradeCap","fields":{"id":{"id":"0x4231bc583a7768d1886f437b805da3b3178fd5ca8918c09eb36a46d4d2809c5d"},"package":"0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651","policy":0,"version":"1"}}}}}}}}]}`),
-			messagePublication: common.MessagePublication{
-				TxID:             []byte("3YTfDnRtnLTx1wKR669jjFHznAxCXLHQZkshwk7K2oTw"),
-				Timestamp:        time.UnixMilli(1747278630),
-				Nonce:            0,
-				Sequence:         211162,
-				ConsistencyLevel: 0,
-				EmitterChain:     21,
-				EmitterAddress:   vaa.Address(decodeStringNoError("ccceeb29348f71bdd22ffef43a2a19c1f5b5e17c5cca5411529120182672ade5")),
-				Payload:          decodeStringNoError("0100000000000000000000000000000000000000000000000000000000f6c0c98bce010e60afedb22717bd63192f54145a3f965a33bb82d2c7029eb2ce1e20826400012f1e9a1d5925ae0d328f84349bb5b3ea96e62011c6e0d1539337e3fc19719f8600010000000000000000000000000000000000000000000000000000000000000000"),
-			},
-		},
-		{
-			description:      "WrappedHigherDepositThanRequired",
-			expectedState:    common.Valid,
-			txDigest:         "3YTfDnRtnLTx1wKR669jjFHznAxCXLHQZkshwk7K2oTw",
-			transactionBlock: []byte(`{"jsonrpc":"2.0","id":1,"result":{"digest":"3YTfDnRtnLTx1wKR669jjFHznAxCXLHQZkshwk7K2oTw","events":[{"id":{"txDigest":"3YTfDnRtnLTx1wKR669jjFHznAxCXLHQZkshwk7K2oTw","eventSeq":"0"},"packageId":"0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a","transactionModule":"publish_message","sender":"0x6a0055cef8a44840cea847ca53bfa269194dc1ec6739383e431822617f95bc01","type":"0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a::publish_message::WormholeMessage","parsedJson":{"consistency_level":0,"nonce":0,"payload":[1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,246,192,201,139,206,1,14,96,175,237,178,39,23,189,99,25,47,84,20,90,63,150,90,51,187,130,210,199,2,158,178,206,30,32,130,100,0,1,47,30,154,29,89,37,174,13,50,143,132,52,155,181,179,234,150,230,32,17,198,224,209,83,147,55,227,252,25,113,159,134,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"sender":"0xccceeb29348f71bdd22ffef43a2a19c1f5b5e17c5cca5411529120182672ade5","sequence":"211162","timestamp":"1747278630"},"bcsEncoding":"base64","bcs":"zM7rKTSPcb3SL/70OioZwfW14XxcylQRUpEgGCZyreXaOAMAAAAAAAAAAACFAQEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA9sDJi84BDmCv7bInF71jGS9UFFo/llozu4LSxwKess4eIIJkAAEvHpodWSWuDTKPhDSbtbPqluYgEcbg0VOTN+P8GXGfhgABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJlslaAAAAAA="}],"objectChanges":[{"type":"mutated","sender":"0x6a0055cef8a44840cea847ca53bfa269194dc1ec6739383e431822617f95bc01","owner":{"AddressOwner":"0x6a0055cef8a44840cea847ca53bfa269194dc1ec6739383e431822617f95bc01"},"objectType":"0x2::coin::Coin<0x2::sui::SUI>","objectId":"0x58e20782ae501807df528e19d43b8c5a1838cfd1f48a33597be4619c18c24f80","version":"557493695","previousVersion":"557350969","digest":"2vNHn2448gNgHWWzsKz1bZ7K4SfgWd4s7zRfCCVSdMM1"},{"type":"mutated","sender":"0x6a0055cef8a44840cea847ca53bfa269194dc1ec6739383e431822617f95bc01","owner":{"Shared":{"initial_shared_version":64}},"objectType":"0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a::state::State","objectId":"0xaeab97f96cf9877fee2883315d459552b2b921edc16d7ceac6eab944dd88919c","version":"557493695","previousVersion":"557493694","digest":"7JB9FuS1jJcP79PmwQhFu3s78JmJ1XPCj6CbXJhwziQk"},{"type":"mutated","sender":"0x6a0055cef8a44840cea847ca53bfa269194dc1ec6739383e431822617f95bc01","owner":{"ObjectOwner":"0x334881831bd89287554a6121087e498fa023ce52c037001b53a4563a00a281a5"},"objectType":"0x2::dynamic_field::Field<0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651::coin::COIN>, 0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::wrapped_asset::WrappedAsset<0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651::coin::COIN>>","objectId":"0xb4a85646ee0f7c22d54c57a06329c67f46e17420bf3654de7dec30ef9a7f18fd","version":"557493695","previousVersion":"557350964","digest":"62XV5uQbzZgGvxp9tD5TdVLSaMetnksTcuxnZzxqSxF1"},{"type":"mutated","sender":"0x6a0055cef8a44840cea847ca53bfa269194dc1ec6739383e431822617f95bc01","owner":{"Shared":{"initial_shared_version":66}},"objectType":"0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::state::State","objectId":"0xc57508ee0d4595e5a8728974a4a93a787d38f339757230d441e895422c07aba9","version":"557493695","previousVersion":"557486576","digest":"3khyLTP7S2Qp5pUnvuPPsWSjcRu2TAPWFycSAq47Jp9o"},{"type":"mutated","sender":"0x6a0055cef8a44840cea847ca53bfa269194dc1ec6739383e431822617f95bc01","owner":{"AddressOwner":"0x6a0055cef8a44840cea847ca53bfa269194dc1ec6739383e431822617f95bc01"},"objectType":"0x2::coin::Coin<0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651::coin::COIN>","objectId":"0xef5b706f1fe9e2c6b42a43dc03daa741599a6d79f1e8ea030a8747ee3c6ba7e6","version":"557493695","previousVersion":"557350969","digest":"3ayiNB8sRCACWTVsnHp8efiPvZz22ZBhk1U7a1MbvvFt"}],"timestampMs":"1747278630259","checkpoint":"145311248"}}`),
-			pastObjects:      []byte(`{"jsonrpc":"2.0","id":1,"result":[{"status":"VersionFound","details":{"objectId":"0xb4a85646ee0f7c22d54c57a06329c67f46e17420bf3654de7dec30ef9a7f18fd","version":"557493695","digest":"62XV5uQbzZgGvxp9tD5TdVLSaMetnksTcuxnZzxqSxF1","content":{"dataType":"moveObject","type":"0x2::dynamic_field::Field<0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651::coin::COIN>, 0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::wrapped_asset::WrappedAsset<0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651::coin::COIN>>","hasPublicTransfer":false,"fields":{"id":{"id":"0xb4a85646ee0f7c22d54c57a06329c67f46e17420bf3654de7dec30ef9a7f18fd"},"name":{"type":"0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651::coin::COIN>","fields":{"dummy_field":false}},"value":{"type":"0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::wrapped_asset::WrappedAsset<0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651::coin::COIN>","fields":{"decimals":6,"info":{"type":"0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::wrapped_asset::ForeignInfo<0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651::coin::COIN>","fields":{"native_decimals":6,"symbol":"USDT","token_address":{"type":"0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a::external_address::ExternalAddress","fields":{"value":{"type":"0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a::bytes32::Bytes32","fields":{"data":[206,1,14,96,175,237,178,39,23,189,99,25,47,84,20,90,63,150,90,51,187,130,210,199,2,158,178,206,30,32,130,100]}}}},"token_chain":1}},"treasury_cap":{"type":"0x2::coin::TreasuryCap<0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651::coin::COIN>","fields":{"id":{"id":"0x220c42d8c6a2b1f9d2cd8a265607d07ecf1858f55d07cfca7ebeabe51fc7298a"},"total_supply":{"type":"0x2::balance::Supply<0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651::coin::COIN>","fields":{"value":"5477949690"}}}},"upgrade_cap":{"type":"0x2::package::UpgradeCap","fields":{"id":{"id":"0x4231bc583a7768d1886f437b805da3b3178fd5ca8918c09eb36a46d4d2809c5d"},"package":"0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651","policy":0,"version":"1"}}}}}}}},{"status":"VersionFound","details":{"objectId":"0xb4a85646ee0f7c22d54c57a06329c67f46e17420bf3654de7dec30ef9a7f18fd","version":"557350964","digest":"DLeLDr1cu6M1rxWuMbhiv2uGTGYDHm7JuPztbQyqQrsM","content":{"dataType":"moveObject","type":"0x2::dynamic_field::Field<0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651::coin::COIN>, 0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::wrapped_asset::WrappedAsset<0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651::coin::COIN>>","hasPublicTransfer":false,"fields":{"id":{"id":"0xb4a85646ee0f7c22d54c57a06329c67f46e17420bf3654de7dec30ef9a7f18fd"},"name":{"type":"0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651::coin::COIN>","fields":{"dummy_field":false}},"value":{"type":"0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::wrapped_asset::WrappedAsset<0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651::coin::COIN>","fields":{"decimals":6,"info":{"type":"0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::wrapped_asset::ForeignInfo<0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651::coin::COIN>","fields":{"native_decimals":6,"symbol":"USDT","token_address":{"type":"0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a::external_address::ExternalAddress","fields":{"value":{"type":"0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a::bytes32::Bytes32","fields":{"data":[206,1,14,96,175,237,178,39,23,189,99,25,47,84,20,90,63,150,90,51,187,130,210,199,2,158,178,206,30,32,130,100]}}}},"token_chain":1}},"treasury_cap":{"type":"0x2::coin::TreasuryCap<0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651::coin::COIN>","fields":{"id":{"id":"0x220c42d8c6a2b1f9d2cd8a265607d07ecf1858f55d07cfca7ebeabe51fc7298a"},"total_supply":{"type":"0x2::balance::Supply<0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651::coin::COIN>","fields":{"value":"9617779433"}}}},"upgrade_cap":{"type":"0x2::package::UpgradeCap","fields":{"id":{"id":"0x4231bc583a7768d1886f437b805da3b3178fd5ca8918c09eb36a46d4d2809c5d"},"package":"0xa69d563d6ff583e8171a7807b4c8c09434e0782aef8b849adb5c8609e9312651","policy":0,"version":"1"}}}}}}}}]}`),
-			messagePublication: common.MessagePublication{
-				TxID:             []byte("3YTfDnRtnLTx1wKR669jjFHznAxCXLHQZkshwk7K2oTw"),
-				Timestamp:        time.UnixMilli(1747278630),
-				Nonce:            0,
-				Sequence:         211162,
-				ConsistencyLevel: 0,
-				EmitterChain:     21,
-				EmitterAddress:   vaa.Address(decodeStringNoError("ccceeb29348f71bdd22ffef43a2a19c1f5b5e17c5cca5411529120182672ade5")),
-				Payload:          decodeStringNoError("0100000000000000000000000000000000000000000000000000000000f6c0c98bce010e60afedb22717bd63192f54145a3f965a33bb82d2c7029eb2ce1e20826400012f1e9a1d5925ae0d328f84349bb5b3ea96e62011c6e0d1539337e3fc19719f8600010000000000000000000000000000000000000000000000000000000000000000"),
-			},
-		},
-	}
-)
+// hexTo32 decodes a 32-byte hex string (with or without a 0x prefix) into a [32]byte.
+func hexTo32(s string) [32]byte {
+	raw := decodeStringNoError(strings.TrimPrefix(s, "0x"))
+	var out [32]byte
+	copy(out[:], raw)
+	return out
+}
 
+func strPtr(s string) *string { return &s }
+func u64Ptr(v uint64) *uint64 { return &v }
+
+// Local BCS mirrors of the on-chain native asset dynamic field, used to synthesize object
+// contents for the verifier. The layout mirrors the txverifier package's internal structs
+// (BCS only depends on field order/types, not the declaring package).
+type bcsBytes32T struct{ Data []byte }
+type bcsExternalAddressT struct{ Value bcsBytes32T }
+type bcsNativeAssetT struct {
+	Custody      uint64
+	TokenAddress bcsExternalAddressT
+	Decimals     uint8
+}
+type bcsNativeAssetFieldT struct {
+	ID    [32]byte
+	Name  bool
+	Value bcsNativeAssetT
+}
+
+func bcsNativeObjectForTest(custody uint64, tokenAddress []byte, decimals uint8) []byte {
+	return mystenbcs.MustMarshal(bcsNativeAssetFieldT{
+		Value: bcsNativeAssetT{
+			Custody:      custody,
+			TokenAddress: bcsExternalAddressT{Value: bcsBytes32T{Data: tokenAddress}},
+			Decimals:     decimals,
+		},
+	})
+}
+
+// transferPayloadForTest builds a minimal Wormhole token-transfer payload (type 1).
+func transferPayloadForTest(amount *big.Int, originAddress []byte, originChain uint16) []byte {
+	p := make([]byte, 0, 101)
+	p = append(p, 1) // payload type 1 == transfer
+	p = append(p, amount.FillBytes(make([]byte, 32))...)
+	p = append(p, originAddress...)
+	p = append(p, byte(originChain>>8), byte(originChain&0xff))
+	p = append(p, make([]byte, 101-len(p))...)
+	return p
+}
+
+// TestVerifyAndPublish_Samples checks that verifyAndPublish runs the transfer verifier and
+// propagates the resulting verification state to the published message. The verifier is driven
+// by a mock gRPC client serving a synthesized native-asset transfer; the exhaustive verifier
+// scenario coverage lives in the txverifier package.
 func TestVerifyAndPublish_Samples(t *testing.T) {
-	// This test runs verifyAndPublish against historical bridge transfers which should
-	// be verified as valid.
-
-	// This test uses mainnet values, since the samples come from mainnet transactions
+	// Mainnet values.
 	suiCoreContract := "0x5306f64e312b581766351c07af79c72fcb1cd25147157fdc2f8ad76de9a3fb6a"
 	//nolint:gosec
 	suiTokenBridgeEmitter := "0xccceeb29348f71bdd22ffef43a2a19c1f5b5e17c5cca5411529120182672ade5"
 	//nolint:gosec
 	suiTokenBridgeContract := "0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d"
-	transactionModule := "publish_message"
-	eventType := fmt.Sprintf("%s::%s::WormholeMessage", suiCoreContract, transactionModule)
+	eventType := fmt.Sprintf("%s::publish_message::WormholeMessage", suiCoreContract)
 
-	// Create mock API connection
-	mockApiConnection := &MockSuiApiConnection{
-		transactionBlockResponses:      make(map[string]txverifier.SuiGetTransactionBlockResponse),
-		tryMultiGetPastObjectsResponse: make(map[string]txverifier.SuiTryMultiGetPastObjectsResponse),
+	emitter32 := hexTo32(suiTokenBridgeEmitter)
+	tokenAddress := decodeStringNoError("9258181f5ceac8dbffb7030890243caed69a9599d2886d957a9cb7656af3bdb3")
+	nativeObjectType := fmt.Sprintf("0x2::dynamic_field::Field<%s::token_registry::Key<0x2::sui::SUI>, %s::native_asset::NativeAsset<0x2::sui::SUI>>", suiTokenBridgeContract, suiTokenBridgeContract)
+	objectId := "0x831c45a8d512c9cf46e7a8a947f7cbbb5e0a59829aa72450ff26fb1873fd0e94"
+	txDigest := "3dFwinvN8cxotrbHmisT1zMnFiFeR5nowo9zzZw7akin"
+	curVersion := uint64(100)
+	prevVersion := uint64(99)
+
+	tests := []struct {
+		description   string
+		expectedState common.VerificationState
+		sequence      uint64
+		amount        *big.Int
+		custodyAfter  uint64
+		custodyBefore uint64
+	}{
+		// Deposit (custody delta 990) covers the 990 requested out of the bridge.
+		{"NativeStandard", common.Valid, 1, big.NewInt(990), 1000, 10},
+		// Deposit (custody delta 50) is far short of the 100000 requested out of the bridge.
+		{"NativeInsufficientDeposit", common.Anomalous, 2, big.NewInt(100000), 1050, 1000},
 	}
 
-	suiTxVerifier := txverifier.NewSuiTransferVerifier(suiCoreContract, suiTokenBridgeEmitter, suiTokenBridgeContract, mockApiConnection)
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			payload := transferPayloadForTest(tt.amount, tokenAddress, uint16(vaa.ChainIDSui))
 
-	// Create message publication channel
-	msgChan := make(chan *common.MessagePublication, 10)
+			event := suiclient.SuiEvent{
+				EventType: eventType,
+				BcsBytes:  mystenbcs.MustMarshal(txverifier.WormholeMessage{Sender: emitter32, Sequence: tt.sequence, Payload: payload}),
+			}
+			change := suiclient.SuiObjectChange{
+				ObjectID:      strPtr(objectId),
+				ObjectType:    strPtr(nativeObjectType),
+				OutputVersion: u64Ptr(curVersion),
+				InputVersion:  u64Ptr(prevVersion),
+			}
 
-	// Create watcher
-	testWatcher := NewSuiWatcherForTest(msgChan, suiTxVerifier, eventType)
+			mock := &mockSuiClient{
+				transactions: map[string]suiclient.SuiTransaction{
+					txDigest: {Events: []suiclient.SuiEvent{event}, ObjectChanges: []suiclient.SuiObjectChange{change}},
+				},
+				objects: map[string][]byte{
+					mockObjectKey(objectId, curVersion):  bcsNativeObjectForTest(tt.custodyAfter, tokenAddress, 8),
+					mockObjectKey(objectId, prevVersion): bcsNativeObjectForTest(tt.custodyBefore, tokenAddress, 8),
+				},
+			}
 
-	// Create empty logger and context
-	testCtx := context.TODO()
-	testLogger := zap.NewNop()
+			suiTxVerifier := txverifier.NewSuiTransferVerifier(suiCoreContract, suiTokenBridgeEmitter, suiTokenBridgeContract, mock)
 
-	// Run verifyAndPublish on samples
-	for _, sample := range Samples {
+			msgChan := make(chan *common.MessagePublication, 1)
+			testWatcher := NewSuiWatcherForTest(msgChan, suiTxVerifier, eventType)
 
-		t.Run(sample.description, func(t *testing.T) {
-			// Set sample data in mock api
-			var transactionBlockResponse txverifier.SuiGetTransactionBlockResponse
-			_ = json.Unmarshal(sample.transactionBlock, &transactionBlockResponse)
+			msg := &common.MessagePublication{
+				TxID:             []byte(txDigest),
+				Timestamp:        time.Unix(1747215154, 0),
+				Sequence:         tt.sequence,
+				EmitterChain:     vaa.ChainIDSui,
+				EmitterAddress:   vaa.Address(emitter32),
+				Payload:          payload,
+				ConsistencyLevel: 0,
+			}
 
-			mockApiConnection.SetTransactionBlock(sample.txDigest, transactionBlockResponse)
+			err := testWatcher.verifyAndPublish(context.TODO(), msg, txDigest, zap.NewNop())
+			require.NoError(t, err)
 
-			var pastObjects txverifier.SuiTryMultiGetPastObjectsResponse
-			_ = json.Unmarshal(sample.pastObjects, &pastObjects)
-
-			objectId, _ := pastObjects.GetObjectId()
-			version, _ := pastObjects.Result[0].GetVersion()
-			previousVersion, _ := pastObjects.Result[1].GetVersion()
-
-			mockApiConnection.SetPastObjects(objectId, version, previousVersion, pastObjects)
-
-			// call verify and publish
-			_ = testWatcher.verifyAndPublish(testCtx, &sample.messagePublication, sample.txDigest, testLogger)
-
-			newMessagePublication := <-msgChan
-			require.Equal(t, sample.expectedState, newMessagePublication.VerificationState())
+			published := <-msgChan
+			require.Equal(t, tt.expectedState, published.VerificationState())
 		})
-
 	}
 }

--- a/scripts/sui-transfer-verifier.sh
+++ b/scripts/sui-transfer-verifier.sh
@@ -8,6 +8,7 @@ TOKEN_BRIDGE_CONTRACT="0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0
 
 TOKEN_BRIDGE_EMITTER="0xccceeb29348f71bdd22ffef43a2a19c1f5b5e17c5cca5411529120182672ade5"
 
+# gRPC endpoint, host:port (e.g. fullnode.mainnet.sui.io:443)
 RPC=<RPC_HERE>
 
 LOG_LEVEL="info"


### PR DESCRIPTION
In this PR we update the Sui watcher and txverifier to call into the new `suiclient` package that was added in #4804. The most significant change is that we now BCS decode the returned on-chain data, instead of decoding the JSON data that was returned by the JSON-RPC. Although the new `gRPC` API does support formatting BCS return data as JSON, we elect to use the BCS return data to avoid theoretically vulnerabilities in that translation layer.

The [watcher_live_test.go](https://github.com/wormhole-foundation/wormhole/pull/4850/changes#diff-8e73bb58efd137d13fb2ecfc8785f68d88279e89a0adcd351012bebee4ec4217) file was added in this PR and it validates that the message data parsed by the new logic exactly matches the data that is returned by the soon to be deprecated JSON-RPC.

A flag has been removed from the txverifier as the new subscription based client is forwards looking. The backwards polling on startup based on the latest block is no longer supported but as far as I can tell this isn't critical functionality.

The `worm` cli tool should also be updated to utilise the new Sui gRPC interface, but that is left for a future PR as it's an intrusive change that requires the updating of numerous dependencies.