### PR TITLE
sdk/js: clarify native SOL transfer signing #4135

### DIFF
--- a/sdk/js/src/solana/utils/transaction.ts
+++ b/sdk/js/src/solana/utils/transaction.ts
@@ -105,12 +105,14 @@ export class NodeWallet {
 }
 
 /**
- * The transactions provided to this function should be ready to send.
+ * Expects an unsigned {@link Transaction}.
  * This function will do the following:
  * 1. Add the {@param payer} as the feePayer and latest blockhash to the {@link Transaction}.
  * 2. Sign using {@param signTransaction}.
  * 3. Send raw transaction.
  * 4. Confirm transaction.
+ *
+ * Do not pass a partially signed transaction.
  */
 export async function signSendAndConfirmTransaction(
   connection: Connection,

--- a/sdk/js/src/solana/utils/transaction.ts
+++ b/sdk/js/src/solana/utils/transaction.ts
@@ -111,8 +111,6 @@ export class NodeWallet {
  * 2. Sign using {@param signTransaction}.
  * 3. Send raw transaction.
  * 4. Confirm transaction.
- *
- * Do not pass a partially signed transaction.
  */
 export async function signSendAndConfirmTransaction(
   connection: Connection,

--- a/sdk/js/src/token_bridge/__tests__/solana-integration.ts
+++ b/sdk/js/src/token_bridge/__tests__/solana-integration.ts
@@ -381,6 +381,29 @@ describe("Solana to Ethereum", () => {
           tryNativeToUint8Array(targetAddress, CHAIN_ID_ETH),
           CHAIN_ID_ETH
         );
+        const wrappedSol = transaction.instructions[0].keys[1].pubkey;
+        const message = transaction.instructions[4].keys.find(
+          (k) =>
+            k.isSigner &&
+            !k.pubkey.equals(keypair.publicKey) &&
+            !k.pubkey.equals(wrappedSol)
+        )?.pubkey;
+        expect(message).toBeDefined();
+        expect(transaction.signatures.length).toBe(3);
+        const payerEntry = transaction.signatures.find((s) =>
+          s.publicKey.equals(keypair.publicKey)
+        );
+        const wrappedSolEntry = transaction.signatures.find((s) =>
+          s.publicKey.equals(wrappedSol)
+        );
+        const messageEntry = transaction.signatures.find((s) =>
+          s.publicKey.equals(message!)
+        );
+        expect(payerEntry).toBeDefined();
+        expect(payerEntry!.signature).toBeNull();
+        expect(wrappedSolEntry?.signature).toBeTruthy();
+        expect(messageEntry?.signature).toBeTruthy();
+        expect(transaction.verifySignatures(false)).toBe(true);
         // sign, send, and confirm transaction
         transaction.partialSign(keypair);
         const txid = await connection.sendRawTransaction(

--- a/sdk/js/src/token_bridge/transfer.ts
+++ b/sdk/js/src/token_bridge/transfer.ts
@@ -357,6 +357,13 @@ export function transferFromXpla(
       ];
 }
 
+/**
+ * Transfers native SOL through the Token Bridge.
+ *
+ * The returned transaction is already signed by the generated message and
+ * temporary wrapped-SOL accounts. Add the payer signature without rebuilding
+ * or changing the transaction.
+ */
 export async function transferNativeSol(
   connection: Connection,
   bridgeAddress: PublicKeyInitData,

--- a/testing/solana-test-validator/sdk-tests/2_token_bridge.ts
+++ b/testing/solana-test-validator/sdk-tests/2_token_bridge.ts
@@ -2313,7 +2313,7 @@ describe("Token Bridge", () => {
         const amount = 6969696969n;
         const targetAddress = Buffer.alloc(32, "deadbeef", "hex");
 
-        const transferNativeSolTx = await transferNativeSol(
+        const transaction = await transferNativeSol(
           connection,
           CORE_BRIDGE_ADDRESS,
           TOKEN_BRIDGE_ADDRESS,
@@ -2321,17 +2321,11 @@ describe("Token Bridge", () => {
           amount,
           targetAddress,
           "ethereum"
-        )
-          .then((transaction) =>
-            signSendAndConfirmTransaction(
-              connection,
-              wallet.key(),
-              wallet.signTransaction,
-              transaction
-            )
-          )
-          .then((response) => response.signature);
-        //console.log(`transferNativeSolTx: ${transferNativeSolTx}`);
+        );
+        transaction.partialSign(wallet.signer());
+        await connection
+          .sendRawTransaction(transaction.serialize())
+          .then((signature) => connection.confirmTransaction(signature));
 
         const balanceAfter = await connection
           .getBalance(wallet.key())


### PR DESCRIPTION
Fixes #4135.

## Summary

Clarifies the signing contract for `transferNativeSol` and fixes an in-repo usage that could invalidate signatures already added by the SDK.

`transferNativeSol` creates and signs the temporary wrapped-SOL account and Wormhole message account before returning the transaction. The caller still needs to add the payer signature, but must keep the returned transaction unchanged.

## Changes

- Document that `transferNativeSol` returns a partially signed transaction.
- Document that `signSendAndConfirmTransaction` expects an unsigned transaction because it sets `feePayer` and `recentBlockhash`.
- Update the Solana validator test to sign and send the transaction returned by `transferNativeSol` directly.
- Add coverage for the three required signer roles and verify the generated account signatures are present before the payer signs.

