### PR TITLE
chore(docs): update wormchain information

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -246,6 +246,8 @@ wormchaind tx bank send <sender-address> <new-validator-address> 1utest \
 
 The easiest way to sync your wormchain node is via a snapshot. Follow [these instructions](../wormchain/syncing.md#sync-from-snapshot) to sync from a snapshot.
 
+**NOTE**: past tx might be held up in the governor if you sync wormchain while running an active guardian. Disable the governor feature before syncing in existing guardians. In general, this should only *ever* happen for initial new guardian setup prior to entering the active set via the vote to update the guardian set.
+
 #### Create your validator via a transaction
 
 The final step before the governance VAA to add your new validator into the guardian set is the `create-validator` wormchain command. Use `<key-name>` from when the `.info` file was created above and run this command:
@@ -267,6 +269,8 @@ wormchaind tx staking create-validator \
   --home=/path/to/wormchain \
   --node=<wormchain-rpc-endpoint>
 ```
+
+The native wormchain gas token is `utest` and it is denominated in `uworm`, much like ETH vs gwei. Since wormchain is a permissioned blockchain, these tokens have no inherent value and are solely for submitting transactions.
 
 <!-- cspell:enable -->
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -210,8 +210,103 @@ This command will ask for a passphrase to be created for it. Both `wormchain.key
 - `--accountantKeyPath`
 - `--accountantKeyPassPhrase`
 
-**Note**
-These steps could be executed directly on the `guardiand` node, having previously built the `wormchaind` binary.
+Feel free to run these directly on the `guardiand` node, having previously built the `wormchaind` binary.
+
+**NOTE**: Share the wormchain public key for your validator with the wormhole foundaton. It should be in the format: `wormhole1xxx`.
+
+#### Allowlist your new validator
+
+Work with the wormhole foundation to have another guardian add your new wormchain validator to the allowlist.
+
+For transparency, the guardian adding your key to the allowlist would run a command like (`<key name>` is from the `.info` file created previously):
+
+```bash
+wormchaind tx wormhole create-allowed-address <new validator public key> \
+	--home $HOME \
+	--from <key_name> \
+	--keyring-backend file \
+	--chain-id wormchain \
+	--broadcast-mode block \
+	--node tcp://127.0.0.1:26657
+```
+
+They will also need to send you at least 1 `utest` token which is the native gas token for wormchain (and has no inherent value). This is an example command they run to do this for you:
+
+```bash
+wormchaind tx bank send <sending wormchain public key> <new validator public key> 1utest \
+	--home $HOME \
+	--from <key_name> \
+	--keyring-backend file \
+	--chain-id wormchain \
+	--broadcast-mode block \
+	--node tcp://127.0.0.1:26657
+```
+
+#### Create your validator via a transaction
+
+The final step before the governance VAA to add your new validator into the guardian set is the `create-validator` wormchain command. Replace `<validator name>` with the `<key name>` from when the `.info` file was created above and run this command:
+
+```bash
+wormchaind tx staking create-validator \
+  --amount=1000000uworm \
+  --pubkey=$(wormchaind tendermint show-validator --home /path/to/wormchain) \
+  --moniker="<your-validator-name>" \
+  --chain-id=wormchain \
+  --commission-rate="0.00" \
+  --commission-max-rate="0.20" \
+  --commission-max-change-rate="0.02" \
+  --min-self-delegation="1" \
+  --from=<validator-name> \
+  --keyring-backend=file \
+  --home=/path/to/wormchain \
+  --node=<wormchain-rpc-endpoint>
+```
+
+After this, all that remains to add your node to the active set is a governance VAA that the existing guardian set must vote on.
+
+##### Creating your validator via an offline transaction
+
+Get the `key` for the `--pubkey` flag from `consensus_pubkey` via `wormchaind q staking validators`.
+
+Generate the offline transaction to sign:
+
+```bash
+wormchaind tx staking create-validator \
+  --from $(wormchaind tendermint show-validator --home /path/to/wormchain) \
+  --amount 0uworm \
+  --min-self-delegation 0 \
+  --pubkey '{"@type":"/cosmos.crypto.ed25519.PubKey","key":"<your-consensus-pubkey>"}' \
+  --moniker "<your-validator-name>" \
+  --commission-rate 0.0 \
+  --commission-max-rate 0.2 \
+  --commission-max-change-rate 0.01 \
+  --chain-id wormchain \
+  --home /path/to/wormchain \
+  --generate-only > tx.json
+```
+
+Sign the offline transaction:
+
+```bash
+wormchaind tx sign tx.json \
+  --from <> \
+  --offline \
+  --account-number 0 \
+  --sequence 0 \
+  --chain-id wormchain \
+  --keyring-backend file \
+  --home /path/to/wormchain > tx-signed.json
+```
+
+Broadcast the signed transaction out to the network:
+
+```bash
+wormchaind tx broadcast tx-signed.json \
+  --node tcp://localhost:26657 \
+  -o json
+```
+
+Once the governance VAA vote passes, your guardian and wormchain will be added into the active set.
 
 #### Wormchain Useful Commands
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -242,6 +242,10 @@ wormchaind tx bank send <sending wormchain public key> <new validator public key
 	--node tcp://127.0.0.1:26657
 ```
 
+#### Sync from a snapshot
+
+The easiest way to sync your wormchain node is via a snapshot. Follow [these instructions](../wormchain/syncing.md#sync-from-snapshot) to sync from a snapshot.
+
 #### Create your validator via a transaction
 
 The final step before the governance VAA to add your new validator into the guardian set is the `create-validator` wormchain command. Replace `<validator name>` with the `<key name>` from when the `.info` file was created above and run this command:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -202,7 +202,7 @@ To generate wormchain keys, run the following command:
 This command will create a `<key-name>.info` file. To extract the key, run the following command:
 
 ```bash
-wormchaind keys export <key_name> --home /path/to/wormchain/directory --keyring-dir . --keyring-backend file
+wormchaind keys export <key-name> --home /path/to/wormchain/directory --keyring-dir . --keyring-backend file
 ```
 
 This command will ask for a passphrase to be created for it. Both `wormchain.key` and `passphrase` will be used by the following `guardiand` flags:
@@ -212,18 +212,18 @@ This command will ask for a passphrase to be created for it. Both `wormchain.key
 
 Feel free to run these directly on the `guardiand` node, having previously built the `wormchaind` binary.
 
-**NOTE**: Share the wormchain public key for your validator with the wormhole foundaton. It should be in the format: `wormhole1xxx`.
+**NOTE**: Share the wormchain public key for your validator with the Wormhole Foundation. It should be in the format: `wormhole1xxx`.
 
 #### Allowlist your new validator
 
-Work with the wormhole foundation to have another guardian add your new wormchain validator to the allowlist.
+Work with the Wormhole Foundation to have another guardian add your new wormchain validator to the allowlist.
 
-For transparency, the guardian adding your key to the allowlist would run a command like (`<key name>` is from the `.info` file created previously):
+For transparency, the guardian adding your key to the allowlist would run a command like this (`<allowlisting-guardian-key-name>` is from the `.info` file created previously):
 
 ```bash
-wormchaind tx wormhole create-allowed-address <new validator public key> \
-	--home $HOME \
-	--from <key_name> \
+wormchaind tx wormhole create-allowed-address "<new-validator-address>" "<new-validator-name>" \
+	--home /path/to/wormchain/directory \
+	--from <allowlisting-guardian-key-name> \
 	--keyring-backend file \
 	--chain-id wormchain \
 	--broadcast-mode block \
@@ -233,9 +233,9 @@ wormchaind tx wormhole create-allowed-address <new validator public key> \
 They will also need to send you at least 1 `utest` token which is the native gas token for wormchain (and has no inherent value). This is an example command they run to do this for you:
 
 ```bash
-wormchaind tx bank send <sending wormchain public key> <new validator public key> 1utest \
-	--home $HOME \
-	--from <key_name> \
+wormchaind tx bank send <sender-address> <new-validator-address> 1utest \
+	--home /path/to/wormchain/directory \
+	--from <key-name> \
 	--keyring-backend file \
 	--chain-id wormchain \
 	--broadcast-mode block \
@@ -248,7 +248,9 @@ The easiest way to sync your wormchain node is via a snapshot. Follow [these ins
 
 #### Create your validator via a transaction
 
-The final step before the governance VAA to add your new validator into the guardian set is the `create-validator` wormchain command. Replace `<validator name>` with the `<key name>` from when the `.info` file was created above and run this command:
+The final step before the governance VAA to add your new validator into the guardian set is the `create-validator` wormchain command. Use `<key-name>` from when the `.info` file was created above and run this command:
+
+<!-- cspell:disable -->
 
 ```bash
 wormchaind tx staking create-validator \
@@ -260,11 +262,13 @@ wormchaind tx staking create-validator \
   --commission-max-rate="0.20" \
   --commission-max-change-rate="0.02" \
   --min-self-delegation="1" \
-  --from=<validator-name> \
+  --from=<key-name> \
   --keyring-backend=file \
   --home=/path/to/wormchain \
   --node=<wormchain-rpc-endpoint>
 ```
+
+<!-- cspell:enable -->
 
 After this, all that remains to add your node to the active set is a governance VAA that the existing guardian set must vote on.
 
@@ -274,9 +278,11 @@ Get the `key` for the `--pubkey` flag from `consensus_pubkey` via `wormchaind q 
 
 Generate the offline transaction to sign:
 
+<!-- cspell:disable -->
+
 ```bash
 wormchaind tx staking create-validator \
-  --from $(wormchaind tendermint show-validator --home /path/to/wormchain) \
+  --from <key-name> \
   --amount 0uworm \
   --min-self-delegation 0 \
   --pubkey '{"@type":"/cosmos.crypto.ed25519.PubKey","key":"<your-consensus-pubkey>"}' \
@@ -289,11 +295,13 @@ wormchaind tx staking create-validator \
   --generate-only > tx.json
 ```
 
+<!-- cspell:enable -->
+
 Sign the offline transaction:
 
 ```bash
 wormchaind tx sign tx.json \
-  --from <> \
+  --from <key-name> \
   --offline \
   --account-number 0 \
   --sequence 0 \

--- a/wormchain/syncing.md
+++ b/wormchain/syncing.md
@@ -25,9 +25,9 @@ make build/wormchaind
 
 Please ask the Wormhole contributors for a recent Wormchain snapshot to use.
 
-You can also use daily snapshots exported by various teams:
-- Polkachu: [https://polkachu.com/tendermint_snapshots/wormchain/](https://polkachu.com/tendermint_snapshots/wormchain/)
-- CryptoCrew: [https://github.com/clemensgg/CryptoCrew-Validators/blob/main/chains/wormchain/service_Node_Snapshot.md](https://github.com/clemensgg/CryptoCrew-Validators/blob/main/chains/wormchain/service_Node_Snapshot.md)
+You can also use regular snapshots exported by various teams:
+- [MCF](https://mcf.rocks/mcf-wormchain-snapshots.rpy)
+- [Polkachu](https://polkachu.com/tendermint_snapshots/wormchain/)
 
 ## Download and Clean Snapshot
 
@@ -43,7 +43,7 @@ Now you should be able to successfully start your node!
 ### Troubleshooting
 
 > We were just able to successfully statesync when retaining the `wasm` folder and deleting the wasm cache, just fyi:
-> 
+>
 > - you need the `wasm` folder from a synced node
 > - then configure statesync + `unsafe-reset-all`
 > - then copy in wasm state `cp -r <your-wasm-folder-location> $DAEMON_HOME/data`
@@ -141,7 +141,7 @@ cp ../mainnet/* config/
 ./build/wormchaind-v2.18.1 start --home . --moniker <your-moniker> --halt-height 4411562
 # check sync status
 ./wormchaind-v2.18.1 status | jq ".SyncInfo.latest_block_height"
-# sync until block 4411562 
+# sync until block 4411562
 ```
 
 ## Sync with v2.18.1.1

--- a/wormchain/syncing.md
+++ b/wormchain/syncing.md
@@ -138,7 +138,7 @@ cp ../mainnet/* config/
 ## Sync with v2.18.1
 
 ```bash
-./build/wormchaind-v2.18.1 start --home . --moniker <your-moniker> --halt-height 4411562
+./wormchaind-v2.18.1 start --home . --moniker <your-moniker> --halt-height 4411562
 # check sync status
 ./wormchaind-v2.18.1 status | jq ".SyncInfo.latest_block_height"
 # sync until block 4411562
@@ -147,8 +147,8 @@ cp ../mainnet/* config/
 ## Sync with v2.18.1.1
 
 ```bash
-./build/wormchaind-v2.18.1.1 rollback --home .
-./build/wormchaind-v2.18.1.1 start --home . --moniker <your-moniker>
+./wormchaind-v2.18.1.1 rollback --home .
+./wormchaind-v2.18.1.1 start --home . --moniker <your-moniker>
 # sync will stop automatically on block 4449129
 # after this stops, you just need to restart your wormchain node with v2.23.0
 # no rollback is required.
@@ -157,9 +157,9 @@ cp ../mainnet/* config/
 ## Sync with v2.23.0
 
 ```bash
-./build/wormchaind-v2.23.0 start --home . --moniker <your-moniker>
+./wormchaind-v2.23.0 start --home . --moniker <your-moniker>
 # check sync status
-./build/wormchaind-v2.23.0 status | jq ".SyncInfo.latest_block_height"
+./wormchaind-v2.23.0 status | jq ".SyncInfo.latest_block_height"
 # Error in validation err="wrong Block.Header.LastResultsHash.  Expected 4C349D91FFFC2B84588E703A5459CBB29D6053D788C32B8AF1445F44CFCD988B, got D2D3EBC9D1249733EE2CBD7CA9C9A63509BB28436BFF200CEB6162BCBA282EC3" module=blockchain
 # Block 8630308
 ```
@@ -167,7 +167,7 @@ cp ../mainnet/* config/
 ## Sync with v2.24.2-wormchaind
 
 ```bash
-./build/wormchaind-v2.24.2-wormchaind rollback --home .
-./build/wormchaind-v2.24.2-wormchaind start --home . --moniker <your-moniker>
+./wormchaind-v2.24.2-wormchaind rollback --home .
+./wormchaind-v2.24.2-wormchaind start --home . --moniker <your-moniker>
 # this will sync until the latest block!
 ```


### PR DESCRIPTION
Add some docs on setting up wormchain.

For syncing, CryptoCrew removed the wormchain bits, Polkachu was behind ~4 months but fixed a broken cronjob, and MCF serves up to date snapshots.