### PR TITLE
fix(node): compact broadcast path skips SentTimestamp freshness, leaving delegate signatures replayable

### DIFF
--- a/node/pkg/p2p/p2p.go
+++ b/node/pkg/p2p/p2p.go
@@ -1706,6 +1706,16 @@ func expandBroadcastToSignedDelegateObservations(broadcast *gossipv1.DelegateSig
 			}
 		}
 
+		// Enforce the same SentTimestamp freshness bound the direct delegate-observation
+		// path enforces (processSignedDelegateObservation); without it, an inner delegate
+		// signature stays replayable indefinitely when re-broadcast in compact form.
+		if time.Until(time.Unix(sig.SentTimestamp, 0)).Abs() > delegateObservationMaxTimeDifference {
+			logger.Warn("broadcast delegate signature has stale or future SentTimestamp",
+				zap.String("addr", claimedAddr.Hex()),
+				zap.Int64("sent_timestamp", sig.SentTimestamp))
+			continue
+		}
+
 		digest := signedDelegateObservationDigest(b)
 		pubKey, err := ethcrypto.Ecrecover(digest.Bytes(), sig.Signature)
 		if err != nil {

--- a/node/pkg/p2p/p2p_test.go
+++ b/node/pkg/p2p/p2p_test.go
@@ -14,6 +14,7 @@ import (
 	gossipv1 "github.com/certusone/wormhole/node/pkg/proto/gossip/v1"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+	"go.uber.org/zap"
 )
 
 func TestSignedHeartbeat(t *testing.T) {
@@ -438,4 +439,67 @@ func TestValidateSignedObservationBatch(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestExpandBroadcastDropsStaleSentTimestamp(t *testing.T) {
+	guardianSigner, err := guardiansigner.GenerateSignerWithPrivatekeyUnsafe(nil)
+	assert.NoError(t, err)
+	gAddr := crypto.PubkeyToAddress(guardianSigner.PublicKey(context.Background()))
+
+	gs := &node_common.GuardianSet{
+		Keys:  []common.Address{gAddr},
+		Index: 1,
+	}
+	logger := zap.NewNop()
+
+	broadcast := &gossipv1.DelegateSignaturesBroadcast{
+		Timestamp:        uint32(time.Now().Unix()),
+		Nonce:            1,
+		EmitterChain:     2,
+		EmitterAddress:   make([]byte, 32),
+		Sequence:         42,
+		ConsistencyLevel: 1,
+		Payload:          []byte("payload"),
+		TxHash:           make([]byte, 32),
+	}
+
+	// Sign a reconstructed DelegateObservation exactly as the expander does, once
+	// with a fresh SentTimestamp and once with a stale one. Both signatures are
+	// cryptographically valid — only freshness may distinguish them.
+	makeSig := func(sentTimestamp int64) *gossipv1.DelegateSignature {
+		d := &gossipv1.DelegateObservation{
+			Timestamp:        broadcast.Timestamp,
+			Nonce:            broadcast.Nonce,
+			EmitterChain:     broadcast.EmitterChain,
+			EmitterAddress:   broadcast.EmitterAddress,
+			Sequence:         broadcast.Sequence,
+			ConsistencyLevel: broadcast.ConsistencyLevel,
+			Payload:          broadcast.Payload,
+			TxHash:           broadcast.TxHash,
+			GuardianAddr:     gAddr.Bytes(),
+			SentTimestamp:    sentTimestamp,
+		}
+		b, err := proto.Marshal(d)
+		assert.NoError(t, err)
+		digest := signedDelegateObservationDigest(b)
+		sig, err := guardianSigner.Sign(context.Background(), digest.Bytes())
+		assert.NoError(t, err)
+		return &gossipv1.DelegateSignature{
+			GuardianAddr:  gAddr.Bytes(),
+			SentTimestamp: sentTimestamp,
+			Signature:     sig,
+		}
+	}
+
+	fresh := time.Now().Unix()
+	stale := time.Now().Add(-2 * delegateObservationMaxTimeDifference).Unix()
+
+	broadcast.Signatures = []*gossipv1.DelegateSignature{makeSig(stale), makeSig(fresh)}
+
+	wrapped := expandBroadcastToSignedDelegateObservations(broadcast, gs, logger)
+	assert.Len(t, wrapped, 1, "stale SentTimestamp signature must be dropped like the direct path drops it")
+
+	var obs gossipv1.DelegateObservation
+	assert.NoError(t, proto.Unmarshal(wrapped[0].DelegateObservation, &obs))
+	assert.Equal(t, fresh, obs.SentTimestamp)
 }


### PR DESCRIPTION
## Summary

- `processSignedDelegateObservation` (direct path) rejects a `DelegateObservation` whose `SentTimestamp` is older/further ahead than `delegateObservationMaxTimeDifference` (15 min).
- The compact `SignedDelegateSignaturesBroadcast` path reconstructs each inner observation in `expandBroadcastToSignedDelegateObservations`, verifies guardian-set membership and the ECDSA signature — but **never checks `SentTimestamp`** — and feeds the result straight into `delegateObsvRecvC`, bypassing the direct path's check.
- This PR applies the same 15-minute freshness bound per inner signature in the broadcast expander, before signature recovery.

## Impact if unsolved

Any inner delegate signature ever observed on the network remains replayable forever when repackaged into a compact broadcast: a stale attestation can be re-injected at any time, and the freshness control that exists precisely to bound this replay is silently absent on one of the two ingest paths. The two paths now enforce the same bound.

## Test plan

- New `TestExpandBroadcastDropsStaleSentTimestamp`: two validly-signed inner observations (one fresh, one 2× the bound old) — only the fresh one is emitted. **Fails without the fix** (mutation-verified).
- `go test ./pkg/p2p -run TestExpandBroadcastDropsStaleSentTimestamp` passes.
- Note: the full `pkg/p2p` suite panics at pristine HEAD in this environment (`crypto/tls bug: where's my session ticket?` from quic-go v0.48.1 vs local Go — pre-existing, unrelated; libp2p network tests).

Made with [Cursor](https://cursor.com)