### PR TITLE
node: Consolidate borsch library usage

### DIFF
--- a/node/go.mod
+++ b/node/go.mod
@@ -21,7 +21,6 @@ require (
 	github.com/libp2p/go-libp2p-pubsub v0.12.0
 	github.com/mr-tron/base58 v1.2.0
 	github.com/multiformats/go-multiaddr v0.13.0
-	github.com/near/borsh-go v0.3.0
 	github.com/prometheus/client_golang v1.20.5
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5

--- a/node/go.sum
+++ b/node/go.sum
@@ -3416,8 +3416,6 @@ github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OS
 github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d/go.mod h1:o96djdrsSGy3AWPyBgZMAGfxZNfgntdJG+11KU4QvbU=
 github.com/nbutton23/zxcvbn-go v0.0.0-20210217022336-fa2cb2858354/go.mod h1:KSVJerMDfblTH7p5MZaTt+8zaT2iEk3AkVb9PQdZuE8=
 github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/ZM=
-github.com/near/borsh-go v0.3.0 h1:+DvG7eApOD3KrHIh7TwZvYzhXUF/OzMTC6aRTUEtW+8=
-github.com/near/borsh-go v0.3.0/go.mod h1:NeMochZp7jN/pYFuxLkrZtmLqbADmnp/y1+/dL+AsyQ=
 github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86/go.mod h1:kHJEU3ofeGjhHklVoIGuVj85JJwZ6kWPaJwCIxgnFmo=
 github.com/neelance/sourcemap v0.0.0-20151028013722-8c68805598ab/go.mod h1:Qr6/a/Q4r9LP1IltGz7tA7iOK1WonHEYhu1HRBA7ZiM=
 github.com/neilotoole/errgroup v0.1.5/go.mod h1:Q2nLGf+594h0CLBs/Mbg6qOr7GtqDK7C2S41udRnToE=

--- a/node/pkg/watchers/solana/client.go
+++ b/node/pkg/watchers/solana/client.go
@@ -22,13 +22,13 @@ import (
 	"github.com/certusone/wormhole/node/pkg/supervisor"
 	"github.com/certusone/wormhole/node/pkg/watchers"
 	"github.com/coder/websocket"
+	bin "github.com/gagliardetto/binary"
 	"github.com/gagliardetto/solana-go"
 	lookup "github.com/gagliardetto/solana-go/programs/address-lookup-table"
 	"github.com/gagliardetto/solana-go/rpc"
 	"github.com/gagliardetto/solana-go/rpc/jsonrpc"
 	"github.com/google/uuid"
 	"github.com/mr-tron/base58"
-	"github.com/near/borsh-go"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/wormhole-foundation/wormhole/sdk/vaa"
@@ -330,6 +330,10 @@ type PostMessageData struct {
 	Nonce            uint32
 	Payload          []byte
 	ConsistencyLevel ConsistencyLevel
+}
+
+func decodeBorsh(dst interface{}, data []byte) error {
+	return bin.UnmarshalBorsh(dst, data)
 }
 
 func NewSolanaWatcher(
@@ -968,7 +972,7 @@ func (s *SolanaWatcher) processInstruction(ctx context.Context, rpcClient *rpc.C
 
 	// Decode instruction data (UNTRUSTED)
 	var data PostMessageData
-	if err := borsh.Deserialize(&data, inst.Data[1:]); err != nil {
+	if err := decodeBorsh(&data, inst.Data[1:]); err != nil {
 		return false, fmt.Errorf("failed to deserialize instruction data: %w", err)
 	}
 
@@ -1306,7 +1310,7 @@ func ParseMessagePublicationAccount(
 	}
 
 	prop := &MessagePublicationAccount{}
-	if err := borsh.Deserialize(prop, data[prefixLength:]); err != nil {
+	if err := decodeBorsh(prop, data[prefixLength:]); err != nil {
 		return nil, err
 	}
 

--- a/node/pkg/watchers/solana/client.go
+++ b/node/pkg/watchers/solana/client.go
@@ -347,6 +347,14 @@ func decodeBorsh(dst any, data []byte) error {
 	return nil
 }
 
+// decodeBorshAllowTrailing deserializes data into dst, ignoring any trailing bytes.
+// Use this only where the corresponding on-chain program is also lenient — the watcher
+// must accept exactly what the chain accepted. The shim's post message parser explicitly
+// ignores trailing bytes (svm/wormhole-core-shims/crates/shim/src/post_message.rs).
+func decodeBorshAllowTrailing(dst any, data []byte) error {
+	return bin.UnmarshalBorsh(dst, data)
+}
+
 func NewSolanaWatcher(
 	rpcUrl string,
 	wsUrl string,

--- a/node/pkg/watchers/solana/client.go
+++ b/node/pkg/watchers/solana/client.go
@@ -332,8 +332,19 @@ type PostMessageData struct {
 	ConsistencyLevel ConsistencyLevel
 }
 
-func decodeBorsh(dst interface{}, data []byte) error {
-	return bin.UnmarshalBorsh(dst, data)
+// decodeBorsh deserializes data into dst, requiring the entire input to be consumed.
+// The Borsh reference implementation (borsh-rs) rejects unconsumed trailing bytes at its
+// API boundary (try_from_slice), but bin.UnmarshalBorsh does not, so we enforce it here.
+// https://github.com/near/borsh#specification
+func decodeBorsh(dst any, data []byte) error {
+	dec := bin.NewBorshDecoder(data)
+	if err := dec.Decode(dst); err != nil {
+		return err
+	}
+	if dec.HasRemaining() {
+		return fmt.Errorf("borsh: %d trailing bytes not consumed", dec.Remaining())
+	}
+	return nil
 }
 
 func NewSolanaWatcher(

--- a/node/pkg/watchers/solana/client_test.go
+++ b/node/pkg/watchers/solana/client_test.go
@@ -218,10 +218,6 @@ func TestParseMessagePublicationAccount(t *testing.T) {
 	)
 
 	const (
-		// Define error string for testing. This is returned by the borsh-go library when it fails to
-		// deserialize a struct. In this case, we're relying on the library to fail when
-		// the message account data can't be deserialized into [MessagePublicationAccount].
-		errStringBorsh         = "failed to read required bytes"
 		errStringParseTooShort = "message account data is too short"
 	)
 
@@ -230,6 +226,7 @@ func TestParseMessagePublicationAccount(t *testing.T) {
 		// Named input parameters for target function.
 		messageAccountData func(t *testing.T) MessageAccountData
 		want               *MessagePublicationAccount
+		wantErr            bool
 		errStr             string
 	}{
 		{
@@ -272,6 +269,25 @@ func TestParseMessagePublicationAccount(t *testing.T) {
 			errStr: "",
 		},
 		{
+			name: "success -- trailing bytes are ignored",
+			messageAccountData: func(t *testing.T) MessageAccountData {
+				withTrailingBytes := append([]byte{}, validMessageAccountDataReliable...)
+				withTrailingBytes = append(withTrailingBytes, 0xff, 0xee, 0xdd)
+				return mustNewMessageAccountData(t, withTrailingBytes)
+			},
+			want: &MessagePublicationAccount{
+				VaaVersion:       0,
+				ConsistencyLevel: 32,
+				SubmissionTime:   1770212672,
+				Nonce:            0,
+				Sequence:         1367797,
+				EmitterChain:     1,
+				EmitterAddress:   emitterAddrReliable,
+				Payload:          payload,
+			},
+			errStr: "",
+		},
+		{
 			name: "success -- reliable message with non-zero vaa time",
 			messageAccountData: func(t *testing.T) MessageAccountData {
 				acct := testMessagePublicationAccount(payload, 32)
@@ -304,8 +320,9 @@ func TestParseMessagePublicationAccount(t *testing.T) {
 			messageAccountData: func(t *testing.T) MessageAccountData {
 				return MessageAccountData{}
 			},
-			want:   &MessagePublicationAccount{},
-			errStr: errStringParseTooShort,
+			want:    &MessagePublicationAccount{},
+			wantErr: true,
+			errStr:  errStringParseTooShort,
 		},
 		{
 			name: "failure -- data too short",
@@ -314,47 +331,60 @@ func TestParseMessagePublicationAccount(t *testing.T) {
 				// defense-in-depth length check rather than the constructor's validation.
 				return MessageAccountData{[]byte("ms")}
 			},
-			want:   &MessagePublicationAccount{},
-			errStr: errStringParseTooShort,
+			want:    &MessagePublicationAccount{},
+			wantErr: true,
+			errStr:  errStringParseTooShort,
 		},
 		{
 			name: "failure -- no data following prefix (msg)",
 			messageAccountData: func(t *testing.T) MessageAccountData {
 				return mustNewMessageAccountData(t, []byte("msg"))
 			},
-			want:   &MessagePublicationAccount{},
-			errStr: errStringBorsh,
+			want:    &MessagePublicationAccount{},
+			wantErr: true,
 		},
 		{
 			name: "failure -- no data following prefix (msu)",
 			messageAccountData: func(t *testing.T) MessageAccountData {
 				return mustNewMessageAccountData(t, []byte("msu"))
 			},
-			want:   &MessagePublicationAccount{},
-			errStr: errStringBorsh,
+			want:    &MessagePublicationAccount{},
+			wantErr: true,
 		},
 		{
 			name: "failure -- truncated data (msg)",
 			messageAccountData: func(t *testing.T) MessageAccountData {
 				return mustNewMessageAccountData(t, validMessageAccountDataReliable[:len(validMessageAccountDataReliable)-1])
 			},
-			want:   &MessagePublicationAccount{},
-			errStr: errStringBorsh,
+			want:    &MessagePublicationAccount{},
+			wantErr: true,
 		},
 		{
 			name: "failure -- truncated data (msu)",
 			messageAccountData: func(t *testing.T) MessageAccountData {
 				return mustNewMessageAccountData(t, validMessageAccountDataUnreliable[:len(validMessageAccountDataUnreliable)-1])
 			},
-			want:   &MessagePublicationAccount{},
-			errStr: errStringBorsh,
+			want:    &MessagePublicationAccount{},
+			wantErr: true,
+		},
+		{
+			name: "failure -- payload length exceeds remaining data",
+			messageAccountData: func(t *testing.T) MessageAccountData {
+				payloadLen := uint32(len(payload) + 1) // #nosec G115 -- Test data, payload length is small.
+				return mustNewMessageAccountData(t, corruptMessagePublicationPayloadLength(t, validMessageAccountDataReliable, payloadLen))
+			},
+			want:    &MessagePublicationAccount{},
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, gotErr := ParseMessagePublicationAccount(tt.messageAccountData(t))
-			if tt.errStr != "" {
-				require.ErrorContains(t, gotErr, tt.errStr)
+			if tt.wantErr {
+				require.Error(t, gotErr)
+				if tt.errStr != "" {
+					require.ErrorContains(t, gotErr, tt.errStr)
+				}
 				return
 			}
 
@@ -661,6 +691,7 @@ func TestProcessAccountSubscriptionData(t *testing.T) {
 func TestProcessInstructionEarlyReturns(t *testing.T) {
 	// Scenario: instruction filtering should return early for non-matching cases.
 	commitmentMismatchData := encodePostMessageData(t, 42, []byte("hi"), consistencyLevelConfirmed)
+	payloadLenExceedsData := corruptPostMessagePayloadLength(t, encodePostMessageData(t, 7, []byte("test"), consistencyLevelFinalized), 6)
 
 	tests := []struct {
 		name    string
@@ -687,6 +718,11 @@ func TestProcessInstructionEarlyReturns(t *testing.T) {
 		{
 			name:    "borsh_error",
 			inst:    solana.CompiledInstruction{ProgramIDIndex: 0, Data: []byte{postMessageInstructionID}, Accounts: make([]uint16, postMessageInstructionMinNumAccounts)},
+			wantErr: true,
+		},
+		{
+			name:    "payload_length_exceeds_data",
+			inst:    solana.CompiledInstruction{ProgramIDIndex: 0, Data: append([]byte{postMessageInstructionID}, payloadLenExceedsData...), Accounts: make([]uint16, postMessageInstructionMinNumAccounts)},
 			wantErr: true,
 		},
 		{
@@ -1487,6 +1523,15 @@ func encodeMessagePublicationAccount(t *testing.T, prefix string, proposal Messa
 	return buf.Bytes()
 }
 
+func corruptMessagePublicationPayloadLength(t *testing.T, data []byte, payloadLen uint32) []byte {
+	t.Helper()
+	const payloadLenOffset = 3 + 1 + 1 + 32 + 1 + 3 + 4 + 4 + 8 + 2 + 32
+	ret := append([]byte{}, data...)
+	require.GreaterOrEqual(t, len(ret), payloadLenOffset+4)
+	binary.LittleEndian.PutUint32(ret[payloadLenOffset:payloadLenOffset+4], payloadLen)
+	return ret
+}
+
 func mustDecodeHex(t *testing.T, s string) []byte {
 	t.Helper()
 	b, err := hex.DecodeString(s)
@@ -1515,6 +1560,15 @@ func encodePostMessageData(t *testing.T, nonce uint32, payload []byte, consisten
 	buf.Write(payload)
 	buf.WriteByte(byte(consistency))
 	return buf.Bytes()
+}
+
+func corruptPostMessagePayloadLength(t *testing.T, data []byte, payloadLen uint32) []byte {
+	t.Helper()
+	const payloadLenOffset = 4
+	ret := append([]byte{}, data...)
+	require.GreaterOrEqual(t, len(ret), payloadLenOffset+4)
+	binary.LittleEndian.PutUint32(ret[payloadLenOffset:payloadLenOffset+4], payloadLen)
+	return ret
 }
 
 func buildSubscriptionPayload(t *testing.T, owner, pubkey string, accountData []byte) []byte {

--- a/node/pkg/watchers/solana/client_test.go
+++ b/node/pkg/watchers/solana/client_test.go
@@ -269,23 +269,15 @@ func TestParseMessagePublicationAccount(t *testing.T) {
 			errStr: "",
 		},
 		{
-			name: "success -- trailing bytes are ignored",
+			name: "failure -- trailing bytes are rejected",
 			messageAccountData: func(t *testing.T) MessageAccountData {
 				withTrailingBytes := append([]byte{}, validMessageAccountDataReliable...)
 				withTrailingBytes = append(withTrailingBytes, 0xff, 0xee, 0xdd)
 				return mustNewMessageAccountData(t, withTrailingBytes)
 			},
-			want: &MessagePublicationAccount{
-				VaaVersion:       0,
-				ConsistencyLevel: 32,
-				SubmissionTime:   1770212672,
-				Nonce:            0,
-				Sequence:         1367797,
-				EmitterChain:     1,
-				EmitterAddress:   emitterAddrReliable,
-				Payload:          payload,
-			},
-			errStr: "",
+			want:    &MessagePublicationAccount{},
+			wantErr: true,
+			errStr:  "trailing bytes",
 		},
 		{
 			name: "success -- reliable message with non-zero vaa time",

--- a/node/pkg/watchers/solana/client_test.go
+++ b/node/pkg/watchers/solana/client_test.go
@@ -718,6 +718,16 @@ func TestProcessInstructionEarlyReturns(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			// The core bridge parses its instruction data strictly on-chain (solitaire
+			// uses borsh's try_from_slice, which rejects trailing bytes), so a padded
+			// instruction can never succeed on-chain and the watcher rejects it too.
+			// Contrast with the shim's PostMessage instruction data, which is parsed
+			// leniently on both sides (see Test_shimParsePostMessage).
+			name:    "trailing_bytes_rejected",
+			inst:    solana.CompiledInstruction{ProgramIDIndex: 0, Data: append([]byte{postMessageInstructionID}, append(encodePostMessageData(t, 7, []byte("test"), consistencyLevelFinalized), 0xff, 0xee)...), Accounts: make([]uint16, postMessageInstructionMinNumAccounts)},
+			wantErr: true,
+		},
+		{
 			name:    "unsupported_consistency_level",
 			inst:    solana.CompiledInstruction{ProgramIDIndex: 0, Data: append([]byte{postMessageInstructionID}, encodePostMessageData(t, 7, []byte("test"), ConsistencyLevel(9))...), Accounts: make([]uint16, postMessageInstructionMinNumAccounts)},
 			wantErr: true,

--- a/node/pkg/watchers/solana/shim.go
+++ b/node/pkg/watchers/solana/shim.go
@@ -37,7 +37,6 @@ import (
 	"github.com/certusone/wormhole/node/pkg/watchers"
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/rpc"
-	"github.com/near/borsh-go"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -116,7 +115,7 @@ func shimParsePostMessage(shimPostMessageDiscriminator []byte, buf []byte) (*Shi
 	}
 
 	data := new(ShimPostMessageData)
-	if err := borsh.Deserialize(data, buf[len(shimPostMessageDiscriminator):]); err != nil {
+	if err := decodeBorsh(data, buf[len(shimPostMessageDiscriminator):]); err != nil {
 		return nil, fmt.Errorf("failed to deserialize shim post message: %w", err)
 	}
 
@@ -135,7 +134,7 @@ func shimVerifyCoreMessage(buf []byte) (bool, error) {
 	}
 
 	var data PostMessageData
-	if err := borsh.Deserialize(&data, buf[1:]); err != nil {
+	if err := decodeBorsh(&data, buf[1:]); err != nil {
 		return false, fmt.Errorf("failed to deserialize core instruction data: %w", err)
 	}
 
@@ -153,7 +152,7 @@ func shimParseMessageEvent(shimMessageEventDiscriminator []byte, buf []byte) (*S
 	}
 
 	data := new(ShimMessageEventData)
-	if err := borsh.Deserialize(data, buf[len(shimMessageEventDiscriminator):]); err != nil {
+	if err := decodeBorsh(data, buf[len(shimMessageEventDiscriminator):]); err != nil {
 		return nil, fmt.Errorf("failed to deserialize shim message event: %w", err)
 	}
 

--- a/node/pkg/watchers/solana/shim.go
+++ b/node/pkg/watchers/solana/shim.go
@@ -115,7 +115,10 @@ func shimParsePostMessage(shimPostMessageDiscriminator []byte, buf []byte) (*Shi
 	}
 
 	data := new(ShimPostMessageData)
-	if err := decodeBorsh(data, buf[len(shimPostMessageDiscriminator):]); err != nil {
+	// The on-chain shim program ignores trailing bytes in post message instruction data,
+	// so the watcher must accept them too or it would fail to observe messages the chain
+	// accepted. All other parse sites mirror strict on-chain parsers and use decodeBorsh.
+	if err := decodeBorshAllowTrailing(data, buf[len(shimPostMessageDiscriminator):]); err != nil {
 		return nil, fmt.Errorf("failed to deserialize shim post message: %w", err)
 	}
 

--- a/node/pkg/watchers/solana/shim_test.go
+++ b/node/pkg/watchers/solana/shim_test.go
@@ -2277,9 +2277,9 @@ func TestShimProcessRestWithoutShimEventShouldFail(t *testing.T) {
 	require.ErrorContains(t, err, "failed to find inner shim message event instruction")
 }
 
-// The core inner instruction has the unreliable PostMessage id (0x08) but its
-// trailing bytes can't be borsh-deserialized, so shimVerifyCoreMessage returns
-// an error and shimProcessRest wraps it.
+// The core inner instruction has the unreliable PostMessage id (0x08), but the
+// remaining bytes are truncated, so shimVerifyCoreMessage returns an error and
+// shimProcessRest wraps it.
 func TestShimProcessRestWithMalformedCoreInstructionShouldFail(t *testing.T) {
 	var txRpc rpc.TransactionWithMeta
 	require.NoError(t, json.Unmarshal([]byte(shimDirectEventJSON), &txRpc))

--- a/node/pkg/watchers/solana/shim_test.go
+++ b/node/pkg/watchers/solana/shim_test.go
@@ -60,6 +60,26 @@ func Test_shimParsePostMessage(t *testing.T) {
 	assert.Equal(t, 11, len(postMsgData.Payload))
 	assert.True(t, bytes.Equal([]byte("hello world"), postMsgData.Payload))
 
+	// Same payload with trailing bytes appended: must parse successfully.
+	//
+	// PostMessage instruction data is written by the integrator, and the on-chain shim
+	// parses it leniently, explicitly ignoring trailing bytes
+	// (svm/wormhole-core-shims/crates/shim/src/post_message.rs). A padded instruction can
+	// therefore succeed on-chain and emit a legitimate message. The watcher must accept
+	// everything the chain accepted, so it must tolerate trailing bytes here — unlike the
+	// shim's MessageEvent data, which only the shim program itself can write (see
+	// Test_shimParseMessageEvent).
+	withTrailingBytes, err := hex.DecodeString("d63264d12622074c2a000000010b00000068656c6c6f20776f726c64ffeedd")
+	require.NoError(t, err)
+
+	postMsgData, err = shimParsePostMessage(shimPostMessage, withTrailingBytes)
+	require.NoError(t, err)
+	require.NotNil(t, postMsgData)
+
+	assert.Equal(t, uint32(42), postMsgData.Nonce)
+	assert.Equal(t, consistencyLevelFinalized, postMsgData.ConsistencyLevel)
+	assert.True(t, bytes.Equal([]byte("hello world"), postMsgData.Payload))
+
 	// Same payload with the first discriminator byte flipped: prefix no longer
 	// matches the shim PostMessage discriminator. Should fail.
 	mismatched, err := hex.DecodeString("d73264d12622074c2a000000010b00000068656c6c6f20776f726c64")
@@ -113,6 +133,16 @@ func Test_shimVerifyCoreMessage(t *testing.T) {
 			hexData: "082a00", // id=0x08 followed by partial nonce
 			wantErr: true,
 		},
+		{
+			// This is core bridge instruction data, not shim data, so the lenient shim
+			// parsing rules do not apply: the core bridge parses its instruction data
+			// strictly on-chain (solitaire uses borsh's try_from_slice, which rejects
+			// trailing bytes), meaning a padded instruction can never succeed on-chain.
+			// The watcher mirrors that and rejects trailing bytes too.
+			name:    "trailing bytes return an error",
+			hexData: "082a0000000000000001ffee", // valid unreliable data followed by two extra bytes
+			wantErr: true,
+		},
 	}
 
 	for _, tc := range tests {
@@ -148,6 +178,20 @@ func Test_shimParseMessageEvent(t *testing.T) {
 	assert.True(t, bytes.Equal(expectedEmitter, msgEventData.EmitterAddress[:]))
 	assert.Equal(t, uint64(0), msgEventData.Sequence)
 	assert.Equal(t, uint32(1736530812), msgEventData.Timestamp)
+
+	// Same event with trailing bytes appended: must be rejected.
+	//
+	// Unlike PostMessage instruction data (integrator-written, parsed leniently on-chain —
+	// see Test_shimParsePostMessage), MessageEvent data is never user input: it is the
+	// event self-CPI that the shim program constructs itself, always exactly 60 bytes
+	// (svm/wormhole-core-shims/programs/post-message/src/lib.rs), and the receiving
+	// instruction requires the shim's event authority PDA as signer, which only the shim
+	// program can provide. Trailing bytes therefore cannot occur on-chain, so we reject them
+	// in the Watcher too.
+	withTrailingBytes := append(append([]byte{}, data...), 0xff, 0xee)
+	msgEventData, err = shimParseMessageEvent(shimMessageEvent, withTrailingBytes)
+	require.ErrorContains(t, err, "trailing bytes")
+	assert.Nil(t, msgEventData)
 }
 
 func Test_shimParseMessageEventDiscriminatorMismatch(t *testing.T) {


### PR DESCRIPTION
I spent some time looking through the existing tests and adding a couple of new ones to check whether we're hitting all the edge cases we care about. Not a place we want to be making a mistake, so I'm happy to abandon these changes if the risks outweigh the upside