### PR TITLE
node: Tighten Sui transaction verifier parsing

### DIFF
--- a/node/pkg/txverifier/sui.go
+++ b/node/pkg/txverifier/sui.go
@@ -153,9 +153,10 @@ func (s *SuiTransferVerifier) extractTransfersIntoBridgeFromObjectChanges(ctx co
 
 		objectType := *objectChange.ObjectType
 
-		// Check that the type information is correct. Doing it here means it's not necessary to do it
-		// again after decoding the object contents.
-		if !validateSuiAssetType(objectType, s.suiTokenBridgePackageId) {
+		// Check that the type information is correct and capture the validated asset type. Doing it
+		// here means it's not necessary to do it again after decoding the object contents.
+		assetType, ok := parseSuiAssetType(objectType, s.suiTokenBridgePackageId)
+		if !ok {
 			continue
 		}
 
@@ -179,13 +180,13 @@ func (s *SuiTransferVerifier) extractTransfersIntoBridgeFromObjectChanges(ctx co
 			continue
 		}
 
-		currentInfo, err := decodeSuiAssetObject(objectType, currentObject.ContentsBytes)
+		currentInfo, err := decodeSuiAssetObject(assetType, currentObject.ContentsBytes)
 		if err != nil {
 			logger.Error("Error decoding current asset object", zap.String("objectId", *objectChange.ObjectID), zap.Error(err))
 			continue
 		}
 
-		previousInfo, err := decodeSuiAssetObject(objectType, previousObject.ContentsBytes)
+		previousInfo, err := decodeSuiAssetObject(assetType, previousObject.ContentsBytes)
 		if err != nil {
 			logger.Error("Error decoding previous asset object", zap.String("objectId", *objectChange.ObjectID), zap.Error(err))
 			continue

--- a/node/pkg/txverifier/sui.go
+++ b/node/pkg/txverifier/sui.go
@@ -155,8 +155,8 @@ func (s *SuiTransferVerifier) extractTransfersIntoBridgeFromObjectChanges(ctx co
 
 		// Check that the type information is correct and capture the validated asset type. Doing it
 		// here means it's not necessary to do it again after decoding the object contents.
-		assetType, ok := parseSuiAssetType(objectType, s.suiTokenBridgePackageId)
-		if !ok {
+		assetType, err := parseSuiAssetType(objectType, s.suiTokenBridgePackageId)
+		if err != nil {
 			continue
 		}
 

--- a/node/pkg/txverifier/sui_test.go
+++ b/node/pkg/txverifier/sui_test.go
@@ -781,23 +781,48 @@ func TestDecodeSuiAssetObject(t *testing.T) {
 	addr := parseByteCSV("0,0,0,0,0,0,0,0,0,0,0,0,160,184,105,145,198,33,139,54,193,209,157,74,46,158,176,206,54,6,235,72")
 
 	// Unknown asset type -> error.
-	_, err := decodeSuiAssetObject("0x2::dynamic_field::Field<x::token_registry::Key<c>, y::other::Other<c>>", bcsNativeObject(1, addr, 8))
+	_, err := decodeSuiAssetObject("other::Other", bcsNativeObject(1, addr, 8))
 	assert.Error(t, err)
 
 	// Native type but undecodable (truncated) bytes -> error.
-	_, err = decodeSuiAssetObject("a::native_asset::NativeAsset<c>", []byte{0x01, 0x02})
+	_, err = decodeSuiAssetObject(suiNativeAssetType, []byte{0x01, 0x02})
 	assert.Error(t, err)
 
 	// Wrapped asset with an unknown token chain -> KnownChainIDFromNumber error.
-	_, err = decodeSuiAssetObject("a::wrapped_asset::WrappedAsset<c>", bcsWrappedObject(1, addr, 60000, 8))
+	_, err = decodeSuiAssetObject(suiWrappedAssetType, bcsWrappedObject(1, addr, 60000, 8))
 	assert.Error(t, err)
 
 	// Wrapped asset happy path.
-	info, err := decodeSuiAssetObject("a::wrapped_asset::WrappedAsset<c>", bcsWrappedObject(990, addr, 2, 8))
+	info, err := decodeSuiAssetObject(suiWrappedAssetType, bcsWrappedObject(990, addr, 2, 8))
 	assert.NoError(t, err)
 	assert.True(t, info.isWrapped)
 	assert.Equal(t, uint64(990), info.balance.Uint64())
 	assert.Equal(t, vaa.ChainIDEthereum, info.tokenChain)
+
+	// Native asset happy path.
+	info, err = decodeSuiAssetObject(suiNativeAssetType, bcsNativeObject(990, addr, 8))
+	assert.NoError(t, err)
+	assert.False(t, info.isWrapped)
+	assert.Equal(t, uint64(990), info.balance.Uint64())
+	assert.Equal(t, vaa.ChainIDSui, info.tokenChain)
+}
+
+func TestParseSuiAssetTypeConfusion(t *testing.T) {
+	const pkg = "0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d"
+
+	// A native asset whose coin type is named to contain the `WrappedAsset` string.
+	coinType := "0xa77ac6e9c1a04ba3af88b6bd1a5b1a48ee0a6e9d5a4a4f4b1c2d3e4f5a6b7c8d::wrapped_asset::WrappedAsset"
+	objectType := fmt.Sprintf(
+		"0x0000000000000000000000000000000000000000000000000000000000000002::dynamic_field::Field<"+
+			"%s::token_registry::Key<%s>,%s::native_asset::NativeAsset<%s>>",
+		pkg, coinType, pkg, coinType)
+
+	assetType, ok := parseSuiAssetType(objectType, pkg)
+	assert.True(t, ok)
+	// The validated verdict must be native, even though the object type string contains the
+	// `WrappedAsset` string inside the coin type.
+	assert.Equal(t, suiNativeAssetType, assetType)
+	assert.Contains(t, objectType, suiWrappedAssetType)
 }
 
 // TestProcessDigestPublic exercises the public ProcessDigest wrapper, including its handling of

--- a/node/pkg/txverifier/sui_test.go
+++ b/node/pkg/txverifier/sui_test.go
@@ -478,7 +478,7 @@ func TestProcessObjectUpdates(t *testing.T) {
 			name: "TestProcessObjectWrongPackageIdType",
 			objectChanges: []ObjectChange{
 				{
-					ObjectType:      "0x2::dynamic_field::Field<0xa340e3db1332c21f20f5c08bef0fa459e733575f9a7e2f5faca64f72cd5a54f2::token_registry::Key<0x2::sui::SUI>, 0xa340e3db1332c21f20f5c08bef0fa459e733575f9a7e2f5faca64f72cd5a54f2::native_asset::NativeAsset<0x2::sui::SUI>",
+					ObjectType:      "0x2::dynamic_field::Field<0xa340e3db1332c21f20f5c08bef0fa459e733575f9a7e2f5faca64f72cd5a54f2::token_registry::Key<0x2::sui::SUI>, 0xa340e3db1332c21f20f5c08bef0fa459e733575f9a7e2f5faca64f72cd5a54f2::native_asset::NativeAsset<0x2::sui::SUI>>",
 					Version:         normalVersion,
 					PreviousVersion: normalPreviousVersion,
 					ObjectId:        normalObjectNativeId,
@@ -494,7 +494,7 @@ func TestProcessObjectUpdates(t *testing.T) {
 			name: "TestProcessObjectNotDynamicField",
 			objectChanges: []ObjectChange{
 				{
-					ObjectType:      "0x11111111111111111111::dynamic_field::Field<0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0x2::sui::SUI>, 0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::native_asset::NativeAsset<0x2::sui::SUI>",
+					ObjectType:      "0x11111111111111111111::dynamic_field::Field<0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0x2::sui::SUI>, 0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::native_asset::NativeAsset<0x2::sui::SUI>>",
 					Version:         normalVersion,
 					PreviousVersion: normalPreviousVersion,
 					ObjectId:        normalObjectNativeId,
@@ -510,7 +510,7 @@ func TestProcessObjectUpdates(t *testing.T) {
 			name: "TestProcessObjectMismatchedCoinTypes",
 			objectChanges: []ObjectChange{
 				{
-					ObjectType:      "0x2::dynamic_field::Field<0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0x2::sui::SUI>, 0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::native_asset::NativeAsset<0x11111111111111111111::sui::SUI>",
+					ObjectType:      "0x2::dynamic_field::Field<0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0x2::sui::SUI>, 0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::native_asset::NativeAsset<0x11111111111111111111::sui::SUI>>",
 					Version:         normalVersion,
 					PreviousVersion: normalPreviousVersion,
 					ObjectId:        normalObjectNativeId,
@@ -526,7 +526,7 @@ func TestProcessObjectUpdates(t *testing.T) {
 			name: "TestProcessObjectNotAssetType",
 			objectChanges: []ObjectChange{
 				{
-					ObjectType:      "0x2::dynamic_field::Field<0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0x2::sui::SUI>, 0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::not_native_asset::NativeAsset<0x2::sui::SUI>",
+					ObjectType:      "0x2::dynamic_field::Field<0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0x2::sui::SUI>, 0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::not_native_asset::NativeAsset<0x2::sui::SUI>>",
 					Version:         normalVersion,
 					PreviousVersion: normalPreviousVersion,
 					ObjectId:        normalObjectNativeId,
@@ -543,7 +543,7 @@ func TestProcessObjectUpdates(t *testing.T) {
 			objectChanges: []ObjectChange{
 				{ObjectType: normalObjectForeignType, Version: normalVersion, PreviousVersion: normalPreviousVersion, ObjectId: normalObjectForeignId},
 				{
-					ObjectType:      "0x2::dynamic_field::Field<0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0x2::sui::SUI>, 0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::not_native_asset::NativeAsset<0x2::sui::SUI>",
+					ObjectType:      "0x2::dynamic_field::Field<0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::token_registry::Key<0x2::sui::SUI>, 0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d::not_native_asset::NativeAsset<0x2::sui::SUI>>",
 					Version:         fmt.Sprintf("%s111", normalVersion),
 					PreviousVersion: normalPreviousVersion,
 					ObjectId:        normalObjectNativeId,
@@ -782,15 +782,15 @@ func TestDecodeSuiAssetObject(t *testing.T) {
 
 	// Unknown asset type -> error.
 	_, err := decodeSuiAssetObject("other::Other", bcsNativeObject(1, addr, 8))
-	assert.Error(t, err)
+	assert.ErrorContains(t, err, "neither a native nor wrapped token-bridge asset")
 
 	// Native type but undecodable (truncated) bytes -> error.
 	_, err = decodeSuiAssetObject(suiNativeAssetType, []byte{0x01, 0x02})
-	assert.Error(t, err)
+	assert.ErrorContains(t, err, "failed to BCS-decode NativeAsset")
 
 	// Wrapped asset with an unknown token chain -> KnownChainIDFromNumber error.
 	_, err = decodeSuiAssetObject(suiWrappedAssetType, bcsWrappedObject(1, addr, 60000, 8))
-	assert.Error(t, err)
+	assert.ErrorContains(t, err, "failed to convert token chain 60000")
 
 	// Wrapped asset happy path.
 	info, err := decodeSuiAssetObject(suiWrappedAssetType, bcsWrappedObject(990, addr, 2, 8))
@@ -817,12 +817,76 @@ func TestParseSuiAssetTypeConfusion(t *testing.T) {
 			"%s::token_registry::Key<%s>,%s::native_asset::NativeAsset<%s>>",
 		pkg, coinType, pkg, coinType)
 
-	assetType, ok := parseSuiAssetType(objectType, pkg)
-	assert.True(t, ok)
+	assetType, err := parseSuiAssetType(objectType, pkg)
+	assert.NoError(t, err)
 	// The validated verdict must be native, even though the object type string contains the
 	// `WrappedAsset` string inside the coin type.
 	assert.Equal(t, suiNativeAssetType, assetType)
-	assert.Contains(t, objectType, suiWrappedAssetType)
+	assert.Contains(t, objectType, string(suiWrappedAssetType))
+}
+
+// TestParseSuiAssetType exercises each accept and reject branch of parseSuiAssetType directly.
+func TestParseSuiAssetType(t *testing.T) {
+	const pkg = "0x26efee2b51c911237888e5dc6702868abca3c7ac12c53f76ef8eba0697695e3d"
+	const otherPkg = "0xa340e3db1332c21f20f5c08bef0fa459e733575f9a7e2f5faca64f72cd5a54f2"
+	const coin = "0x2::sui::SUI"
+
+	// build assembles a token-registry dynamic field object type from its variable parts.
+	build := func(keyPkg, keyCoin, valuePkg, valueAsset, valueCoin string) string {
+		return fmt.Sprintf("0x2::dynamic_field::Field<%s::token_registry::Key<%s>,%s::%s<%s>>",
+			keyPkg, keyCoin, valuePkg, valueAsset, valueCoin)
+	}
+
+	tests := []struct {
+		name          string
+		objectType    string
+		wantAssetType suiAssetType
+		wantErr       error
+	}{
+		{
+			name:          "ValidNative",
+			objectType:    build(pkg, coin, pkg, "native_asset::NativeAsset", coin),
+			wantAssetType: suiNativeAssetType,
+		},
+		{
+			name:          "ValidWrapped",
+			objectType:    build(pkg, coin, pkg, "wrapped_asset::WrappedAsset", coin),
+			wantAssetType: suiWrappedAssetType,
+		},
+		{
+			name:       "MalformedMissingClosingBracket",
+			objectType: strings.TrimSuffix(build(pkg, coin, pkg, "native_asset::NativeAsset", coin), ">"),
+			wantErr:    errNotTokenRegistryField,
+		},
+		{
+			name:       "NotAnAssetType",
+			objectType: build(pkg, coin, pkg, "not_native_asset::NativeAsset", coin),
+			wantErr:    errNotAssetType,
+		},
+		{
+			name:       "WrongPackageIdInKey",
+			objectType: build(otherPkg, coin, pkg, "native_asset::NativeAsset", coin),
+			wantErr:    errWrongPackageId,
+		},
+		{
+			name:       "WrongPackageIdInValue",
+			objectType: build(pkg, coin, otherPkg, "native_asset::NativeAsset", coin),
+			wantErr:    errWrongPackageId,
+		},
+		{
+			name:       "MismatchedCoinTypes",
+			objectType: build(pkg, coin, pkg, "native_asset::NativeAsset", "0x11111111111111111111::sui::SUI"),
+			wantErr:    errMismatchedCoinTypes,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assetType, err := parseSuiAssetType(tt.objectType, pkg)
+			assert.ErrorIs(t, err, tt.wantErr)
+			assert.Equal(t, tt.wantAssetType, assetType)
+		})
+	}
 }
 
 // TestProcessDigestPublic exercises the public ProcessDigest wrapper, including its handling of

--- a/node/pkg/txverifier/suitypes.go
+++ b/node/pkg/txverifier/suitypes.go
@@ -2,6 +2,7 @@ package txverifier
 
 import (
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"math/big"
 	"regexp"
@@ -116,12 +117,13 @@ type suiAssetInfo struct {
 	balance      *big.Int
 }
 
-// The fully-qualified `<module>::<Type>` names of the two token-registry asset value types,
-// exactly as they appear in the object type's asset-module capture group. These must be
-// compared for equality, never with substring checks.
+// suiAssetType is the fully-qualified `<module>::<Type>` name of a token-registry asset value
+// type. Only the two constants below are valid values.
+type suiAssetType string
+
 const (
-	suiNativeAssetType  = "native_asset::NativeAsset"
-	suiWrappedAssetType = "wrapped_asset::WrappedAsset"
+	suiNativeAssetType  suiAssetType = "native_asset::NativeAsset"
+	suiWrappedAssetType suiAssetType = "wrapped_asset::WrappedAsset"
 )
 
 // suiDynamicFieldTypeRegex matches a token-registry dynamic field object type of the form
@@ -134,50 +136,53 @@ const (
 // form and a trailing space.
 var suiDynamicFieldTypeRegex = regexp.MustCompile(`^0x0*2::dynamic_field::Field<([^:]+)::token_registry::Key<([^>]+)>,\s*([^:]+)::([^<]+)<([^>]+)>>$`)
 
+// Errors identifying which parseSuiAssetType check rejected an object type.
+var (
+	errNotTokenRegistryField = errors.New("object type is not a token-registry dynamic field")
+	errNotAssetType          = errors.New("asset value type is not a native or wrapped token-bridge asset")
+	errWrongPackageId        = errors.New("package ID does not match the token bridge package ID")
+	errMismatchedCoinTypes   = errors.New("key coin type does not match the asset value coin type")
+)
+
 // parseSuiAssetType validates the type information of a token-registry dynamic field object and
-// returns the validated asset value type ("native_asset::NativeAsset" or
-// "wrapped_asset::WrappedAsset"). The following checks are performed:
+// returns the validated asset value type. The following checks are performed:
 //   - the type matches the token-registry dynamic field shape
 //   - the asset type is a wrapped or native token-bridge asset
 //   - both package IDs match the expected token bridge package ID
 //   - the coin type referenced by the field key matches the coin type of the asset value
 //
-// On any validation failure it returns ("", false).
-func parseSuiAssetType(objectType string, expectedPackageId string) (assetType string, ok bool) {
+// On validation failure it returns the sentinel error for the check that failed.
+func parseSuiAssetType(objectType string, expectedPackageId string) (suiAssetType, error) {
 	matches := suiDynamicFieldTypeRegex.FindStringSubmatch(objectType)
 
 	if len(matches) != 6 {
-		return "", false
+		return "", errNotTokenRegistryField
 	}
 
 	scanPackage1 := matches[1]
 	scanCoinType1 := matches[2]
 	scanPackage2 := matches[3]
-	scanAssetType := matches[4]
+	scanAssetType := suiAssetType(matches[4])
 	scanCoinType2 := matches[5]
 
-	// Ensure that the asset type is wrapped or native
 	if scanAssetType != suiWrappedAssetType && scanAssetType != suiNativeAssetType {
-		return "", false
+		return "", errNotAssetType
 	}
 
-	// Ensure that the package IDs match the expected package ID
 	if scanPackage1 != expectedPackageId || scanPackage2 != expectedPackageId {
-		return "", false
+		return "", errWrongPackageId
 	}
 
-	// Ensure that the coin types match
 	if scanCoinType1 != scanCoinType2 {
-		return "", false
+		return "", errMismatchedCoinTypes
 	}
 
-	return scanAssetType, true
+	return scanAssetType, nil
 }
 
 // decodeSuiAssetObject decodes a token-registry dynamic field object's BCS contents into
-// normalized asset info. `assetType` selects the decode layout and must be a validated asset
-// type returned by parseSuiAssetType.
-func decodeSuiAssetObject(assetType string, contents []byte) (*suiAssetInfo, error) {
+// normalized asset info. `assetType` selects the decode layout.
+func decodeSuiAssetObject(assetType suiAssetType, contents []byte) (*suiAssetInfo, error) {
 	switch assetType {
 	case suiWrappedAssetType:
 		field, err := suiclient.DecodeBcs[suiWrappedAssetField](contents)

--- a/node/pkg/txverifier/suitypes.go
+++ b/node/pkg/txverifier/suitypes.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math/big"
 	"regexp"
-	"strings"
 
 	"github.com/certusone/wormhole/node/pkg/suiclient"
 	"github.com/wormhole-foundation/wormhole/sdk/vaa"
@@ -117,6 +116,14 @@ type suiAssetInfo struct {
 	balance      *big.Int
 }
 
+// The fully-qualified `<module>::<Type>` names of the two token-registry asset value types,
+// exactly as they appear in the object type's asset-module capture group. These must be
+// compared for equality, never with substring checks.
+const (
+	suiNativeAssetType  = "native_asset::NativeAsset"
+	suiWrappedAssetType = "wrapped_asset::WrappedAsset"
+)
+
 // suiDynamicFieldTypeRegex matches a token-registry dynamic field object type of the form
 //
 //	0x...2::dynamic_field::Field<<pkg>::token_registry::Key<<coin>>,<pkg>::<asset>::<Asset><<coin>>>
@@ -127,17 +134,20 @@ type suiAssetInfo struct {
 // form and a trailing space.
 var suiDynamicFieldTypeRegex = regexp.MustCompile(`^0x0*2::dynamic_field::Field<([^:]+)::token_registry::Key<([^>]+)>,\s*([^:]+)::([^<]+)<([^>]+)>>$`)
 
-// validateSuiAssetType validates the type information of a token-registry dynamic field object.
-// The following checks are performed:
+// parseSuiAssetType validates the type information of a token-registry dynamic field object and
+// returns the validated asset value type ("native_asset::NativeAsset" or
+// "wrapped_asset::WrappedAsset"). The following checks are performed:
 //   - the type matches the token-registry dynamic field shape
 //   - the asset type is a wrapped or native token-bridge asset
 //   - both package IDs match the expected token bridge package ID
 //   - the coin type referenced by the field key matches the coin type of the asset value
-func validateSuiAssetType(objectType string, expectedPackageId string) bool {
+//
+// On any validation failure it returns ("", false).
+func parseSuiAssetType(objectType string, expectedPackageId string) (assetType string, ok bool) {
 	matches := suiDynamicFieldTypeRegex.FindStringSubmatch(objectType)
 
 	if len(matches) != 6 {
-		return false
+		return "", false
 	}
 
 	scanPackage1 := matches[1]
@@ -147,29 +157,29 @@ func validateSuiAssetType(objectType string, expectedPackageId string) bool {
 	scanCoinType2 := matches[5]
 
 	// Ensure that the asset type is wrapped or native
-	if scanAssetType != "wrapped_asset::WrappedAsset" && scanAssetType != "native_asset::NativeAsset" {
-		return false
+	if scanAssetType != suiWrappedAssetType && scanAssetType != suiNativeAssetType {
+		return "", false
 	}
 
 	// Ensure that the package IDs match the expected package ID
 	if scanPackage1 != expectedPackageId || scanPackage2 != expectedPackageId {
-		return false
+		return "", false
 	}
 
 	// Ensure that the coin types match
 	if scanCoinType1 != scanCoinType2 {
-		return false
+		return "", false
 	}
 
-	return true
+	return scanAssetType, true
 }
 
 // decodeSuiAssetObject decodes a token-registry dynamic field object's BCS contents into
-// normalized asset info. `objectType` is used to decide whether the field value is a native
-// or wrapped asset.
-func decodeSuiAssetObject(objectType string, contents []byte) (*suiAssetInfo, error) {
-	switch {
-	case strings.Contains(objectType, "wrapped_asset::WrappedAsset"):
+// normalized asset info. `assetType` selects the decode layout and must be a validated asset
+// type returned by parseSuiAssetType.
+func decodeSuiAssetObject(assetType string, contents []byte) (*suiAssetInfo, error) {
+	switch assetType {
+	case suiWrappedAssetType:
 		field, err := suiclient.DecodeBcs[suiWrappedAssetField](contents)
 		if err != nil {
 			return nil, fmt.Errorf("failed to BCS-decode WrappedAsset: %w", err)
@@ -188,7 +198,7 @@ func decodeSuiAssetObject(objectType string, contents []byte) (*suiAssetInfo, er
 			balance:      new(big.Int).SetUint64(field.Value.TreasuryCap.TotalSupply),
 		}, nil
 
-	case strings.Contains(objectType, "native_asset::NativeAsset"):
+	case suiNativeAssetType:
 		field, err := suiclient.DecodeBcs[suiNativeAssetField](contents)
 		if err != nil {
 			return nil, fmt.Errorf("failed to BCS-decode NativeAsset: %w", err)
@@ -203,6 +213,6 @@ func decodeSuiAssetObject(objectType string, contents []byte) (*suiAssetInfo, er
 		}, nil
 
 	default:
-		return nil, fmt.Errorf("object type is neither a native nor wrapped token-bridge asset: %s", objectType)
+		return nil, fmt.Errorf("object type is neither a native nor wrapped token-bridge asset: %s", assetType)
 	}
 }


### PR DESCRIPTION
Avoid the use of `string.Contains` in this context where it can be overly permissive. Instead of re-deriving the asset type, we instead take it from the parsing/validation step.