### PR TITLE
algorand: fix trivial exit in tests when local indexer is broken

### DIFF
--- a/algorand/test/test.py
+++ b/algorand/test/test.py
@@ -113,7 +113,7 @@ class AlgoTest(PortalCore):
 
         if (self.INDEXER_ROUND > 512 and not self.args.testnet):  # until they fix it
             print("indexer is broken in local net... stop/clean/restart the sandbox")
-            sys.exit(0)
+            sys.exit(1)
 
         txns = []
 

--- a/algorand/test/test.py
+++ b/algorand/test/test.py
@@ -685,7 +685,6 @@ class AlgoTest(PortalCore):
 
             assert result, f"!!! ERR: sending same VAA twice worked. offending vaa hex:\n{vaa.hex()}"
             seq+=1
-        return
 
         def sending_vaa_version_not_one_fails(seq, version):
             vaa = bytearray.fromhex(gt.genRandomValidTransfer(


### PR DESCRIPTION
The test previously exited successfully when the local indexer was broken, allowing CI to pass
while skipping the remaining test cases. Exit with an error so incomplete test runs are reported as failures.
