### PR TITLE
node: close EVM watcher connector on supervisor restart

### DIFF
--- a/node/go.mod
+++ b/node/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/ethereum/go-ethereum v1.10.21
 	github.com/gagliardetto/solana-go v1.8.4
 	github.com/gorilla/mux v1.8.0
-	github.com/gorilla/websocket v1.5.3 // indirect
+	github.com/gorilla/websocket v1.5.3
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.2
@@ -67,6 +67,7 @@ require (
 	github.com/prometheus/common v0.60.0
 	github.com/wormhole-foundation/wormchain v0.0.0-00010101000000-000000000000
 	github.com/wormhole-foundation/wormhole/sdk v0.0.0-20220926172624-4b38dc650bb0
+	go.uber.org/goleak v1.3.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20250707201910-8d1bb00bc6a7
 	nhooyr.io/websocket v1.8.7
 )
@@ -355,7 +356,6 @@ require (
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/dig v1.18.0 // indirect
 	go.uber.org/fx v1.23.0 // indirect
-	go.uber.org/goleak v1.3.0 // indirect
 	go.uber.org/mock v0.5.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/ratelimit v0.2.0 // indirect

--- a/node/pkg/adminrpc/adminserver_test.go
+++ b/node/pkg/adminrpc/adminserver_test.go
@@ -93,7 +93,7 @@ func (c mockEVMConnector) Client() *ethclient.Client {
 	panic("unimplemented")
 }
 
-func (c mockEVMConnector) Close() error { return nil }
+func (c mockEVMConnector) Close() {}
 
 func (c mockEVMConnector) SubscribeNewHead(ctx context.Context, ch chan<- *types.Header) (ethereum.Subscription, error) {
 	panic("unimplemented")

--- a/node/pkg/adminrpc/adminserver_test.go
+++ b/node/pkg/adminrpc/adminserver_test.go
@@ -93,6 +93,8 @@ func (c mockEVMConnector) Client() *ethclient.Client {
 	panic("unimplemented")
 }
 
+func (c mockEVMConnector) Close() error { return nil }
+
 func (c mockEVMConnector) SubscribeNewHead(ctx context.Context, ch chan<- *types.Header) (ethereum.Subscription, error) {
 	panic("unimplemented")
 }

--- a/node/pkg/watchers/evm/chain_config.go
+++ b/node/pkg/watchers/evm/chain_config.go
@@ -232,6 +232,8 @@ func QueryEvmChainID(ctx context.Context, url string) (uint64, error) {
 	if err != nil {
 		return 0, fmt.Errorf("failed to connect to endpoint: %w", err)
 	}
+	// The context only bounds the dial; the client must be closed explicitly.
+	defer c.Close()
 
 	var str string
 	err = c.CallContext(ctx, &str, "eth_chainId")
@@ -261,6 +263,7 @@ func (w *Watcher) verifyEvmChainID(ctx context.Context, logger *zap.Logger, url 
 	if err != nil {
 		return fmt.Errorf("failed to connect to endpoint: %w", err)
 	}
+	defer c.Close()
 
 	var str string
 	err = c.CallContext(ctx, &str, "eth_chainId")

--- a/node/pkg/watchers/evm/connectors/batch_poller_test.go
+++ b/node/pkg/watchers/evm/connectors/batch_poller_test.go
@@ -186,6 +186,8 @@ func (e *mockConnectorForBatchPoller) Client() *ethClient.Client {
 	return e.client
 }
 
+func (e *mockConnectorForBatchPoller) Close() error { return nil }
+
 type mockSubscription struct {
 	errC chan error
 }

--- a/node/pkg/watchers/evm/connectors/batch_poller_test.go
+++ b/node/pkg/watchers/evm/connectors/batch_poller_test.go
@@ -186,7 +186,7 @@ func (e *mockConnectorForBatchPoller) Client() *ethClient.Client {
 	return e.client
 }
 
-func (e *mockConnectorForBatchPoller) Close() error { return nil }
+func (e *mockConnectorForBatchPoller) Close() {}
 
 type mockSubscription struct {
 	errC chan error

--- a/node/pkg/watchers/evm/connectors/common.go
+++ b/node/pkg/watchers/evm/connectors/common.go
@@ -63,6 +63,9 @@ type Connector interface {
 	RawBatchCallContext(ctx context.Context, b []rpc.BatchElem) error
 	Client() *ethClient.Client
 	SubscribeNewHead(ctx context.Context, ch chan<- *types.Header) (ethereum.Subscription, error)
+	// Close releases the underlying rpc.Client (and its dispatch goroutine),
+	// which is otherwise leaked when the watcher restarts the connector.
+	Close() error
 }
 
 type PollSubscription struct {

--- a/node/pkg/watchers/evm/connectors/common.go
+++ b/node/pkg/watchers/evm/connectors/common.go
@@ -63,9 +63,8 @@ type Connector interface {
 	RawBatchCallContext(ctx context.Context, b []rpc.BatchElem) error
 	Client() *ethClient.Client
 	SubscribeNewHead(ctx context.Context, ch chan<- *types.Header) (ethereum.Subscription, error)
-	// Close releases the underlying rpc.Client (and its dispatch goroutine),
-	// which is otherwise leaked when the watcher restarts the connector.
-	Close() error
+	// Close releases the underlying rpc.Client and its goroutines.
+	Close()
 }
 
 type PollSubscription struct {

--- a/node/pkg/watchers/evm/connectors/ethereum.go
+++ b/node/pkg/watchers/evm/connectors/ethereum.go
@@ -145,11 +145,9 @@ func (e *EthereumBaseConnector) SubscribeNewHead(ctx context.Context, ch chan<- 
 	return e.client.SubscribeNewHead(ctx, ch)
 }
 
-// Close releases the JSON-RPC client, signalling its dispatch/read/write
-// goroutines to exit. Safe to call multiple times.
-func (e *EthereumBaseConnector) Close() error {
+// Close releases the JSON-RPC client and its goroutines. Safe to call multiple times.
+func (e *EthereumBaseConnector) Close() {
 	if e.rawClient != nil {
 		e.rawClient.Close()
 	}
-	return nil
 }

--- a/node/pkg/watchers/evm/connectors/ethereum.go
+++ b/node/pkg/watchers/evm/connectors/ethereum.go
@@ -144,3 +144,12 @@ func (e *EthereumBaseConnector) Client() *ethClient.Client {
 func (e *EthereumBaseConnector) SubscribeNewHead(ctx context.Context, ch chan<- *ethTypes.Header) (ethereum.Subscription, error) {
 	return e.client.SubscribeNewHead(ctx, ch)
 }
+
+// Close releases the JSON-RPC client, signalling its dispatch/read/write
+// goroutines to exit. Safe to call multiple times.
+func (e *EthereumBaseConnector) Close() error {
+	if e.rawClient != nil {
+		e.rawClient.Close()
+	}
+	return nil
+}

--- a/node/pkg/watchers/evm/connectors/ethereum_close_test.go
+++ b/node/pkg/watchers/evm/connectors/ethereum_close_test.go
@@ -50,7 +50,7 @@ func TestEthereumBaseConnector_CloseReleasesGoroutines(t *testing.T) {
 	defer cancel()
 	warm, err := NewEthereumBaseConnector(ctx, "warmup", url, addr, nil, logger)
 	require.NoError(t, err)
-	require.NoError(t, warm.Close())
+	warm.Close()
 
 	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 
@@ -59,6 +59,6 @@ func TestEthereumBaseConnector_CloseReleasesGoroutines(t *testing.T) {
 		c, err := NewEthereumBaseConnector(dctx, "test", url, addr, nil, logger)
 		dcancel()
 		require.NoError(t, err, "dial %d", i)
-		require.NoError(t, c.Close(), "close %d", i)
+		c.Close()
 	}
 }

--- a/node/pkg/watchers/evm/connectors/ethereum_close_test.go
+++ b/node/pkg/watchers/evm/connectors/ethereum_close_test.go
@@ -1,0 +1,64 @@
+package connectors
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	ethCommon "github.com/ethereum/go-ethereum/common"
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+	"go.uber.org/zap/zaptest"
+)
+
+// idleWSServer accepts WebSocket upgrades and holds them open, which is enough
+// for go-ethereum's rpc.Client to spawn its dispatch/read/write goroutines.
+func idleWSServer(t *testing.T) string {
+	t.Helper()
+	up := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := up.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		for {
+			if _, _, err := c.NextReader(); err != nil {
+				_ = c.Close()
+				return
+			}
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return "ws" + strings.TrimPrefix(srv.URL, "http")
+}
+
+// TestEthereumBaseConnector_CloseReleasesGoroutines asserts that dialing and
+// Close()-ing connectors leaks no goroutines. Without Close(), each dial
+// strands the rpc.Client's dispatch/read/write goroutines.
+func TestEthereumBaseConnector_CloseReleasesGoroutines(t *testing.T) {
+	url := idleWSServer(t)
+	logger := zaptest.NewLogger(t)
+	addr := ethCommon.HexToAddress("0x0")
+
+	// Warm up shared transport singletons before the baseline so IgnoreCurrent
+	// does not flag them; the check then sees only goroutines from the loop.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	warm, err := NewEthereumBaseConnector(ctx, "warmup", url, addr, nil, logger)
+	require.NoError(t, err)
+	require.NoError(t, warm.Close())
+
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	for i := 0; i < 25; i++ {
+		dctx, dcancel := context.WithTimeout(context.Background(), 5*time.Second)
+		c, err := NewEthereumBaseConnector(dctx, "test", url, addr, nil, logger)
+		dcancel()
+		require.NoError(t, err, "dial %d", i)
+		require.NoError(t, c.Close(), "close %d", i)
+	}
+}

--- a/node/pkg/watchers/evm/connectors/poller_test.go
+++ b/node/pkg/watchers/evm/connectors/poller_test.go
@@ -70,6 +70,7 @@ func (m *mockConnectorForPoller) GetLatest(ctx context.Context) (latest, finaliz
 	return m.prevLatest, m.prevFinalized, m.prevSafe, nil
 }
 func (m *mockConnectorForPoller) Client() *ethClient.Client { return m.client }
+func (m *mockConnectorForPoller) Close() error              { return nil }
 func (m *mockConnectorForPoller) SubscribeNewHead(ctx context.Context, ch chan<- *ethTypes.Header) (ethereum.Subscription, error) {
 	return nil, fmt.Errorf("not supported on HTTP")
 }

--- a/node/pkg/watchers/evm/connectors/poller_test.go
+++ b/node/pkg/watchers/evm/connectors/poller_test.go
@@ -70,7 +70,7 @@ func (m *mockConnectorForPoller) GetLatest(ctx context.Context) (latest, finaliz
 	return m.prevLatest, m.prevFinalized, m.prevSafe, nil
 }
 func (m *mockConnectorForPoller) Client() *ethClient.Client { return m.client }
-func (m *mockConnectorForPoller) Close() error              { return nil }
+func (m *mockConnectorForPoller) Close()                    {}
 func (m *mockConnectorForPoller) SubscribeNewHead(ctx context.Context, ch chan<- *ethTypes.Header) (ethereum.Subscription, error) {
 	return nil, fmt.Errorf("not supported on HTTP")
 }

--- a/node/pkg/watchers/evm/reobserve.go
+++ b/node/pkg/watchers/evm/reobserve.go
@@ -158,6 +158,7 @@ func (w *Watcher) Reobserve(ctx context.Context, chainID vaa.ChainID, txID []byt
 	if err != nil {
 		return 0, fmt.Errorf(`failed to connect to endpoint "%v": %w`, customEndpoint, err)
 	}
+	defer ethConn.Close()
 
 	// Get the current finalized and safe blocks.
 	_, finalized, safe, err := ethConn.GetLatest(timeout)

--- a/node/pkg/watchers/evm/watcher.go
+++ b/node/pkg/watchers/evm/watcher.go
@@ -289,6 +289,12 @@ func (w *Watcher) Run(parentCtx context.Context) error {
 		return fmt.Errorf("failed to verify evm chain id: %w", verifyErr)
 	}
 
+	// Reset Run-scoped state: the watcher value persists across supervisor
+	// restarts, so a map left full by a prior Run accumulates without this.
+	w.pendingMu.Lock()
+	w.pending = make(map[pendingKey]*pendingMessage)
+	w.pendingMu.Unlock()
+
 	// Connect to the node using the appropriate type of connector.
 	{
 		var finalizedPollingSupported, safePollingSupported bool
@@ -300,6 +306,15 @@ func (w *Watcher) Run(parentCtx context.Context) error {
 			p2p.DefaultRegistry.AddErrorCount(w.chainID, 1)
 			return fmt.Errorf(`failed to create connection to url "%s": %w`, w.url, err)
 		}
+
+		// Release the rpc.Client when Run returns so a supervisor restart does
+		// not strand the prior client's dispatch goroutines. Captured by value.
+		ethConnToClose := w.ethConn
+		defer func() {
+			if ethConnToClose != nil {
+				_ = ethConnToClose.Close()
+			}
+		}()
 
 		// Log the connector details for troubleshooting purposes.
 		if finalizedPollingSupported {

--- a/node/pkg/watchers/evm/watcher.go
+++ b/node/pkg/watchers/evm/watcher.go
@@ -289,12 +289,6 @@ func (w *Watcher) Run(parentCtx context.Context) error {
 		return fmt.Errorf("failed to verify evm chain id: %w", verifyErr)
 	}
 
-	// Reset Run-scoped state: the watcher value persists across supervisor
-	// restarts, so a map left full by a prior Run accumulates without this.
-	w.pendingMu.Lock()
-	w.pending = make(map[pendingKey]*pendingMessage)
-	w.pendingMu.Unlock()
-
 	// Connect to the node using the appropriate type of connector.
 	{
 		var finalizedPollingSupported, safePollingSupported bool
@@ -307,14 +301,9 @@ func (w *Watcher) Run(parentCtx context.Context) error {
 			return fmt.Errorf(`failed to create connection to url "%s": %w`, w.url, err)
 		}
 
-		// Release the rpc.Client when Run returns so a supervisor restart does
-		// not strand the prior client's dispatch goroutines. Captured by value.
-		ethConnToClose := w.ethConn
-		defer func() {
-			if ethConnToClose != nil {
-				_ = ethConnToClose.Close()
-			}
-		}()
+		// Close this Run's connector on return so its goroutines exit.
+		// w.pending is deliberately kept: clearing it would drop messages.
+		defer w.ethConn.Close()
 
 		// Log the connector details for troubleshooting purposes.
 		if finalizedPollingSupported {
@@ -884,6 +873,8 @@ func (w *Watcher) getFinality(ctx context.Context) (bool, bool, error) {
 		if err != nil {
 			return false, false, fmt.Errorf("failed to connect to endpoint: %w", err)
 		}
+		// The context only bounds the dial; the client must be closed explicitly.
+		defer c.Close()
 
 		type Marshaller struct {
 			Number *eth_hexutil.Big


### PR DESCRIPTION
## Summary

Fixes a guardian EVM watcher leak. The `Connector` had no `Close()`, so on supervisor restart the previous connector's `*rpc.Client` (and its dispatch goroutine) was never released, and the pending-observation map — held on the watcher value, which persists across restarts — was reused with stale entries.

## Change

- Add `Close()` to the `Connector` interface and `EthereumBaseConnector`.
- `Run()` defers `Close()` and re-initialises the pending-observation map on entry.

## Test

`TestEthereumBaseConnector_CloseReleasesGoroutines` dials and closes 25 connectors against an in-process WebSocket endpoint and asserts no goroutine leak via `goleak`. The `go.mod` change only promotes `goleak` and `gorilla/websocket` from indirect to direct — no new modules.

## Notes

Scoped to the EVM connector fix only. The Sui data-pump backoff / RPC-error-surfacing change has been dropped from this PR; it will be handled as part of the upcoming Sui SDK migration.