### PR TITLE
fix(notary,security): persist before mutating in-memory state

### DIFF
--- a/node/pkg/notary/notary.go
+++ b/node/pkg/notary/notary.go
@@ -388,18 +388,20 @@ func (n *Notary) delay(msg *common.MessagePublication, dur time.Duration) error 
 		ReleaseTime: release.Add(dur),
 	}
 
-	// Store in in-memory slice. This should happen even if a database error occurs.
-	n.delayed.Push(pMsg)
-
-	// Store in database.
-	dbErr := n.database.StoreDelayed(pMsg)
-	if dbErr != nil {
+	// Persist first. The database is the source of truth across guardian
+	// restarts. Mutating in-memory ahead of a failed disk write would leave the
+	// running process behaving as if the message were delayed while
+	// loadFromDB() on the next restart would silently drop the entry.
+	if dbErr := n.database.StoreDelayed(pMsg); dbErr != nil {
 		return dbErr
 	}
 
+	// Persistence succeeded; commit the in-memory representation.
+	n.delayed.Push(pMsg)
+
 	n.logger.Info("notary: delayed message", msg.ZapFields()...)
 
-	return dbErr
+	return nil
 }
 
 // blackhole adds a message publication to the blackholed in-memory set and stores it in the database.
@@ -432,14 +434,18 @@ func (n *Notary) blackhole(msg *common.MessagePublication) error {
 	n.mutex.Lock()
 	defer n.mutex.Unlock()
 
-	// Store in in-memory slice. This should happen even if a database error occurs.
-	n.blackholed.Add(msg.MessageID())
-
-	// Store in database.
-	dbErr := n.database.StoreBlackholed(msg)
-	if dbErr != nil {
+	// Persist first. The database is the source of truth across guardian
+	// restarts. The whitepaper at whitepapers/0015_notary.md guarantees that
+	// blackholed messages "cannot be automatically released - requires manual
+	// intervention." That guarantee is only enforceable if the persisted set
+	// of blackholed messages matches the in-memory set at every point where a
+	// restart could intervene.
+	if dbErr := n.database.StoreBlackholed(msg); dbErr != nil {
 		return dbErr
 	}
+
+	// Persistence succeeded; commit the in-memory representation.
+	n.blackholed.Add(msg.MessageID())
 
 	n.logger.Info("notary: blackholed message", msg.ZapFields()...)
 
@@ -486,21 +492,24 @@ func (n *Notary) removeBlackholed(msgID []byte) (*common.MessagePublication, err
 	n.mutex.Lock()
 	defer n.mutex.Unlock()
 
+	// Persist-delete first. If the disk delete fails and we had already
+	// removed the entry from the in-memory set, IsBlackholed(msgID) would
+	// return false for the remainder of the process lifetime while disk still
+	// held the entry, silently defeating the operator's kill switch until the
+	// next restart reloaded state from disk.
+	deletedMsgPub, err := n.database.DeleteBlackholed(msgID)
+	if err != nil {
+		return nil, err
+	}
+
 	currLen := n.blackholed.Len()
 	n.blackholed.Remove(msgID)
 	removeOccurred := n.blackholed.Len() < currLen
 
-	// Log if the message was not removed, then continue to try to delete it from the database
-	// for consistency.
 	if !removeOccurred {
 		n.logger.Info("notary: call to removeBlackholed did not remove a message", zap.String("msgID", string(msgID)))
 	} else {
 		n.logger.Info("notary: removed blackholed message from in-memory set", zap.String("msgID", string(msgID)))
-	}
-
-	deletedMsgPub, err := n.database.DeleteBlackholed(msgID)
-	if err != nil {
-		return nil, err
 	}
 
 	// No-op if the message is not in the database.
@@ -576,12 +585,17 @@ func (n *Notary) removeDelayed(msgID []byte) (*common.PendingMessage, error) {
 	n.mutex.Lock()
 	defer n.mutex.Unlock()
 
-	removed, err := n.delayed.RemoveItem(msgID)
+	// Persist-delete first. If the disk delete fails and we had already
+	// removed the entry from the in-memory delayed queue, IsDelayed would
+	// return false for the remainder of the process lifetime while disk still
+	// held the entry, producing divergent in-memory / on-disk views of the
+	// delayed set that only reconverge on the next restart.
+	deletedPendingMsg, err := n.database.DeleteDelayed(msgID)
 	if err != nil {
 		return nil, err
 	}
 
-	deletedPendingMsg, err := n.database.DeleteDelayed(msgID)
+	removed, err := n.delayed.RemoveItem(msgID)
 	if err != nil {
 		return nil, err
 	}

--- a/node/pkg/notary/notary_persistence_ordering_test.go
+++ b/node/pkg/notary/notary_persistence_ordering_test.go
@@ -1,0 +1,269 @@
+// Regression tests for the persist-first ordering in delay(), blackhole(),
+// removeDelayed(), and removeBlackholed().
+//
+// The Notary's whitepaper (whitepapers/0015_notary.md) guarantees that
+// delayed and blackholed entries survive guardian restart. That guarantee
+// is only enforceable if disk persistence is the source of truth for state
+// mutations. Prior to the persist-first refactor, the four listed functions
+// mutated in-memory state ahead of the database write and returned the disk
+// error without rolling back, producing divergent in-memory / on-disk views
+// that only reconverged on restart via loadFromDB() -- silently dropping
+// the un-persisted entries in the process.
+//
+// Each test injects a database failure and asserts that in-memory state is
+// NOT mutated. If a future refactor reintroduces the in-memory-first
+// ordering, these tests will fail loudly.
+//
+// Original disclosure: Immunefi report #76768, filed 2026-05-05 by
+// @Venator (Matthew S. Hintz).
+
+package notary
+
+import (
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/certusone/wormhole/node/pkg/common"
+	"github.com/certusone/wormhole/node/pkg/db"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// injectingDB is a NotaryDBInterface implementation that returns the exact
+// *db.DBError wrapper used by the production db.NotaryDB when BadgerDB
+// surfaces "too many open files" or similar I/O failures. Tests toggle the
+// per-method failure flags before each Notary call.
+type injectingDB struct {
+	mu               sync.Mutex
+	failStoreDelayed bool
+	failStoreBlack   bool
+	failDeleteDelay  bool
+	failDeleteBlack  bool
+	delayed          map[string]*common.PendingMessage
+	blackholed       map[string]*common.MessagePublication
+}
+
+func newInjectingDB() *injectingDB {
+	return &injectingDB{
+		delayed:    make(map[string]*common.PendingMessage),
+		blackholed: make(map[string]*common.MessagePublication),
+	}
+}
+
+func (i *injectingDB) StoreDelayed(p *common.PendingMessage) error {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.failStoreDelayed {
+		return &db.DBError{
+			Op:  db.OpUpdate,
+			Key: []byte("NOTARY:DELAY:V1:" + string(p.Msg.MessageID())),
+			Err: errors.New("simulated badger write failure: too many open files"),
+		}
+	}
+	i.delayed[string(p.Msg.MessageID())] = p
+	return nil
+}
+
+func (i *injectingDB) StoreBlackholed(m *common.MessagePublication) error {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.failStoreBlack {
+		return &db.DBError{
+			Op:  db.OpUpdate,
+			Key: []byte("NOTARY:BLACKHOLE:V1:" + string(m.MessageID())),
+			Err: errors.New("simulated badger write failure: too many open files"),
+		}
+	}
+	i.blackholed[string(m.MessageID())] = m
+	return nil
+}
+
+func (i *injectingDB) DeleteDelayed(msgID []byte) (*common.PendingMessage, error) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.failDeleteDelay {
+		return nil, &db.DBError{
+			Op:  db.OpUpdate,
+			Key: []byte("NOTARY:DELAY:V1:" + string(msgID)),
+			Err: errors.New("simulated badger delete failure: too many open files"),
+		}
+	}
+	p, ok := i.delayed[string(msgID)]
+	if !ok {
+		return nil, nil
+	}
+	delete(i.delayed, string(msgID))
+	return p, nil
+}
+
+func (i *injectingDB) DeleteBlackholed(msgID []byte) (*common.MessagePublication, error) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	if i.failDeleteBlack {
+		return nil, &db.DBError{
+			Op:  db.OpUpdate,
+			Key: []byte("NOTARY:BLACKHOLE:V1:" + string(msgID)),
+			Err: errors.New("simulated badger delete failure: too many open files"),
+		}
+	}
+	m, ok := i.blackholed[string(msgID)]
+	if !ok {
+		return nil, nil
+	}
+	delete(i.blackholed, string(msgID))
+	return m, nil
+}
+
+func (i *injectingDB) LoadAll(_ *zap.Logger) (*db.NotaryLoadResult, error) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	delayed := make([]*common.PendingMessage, 0, len(i.delayed))
+	for _, p := range i.delayed {
+		delayed = append(delayed, p)
+	}
+	blackholed := make([]*common.MessagePublication, 0, len(i.blackholed))
+	for _, m := range i.blackholed {
+		blackholed = append(blackholed, m)
+	}
+	return &db.NotaryLoadResult{Delayed: delayed, Blackholed: blackholed}, nil
+}
+
+func newTestNotaryWithInjectingDB(t *testing.T, idb *injectingDB) *Notary {
+	t.Helper()
+	n := makeTestNotary(t)
+	n.database = idb
+	return n
+}
+
+// TestPersistOrdering_DelayLeavesInMemoryEmptyOnDBFailure asserts that
+// n.delay() does NOT mutate the in-memory delayed queue when the disk write
+// fails. This is the add-side regression guard for delay().
+func TestPersistOrdering_DelayLeavesInMemoryEmptyOnDBFailure(t *testing.T) {
+	idb := newInjectingDB()
+	n := newTestNotaryWithInjectingDB(t, idb)
+	msg := makeUniqueMessagePublication(t)
+
+	idb.mu.Lock()
+	idb.failStoreDelayed = true
+	idb.mu.Unlock()
+
+	err := n.delay(msg, DefaultDelay)
+	require.Error(t, err, "delay() must propagate the disk-write error")
+
+	require.False(t, n.IsDelayed(msg),
+		"in-memory delayed queue must NOT contain the entry after a failed disk write; "+
+			"a persist-first ordering keeps in-memory and on-disk views consistent across restart")
+
+	idb.mu.Lock()
+	require.Empty(t, idb.delayed,
+		"on-disk delayed store must be empty after a failed StoreDelayed")
+	idb.mu.Unlock()
+}
+
+// TestPersistOrdering_BlackholeLeavesInMemoryEmptyOnDBFailure asserts that
+// n.blackhole() does NOT mutate the in-memory blackholed set when the disk
+// write fails. This is the add-side regression guard for blackhole().
+func TestPersistOrdering_BlackholeLeavesInMemoryEmptyOnDBFailure(t *testing.T) {
+	idb := newInjectingDB()
+	n := newTestNotaryWithInjectingDB(t, idb)
+	msg := makeUniqueMessagePublication(t)
+
+	idb.mu.Lock()
+	idb.failStoreBlack = true
+	idb.mu.Unlock()
+
+	err := n.blackhole(msg)
+	require.Error(t, err, "blackhole() must propagate the disk-write error")
+
+	require.False(t, n.IsBlackholed(msg.MessageID()),
+		"in-memory blackholed set must NOT contain the entry after a failed disk write; "+
+			"a persist-first ordering keeps in-memory and on-disk views consistent across restart")
+
+	idb.mu.Lock()
+	require.Empty(t, idb.blackholed,
+		"on-disk blackholed store must be empty after a failed StoreBlackholed")
+	idb.mu.Unlock()
+}
+
+// TestPersistOrdering_RemoveBlackholedKeepsInMemoryOnDBFailure asserts that
+// n.removeBlackholed() does NOT remove the entry from in-memory when the
+// disk-delete fails. This is the remove-side regression guard for
+// removeBlackholed() and closes the pre-restart kill-switch-bypass window.
+func TestPersistOrdering_RemoveBlackholedKeepsInMemoryOnDBFailure(t *testing.T) {
+	idb := newInjectingDB()
+	n := newTestNotaryWithInjectingDB(t, idb)
+	msg := makeUniqueMessagePublication(t)
+
+	// Seed both in-memory and on-disk with the blackholed entry.
+	require.NoError(t, n.blackhole(msg), "seed blackhole must succeed")
+	require.True(t, n.IsBlackholed(msg.MessageID()), "seed blackhole must be in-memory")
+
+	// Now flip the delete-failure flag and try to remove.
+	idb.mu.Lock()
+	idb.failDeleteBlack = true
+	idb.mu.Unlock()
+
+	_, err := n.removeBlackholed(msg.MessageID())
+	require.Error(t, err, "removeBlackholed must propagate the disk-delete error")
+
+	require.True(t, n.IsBlackholed(msg.MessageID()),
+		"in-memory blackholed set MUST still contain the entry after a failed disk-delete; "+
+			"otherwise operator's kill switch is silently bypassable until next restart")
+
+	idb.mu.Lock()
+	_, stillOnDisk := idb.blackholed[string(msg.MessageID())]
+	require.True(t, stillOnDisk,
+		"on-disk blackholed record must still be present after a failed disk delete")
+	idb.mu.Unlock()
+}
+
+// TestPersistOrdering_RemoveDelayedKeepsInMemoryOnDBFailure asserts that
+// n.removeDelayed() does NOT remove the entry from the in-memory delayed
+// queue when the disk-delete fails.
+func TestPersistOrdering_RemoveDelayedKeepsInMemoryOnDBFailure(t *testing.T) {
+	idb := newInjectingDB()
+	n := newTestNotaryWithInjectingDB(t, idb)
+	msg := makeUniqueMessagePublication(t)
+
+	require.NoError(t, n.delay(msg, DefaultDelay), "seed delay must succeed")
+	require.True(t, n.IsDelayed(msg), "seed delayed entry must be in-memory")
+
+	idb.mu.Lock()
+	idb.failDeleteDelay = true
+	idb.mu.Unlock()
+
+	_, err := n.removeDelayed(msg.MessageID())
+	require.Error(t, err, "removeDelayed must propagate the disk-delete error")
+
+	require.True(t, n.IsDelayed(msg),
+		"in-memory delayed queue MUST still contain the entry after a failed disk-delete")
+
+	idb.mu.Lock()
+	_, stillOnDisk := idb.delayed[string(msg.MessageID())]
+	require.True(t, stillOnDisk,
+		"on-disk delayed record must still be present after a failed disk delete")
+	idb.mu.Unlock()
+}
+
+// TestPersistOrdering_HappyPathPersistsAndPopulates confirms that when the
+// disk writes succeed, both in-memory and on-disk contain the entry. This
+// is the honesty control for the failure-injection tests above.
+func TestPersistOrdering_HappyPathPersistsAndPopulates(t *testing.T) {
+	idb := newInjectingDB()
+	n := newTestNotaryWithInjectingDB(t, idb)
+	msg := makeUniqueMessagePublication(t)
+
+	require.NoError(t, n.delay(msg, DefaultDelay))
+	require.True(t, n.IsDelayed(msg))
+	idb.mu.Lock()
+	require.Len(t, idb.delayed, 1)
+	idb.mu.Unlock()
+
+	bhMsg := makeUniqueMessagePublication(t)
+	require.NoError(t, n.blackhole(bhMsg))
+	require.True(t, n.IsBlackholed(bhMsg.MessageID()))
+	idb.mu.Lock()
+	require.Len(t, idb.blackholed, 1)
+	idb.mu.Unlock()
+}


### PR DESCRIPTION
# fix(notary,security): persist before mutating in-memory state

**Scope:** `node/pkg/notary/`
**Base branch:** `main` at `415fa04`
**Head branch (in fork):** `security/notary-persistence-ordering-2026-07-12`
**Original disclosure:** Immunefi report [#76768](https://bugs.immunefi.com/dashboard/submission/76768), filed 2026-05-05, closed 2 hours after Immunefi escalation as *"AI Report"* on 2026-05-06 without technical response.

## Summary

The `delay()`, `blackhole()`, `removeDelayed()`, and `removeBlackholed()` functions in `node/pkg/notary/notary.go` all mutated their in-memory data structure **before** attempting the BadgerDB write, then propagated the disk error to the caller **without rolling back the in-memory mutation**. The package's own source comment documented this as deliberate:

```go
// Store in in-memory slice. This should happen even if a database error occurs.
n.delayed.Push(pMsg)

// Store in database.
dbErr := n.database.StoreDelayed(pMsg)
if dbErr != nil {
    return dbErr
}
```

This contradicts the persistence guarantee stated at `whitepapers/0015_notary.md`:

- Line 20: *"a persistent record of delayed and blocked messages across Guardian restarts"*
- Line 87: *"Cannot be automatically released — requires manual intervention"*

When the BadgerDB write fails (file-descriptor pressure, `ErrDBClosed`, `ErrTxnTooBig`, value-log corruption recovery, or any other reachable BadgerDB error path), the running process holds the entry in memory while disk has no record. On the next guardian restart (deploy, OOM, hardware fault), `loadFromDB()` returns the persisted-empty set and the previously-flagged message re-enters processing as if it had never been flagged. For blackholed messages this silently inverts the whitepaper's "manual intervention required" guarantee into a 4-day auto-release timer.

## Fix

Reverse the ordering at all four sites. Persist first; mutate in-memory only after the persistence write succeeds. This matches the in-tree Governor's already-correct pattern at `node/pkg/governor/governor.go:622-690`, whose source comment states the same principle explicitly (`governor.go:947-948`): *"This causes the processor to die. We can't tolerate DB connection errors."*

## Diff summary

```
 node/pkg/notary/notary.go                              | +32 -22
 node/pkg/notary/notary_persistence_ordering_test.go    | +259
 2 files changed, 291 insertions(+), 22 deletions(-)
```

### Four ordering-reversal sites

| Function | Before | After |
|---|---|---|
| `delay()` @ `notary.go:386-405` | `n.delayed.Push(pMsg)` → `n.database.StoreDelayed(pMsg)` → return error | `n.database.StoreDelayed(pMsg)` → return on error → `n.delayed.Push(pMsg)` |
| `blackhole()` @ `notary.go:432-453` | `n.blackholed.Add(...)` → `n.database.StoreBlackholed(msg)` → return error | `n.database.StoreBlackholed(msg)` → return on error → `n.blackholed.Add(...)` |
| `removeBlackholed()` @ `notary.go:488-523` | `n.blackholed.Remove(msgID)` → `n.database.DeleteBlackholed(msgID)` → return error | `n.database.DeleteBlackholed(msgID)` → return on error → `n.blackholed.Remove(msgID)` |
| `removeDelayed()` @ `notary.go:580-610` | `n.delayed.RemoveItem(msgID)` → `n.database.DeleteDelayed(msgID)` → return error | `n.database.DeleteDelayed(msgID)` → return on error → `n.delayed.RemoveItem(msgID)` |

### Regression tests

Five new tests at `node/pkg/notary/notary_persistence_ordering_test.go`, each asserting the correct post-fix behavior via a fault-injection `NotaryDBInterface` mock that produces the same `*db.DBError` wrapper the production `db.NotaryDB` produces under BadgerDB failure:

- `TestPersistOrdering_DelayLeavesInMemoryEmptyOnDBFailure` — `IsDelayed(msg)` must be **false** after a failed `StoreDelayed`.
- `TestPersistOrdering_BlackholeLeavesInMemoryEmptyOnDBFailure` — `IsBlackholed(msg.MessageID())` must be **false** after a failed `StoreBlackholed`.
- `TestPersistOrdering_RemoveBlackholedKeepsInMemoryOnDBFailure` — `IsBlackholed` must **remain true** after a failed `DeleteBlackholed` on a previously-persisted entry.
- `TestPersistOrdering_RemoveDelayedKeepsInMemoryOnDBFailure` — `IsDelayed` must **remain true** after a failed `DeleteDelayed`.
- `TestPersistOrdering_HappyPathPersistsAndPopulates` — honesty control; ensures the four failure tests are not passing for a trivial reason.

If a future refactor reintroduces the in-memory-first ordering, these tests will fail loudly.

## Verification

```bash
git fetch origin pull/<PR_NUMBER>/head:notary-persist-fix
git checkout notary-persist-fix

cd node
go test -v -count=1 -run 'TestPersistOrdering' ./pkg/notary/
go test -count=1 ./pkg/notary/ ./pkg/db/ ./pkg/processor/
```

Expected output for both commands: `ok`.

## Compatibility

- **No public API change.** The four affected functions preserve their signatures and error semantics. Behavior change is limited to the persist-vs-in-memory ordering.
- **No database schema change.** BadgerDB layout, key prefixes, and value formats are unchanged.
- **No admin command change.** `notary-blackhole`, `notary-forget`, `notary-drop`, `notary-release`, and `notary-set-duration` all continue to work as before; they now correctly surface disk-write failures without silently orphaning in-memory state.
- **Metrics unchanged.** `notaryDelayedMessagesGauge` and `notaryBlackholedMessagesGauge` continue to read from in-memory. After the fix, in-memory converges with disk on error paths, so the metrics gain a cross-check property they did not have before.
- **Behavioral change on error paths.** Prior to this fix, a failed `StoreDelayed`/`StoreBlackholed` would leave the running process behaving as if the message were flagged, then silently unflag it on the next restart. After this fix, the failed store returns the error to the caller (as it already did) but leaves in-memory state consistent with disk. The processor caller at `node/pkg/processor/observation.go:140-147` already logs the error and returns; that behavior is unchanged.

## Full disclosure record

The full technical writeup, fund-theft-lane analysis, closure-response, and PoC gist are public:

- **Fund-theft analysis:** *(gist to be linked in first comment)*
- **PoC gist (public since 2026-05-05):** https://gist.github.com/MattHintz/76cbc1d550f32854eec3af95d66b053d
- **Immunefi report #76768:** https://bugs.immunefi.com/dashboard/submission/76768 (access-limited; the gist above contains the full public content)

## License

This patch is provided under the same LGPL-3.0 license as the rest of the workspace.
