### PR TITLE
chore(node): tron mainnet

### DIFF
--- a/node/pkg/watchers/evm/chain_config.go
+++ b/node/pkg/watchers/evm/chain_config.go
@@ -105,6 +105,7 @@ var (
 		vaa.ChainIDTempo:       {Finalized: true, Safe: true, EvmChainID: 4217, PublicRPC: "https://rpc.tempo.xyz", ContractAddr: "0xbebdb6C8ddC678FfA9f8748f85C815C556Dd8ac6"},
 		vaa.ChainIDArc:         {Finalized: true, Safe: true, EvmChainID: 5042, PublicRPC: "https://rpc.arc.network", ContractAddr: "0xC8aD24fC6063c41cB5C12a8e3851AafC3b3CF027"},
 		vaa.ChainIDHydration:   {Finalized: true, Safe: true, EvmChainID: 222222, PublicRPC: "https://rpc.coke.hydration.cloud", ContractAddr: "0x3792a6d63c31941B2805181771795D9176fA82A1"},
+		vaa.ChainIDTron:        {Finalized: true, Safe: false, EvmChainID: 728126428, PublicRPC: "https://api.trongrid.io/jsonrpc", ContractAddr: "0x3e7d05181025c985603960e6b2f7008f98b95659"},
 	}
 
 	// testnetChainConfig specifies the configuration for all chains enabled in Testnet.


### PR DESCRIPTION
Enables the Tron chain in the guardian EVM watcher for Mainnet.

Adds a `vaa.ChainIDTron` entry to `mainnetChainConfig` in `node/pkg/watchers/evm/chain_config.go`. Tron's eth-compat JSON-RPC is HTTP-only, so the watcher uses the `PollConnector` (already in place from the Nile testnet enablement); `Safe: false` since Tron does not support the `safe` tag.

All other Tron wiring (SDK chain ID 70, `--tronRPC`/`--tronContract` flags, watcher config, CCQ, adminnodes, publicrpc proto) already exists from the testnet work, so this is the only node change needed to enable mainnet.

**Core contract:** `0x3e7d05181025c985603960e6b2f7008f98b95659` (`TFfcfVDaHZNUYZ1nAv3oqgiPeSqpDEUzzD`)
**EVM chain ID:** `728126428`

## Testing
- `node/pkg/watchers/evm$ go test ./...` — passes
- `node/pkg/watchers/evm/verify_chain_config$ go run verify.go` — Tron passes (EVM chain ID, finality, and contract address all verified against `https://api.trongrid.io/jsonrpc`)