### PR TITLE
Update codeowners for go.sum

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -135,9 +135,11 @@
 
 /node/pkg/suiclient @djb15 @mdulin2 @pleasew8t
 
-## Guardian Dependency Upgrades (go.mod) 
+## Guardian Dependency Upgrades (go.mod + go.sum)
 /node/go.mod @djb15 @johnsaigle @mdulin2 @pleasew8t @bemic
+/node/go.sum @djb15 @johnsaigle @mdulin2 @pleasew8t @bemic
 /sdk/go.mod @djb15 @johnsaigle @mdulin2 @pleasew8t @bemic
+/sdk/go.sum @djb15 @johnsaigle @mdulin2 @pleasew8t @bemic
 
 ## Node (package)
 


### PR DESCRIPTION
Practically, it would be useful for the same codeowners of `go.mod` to also be able to approve changes to `go.sum`. 