### PR TITLE
node: Governor token list update

### DIFF
--- a/node/pkg/governor/generated_mainnet_tokens.go
+++ b/node/pkg/governor/generated_mainnet_tokens.go
@@ -1,6 +1,6 @@
 // This file contains the token config to be used in the mainnet environment.
 //
-// This file was generated: Wed Jul 01 2026 00:42:42 GMT+0000 (Coordinated Universal Time) using a min notional of 0
+// This file was generated: Sat Aug 01 2026 00:30:02 GMT+0000 (Coordinated Universal Time) using a min notional of 0
 
 package governor
 


### PR DESCRIPTION
```
Tokens before = 1714
Tokens after = 1714

Tokens added = 0:
<WH_chain_id>-<WH_token_addr>-<token_symbol>

[]

Tokens removed = 0:
<WH_chain_id>-<WH_token_addr>-<token_symbol>

[]

Tokens with changed symbols = 0:
<WH_chain_id>-<WH_token_addr>-<old_token_symbol>-><new_token_symbol>

[]

Token identity counts by chain:
<WH_chain_id>: <before> -> <after> (delta <after-before>)

[
 "1: 232 -> 232 (delta 0)",
 "2: 561 -> 561 (delta 0)",
 "4: 327 -> 327 (delta 0)",
 "5: 136 -> 136 (delta 0)",
 "6: 56 -> 56 (delta 0)",
 "8: 15 -> 15 (delta 0)",
 "13: 9 -> 9 (delta 0)",
 "14: 11 -> 11 (delta 0)",
 "15: 11 -> 11 (delta 0)",
 "16: 11 -> 11 (delta 0)",
 "21: 22 -> 22 (delta 0)",
 "22: 10 -> 10 (delta 0)",
 "23: 84 -> 84 (delta 0)",
 "24: 36 -> 36 (delta 0)",
 "30: 193 -> 193 (delta 0)"
]

Token symbols changed with same identity = 0:
<WH_chain_id>-<WH_token_addr>: <old_token_symbol> -> <new_token_symbol>

[]

Tokens with invalid symbols = 0:
<WH_chain_id>-<WH_token_addr>-<token_symbol>

[]

Potentially depegged USD stablecoins (>10%) = 27:
<WH_chain_id>-<WH_token_addr>-<token_symbol> = <token_price>

[
 "1-aa77c1f5d0d2c07ce7075e31d348ca1c0965bb287be13984dec1c5615bf22665-cusd = 0.329236 (https://www.coingecko.com/en/coins/coin98-dollar)",
 "2-00000000000000000000000000c5ca160a968f47e7272a0cfcda36428f386cb6-usdebt = 8.09955e-10 (https://www.coingecko.com/en/coins/usdebt)",
 "2-0000000000000000000000003432b6a60d23ca0dfca7761b7ab56459d9c964d0-frax = 0.261137 (https://www.coingecko.com/en/coins/frax-share)",
 "2-00000000000000000000000045804880de22913dafe09f4980848ece6ecbaf78-paxg = 4150.91 (https://www.coingecko.com/en/coins/pax-gold)",
 "2-00000000000000000000000083f20f44975d03b1b09e64809b757c47f942beea-sdai = 1.18 (https://www.coingecko.com/en/coins/savings-dai)",
 "2-00000000000000000000000099999999999999cc837c997b882957dafdcb1af9-wusdn = 1.17 (https://www.coingecko.com/en/coins/smardex-wrapped-usdn)",
 "2-0000000000000000000000009d39a5de30e57443bff2a8307a4256c8797a3497-susde = 1.23 (https://www.coingecko.com/en/coins/ethena-staked-usde)",
 "2-000000000000000000000000b7b37b81d4497ab317fc9d4a370cf243043d6bbe-vaix = 0.00124486 (https://www.coingecko.com/en/coins/vectorspace)",
 "2-000000000000000000000000d13cfd3133239a3c73a9e535a5c4dadee36b395c-vai = 0.00261825 (https://www.coingecko.com/en/coins/vaiot)",
 "2-000000000000000000000000df574c24545e5ffecb9a659c229253d4111d87e1-husd = 0.03678714 (https://www.coingecko.com/en/coins/husd)",
 "2-000000000000000000000000dfdb7f72c1f195c5951a234e8db9806eb0635346-nfd = 0.00002046 (https://www.coingecko.com/en/coins/feisty-doge-nft)",
 "2-000000000000000000000000eeb4d8400aeefafc1b2953e0094134a887c76bd8-avail = 0.00340487 (https://www.coingecko.com/en/coins/avail)",
 "4-00000000000000000000000023e8a70534308a4aaf76fb8c32ec13d17a3bd89e-lusd = 0.00000253 (https://www.coingecko.com/en/coins/lusd)",
 "4-00000000000000000000000039702843a6733932ec7ce0dde404e5a6dbd8c989-avail = 0.00340487 (https://www.coingecko.com/en/coins/avail)",
 "4-000000000000000000000000734d66f635523d7ddb7d2373c128333da313041b-usdz = 0.00442558 (https://www.coingecko.com/en/coins/zedxion-usdz)",
 "5-000000000000000000000000ee327f889d5947c1dc1934bb208a1e792f953e96-frxeth = 1703.99 (https://www.coingecko.com/en/coins/frax-ether)",
 "13-0000000000000000000000005c74070fdea071359b86082bd9f9b3deaafbe32b-kdai = 0.094959 (https://www.coingecko.com/en/coins/klaytn-dai)",
 "13-000000000000000000000000754288077d0ff82af7a5317c7cb8c444d421d103-ousdc = 0.296497 (https://www.coingecko.com/en/coins/orbit-bridge-klaytn-usdc)",
 "13-000000000000000000000000cee8faf64bb97a73bb51e115aa89c17ffa8dd167-ousdt = 0.105002 (https://www.coingecko.com/en/coins/orbit-bridge-klaytn-usd-tether)",
 "16-000000000000000000000000818ec0a7fe18ff94269904fced6ae3dae6d6dc0b-usdc = 0.01533007 (https://www.coingecko.com/en/coins/multichain-bridged-usdc-moonbeam)",
 "16-0000000000000000000000008f552a71efe5eefc207bf75485b356a0b3f01ec9-usdc = 0.140116 (https://www.coingecko.com/en/coins/nomad-bridged-usdc-moonbeam)",
 "23-0000000000000000000000001dd6b5f9281c6b4f043c02a83a46c2772024636c-luausd = 0.758095 (https://www.coingecko.com/en/coins/lumi-finance-luausd)",
 "23-00000000000000000000000051318b7d00db7acc4026c88c3952b66278b6a67f-pls = 0.00257718 (https://www.coingecko.com/en/coins/plutusdao)",
 "23-0000000000000000000000009d2f299715d94d8a7e6f5eaa8e654e8c74a988a7-frax = 0.261137 (https://www.coingecko.com/en/coins/frax-share)",
 "24-0000000000000000000000008c6f28f2f1a3c87f0f938b96d27520d9751ec8d9-susd = 0.246073 (https://www.coingecko.com/en/coins/nusd)",
 "30-0000000000000000000000006c7ebb64e258f5712eeec83ceaf41c3dcbb534b1-vain = 0.0000333 (https://www.coingecko.com/en/coins/vainguard)",
 "30-000000000000000000000000d89d90d26b48940fa8f58385fe84625d468e057a-avail = 0.00340487 (https://www.coingecko.com/en/coins/avail)"
]

Tokens with significant price drops (>50%) = 0:

[]
```