### PR TITLE
node: migrate solana-go imports to foundation path

### DIFF
--- a/node/go.mod
+++ b/node/go.mod
@@ -381,6 +381,11 @@ require (
 // https://github.com/cosmos/cosmos-sdk/issues/10925 for more details.
 replace github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 
+// The solana-foundation repository still declares its module identity as
+// github.com/gagliardetto/solana-go. Keep importing the declared module path
+// until a future solana-foundation version updates its go.mod module path.
+replace github.com/gagliardetto/solana-go => github.com/solana-foundation/solana-go v1.8.4
+
 replace github.com/wormhole-foundation/wormhole/sdk => ../sdk
 
 replace github.com/wormhole-foundation/wormchain => ../wormchain

--- a/node/go.sum
+++ b/node/go.sum
@@ -3922,6 +3922,8 @@ github.com/snikch/goodman v0.0.0-20171125024755-10e37e294daa/go.mod h1:oJyF+mSPH
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/soheilhy/cmux v0.1.5 h1:jjzc5WVemNEDTLwv9tlmemhC73tI08BNOIGwBOo10Js=
 github.com/soheilhy/cmux v0.1.5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE1GqG0=
+github.com/solana-foundation/solana-go v1.8.4 h1:gY+bAzgylupRGe0BVr1ZaFKDVMfny25KWr8XE30hZHA=
+github.com/solana-foundation/solana-go v1.8.4/go.mod h1:i+7aAyNDTHG0jK8GZIBSI4OVvDqkt2Qx+LklYclRNG8=
 github.com/sonatard/noctx v0.0.1/go.mod h1:9D2D/EoULe8Yy2joDHJj7bv3sZoq9AaSb8B4lqBjiZI=
 github.com/sony/gobreaker v0.4.1/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJOjmxWY=
 github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:UdhH50NIW0fCiwBSr0co2m7BnFLdv4fQTgdqdJTHFeE=


### PR DESCRIPTION
Add replace directive for solana-foundation's version of solana-go.
This module is still exported by them under the `gagliardetto` name
so we can't change the actual import directives in the files that
use this package.

Verification that v1.8.4 is identical across both repos:

git ls-remote --tags https://github.com/gagliardetto/solana-go.git refs/tags/v1.8.4
git ls-remote --tags https://github.com/solana-foundation/solana-go.git refs/tags/v1.8.4

Both resolve to:
834605a343769985bdad2bd0c8ba7dbf7ff7ba7d

go mod download -json github.com/gagliardetto/solana-go@v1.8.4
go mod download -json github.com/solana-foundation/solana-go@v1.8.4

Both report Origin.Hash:
834605a343769985bdad2bd0c8ba7dbf7ff7ba7d

diff -qr \
  "$HOME/go/pkg/mod/github.com/gagliardetto/solana-go@v1.8.4" \
  "$HOME/go/pkg/mod/github.com/solana-foundation/solana-go@v1.8.4"

No diff output confirms the extracted module trees are identical.
