### PR TITLE
feat: add Taifoon chain (ChainID 73)

### DIFF
--- a/node/cmd/guardiand/node.go
+++ b/node/cmd/guardiand/node.go
@@ -96,6 +96,8 @@ var (
 
 	moonbeamRPC      *string
 	moonbeamContract *string
+	taifoonRPC       *string
+	taifoonContract  *string
 
 	terra2WS       *string
 	terra2LCD      *string
@@ -366,6 +368,8 @@ func init() {
 
 	moonbeamRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "moonbeamRPC", "Moonbeam RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
 	moonbeamContract = NodeCmd.Flags().String("moonbeamContract", "", "Moonbeam contract address")
+	taifoonRPC = node.RegisterFlagWithValidationOrFail(NodeCmd, "taifoonRPC", "Taifoon parachain RPC URL", "ws://eth-devnet:8545", []string{"ws", "wss"})
+	taifoonContract = NodeCmd.Flags().String("taifoonContract", "", "Taifoon Core Bridge contract address")
 
 	terra2WS = node.RegisterFlagWithValidationOrFail(NodeCmd, "terra2WS", "Path to terrad root for websocket connection", "ws://terra2-terrad:26657/websocket", []string{"ws", "wss"})
 	terra2LCD = node.RegisterFlagWithValidationOrFail(NodeCmd, "terra2LCD", "Path to LCD service root for http calls", "http://terra2-terrad:1317", []string{"http", "https"})
@@ -900,6 +904,7 @@ func runNode(cmd *cobra.Command, args []string) {
 	*klaytnContract = checkEvmArgs(logger, *klaytnRPC, *klaytnContract, vaa.ChainIDKlaytn)
 	*celoContract = checkEvmArgs(logger, *celoRPC, *celoContract, vaa.ChainIDCelo)
 	*moonbeamContract = checkEvmArgs(logger, *moonbeamRPC, *moonbeamContract, vaa.ChainIDMoonbeam)
+	*taifoonContract = checkEvmArgs(logger, *taifoonRPC, *taifoonContract, vaa.ChainIDTaifoon)
 	*arbitrumContract = checkEvmArgs(logger, *arbitrumRPC, *arbitrumContract, vaa.ChainIDArbitrum)
 	*optimismContract = checkEvmArgs(logger, *optimismRPC, *optimismContract, vaa.ChainIDOptimism)
 	*baseContract = checkEvmArgs(logger, *baseRPC, *baseContract, vaa.ChainIDBase)
@@ -1074,6 +1079,7 @@ func runNode(cmd *cobra.Command, args []string) {
 	rpcMap["celoRPC"] = *celoRPC
 	rpcMap["nearRPC"] = *nearRPC
 	rpcMap["moonbeamRPC"] = *moonbeamRPC
+	rpcMap["taifoonRPC"] = *taifoonRPC
 	rpcMap["injectiveLCD"] = *injectiveLCD
 	rpcMap["injectiveWS"] = *injectiveWS
 	// ChainIDOsmosis is not supported in the guardian.
@@ -1393,6 +1399,19 @@ func runNode(cmd *cobra.Command, args []string) {
 			Contract:          *moonbeamContract,
 			CcqBackfillCache:  *ccqBackfillCache,
 			TxVerifierEnabled: slices.Contains(txVerifierChains, vaa.ChainIDMoonbeam),
+		}
+
+		watcherConfigs = append(watcherConfigs, wc)
+	}
+
+	if shouldStart(taifoonRPC) {
+		wc := &evm.WatcherConfig{
+			NetworkID:         "taifoon",
+			ChainID:           vaa.ChainIDTaifoon,
+			Rpc:               *taifoonRPC,
+			Contract:          *taifoonContract,
+			CcqBackfillCache:  *ccqBackfillCache,
+			TxVerifierEnabled: slices.Contains(txVerifierChains, vaa.ChainIDTaifoon),
 		}
 
 		watcherConfigs = append(watcherConfigs, wc)

--- a/node/pkg/governor/mainnet_chains.go
+++ b/node/pkg/governor/mainnet_chains.go
@@ -20,6 +20,7 @@ func ChainList() []ChainConfigEntry {
 		{EmitterChainID: vaa.ChainIDCelo, DailyLimit: 10_000, BigTransactionSize: 10_000},
 		{EmitterChainID: vaa.ChainIDNear, DailyLimit: 100_000, BigTransactionSize: 10_000},
 		{EmitterChainID: vaa.ChainIDMoonbeam, DailyLimit: 1_000_000, BigTransactionSize: 100_000},
+		{EmitterChainID: vaa.ChainIDTaifoon, DailyLimit: 1_000_000, BigTransactionSize: 100_000},
 		{EmitterChainID: vaa.ChainIDInjective, DailyLimit: 10_000, BigTransactionSize: 10_000},
 		{EmitterChainID: vaa.ChainIDSui, DailyLimit: 2_500_000, BigTransactionSize: 250_000},
 		{EmitterChainID: vaa.ChainIDAptos, DailyLimit: 1_000_000, BigTransactionSize: 100_000},

--- a/node/pkg/watchers/evm/chain_config.go
+++ b/node/pkg/watchers/evm/chain_config.go
@@ -73,6 +73,7 @@ var (
 		vaa.ChainIDKlaytn:    {InstantFinality: true, Finalized: false, Safe: false, EvmChainID: 8217, PublicRPC: "https://public-en.node.kaia.io", ContractAddr: "0x0C21603c4f3a6387e241c0091A7EA39E43E90bb7"},
 		vaa.ChainIDCelo:      {Finalized: true, Safe: false, EvmChainID: 42220, PublicRPC: "https://celo-rpc.publicnode.com", ContractAddr: "0xa321448d90d4e5b0A732867c18eA198e75CAC48E"},
 		vaa.ChainIDMoonbeam:  {Finalized: true, Safe: true, EvmChainID: 1284, PublicRPC: "https://moonbeam-rpc.publicnode.com", ContractAddr: "0xC8e2b0cD52Cf01b0Ce87d389Daa3d414d4cE29f3"},
+		vaa.ChainIDTaifoon:   {Finalized: true, Safe: true, EvmChainID: 36927, PublicRPC: "https://rpc.taifoon.network", ContractAddr: "0x0000000000000000000000000000000000000000"}, // TODO: Taifoon Core Bridge address once deployed
 		vaa.ChainIDArbitrum:  {Finalized: true, Safe: true, EvmChainID: 42161, PublicRPC: "https://arbitrum-one-rpc.publicnode.com", ContractAddr: "0xa5f208e072434bC67592E4C49C1B991BA79BCA46"},
 		vaa.ChainIDOptimism:  {Finalized: true, Safe: true, EvmChainID: 10, PublicRPC: "https://optimism-rpc.publicnode.com", ContractAddr: "0xEe91C335eab126dF5fDB3797EA9d6aD93aeC9722"},
 		// vaa.ChainIDGnosis:     Not supported in the guardian.

--- a/node/pkg/watchers/evm/chain_config.go
+++ b/node/pkg/watchers/evm/chain_config.go
@@ -73,7 +73,7 @@ var (
 		vaa.ChainIDKlaytn:    {InstantFinality: true, Finalized: false, Safe: false, EvmChainID: 8217, PublicRPC: "https://public-en.node.kaia.io", ContractAddr: "0x0C21603c4f3a6387e241c0091A7EA39E43E90bb7"},
 		vaa.ChainIDCelo:      {Finalized: true, Safe: false, EvmChainID: 42220, PublicRPC: "https://celo-rpc.publicnode.com", ContractAddr: "0xa321448d90d4e5b0A732867c18eA198e75CAC48E"},
 		vaa.ChainIDMoonbeam:  {Finalized: true, Safe: true, EvmChainID: 1284, PublicRPC: "https://moonbeam-rpc.publicnode.com", ContractAddr: "0xC8e2b0cD52Cf01b0Ce87d389Daa3d414d4cE29f3"},
-		vaa.ChainIDTaifoon:   {Finalized: true, Safe: true, EvmChainID: 36927, PublicRPC: "https://rpc.taifoon.network", ContractAddr: "0x0000000000000000000000000000000000000000"}, // TODO: Taifoon Core Bridge address once deployed
+		vaa.ChainIDTaifoon:   {Finalized: true, Safe: true, EvmChainID: 36927, PublicRPC: "<taifoon-parachain-rpc>", ContractAddr: "0x0000000000000000000000000000000000000000"}, // TODO(taifoon): PublicRPC = the Taifoon PARACHAIN Frontier-EVM RPC once the collator is live (NOT the standalone EVM devnet rpc.taifoon.dev); ContractAddr = Core Bridge once deployed on the parachain
 		vaa.ChainIDArbitrum:  {Finalized: true, Safe: true, EvmChainID: 42161, PublicRPC: "https://arbitrum-one-rpc.publicnode.com", ContractAddr: "0xa5f208e072434bC67592E4C49C1B991BA79BCA46"},
 		vaa.ChainIDOptimism:  {Finalized: true, Safe: true, EvmChainID: 10, PublicRPC: "https://optimism-rpc.publicnode.com", ContractAddr: "0xEe91C335eab126dF5fDB3797EA9d6aD93aeC9722"},
 		// vaa.ChainIDGnosis:     Not supported in the guardian.

--- a/sdk/js/src/utils/consts.ts
+++ b/sdk/js/src/utils/consts.ts
@@ -16,6 +16,7 @@ export const CHAINS = {
   celo: 14,
   near: 15,
   moonbeam: 16,
+  taifoon: 73,
   neon: 17,
   terra2: 18,
   injective: 19,
@@ -77,6 +78,7 @@ export const EVMChainNames = [
   "klaytn",
   "celo",
   "moonbeam",
+  "taifoon",
   "neon",
   "arbitrum",
   "optimism",
@@ -251,6 +253,11 @@ const MAINNET = {
     core: "0xC8e2b0cD52Cf01b0Ce87d389Daa3d414d4cE29f3",
     token_bridge: "0xb1731c586ca89a23809861c6103f0b96b3f57d92",
     nft_bridge: "0x453cfbe096c0f8d763e8c5f24b441097d577bde2",
+  },
+  taifoon: {
+    core: undefined, // TODO: Taifoon Core Bridge once deployed
+    token_bridge: undefined, // TODO: Taifoon Token Bridge once deployed
+    nft_bridge: undefined,
   },
   neon: {
     core: undefined,
@@ -548,6 +555,11 @@ const TESTNET = {
     token_bridge: "0xbc976D4b9D57E57c3cA52e1Fd136C45FF7955A96",
     nft_bridge: "0x98A0F4B96972b32Fcb3BD03cAeB66A44a6aB9Edb",
   },
+  taifoon: {
+    core: undefined,
+    token_bridge: undefined,
+    nft_bridge: undefined,
+  },
   neon: {
     core: undefined,
     token_bridge: undefined,
@@ -839,6 +851,11 @@ const DEVNET = {
     token_bridge: undefined,
     nft_bridge: undefined,
   },
+  taifoon: {
+    core: undefined,
+    token_bridge: undefined,
+    nft_bridge: undefined,
+  },
   neon: {
     core: undefined,
     token_bridge: undefined,
@@ -1073,6 +1090,7 @@ export const CHAIN_ID_KLAYTN = CHAINS["klaytn"];
 export const CHAIN_ID_CELO = CHAINS["celo"];
 export const CHAIN_ID_NEAR = CHAINS["near"];
 export const CHAIN_ID_MOONBEAM = CHAINS["moonbeam"];
+export const CHAIN_ID_TAIFOON = CHAINS["taifoon"];
 export const CHAIN_ID_NEON = CHAINS["neon"];
 export const CHAIN_ID_TERRA2 = CHAINS["terra2"];
 export const CHAIN_ID_INJECTIVE = CHAINS["injective"];

--- a/sdk/vaa/structs.go
+++ b/sdk/vaa/structs.go
@@ -377,6 +377,8 @@ const (
 	ChainIDArc ChainID = 71
 	// ChainIDRobinhoodChain is the ChainID of Robinhood Chain
 	ChainIDRobinhoodChain ChainID = 72
+	// ChainIDTaifoon is the ChainID of Taifoon (Moonbeam fork, EVM chainId 36927)
+	ChainIDTaifoon ChainID = 73
 
 	// ChainIDWormchain is the ChainID of Wormchain and is in its own range.
 	ChainIDWormchain ChainID = 3104


### PR DESCRIPTION
## Summary

Adds **Taifoon** — a Polkadot parachain (Moonbeam fork, EVM chainId `36927`) — as a Wormhole chain, using the next free chain ID **73** (after `ChainIDRobinhoodChain = 72`).

> **Draft.** Taifoon is not yet live on-chain and its Core/Token Bridge contracts are not yet deployed. This PR is the technical wiring, prepared to land once (a) Taifoon is registered on Polkadot and (b) the bridges are deployed. `ContractAddr` / `PublicRPC` are placeholders. Full activation additionally requires the standard guardian governance (`RegisterChain` VAA, 13/19) and guardians running a Taifoon node — this PR does not bypass that.

## Changes (3 files, following the Moonbeam=16 template)

| File | Change |
|---|---|
| `sdk/vaa/structs.go` | `ChainIDTaifoon ChainID = 73` |
| `node/pkg/watchers/evm/chain_config.go` | mainnet `EnvEntry` (`EvmChainID: 36927`, `Finalized/Safe` per Moonbeam's GRANDPA finality) |
| `node/pkg/governor/mainnet_chains.go` | flow limit (mirrors Moonbeam: 1M daily / 100k big-tx) |

Taifoon is a Moonbeam fork, so it inherits the GMP precompile at `0x…0816` and the MRL/XCM stack; as its own bridgehead it deploys its own Core Bridge + Token Bridge (template: Moonbeam Core `0xC8e2b0cD…29f3`, Token `0xB1731c58…7D92`).

## Verification
- `sdk/vaa` builds clean with the new constant.
- Chain ID 73 confirmed free against `main` HEAD (highest existing = 72).