### PR TITLE
cleanup: remove CGO

### DIFF
--- a/Dockerfile.proto
+++ b/Dockerfile.proto
@@ -7,7 +7,7 @@ COPY tools/build.sh /app/tools/
 COPY tools/go.* /app/tools/
 
 RUN --mount=type=cache,target=/root/.cache --mount=type=cache,target=/go \
-	cd /app/tools && CGO_ENABLED=0 ./build.sh
+	cd /app/tools && ./build.sh
 
 # syntax=docker.io/docker/dockerfile:1.3@sha256:42399d4635eddd7a9b8a24be879d2f9a930d0ed040a61324cfdf59ef1357b3b2
 FROM docker.io/golang:1.25.10-bookworm@sha256:154bd7001b6eb339e88c964442c0ad6ed5e53f09844cc818a41ce4ecb3ce3b43 AS go-build

--- a/Dockerfile.proto
+++ b/Dockerfile.proto
@@ -6,8 +6,12 @@ RUN mkdir /app
 COPY tools/build.sh /app/tools/
 COPY tools/go.* /app/tools/
 
+# Build these tools as static binaries. They are compiled in this Debian-based
+# image but later copied into Alpine (below in the `node-build` step), which 
+# does not provide Debian's glibc dynamic loader. Without CGO_ENABLED=0, tools 
+# such as buf can be linked against glibc and fail in Alpine with a misleading "not found" error.
 RUN --mount=type=cache,target=/root/.cache --mount=type=cache,target=/go \
-	cd /app/tools && ./build.sh
+	cd /app/tools && CGO_ENABLED=0 ./build.sh
 
 # syntax=docker.io/docker/dockerfile:1.3@sha256:42399d4635eddd7a9b8a24be879d2f9a930d0ed040a61324cfdf59ef1357b3b2
 FROM docker.io/golang:1.25.10-bookworm@sha256:154bd7001b6eb339e88c964442c0ad6ed5e53f09844cc818a41ce4ecb3ce3b43 AS go-build

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,6 @@ lint-rust:
 node: $(BIN)/guardiand
 
 .PHONY: $(BIN)/guardiand
-$(BIN)/guardiand: CGO_ENABLED=1
 $(BIN)/guardiand: dirs generate
 	cd node && go build -ldflags "-X github.com/certusone/wormhole/node/pkg/version.version=${VERSION}" \
 	  -mod=readonly -o ../$(BIN)/guardiand \

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -17,7 +17,6 @@ COPY wormchain wormchain
 ARG GO_BUILD_ARGS=-race
 
 RUN --mount=type=cache,target=/root/.cache --mount=type=cache,target=/go \
-  export CGO_ENABLED=1 && \
   cd node && \
   go build ${GO_BUILD_ARGS} -gcflags="all=-N -l" --ldflags '-X "github.com/certusone/wormhole/node/cmd/guardiand.Build=dev"' -mod=readonly -o /guardiand github.com/certusone/wormhole/node && \
   go get github.com/CosmWasm/wasmvm@v1.1.1 && \

--- a/node/hack/query/ccqlistener/Dockerfile
+++ b/node/hack/query/ccqlistener/Dockerfile
@@ -16,7 +16,6 @@ COPY wormchain wormchain
 ARG GO_BUILD_ARGS=-race
 
 RUN --mount=type=cache,target=/root/.cache --mount=type=cache,target=/go \
-  export CGO_ENABLED=1 && \
   cd node/hack/query/ccqlistener && \
   go build ${GO_BUILD_ARGS} -gcflags="all=-N -l" --ldflags '-X "github.com/certusone/wormhole/node/cmd/guardiand.Build=dev"' -mod=readonly -o /ccqlistener ccqlistener.go && \
   go get github.com/CosmWasm/wasmvm@v1.1.1 && \


### PR DESCRIPTION
CGO was originally required in order to support Celo. However, their
architecture has changed substantially and so we shouldn't need CGO
support anymore.

See also `56cf37a7ecee3de2d8eae0456c4360f3023922e9` for prior work.
