### PR TITLE
fix(node): one malformed delegated-guardian governance config can kill every guardian's EVM watcher

### DIFF
--- a/node/pkg/watchers/evm/delegated_guardian_config_test.go
+++ b/node/pkg/watchers/evm/delegated_guardian_config_test.go
@@ -1,0 +1,52 @@
+package evm
+
+import (
+	"testing"
+
+	"github.com/wormhole-foundation/wormhole/sdk/vaa"
+	dgAbi "github.com/certusone/wormhole/node/pkg/watchers/evm/connectors/delegated_guardians"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+// The on-chain WormholeDelegatedGuardians contract accepts configs the node rejects.
+// buildDelegatedGuardianConfig must skip those chains (fail closed) instead of
+// surfacing an error that would kill the EVM watcher via the polling routine.
+func TestBuildDelegatedGuardianConfigSkipsInvalidChains(t *testing.T) {
+	logger := zap.NewNop()
+
+	mkKeys := func(n int, offset byte) []common.Address {
+		keys := make([]common.Address, n)
+		for i := 0; i < n; i++ {
+			keys[i] = common.Address{offset, byte(i + 1)}
+		}
+		return keys
+	}
+
+	validKeys := mkKeys(4, 0x01)
+	validThreshold := uint8(vaa.CalculateQuorum(4))
+
+	configs := []dgAbi.WormholeDelegatedGuardiansDelegatedGuardianSet{
+		// valid chain — must be included
+		{ChainId: 2, Threshold: validThreshold, Keys: validKeys, Timestamp: 100},
+		// threshold above key count — node rejects, must be skipped not fatal
+		{ChainId: 5, Threshold: 7, Keys: mkKeys(3, 0x02), Timestamp: 100},
+		// threshold below the quorum floor — node rejects, must be skipped not fatal
+		{ChainId: 7, Threshold: 1, Keys: mkKeys(6, 0x03), Timestamp: 100},
+		// duplicate keys — node rejects, must be skipped not fatal
+		{ChainId: 9, Threshold: 2, Keys: []common.Address{{0x09}, {0x09}}, Timestamp: 100},
+		// no keys — already skipped by the pre-existing rule
+		{ChainId: 11, Threshold: 0, Keys: nil, Timestamp: 100},
+	}
+
+	dgConfig := buildDelegatedGuardianConfig(configs, logger)
+
+	assert.Len(t, dgConfig.Chains, 1, "only the valid chain config must be included")
+	_, ok := dgConfig.Chains[vaa.ChainID(2)]
+	assert.True(t, ok, "valid chain must survive")
+	for _, id := range []uint16{5, 7, 9, 11} {
+		_, ok := dgConfig.Chains[vaa.ChainID(id)]
+		assert.False(t, ok, "chain %d with invalid config must be skipped", id)
+	}
+}

--- a/node/pkg/watchers/evm/watcher.go
+++ b/node/pkg/watchers/evm/watcher.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/certusone/wormhole/node/pkg/watchers"
 	"github.com/certusone/wormhole/node/pkg/watchers/evm/connectors"
+	dgAbi "github.com/certusone/wormhole/node/pkg/watchers/evm/connectors/delegated_guardians"
 	"github.com/certusone/wormhole/node/pkg/watchers/evm/connectors/ethabi"
 
 	"github.com/certusone/wormhole/node/pkg/p2p"
@@ -653,35 +654,54 @@ func (w *Watcher) fetchAndUpdateDelegatedGuardianConfig(
 		w.currentDelegatedGuardianConfigTimestamp = maxTimestamp
 
 		// Build the DelegatedGuardianConfig
-		dgConfig := processor.NewDelegatedGuardianConfig()
-		for _, cfg := range configs {
-			// skip config without keys
-			if len(cfg.Keys) == 0 {
-				w.logger.Info("skipping delegated guardian config with no keys",
-					zap.Uint32("chainID", uint32(cfg.ChainId)),
-					zap.Uint32("timestamp", cfg.Timestamp))
-				continue
-			}
-
-			chainID := vaa.ChainID(cfg.ChainId)
-			chainConfig, err := processor.NewDelegatedGuardianChainConfig(cfg.Keys, int(cfg.Threshold))
-			if err != nil {
-				w.logger.Error("failed to instantiate delegated guardian chain config", zap.Error(err))
-				return err
-			}
-			dgConfig.Chains[chainID] = chainConfig
-			w.logger.Info("delegated guardian config for chain",
-				zap.Stringer("chainID", chainID),
-				zap.Int("numKeys", len(cfg.Keys)),
-				zap.Uint8("threshold", cfg.Threshold),
-				zap.Uint32("timestamp", cfg.Timestamp))
-		}
+		dgConfig := buildDelegatedGuardianConfig(configs, w.logger)
 
 		w.dgConfigC <- dgConfig // Note on channel capacity: Will only block the delegated guardian config update routine
 		w.logger.Info("sent delegated guardian config update to processor")
 	}
 
 	return nil
+}
+
+// buildDelegatedGuardianConfig converts the on-chain config sets into the processor's
+// DelegatedGuardianConfig. Chains whose config this node cannot accept are skipped
+// (fail closed) rather than aborting the whole update: the on-chain
+// WormholeDelegatedGuardians contract accepts configs the node rejects (threshold
+// above the key count, below the quorum floor, or duplicate keys), and surfacing that
+// as an error would kill the entire EVM watcher via the polling routine's fatal
+// channel — one malformed governance config taking down the chain's whole observation
+// pipeline on every guardian. Skipped chains stay without delegated attestation until
+// a valid config arrives; other chains keep working.
+func buildDelegatedGuardianConfig(configs []dgAbi.WormholeDelegatedGuardiansDelegatedGuardianSet, logger *zap.Logger) *processor.DelegatedGuardianConfig {
+	dgConfig := processor.NewDelegatedGuardianConfig()
+	for _, cfg := range configs {
+		// skip config without keys
+		if len(cfg.Keys) == 0 {
+			logger.Info("skipping delegated guardian config with no keys",
+				zap.Uint32("chainID", uint32(cfg.ChainId)),
+				zap.Uint32("timestamp", cfg.Timestamp))
+			continue
+		}
+
+		chainID := vaa.ChainID(cfg.ChainId)
+		chainConfig, err := processor.NewDelegatedGuardianChainConfig(cfg.Keys, int(cfg.Threshold))
+		if err != nil {
+			logger.Error("skipping invalid delegated guardian chain config",
+				zap.Error(err),
+				zap.Stringer("chainID", chainID),
+				zap.Int("numKeys", len(cfg.Keys)),
+				zap.Uint8("threshold", cfg.Threshold),
+				zap.Uint32("timestamp", cfg.Timestamp))
+			continue
+		}
+		dgConfig.Chains[chainID] = chainConfig
+		logger.Info("delegated guardian config for chain",
+			zap.Stringer("chainID", chainID),
+			zap.Int("numKeys", len(cfg.Keys)),
+			zap.Uint8("threshold", cfg.Threshold),
+			zap.Uint32("timestamp", cfg.Timestamp))
+	}
+	return dgConfig
 }
 
 // getFinality determines if the chain supports "finalized" and "safe". This is hard coded so it requires thought to change something. However, it also reads the RPC


### PR DESCRIPTION
## Summary

- `WormholeDelegatedGuardians` (immutable) accepts any config where `threshold == 0` XOR `keys empty` — it does **not** check `threshold <= keys.length`, the quorum floor, or duplicate keys.
- Every guardian node *does* reject those configs in `NewDelegatedGuardianChainConfig` — and the EVM watcher propagated that rejection as an error, which the polling routine forwards to the fatal channel (`The watcher will exit anyway`).
- Result: a single malformed (or compromised) governance config VAA exits the entire observation pipeline for that chain on **every** guardian until a corrective governance VAA lands — delegated attestation and normal VAA observation alike.
- Fix: `buildDelegatedGuardianConfig` (extracted pure helper) skips the offending chain — fail closed, so delegated attestation for that chain stays off until a valid config arrives — while valid chains in the same config keep working. Mirrors the existing "no keys" skip pattern. A contract-side validation mirror is still worthwhile for future deployments, but the node-side resilience fixes the live liveness DoS on the already-deployed immutable contract.

## Impact if unsolved

Governance (or a governance-key compromise) can publish one config with `threshold > keys.length` and halt observation for an entire chain across the guardian set — a network-wide liveness failure triggered by a single on-chain write, on a contract that cannot be patched.

## Test plan

- New `TestBuildDelegatedGuardianConfigSkipsInvalidChains`: valid chain survives; threshold-too-high, threshold-below-quorum, duplicate-keys, and no-keys chains are all skipped without error.
- `go test ./pkg/watchers/evm` passes; package builds clean.

Made with [Cursor](https://cursor.com)